### PR TITLE
feat(hangar-daemon): run a task over ACP behind HANGAR_TASK_EXECUTOR (spine A5)

### DIFF
--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "agent-client-protocol",
  "ainb-hangar-core",
  "ainb-hangar-proto",
+ "ainb-hangar-sandbox",
  "ainb-hangar-store",
  "rand 0.8.7",
  "serde_json",

--- a/ainb-tui/crates/ainb-acp/Cargo.toml
+++ b/ainb-tui/crates/ainb-acp/Cargo.toml
@@ -26,6 +26,11 @@ ainb-hangar-core = { path = "../ainb-hangar-core" }
 # Home of the re-primed untrusted-text envelope (`reprime`), shared with the
 # copilot's MCP tool server. Pure data crate, so it costs this crate nothing.
 ainb-hangar-proto = { path = "../ainb-hangar-proto" }
+# The OS FS confinement a PER-TASK adapter child is spawned under. Only the
+# policy crosses this boundary: Landlock lives in a `pre_exec` closure on the
+# command, which no `(command, args)` recipe can carry, so the command has to be
+# built at spawn. Leaf crate (thiserror + landlock), so it costs this one little.
+ainb-hangar-sandbox = { path = "../ainb-hangar-sandbox" }
 tokio = { workspace = true }
 # `compat` bridges tokio's child stdio to the futures AsyncRead/AsyncWrite the
 # upstream `ByteStreams` transport wants.

--- a/ainb-tui/crates/ainb-acp/src/client.rs
+++ b/ainb-tui/crates/ainb-acp/src/client.rs
@@ -680,7 +680,28 @@ impl Drop for AdapterProcess {
 }
 
 fn spawn_child(config: &AdapterConfig) -> Result<Child, AcpError> {
-    let mut command = Command::new(&config.command);
+    let mut command = match config.sandbox.as_ref() {
+        // The confinement travels WITH the command (an inline Seatbelt profile
+        // on macOS, a `pre_exec` Landlock closure on Linux), so the tokio
+        // conversion preserves it and there is no guard to keep alive. An
+        // unsupported platform degrades to the bare program rather than
+        // refusing to spawn, exactly as the hangar runner's own wrapper does.
+        Some(policy) => {
+            let sandboxed = ainb_hangar_sandbox::sandboxed_command(&config.command, policy)
+                .map_err(|source| AcpError::Spawn {
+                    adapter: config.name.clone(),
+                    source: std::io::Error::other(format!("sandbox setup: {source}")),
+                })?;
+            if sandboxed.enforcement() == ainb_hangar_sandbox::Enforcement::None {
+                tracing::warn!(
+                    adapter = %config.name,
+                    "OS sandbox unavailable on this platform; the adapter runs unconfined"
+                );
+            }
+            Command::from(sandboxed.into_inner())
+        }
+        None => Command::new(&config.command),
+    };
     command
         .args(&config.args)
         // I13: the child starts from NOTHING and gets exactly the allowlist.

--- a/ainb-tui/crates/ainb-acp/src/config.rs
+++ b/ainb-tui/crates/ainb-acp/src/config.rs
@@ -22,7 +22,7 @@ pub const CODEX_ADAPTER: &str = "codex-acp";
 pub const BASE_ENV_ALLOWLIST: &[&str] = &["PATH", "HOME"];
 
 /// One adapter's static definition.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AdapterConfig {
     /// Registry token, also the wire value of `fleet_acp_session.provider`.
     pub name: String,
@@ -67,6 +67,33 @@ pub struct AdapterConfig {
     /// Set by the per-task adapter a hangar task registers, whose child is one
     /// agent working in one worktree and so has a confinable blast radius.
     pub sandbox: Option<ainb_hangar_sandbox::SandboxPolicy>,
+}
+
+/// Hand-written so `extra_env` VALUES never render.
+///
+/// A hangar task copies its agent's per-agent environment in here, and
+/// `AgentEnv` masks its values in `Debug` precisely because they are the one
+/// permitted plaintext secret escape. A derived `Debug` on this struct would
+/// undo that for the whole life of the run: the config is held in the pool's
+/// adapter registry, and one `{:?}` added later (a `tracing::debug!`, an
+/// `anyhow` context, a panic message) would print every value.
+impl std::fmt::Debug for AdapterConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdapterConfig")
+            .field("name", &self.name)
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("permission_mode", &self.permission_mode)
+            .field("env_passthrough", &self.env_passthrough)
+            // Names only. The names are diagnostic; the values are the secret.
+            .field(
+                "extra_env",
+                &self.extra_env.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            )
+            .field("config_options", &self.config_options)
+            .field("sandbox", &self.sandbox)
+            .finish()
+    }
 }
 
 impl AdapterConfig {
@@ -222,6 +249,23 @@ mod tests {
             .extra_env(vec![("PATH".to_string(), "/opt/pinned".to_string())]);
         let env = allowlisted_env(&config, &fixed_env(&[("PATH", "/usr/bin")]));
         assert_eq!(env, vec![("PATH".to_string(), "/opt/pinned".to_string())]);
+    }
+
+    #[test]
+    fn debug_prints_extra_env_names_but_never_their_values() {
+        let config = AdapterConfig::new(CLAUDE_ADAPTER, "default").extra_env(vec![(
+            "SECRET_TOKEN".to_string(),
+            "sk-live-DEADBEEF".to_string(),
+        )]);
+        let rendered = format!("{config:?}");
+        assert!(
+            rendered.contains("SECRET_TOKEN"),
+            "the name is diagnostic: {rendered}"
+        );
+        assert!(
+            !rendered.contains("sk-live-DEADBEEF"),
+            "a per-agent secret must not render: {rendered}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-acp/src/config.rs
+++ b/ainb-tui/crates/ainb-acp/src/config.rs
@@ -54,6 +54,19 @@ pub struct AdapterConfig {
     /// Empty by default: part 1 ships no configured model or reasoning value,
     /// only the mechanism that keeps one from being silently lost on resume.
     pub config_options: Vec<(String, String)>,
+    /// OS-level FS confinement for this adapter's child, or `None` to spawn it
+    /// unconfined (the daemon-wide adapters, which serve every chat tenant).
+    ///
+    /// A POLICY rather than a wrapped command, because the two platforms
+    /// express confinement differently and only one of them is expressible as
+    /// `(command, args)`: macOS swaps the program for `/usr/bin/sandbox-exec`,
+    /// but Linux installs a Landlock ruleset in a `pre_exec` closure that lives
+    /// ON the command object. Carrying the policy and building the command at
+    /// spawn ([`crate::client`]) is the one shape that confines both.
+    ///
+    /// Set by the per-task adapter a hangar task registers, whose child is one
+    /// agent working in one worktree and so has a confinable blast radius.
+    pub sandbox: Option<ainb_hangar_sandbox::SandboxPolicy>,
 }
 
 impl AdapterConfig {
@@ -69,6 +82,7 @@ impl AdapterConfig {
             env_passthrough: Vec::new(),
             extra_env: Vec::new(),
             config_options: Vec::new(),
+            sandbox: None,
         }
     }
 
@@ -97,6 +111,13 @@ impl AdapterConfig {
     #[must_use]
     pub fn config_options(mut self, options: Vec<(String, String)>) -> Self {
         self.config_options = options;
+        self
+    }
+
+    /// Confine this adapter's child to `policy` (see [`AdapterConfig::sandbox`]).
+    #[must_use]
+    pub fn sandbox(mut self, policy: ainb_hangar_sandbox::SandboxPolicy) -> Self {
+        self.sandbox = Some(policy);
         self
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -2673,7 +2673,15 @@ impl SessionActor {
             id: attention_id.clone(),
             session_id: self.session_key.clone(),
             cwd: self.cwd.clone(),
-            workspace_id: None,
+            // A TASK's session knows its workspace through its scope, and an
+            // unscoped approval misses every workspace-filtered inbox — which
+            // is every operator surface an ACP task's permission has to reach.
+            // A chat session's scope names no workspace, so it stays `None`.
+            workspace_id: crate::acp_task::workspace_for_scope(
+                self.pool.store.pool(),
+                &self.scope_key,
+            )
+            .await,
             kind: ainb_hangar_store::repo::attention::AttentionKind::Approval,
             payload: payload.to_string(),
             degraded: false,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -2674,7 +2674,7 @@ impl SessionActor {
             session_id: self.session_key.clone(),
             cwd: self.cwd.clone(),
             // A TASK's session knows its workspace through its scope, and an
-            // unscoped approval misses every workspace-filtered inbox — which
+            // unscoped approval misses every workspace-filtered inbox, which
             // is every operator surface an ACP task's permission has to reach.
             // A chat session's scope names no workspace, so it stays `None`.
             workspace_id: crate::acp_task::workspace_for_scope(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -97,26 +97,115 @@ use tracing::Instrument as _;
 
 // ------------------------------------------------------------ detail taxonomy
 
+/// The enumerated delivery-detail vocabulary, as a TYPE.
+///
+/// The `DELIVERY_*` constants below are its wire spellings and are derived from
+/// it, so the two cannot drift. It exists as an enum for one reason: every
+/// reader of this taxonomy matches on it exhaustively, so adding a token here
+/// without deciding what it means for a task run is a COMPILE ERROR rather than
+/// a silent fall-through. The reader that matters is
+/// [`crate::acp_task::outcome_for`], which decides whether a task finalizes
+/// `done`, `failed` or `cancelled` and whether it is retried; the previous
+/// hand-written token list let a new token reach it as contract drift, and its
+/// own regression test could not see the gap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryToken {
+    /// See [`DELIVERY_QUEUE_FULL`].
+    QueueFull,
+    /// See [`DELIVERY_BREAKER_OPEN`].
+    BreakerOpen,
+    /// See [`DELIVERY_ADAPTER_EXIT`].
+    AdapterExit,
+    /// See [`DELIVERY_OPERATOR_STOP`].
+    OperatorStop,
+    /// See [`DELIVERY_TURN_DEADLINE`].
+    TurnDeadline,
+    /// See [`DELIVERY_DAEMON_RESTART`].
+    DaemonRestart,
+    /// See [`DELIVERY_SPAWN_FAILED`].
+    SpawnFailed,
+    /// See [`DELIVERY_TURN_FAILED`].
+    TurnFailed,
+    /// See [`DELIVERY_TURN_UNRECORDED`].
+    TurnUnrecorded,
+    /// See [`DELIVERY_SESSION_GONE`].
+    SessionGone,
+    /// See [`DELIVERY_PROVIDER_AT_CAPACITY`].
+    ProviderAtCapacity,
+    /// See [`DELIVERY_MODE_UNPROVEN`].
+    ModeUnproven,
+}
+
+impl DeliveryToken {
+    /// Every variant, so a test enumerating the vocabulary reads it from here
+    /// instead of a hand-written list that falls behind in silence.
+    ///
+    /// ponytail: a variant added to the enum but not to this array degrades to
+    /// "unparsed", which fails closed as contract drift; the exhaustive
+    /// [`Self::as_str`] and the exhaustive match in `acp_task` are what force
+    /// the author to decide its meaning.
+    pub const ALL: &'static [Self] = &[
+        Self::QueueFull,
+        Self::BreakerOpen,
+        Self::AdapterExit,
+        Self::OperatorStop,
+        Self::TurnDeadline,
+        Self::DaemonRestart,
+        Self::SpawnFailed,
+        Self::TurnFailed,
+        Self::TurnUnrecorded,
+        Self::SessionGone,
+        Self::ProviderAtCapacity,
+        Self::ModeUnproven,
+    ];
+
+    /// The wire spelling persisted in `fleet_message_delivery.detail`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::QueueFull => "queue_full",
+            Self::BreakerOpen => "breaker_open",
+            Self::AdapterExit => "adapter_exit",
+            Self::OperatorStop => "operator_stop",
+            Self::TurnDeadline => "turn_deadline",
+            Self::DaemonRestart => "daemon_restart",
+            Self::SpawnFailed => "spawn_failed",
+            Self::TurnFailed => "turn_failed",
+            Self::TurnUnrecorded => "turn_unrecorded",
+            Self::SessionGone => "session_gone",
+            Self::ProviderAtCapacity => "provider_at_capacity",
+            Self::ModeUnproven => "mode_unproven",
+        }
+    }
+
+    /// The token `raw` names, or `None` when it is not one of ours (free error
+    /// text, a `resume=`/`stop=` pair, or a spelling this build does not know).
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|token| token.as_str() == raw)
+    }
+}
+
 /// The per-scope FIFO was full; the prompt was never accepted.
-pub const DELIVERY_QUEUE_FULL: &str = "queue_full";
+pub const DELIVERY_QUEUE_FULL: &str = DeliveryToken::QueueFull.as_str();
 /// The provider's breaker is open; every scope routed there fails fast.
-pub const DELIVERY_BREAKER_OPEN: &str = "breaker_open";
+pub const DELIVERY_BREAKER_OPEN: &str = DeliveryToken::BreakerOpen.as_str();
 /// The adapter process went away (crash or kill).
-pub const DELIVERY_ADAPTER_EXIT: &str = "adapter_exit";
+pub const DELIVERY_ADAPTER_EXIT: &str = DeliveryToken::AdapterExit.as_str();
 /// An operator stopped the session while the adapter was alive.
 ///
 /// DISTINCT from [`DELIVERY_ADAPTER_EXIT`] on purpose: the runbook's first
 /// question is "did the adapter exit", and answering it `yes` for a warm
 /// process would inflate every crash count by every operator interrupt.
-pub const DELIVERY_OPERATOR_STOP: &str = "operator_stop";
+pub const DELIVERY_OPERATOR_STOP: &str = DeliveryToken::OperatorStop.as_str();
 /// The turn outlived its wall-clock deadline and was cancelled.
-pub const DELIVERY_TURN_DEADLINE: &str = "turn_deadline";
+pub const DELIVERY_TURN_DEADLINE: &str = DeliveryToken::TurnDeadline.as_str();
 /// Convergence ran at boot: the daemon that owned this turn is gone.
-pub const DELIVERY_DAEMON_RESTART: &str = "daemon_restart";
+pub const DELIVERY_DAEMON_RESTART: &str = DeliveryToken::DaemonRestart.as_str();
 /// The adapter could not be started at all.
-pub const DELIVERY_SPAWN_FAILED: &str = "spawn_failed";
+pub const DELIVERY_SPAWN_FAILED: &str = DeliveryToken::SpawnFailed.as_str();
 /// The turn ended with an adapter-reported failure (refusal, cancel).
-pub const DELIVERY_TURN_FAILED: &str = "turn_failed";
+pub const DELIVERY_TURN_FAILED: &str = DeliveryToken::TurnFailed.as_str();
 /// The turn could not be RECORDED, so it was never issued (I16).
 ///
 /// Both convergence paths key off the persisted `open_turn_id`: the deadline
@@ -125,20 +214,20 @@ pub const DELIVERY_TURN_FAILED: &str = "turn_failed";
 /// failed would be invisible to both, so a hung adapter would never be swept
 /// and a dying one would resolve the leg with no marker. Nothing reached the
 /// adapter, so FAILED is honest and an operator can resend.
-pub const DELIVERY_TURN_UNRECORDED: &str = "turn_unrecorded";
+pub const DELIVERY_TURN_UNRECORDED: &str = DeliveryToken::TurnUnrecorded.as_str();
 /// The recipient exists but its session row is gone or dead.
-pub const DELIVERY_SESSION_GONE: &str = "session_gone";
+pub const DELIVERY_SESSION_GONE: &str = DeliveryToken::SessionGone.as_str();
 /// The provider's process is at its session cap and every tenant is busy.
 ///
 /// Terminal, never requeued: the cap is a standing ceiling, not a transient
 /// fault, and a retry that ignored it would put the process one tenant over the
 /// maximum an operator configured. An operator resends once a turn ends.
-pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = "provider_at_capacity";
+pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = DeliveryToken::ProviderAtCapacity.as_str();
 /// The pinned permission mode could not be proven for the session (I13).
 ///
 /// Terminal, never requeued: retrying an adapter that will not hold the mode
 /// just drives the same session in the wrong permission regime a second time.
-pub const DELIVERY_MODE_UNPROVEN: &str = "mode_unproven";
+pub const DELIVERY_MODE_UNPROVEN: &str = DeliveryToken::ModeUnproven.as_str();
 /// Prefix of the token a leg carries when the turn stopped for a reason worth
 /// naming: `stop=<reason>`, in the ACP wire spelling ([`stop_reason_token`]),
 /// so `stop=max_tokens`, `stop=max_turn_requests`, `stop=refusal`.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -1,0 +1,591 @@
+//! Run one hangar task over ACP instead of spawning a provider CLI.
+//!
+//! The third arm of [`crate::run_loop::execute_claimed`]'s exec-path branch,
+//! selected by `HANGAR_TASK_EXECUTOR=acp` and returning the same
+//! [`RunOutcome`] the two process arms do, so everything below `let outcome =`
+//! (finalize, PR capture, board advance, retry) is untouched.
+//!
+//! ```text
+//!   register claude-agent-acp#task:<id>  ── per-task adapter PROCESS
+//!            │  cwd + agent_env + permission mode + OS sandbox are per process
+//!            ▼
+//!   acp_session::ensure(scope_key = "task:<id>")  ── no spawn, one txn
+//!            ▼
+//!   acp_session::enqueue  ─▶  pool.submit_prompt  ─▶  the adapter's turn
+//!            ▼
+//!   POLL the delivery leg (the pool resolves it on EVERY path)
+//!            ▼
+//!   leg state + detail token set ──▶ RunOutcome  (unmapped ⇒ contract drift)
+//! ```
+//!
+//! Two shapes here are load-bearing and are not preferences.
+//!
+//! **The leg is polled, never awaited.** The pool resolves the PENDING delivery
+//! leg in one transaction on turn end, on adapter exit, on the deadline sweep
+//! and on boot convergence ([`crate::acp_pool`]), so it is the one signal that
+//! is always written. A `oneshot` on the prompt job would be ~40 lines and one
+//! missed send would freeze the task at `running` until the multi-hour TTL —
+//! the exact black hole `execute_claimed`'s spawn-setup umbrella exists to
+//! close.
+//!
+//! **The adapter process is per TASK, not the shared pool's.** The permission
+//! mode, the child environment and the OS sandbox are all per PROCESS
+//! ([`ainb_acp::config::AdapterConfig`]), so a shared `claude-agent-acp` cannot
+//! host one task's `agent_env` without handing it to every other tenant, and
+//! its `max_in_flight_per_process: 4` would cap the whole fleet's concurrent
+//! task turns at four.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ainb_acp::config::AdapterConfig;
+use ainb_hangar_store::repo::fleet_acp_session::FleetAcpSessionRepo;
+use ainb_hangar_store::repo::fleet_message::FleetMessageRepo;
+use ainb_hangar_store::repo::task::Task;
+use ainb_hangar_store::service::fail::FailureReason;
+use sqlx::SqlitePool;
+
+use crate::acp_pool::{AcpPool, ConvergeCause, SubmitOutcome};
+use crate::events::EventSink;
+use crate::execenv::ExecEnv;
+use crate::runner::{Backend, RunLocation, RunOutcome, RunnerResult};
+
+/// How often the delivery leg is re-read while the turn is open.
+///
+/// One indexed read per second per running ACP task, bounded by the agent's
+/// `max_concurrent_tasks`. The pool's own deadline sweep runs at 15 s, so a
+/// tighter poll buys nothing an operator can see.
+const LEG_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How many transcript replies are scanned for the run's final message.
+///
+/// A turn writes exactly one `agent` reply threaded to its prompt
+/// (`acp_pool::finish_turn`), so this is a bound on a pathological store, not a
+/// window that has to be tuned.
+const REPLY_SCAN_LIMIT: i64 = 8;
+
+/// The `fleet_acp_session.scope_key` a task's session is created under.
+///
+/// Deliberately derivable from the task id alone: the cancel arm, the durable
+/// timeline read and this module all resolve the same session without a new
+/// column on either side, and `acp_session::ensure` is already idempotent per
+/// live scope.
+#[must_use]
+pub fn scope_key(task_id: &str) -> String {
+    format!("task:{task_id}")
+}
+
+/// The workspace an ACP session's scope belongs to, or `None` when the scope
+/// is not a task's.
+///
+/// The one place the `task:<id>` scope convention is read back, so the pool
+/// does not have to know it. An attention row raised by a task's session lands
+/// unscoped without this, and a workspace-filtered inbox — which is every
+/// operator surface — never shows it.
+pub async fn workspace_for_scope(pool: &SqlitePool, scope: &str) -> Option<String> {
+    let task_id = scope.strip_prefix("task:")?;
+    ainb_hangar_store::repo::task::TaskRepo::get_by_id(pool, task_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|task| task.workspace_id)
+}
+
+/// The adapter-registry key a task's OWN adapter process is registered under.
+///
+/// `<base>#task:<id>`, so the pool's one-process-per-key rule is the isolation
+/// and the base adapter every chat tenant shares is never reconfigured.
+fn adapter_key(base: &str, task_id: &str) -> String {
+    format!("{base}#task:{task_id}")
+}
+
+/// The `CLAUDE_CONFIG_DIR` a task's adapter is pointed at, inside the task's
+/// own execenv root (so the OS sandbox already allows writes to it).
+///
+/// Without it the adapter merges the OPERATOR's `~/.claude`: proven live on a
+/// dev box, a `settings.json` carrying `permissions.defaultMode: auto` makes
+/// `session/new` fail outright with `-32603 Invalid permissions.defaultMode`,
+/// and even when it parses the task inherits every globally-installed skill and
+/// the global `CLAUDE.md`. The operator's own directory is never touched.
+fn task_config_dir(env: &ExecEnv) -> std::path::PathBuf {
+    env.root().join("claude-config")
+}
+
+/// Which ACP adapter serves `backend`.
+///
+/// Refused rather than defaulted for anything else: silently prompting
+/// `claude-agent-acp` for a task whose agent asked for copilot is the same
+/// class of bug as spawning the headless argv into an interactive pane.
+const fn adapter_for(backend: Backend) -> Option<&'static str> {
+    match backend {
+        Backend::Claude => Some(ainb_acp::config::CLAUDE_ADAPTER),
+        Backend::Codex => Some(ainb_acp::config::CODEX_ADAPTER),
+        Backend::Copilot | Backend::Antigravity => None,
+    }
+}
+
+/// Unregisters a task's adapter key (and stops its process) on EVERY exit path,
+/// including the cancel that DROPS [`run_acp`] mid-poll.
+///
+/// `Drop` cannot await, so the removal rides a detached task.
+/// `AcpPool::unregister_adapter` is idempotent, so the ordinary end-of-run path
+/// needs no separate call and a double drop is benign.
+struct AdapterLease {
+    pool: Arc<AcpPool>,
+    key: String,
+}
+
+impl Drop for AdapterLease {
+    fn drop(&mut self) {
+        let pool = Arc::clone(&self.pool);
+        let key = std::mem::take(&mut self.key);
+        tokio::spawn(async move {
+            if pool.unregister_adapter(&key).await {
+                tracing::debug!(adapter = %key, "released a task's adapter process");
+            }
+        });
+    }
+}
+
+/// Run `task`'s brief as one ACP turn and map the delivery leg onto a
+/// [`RunOutcome`].
+///
+/// Never returns `Err` for an agent-side failure: every refusal, timeout and
+/// adapter fault is a terminal outcome the caller finalizes through the same
+/// seam the process executor uses. `Err` is reserved for a store fault that
+/// leaves the run undecidable.
+///
+/// # Errors
+///
+/// Returns an error only when the session or the prompt cannot be written to
+/// the store, so the caller terminalises rather than freezing at `running`.
+// One over the lint's 7, and the same shape the sibling run functions in
+// `run_loop` carry: every argument is a distinct collaborator the run needs and
+// bundling them into a context struct is a wider refactor than this arm wants.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_acp(
+    pool: &SqlitePool,
+    events: &EventSink,
+    task: &Task,
+    dispatch: &crate::run_loop::ResolvedDispatch,
+    env: &ExecEnv,
+    location: &RunLocation,
+    task_env: HashMap<String, String>,
+    max_runtime: Duration,
+) -> anyhow::Result<RunOutcome> {
+    let Some(acp) = crate::acp_pool::active_handle().await else {
+        tracing::error!(task_id = %task.id, "no acp pool installed; cannot run this task over acp");
+        return Ok(spawn_error());
+    };
+    let Some(base) = adapter_for(dispatch.backend) else {
+        tracing::error!(
+            task_id = %task.id,
+            provider = dispatch.backend.name(),
+            "no acp adapter serves this provider; run it under HANGAR_TASK_EXECUTOR=process"
+        );
+        return Ok(RunOutcome::Failed {
+            reason: FailureReason::ProvisionError,
+            result: RunnerResult::default(),
+        });
+    };
+    let Some(recipe) = acp.config().adapters.get(base).cloned() else {
+        tracing::error!(task_id = %task.id, adapter = base, "adapter is not in the registry");
+        return Ok(spawn_error());
+    };
+
+    let key = adapter_key(base, &task.id);
+    let cwd = location.cwd.clone();
+    acp.register_adapter(
+        key.clone(),
+        task_adapter(
+            &recipe,
+            &key,
+            env,
+            location,
+            task_env,
+            dispatch.agent_env.clone().expose_for_child_env(),
+        ),
+    );
+    // Held from BEFORE the session exists: a store fault below still has to
+    // release the key, and an early `?` would otherwise leak a registry entry.
+    let _lease = AdapterLease {
+        pool: Arc::clone(&acp),
+        key: key.clone(),
+    };
+
+    // The session is minted against the TASK's key, not the base adapter, so
+    // its first prompt spawns the process this run just registered.
+    let scope = scope_key(&task.id);
+    let session =
+        crate::acp_session::ensure(pool, events, &key, &cwd.to_string_lossy(), Some(&scope))
+            .await?;
+    let session_key = session.session_key;
+    // Written the moment it exists, so a run that later fails or is cancelled
+    // still points at the transcript it produced; the success path would
+    // otherwise be the only one that records it (`CompleteTaskService`).
+    if let Err(error) =
+        ainb_hangar_store::repo::task::TaskRepo::set_session_id(pool, &task.id, &session_key).await
+    {
+        tracing::warn!(task_id = %task.id, %error, "could not record the acp session on the task");
+    }
+
+    let message_id =
+        crate::acp_session::enqueue(pool, &session_key, &scope, &dispatch.invocation.prompt)
+            .await?;
+    if let SubmitOutcome::Rejected(detail) =
+        acp.submit_prompt(&session_key, &message_id, &dispatch.invocation.prompt).await
+    {
+        tracing::warn!(task_id = %task.id, detail, "the acp pool refused the task's prompt");
+        return Ok(outcome_for(
+            "REJECTED",
+            Some(detail),
+            RunnerResult::default(),
+        ));
+    }
+
+    let (state, detail) = match await_leg(pool, &acp, &session_key, &message_id, max_runtime).await
+    {
+        Some(resolved) => resolved,
+        None => (
+            "UNKNOWN".to_string(),
+            Some(crate::acp_pool::DELIVERY_TURN_DEADLINE.to_string()),
+        ),
+    };
+    let result = build_result(pool, &session_key, &message_id).await;
+    Ok(outcome_for(&state, detail.as_deref(), result))
+}
+
+/// `session/cancel` the task's open turn — the ACP analogue of the interactive
+/// arm's `kill_session`.
+///
+/// Dropping [`run_acp`] stops POLLING; it does not stop the agent, which lives
+/// in another process that has not been told anything. Called from the cancel
+/// arm of `execute_claimed`'s `select!` for exactly that reason.
+///
+/// Returns after the actor has HANDLED the cancel (its convergence resolves
+/// every pending leg on the session), not merely after the message was sent:
+/// the lease drop that follows kills the adapter process, and killing it first
+/// would mean the adapter never saw the `session/cancel` it is being stopped
+/// by. Bounded, so a wedged actor delays a cancel by seconds rather than
+/// forever.
+pub async fn cancel_run(pool: &SqlitePool, task_id: &str) {
+    let Some(acp) = crate::acp_pool::active_handle().await else {
+        return;
+    };
+    let session = FleetAcpSessionRepo::get_live_by_scope(pool, &scope_key(task_id)).await;
+    let Ok(Some(session)) = session else {
+        return;
+    };
+    if !acp.cancel(&session.session_key, ConvergeCause::OperatorStop).await {
+        return;
+    }
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        match FleetMessageRepo::pending_deliveries_for_session(pool, &session.session_key).await {
+            Ok(legs) if legs.is_empty() => return,
+            _ => tokio::time::sleep(Duration::from_millis(20)).await,
+        }
+    }
+    tracing::warn!(
+        task_id,
+        session_key = %session.session_key,
+        "acp cancel did not converge in time; tearing the adapter down anyway"
+    );
+}
+
+/// The per-task adapter recipe: the base adapter's program, this task's
+/// environment, permission mode and confinement.
+fn task_adapter(
+    base: &AdapterConfig,
+    key: &str,
+    env: &ExecEnv,
+    location: &RunLocation,
+    task_env: HashMap<String, String>,
+    agent_env: Vec<(String, String)>,
+) -> AdapterConfig {
+    let config_dir = task_config_dir(env);
+    // Best-effort: an adapter handed a config dir it has to create itself still
+    // gets a CLEAN one, which is the whole point of pointing it here.
+    if let Err(error) = std::fs::create_dir_all(&config_dir) {
+        tracing::warn!(%error, dir = %config_dir.display(), "could not pre-create the task config dir");
+    }
+    let mut extra_env: Vec<(String, String)> = task_env.into_iter().collect();
+    // Deterministic, so a leaked-env assertion reads the same list every run.
+    extra_env.sort();
+    // The ONE permitted plaintext escape: the child env. Layered last so the
+    // agent's own values win, matching `compose_child_env` on the process path.
+    extra_env.extend(agent_env);
+    extra_env.push((
+        "CLAUDE_CONFIG_DIR".to_string(),
+        config_dir.to_string_lossy().into_owned(),
+    ));
+
+    let mut adapter = AdapterConfig {
+        name: key.to_string(),
+        command: base.command.clone(),
+        args: base.args.clone(),
+        permission_mode: base.permission_mode.clone(),
+        // The adapter authenticates itself; this names the variable it reads
+        // WITHOUT the daemon minting one, so a token that is present in the
+        // daemon's environment is honoured and an absent one is not faked.
+        env_passthrough: base.env_passthrough.clone(),
+        extra_env,
+        config_options: base.config_options.clone(),
+        sandbox: None,
+    };
+    if sandbox_enabled() {
+        let mut policy = ainb_hangar_sandbox::SandboxPolicy::confined_to(env.root());
+        if let Some(root) = location.extra_root.as_deref() {
+            policy = policy.allow_read(root).allow_write(root);
+        }
+        adapter.sandbox = Some(policy);
+    }
+    adapter
+}
+
+/// The headless OS sandbox posture, read through the daemon's own pure
+/// resolver so this path and the process path cannot disagree about what
+/// `HANGAR_DAEMON_DISABLE_SANDBOX` means.
+fn sandbox_enabled() -> bool {
+    crate::run_loop::DaemonConfig::resolve_sandbox(
+        std::env::var_os("HANGAR_DAEMON_DISABLE_SANDBOX").as_deref(),
+    )
+}
+
+/// Poll the delivery leg until it leaves `PENDING`, or the run outlives
+/// `max_runtime`.
+///
+/// `None` means the deadline was hit: the turn is cancelled on the way out so
+/// the adapter is not left working on a run nobody is waiting for.
+async fn await_leg(
+    pool: &SqlitePool,
+    acp: &Arc<AcpPool>,
+    session_key: &str,
+    message_id: &str,
+    max_runtime: Duration,
+) -> Option<(String, Option<String>)> {
+    let deadline = Instant::now() + max_runtime;
+    loop {
+        match FleetMessageRepo::deliveries_for_message(pool, message_id).await {
+            Ok(legs) => match legs.into_iter().find(|leg| leg.session_key == session_key) {
+                Some(leg) if leg.state != "PENDING" => return Some((leg.state, leg.detail)),
+                Some(_) => {}
+                // The leg is written in the same transaction as the message, so
+                // its absence is not a race: it is a store that lost a row.
+                // Answered as drift by the caller rather than polled forever.
+                None => return Some(("MISSING".to_string(), None)),
+            },
+            // Transient: keep polling, the deadline is still the bound.
+            Err(error) => tracing::warn!(%session_key, %error, "acp delivery leg read failed"),
+        }
+        if Instant::now() >= deadline {
+            acp.cancel(session_key, ConvergeCause::TurnDeadline).await;
+            return None;
+        }
+        tokio::time::sleep(LEG_POLL_INTERVAL).await;
+    }
+}
+
+/// The run artefacts a finalize reads: the session key as the run's session id,
+/// and the turn's final agent message as the stdout tail PR capture scans.
+async fn build_result(pool: &SqlitePool, session_key: &str, message_id: &str) -> RunnerResult {
+    // The turn's final message is already persisted as a threaded `agent` reply
+    // in the task's own scope (`acp_pool::finish_turn`), so this reads ONE row
+    // rather than re-deriving it from the transcript chunk stream.
+    let stdout_tail = FleetMessageRepo::list_by_origin(pool, message_id, 0, REPLY_SCAN_LIMIT)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|row| row.kind == "agent")
+        .map(|row| row.body)
+        .collect::<Vec<_>>()
+        .join("\n");
+    RunnerResult {
+        // An ACP turn has no process and so no exit code; the leg carries the
+        // outcome instead.
+        exit_code: None,
+        session_id: Some(session_key.to_string()),
+        // A7 parses the `acp.usage` rows; until then an ACP run reports none
+        // rather than a fabricated zero.
+        usage: None,
+        stdout_tail,
+        // The adapter's stderr is INHERITED by the daemon (`ainb_acp::client`),
+        // so there is no tail to capture here.
+        stderr_tail: String::new(),
+    }
+}
+
+/// [`FailureReason::SpawnError`] with no captured output — the pool or its
+/// registry could not produce an adapter at all.
+fn spawn_error() -> RunOutcome {
+    RunOutcome::Failed {
+        reason: FailureReason::SpawnError,
+        result: RunnerResult::default(),
+    }
+}
+
+/// Map a resolved delivery leg onto the outcome the task FSM finalizes.
+///
+/// The detail is read as a `; `-joined TOKEN SET, never by equality: a plain
+/// success can read `resume=loaded`, a budget stop `stop=max_tokens;
+/// resume=reprimed`, and an adapter exit appends the raw error text after its
+/// token. An unmapped detail is
+/// [`FailureReason::ProviderContractDrift`] on purpose — an unknown token means
+/// the pool's taxonomy grew, not that the agent succeeded.
+#[must_use]
+pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> RunOutcome {
+    use crate::acp_pool as tokens;
+
+    let set: Vec<&str> = detail
+        .unwrap_or_default()
+        .split("; ")
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .collect();
+    let has = |token: &str| set.contains(&token);
+    let stop = set.iter().find_map(|token| token.strip_prefix(tokens::DELIVERY_STOP_PREFIX));
+
+    let failed = |reason: FailureReason| RunOutcome::Failed {
+        reason,
+        result: result.clone(),
+    };
+    match state {
+        // No `stop=` token on a DELIVERED leg IS the ordinary `EndTurn`: the
+        // pool writes the token only when the reason is worth naming.
+        "DELIVERED" => match stop {
+            None => RunOutcome::Success(result),
+            Some("max_tokens" | "max_turn_requests") => failed(FailureReason::IterationLimit),
+            Some(_) => failed(FailureReason::ProviderContractDrift),
+        },
+        "FAILED" if has(tokens::DELIVERY_TURN_FAILED) => match stop {
+            Some("refusal") => failed(FailureReason::AgentError),
+            Some("cancelled") => RunOutcome::Cancelled(result),
+            _ => failed(FailureReason::ProviderContractDrift),
+        },
+        "FAILED" if has(tokens::DELIVERY_OPERATOR_STOP) => RunOutcome::Cancelled(result),
+        "FAILED"
+            if has(tokens::DELIVERY_SPAWN_FAILED)
+                || has(tokens::DELIVERY_MODE_UNPROVEN)
+                || has(tokens::DELIVERY_TURN_UNRECORDED) =>
+        {
+            failed(FailureReason::SpawnError)
+        }
+        "FAILED" if has(tokens::DELIVERY_SESSION_GONE) => failed(FailureReason::ProvisionError),
+        "FAILED"
+            if has(tokens::DELIVERY_BREAKER_OPEN)
+                || has(tokens::DELIVERY_PROVIDER_AT_CAPACITY)
+                || has(tokens::DELIVERY_QUEUE_FULL) =>
+        {
+            failed(FailureReason::RuntimeOffline)
+        }
+        "UNKNOWN" if has(tokens::DELIVERY_ADAPTER_EXIT) => failed(FailureReason::RuntimeOffline),
+        "UNKNOWN" if has(tokens::DELIVERY_TURN_DEADLINE) => failed(FailureReason::Timeout),
+        "UNKNOWN" if has(tokens::DELIVERY_DAEMON_RESTART) => failed(FailureReason::RuntimeRecovery),
+        // Refused at the door: nothing reached the adapter, and the refusal
+        // reason is a standing condition a re-dispatch will meet again.
+        "REJECTED" => failed(FailureReason::SpawnError),
+        _ => failed(FailureReason::ProviderContractDrift),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    fn exec_env(root: &Path) -> ExecEnv {
+        ExecEnv {
+            workdir: root.join("workdir"),
+            output: root.join("output"),
+            logs: root.join("logs"),
+            gc_meta: root.join(".gc_meta.json"),
+        }
+    }
+
+    #[test]
+    fn scope_and_adapter_keys_name_the_task() {
+        assert_eq!(scope_key("t-1"), "task:t-1");
+        assert_eq!(
+            adapter_key(ainb_acp::config::CLAUDE_ADAPTER, "t-1"),
+            "claude-agent-acp#task:t-1"
+        );
+    }
+
+    #[test]
+    fn only_the_two_acp_backends_are_servable() {
+        assert_eq!(adapter_for(Backend::Claude), Some("claude-agent-acp"));
+        assert_eq!(adapter_for(Backend::Codex), Some("codex-acp"));
+        assert_eq!(adapter_for(Backend::Copilot), None);
+        assert_eq!(adapter_for(Backend::Antigravity), None);
+    }
+
+    #[test]
+    fn the_per_task_adapter_carries_this_task_and_no_other() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let env = exec_env(dir.path());
+        let base = AdapterConfig::new(ainb_acp::config::CLAUDE_ADAPTER, "bypassPermissions")
+            .command("/opt/claude-agent-acp")
+            .env_passthrough(vec!["CLAUDE_CODE_OAUTH_TOKEN".to_string()]);
+        let location = RunLocation {
+            cwd: dir.path().join("worktree"),
+            extra_root: Some(dir.path().join("worktree")),
+        };
+        let adapter = task_adapter(
+            &base,
+            "claude-agent-acp#task:t-1",
+            &env,
+            &location,
+            HashMap::from([("PATH".to_string(), "/usr/bin".to_string())]),
+            vec![("SECRET_TOKEN".to_string(), "sk-live-1".to_string())],
+        );
+
+        assert_eq!(adapter.name, "claude-agent-acp#task:t-1");
+        assert_eq!(
+            adapter.command,
+            std::path::PathBuf::from("/opt/claude-agent-acp")
+        );
+        // The mode is the base's, not a default: an unpinned adapter has been
+        // observed inheriting `bypassPermissions` from ambient state.
+        assert_eq!(adapter.permission_mode, "bypassPermissions");
+        assert_eq!(
+            adapter.env_passthrough,
+            vec!["CLAUDE_CODE_OAUTH_TOKEN".to_string()]
+        );
+
+        let env_map: HashMap<&str, &str> = adapter
+            .extra_env
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect();
+        assert_eq!(env_map.get("SECRET_TOKEN"), Some(&"sk-live-1"));
+        assert_eq!(env_map.get("PATH"), Some(&"/usr/bin"));
+        // Pointed at the task's OWN config tree, inside the execenv root the
+        // sandbox already allows writes to, so the adapter never merges the
+        // operator's `~/.claude`.
+        let config_dir = env.root().join("claude-config");
+        assert_eq!(
+            env_map.get("CLAUDE_CONFIG_DIR").map(std::path::Path::new),
+            Some(config_dir.as_path())
+        );
+        assert!(
+            config_dir.is_dir(),
+            "the task config dir is created up front"
+        );
+    }
+
+    #[test]
+    fn a_delivered_leg_with_no_stop_token_is_the_ordinary_success() {
+        assert!(matches!(
+            outcome_for("DELIVERED", None, RunnerResult::default()),
+            RunOutcome::Success(_)
+        ));
+        // `resume=loaded` rides on an ORDINARY success, so equality on the
+        // detail would read a healthy turn as drift.
+        assert!(matches!(
+            outcome_for("DELIVERED", Some("resume=loaded"), RunnerResult::default()),
+            RunOutcome::Success(_)
+        ));
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -163,7 +163,9 @@ impl Drop for AdapterLease {
 // One over the lint's 7, and the same shape the sibling run functions in
 // `run_loop` carry: every argument is a distinct collaborator the run needs and
 // bundling them into a context struct is a wider refactor than this arm wants.
-#[allow(clippy::too_many_arguments)]
+// `task_env` is the map `prepare_spawn_inputs` returns verbatim; generalising
+// its hasher would only make the one call site spell out a type parameter.
+#[allow(clippy::too_many_arguments, clippy::implicit_hasher)]
 pub async fn run_acp(
     pool: &SqlitePool,
     events: &EventSink,
@@ -205,6 +207,7 @@ pub async fn run_acp(
             location,
             task_env,
             dispatch.agent_env.clone().expose_for_child_env(),
+            sandbox_enabled(),
         ),
     );
     // Held from BEFORE the session exists: a store fault below still has to
@@ -244,14 +247,7 @@ pub async fn run_acp(
         ));
     }
 
-    let (state, detail) = match await_leg(pool, &acp, &session_key, &message_id, max_runtime).await
-    {
-        Some(resolved) => resolved,
-        None => (
-            "UNKNOWN".to_string(),
-            Some(crate::acp_pool::DELIVERY_TURN_DEADLINE.to_string()),
-        ),
-    };
+    let (state, detail) = await_leg(pool, &acp, &session_key, &message_id, max_runtime).await;
     let result = build_result(pool, &session_key, &message_id).await;
     Ok(outcome_for(&state, detail.as_deref(), result))
 }
@@ -303,6 +299,7 @@ fn task_adapter(
     location: &RunLocation,
     task_env: HashMap<String, String>,
     agent_env: Vec<(String, String)>,
+    sandbox: bool,
 ) -> AdapterConfig {
     let config_dir = task_config_dir(env);
     // Best-effort: an adapter handed a config dir it has to create itself still
@@ -334,7 +331,7 @@ fn task_adapter(
         config_options: base.config_options.clone(),
         sandbox: None,
     };
-    if sandbox_enabled() {
+    if sandbox {
         let mut policy = ainb_hangar_sandbox::SandboxPolicy::confined_to(env.root());
         if let Some(root) = location.extra_root.as_deref() {
             policy = policy.allow_read(root).allow_write(root);
@@ -354,34 +351,39 @@ fn sandbox_enabled() -> bool {
 }
 
 /// Poll the delivery leg until it leaves `PENDING`, or the run outlives
-/// `max_runtime`.
+/// `max_runtime`, and answer the `(state, detail)` the outcome mapping reads.
 ///
-/// `None` means the deadline was hit: the turn is cancelled on the way out so
-/// the adapter is not left working on a run nobody is waiting for.
+/// On the deadline the turn is CANCELLED on the way out — the adapter would
+/// otherwise keep working on a run nobody is waiting for — and the pair
+/// returned is the same one the pool's own deadline sweep would have written,
+/// so both routes to a timed-out task map identically.
 async fn await_leg(
     pool: &SqlitePool,
     acp: &Arc<AcpPool>,
     session_key: &str,
     message_id: &str,
     max_runtime: Duration,
-) -> Option<(String, Option<String>)> {
+) -> (String, Option<String>) {
     let deadline = Instant::now() + max_runtime;
     loop {
         match FleetMessageRepo::deliveries_for_message(pool, message_id).await {
             Ok(legs) => match legs.into_iter().find(|leg| leg.session_key == session_key) {
-                Some(leg) if leg.state != "PENDING" => return Some((leg.state, leg.detail)),
+                Some(leg) if leg.state != "PENDING" => return (leg.state, leg.detail),
                 Some(_) => {}
                 // The leg is written in the same transaction as the message, so
                 // its absence is not a race: it is a store that lost a row.
                 // Answered as drift by the caller rather than polled forever.
-                None => return Some(("MISSING".to_string(), None)),
+                None => return ("MISSING".to_string(), None),
             },
             // Transient: keep polling, the deadline is still the bound.
             Err(error) => tracing::warn!(%session_key, %error, "acp delivery leg read failed"),
         }
         if Instant::now() >= deadline {
             acp.cancel(session_key, ConvergeCause::TurnDeadline).await;
-            return None;
+            return (
+                "UNKNOWN".to_string(),
+                Some(crate::acp_pool::DELIVERY_TURN_DEADLINE.to_string()),
+            );
         }
         tokio::time::sleep(LEG_POLL_INTERVAL).await;
     }
@@ -539,6 +541,7 @@ mod tests {
             &location,
             HashMap::from([("PATH".to_string(), "/usr/bin".to_string())]),
             vec![("SECRET_TOKEN".to_string(), "sk-live-1".to_string())],
+            false,
         );
 
         assert_eq!(adapter.name, "claude-agent-acp#task:t-1");
@@ -573,6 +576,47 @@ mod tests {
             config_dir.is_dir(),
             "the task config dir is created up front"
         );
+    }
+
+    #[test]
+    fn the_sandbox_policy_widens_to_the_run_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let env = exec_env(dir.path());
+        let worktree = dir.path().join("worktree");
+        let location = RunLocation {
+            cwd: worktree.clone(),
+            extra_root: Some(worktree.clone()),
+        };
+        let base = AdapterConfig::new(ainb_acp::config::CLAUDE_ADAPTER, "default");
+        let build = |sandbox| {
+            task_adapter(
+                &base,
+                "k",
+                &env,
+                &location,
+                HashMap::new(),
+                Vec::new(),
+                sandbox,
+            )
+        };
+
+        // Sandbox OFF is an explicit posture, not an accident of construction.
+        assert!(build(false).sandbox.is_none());
+
+        let policy = build(true).sandbox.expect("a confined per-task adapter");
+        assert!(
+            policy.write_roots.contains(&env.root().to_path_buf()),
+            "the task tree must be writable: {:?}",
+            policy.write_roots
+        );
+        // The provisioned worktree lives OUTSIDE the task tree, so without the
+        // widening the confined agent could not touch its own checkout.
+        assert!(
+            policy.write_roots.contains(&worktree),
+            "the run worktree must be writable: {:?}",
+            policy.write_roots
+        );
+        assert!(policy.read_roots.contains(&worktree));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -427,6 +427,47 @@ fn spawn_error() -> RunOutcome {
     }
 }
 
+/// The outcome ONE enumerated delivery token names, whichever terminal state
+/// carries it.
+///
+/// The token is the whole answer, and the state is not part of the key. The
+/// pool writes the SAME converge cause under two different states depending on
+/// where the prompt was standing when the session converged — `drain_queue`
+/// resolves a still-queued prompt `FAILED`, `converge_dirty_session` resolves
+/// an issued one `UNKNOWN` — and `attach_with_one_requeue` writes
+/// `adapter_exit` on a `FAILED` leg while the exit watcher writes it on an
+/// `UNKNOWN` one. Neither difference changes how the task should be retried, so
+/// keying on the pair meant four reachable combinations (`FAILED`+`adapter_exit`,
+/// `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`, `UNKNOWN`+`operator_stop`)
+/// answered `ProviderContractDrift`/NoRetry — burning the retry chain on
+/// exactly the transient faults that should resume.
+fn outcome_for_token(token: &str, result: &RunnerResult) -> Option<RunOutcome> {
+    use crate::acp_pool as tokens;
+
+    let failed = |reason| {
+        Some(RunOutcome::Failed {
+            reason,
+            result: result.clone(),
+        })
+    };
+    match token {
+        tokens::DELIVERY_OPERATOR_STOP => Some(RunOutcome::Cancelled(result.clone())),
+        // Infrastructure, not the work: resume the same conversation.
+        tokens::DELIVERY_ADAPTER_EXIT
+        | tokens::DELIVERY_BREAKER_OPEN
+        | tokens::DELIVERY_PROVIDER_AT_CAPACITY
+        | tokens::DELIVERY_QUEUE_FULL => failed(FailureReason::RuntimeOffline),
+        tokens::DELIVERY_TURN_DEADLINE => failed(FailureReason::Timeout),
+        tokens::DELIVERY_DAEMON_RESTART => failed(FailureReason::RuntimeRecovery),
+        // A misconfigured adapter will not self-heal on a re-dispatch.
+        tokens::DELIVERY_SPAWN_FAILED
+        | tokens::DELIVERY_MODE_UNPROVEN
+        | tokens::DELIVERY_TURN_UNRECORDED => failed(FailureReason::SpawnError),
+        tokens::DELIVERY_SESSION_GONE => failed(FailureReason::ProvisionError),
+        _ => None,
+    }
+}
+
 /// Map a resolved delivery leg onto the outcome the task FSM finalizes.
 ///
 /// The detail is read as a `; `-joined TOKEN SET, never by equality: a plain
@@ -435,6 +476,14 @@ fn spawn_error() -> RunOutcome {
 /// token. An unmapped detail is
 /// [`FailureReason::ProviderContractDrift`] on purpose — an unknown token means
 /// the pool's taxonomy grew, not that the agent succeeded.
+///
+/// Only two shapes read the STATE: a `DELIVERED` leg, where the stop reason
+/// separates a finished turn from an exhausted budget, and a `turn_failed` leg,
+/// where it separates a refusal from a cancellation. Everything else is decided
+/// by [`outcome_for_token`], which is why `REJECTED` no longer flattens a
+/// transient `breaker_open` refusal into a terminal `SpawnError` while the
+/// identical token on a `FAILED` leg resumed (a deliberate deviation from the
+/// plan's 2f row, which said "REJECTED | any").
 #[must_use]
 pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> RunOutcome {
     use crate::acp_pool as tokens;
@@ -445,11 +494,10 @@ pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> R
         .map(str::trim)
         .filter(|token| !token.is_empty())
         .collect();
-    let has = |token: &str| set.contains(&token);
     let stop = set.iter().find_map(|token| token.strip_prefix(tokens::DELIVERY_STOP_PREFIX));
 
-    let failed = |reason: FailureReason| RunOutcome::Failed {
-        reason,
+    let drift = || RunOutcome::Failed {
+        reason: FailureReason::ProviderContractDrift,
         result: result.clone(),
     };
     match state {
@@ -457,37 +505,26 @@ pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> R
         // pool writes the token only when the reason is worth naming.
         "DELIVERED" => match stop {
             None => RunOutcome::Success(result),
-            Some("max_tokens" | "max_turn_requests") => failed(FailureReason::IterationLimit),
-            Some(_) => failed(FailureReason::ProviderContractDrift),
+            Some("max_tokens" | "max_turn_requests") => RunOutcome::Failed {
+                reason: FailureReason::IterationLimit,
+                result,
+            },
+            Some(_) => drift(),
         },
-        "FAILED" if has(tokens::DELIVERY_TURN_FAILED) => match stop {
-            Some("refusal") => failed(FailureReason::AgentError),
+        // The agent ended the turn itself; only the stop reason says how.
+        _ if set.contains(&tokens::DELIVERY_TURN_FAILED) => match stop {
+            Some("refusal") => RunOutcome::Failed {
+                reason: FailureReason::AgentError,
+                result,
+            },
             Some("cancelled") => RunOutcome::Cancelled(result),
-            _ => failed(FailureReason::ProviderContractDrift),
+            _ => drift(),
         },
-        "FAILED" if has(tokens::DELIVERY_OPERATOR_STOP) => RunOutcome::Cancelled(result),
-        "FAILED"
-            if has(tokens::DELIVERY_SPAWN_FAILED)
-                || has(tokens::DELIVERY_MODE_UNPROVEN)
-                || has(tokens::DELIVERY_TURN_UNRECORDED) =>
-        {
-            failed(FailureReason::SpawnError)
-        }
-        "FAILED" if has(tokens::DELIVERY_SESSION_GONE) => failed(FailureReason::ProvisionError),
-        "FAILED"
-            if has(tokens::DELIVERY_BREAKER_OPEN)
-                || has(tokens::DELIVERY_PROVIDER_AT_CAPACITY)
-                || has(tokens::DELIVERY_QUEUE_FULL) =>
-        {
-            failed(FailureReason::RuntimeOffline)
-        }
-        "UNKNOWN" if has(tokens::DELIVERY_ADAPTER_EXIT) => failed(FailureReason::RuntimeOffline),
-        "UNKNOWN" if has(tokens::DELIVERY_TURN_DEADLINE) => failed(FailureReason::Timeout),
-        "UNKNOWN" if has(tokens::DELIVERY_DAEMON_RESTART) => failed(FailureReason::RuntimeRecovery),
-        // Refused at the door: nothing reached the adapter, and the refusal
-        // reason is a standing condition a re-dispatch will meet again.
-        "REJECTED" => failed(FailureReason::SpawnError),
-        _ => failed(FailureReason::ProviderContractDrift),
+        "FAILED" | "UNKNOWN" | "REJECTED" => set
+            .iter()
+            .find_map(|token| outcome_for_token(token, &result))
+            .unwrap_or_else(drift),
+        _ => drift(),
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -24,7 +24,7 @@
 //! leg in one transaction on turn end, on adapter exit, on the deadline sweep
 //! and on boot convergence ([`crate::acp_pool`]), so it is the one signal that
 //! is always written. A `oneshot` on the prompt job would be ~40 lines and one
-//! missed send would freeze the task at `running` until the multi-hour TTL —
+//! missed send would freeze the task at `running` until the multi-hour TTL:
 //! the exact black hole `execute_claimed`'s spawn-setup umbrella exists to
 //! close.
 //!
@@ -65,6 +65,19 @@ const LEG_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// window that has to be tuned.
 const REPLY_SCAN_LIMIT: i64 = 8;
 
+/// How long a cancel waits for the pool actor to converge the session before
+/// the adapter process is torn down anyway. See [`await_converged`].
+const CONVERGE_WAIT: Duration = Duration::from_secs(2);
+
+/// The `fleet_acp_session.scope_key` namespace RESERVED for task runs.
+///
+/// Reserved, not merely used: `fleet/acp_session_create` refuses it, because a
+/// chat session minted under a real task's scope would make that task's later
+/// run fail `ScopeHeld` (terminal, `SpawnError`) and would make
+/// [`workspace_for_scope`] stamp the chat session's approvals with the task's
+/// workspace.
+pub const TASK_SCOPE_PREFIX: &str = "task:";
+
 /// The `fleet_acp_session.scope_key` a task's session is created under.
 ///
 /// Deliberately derivable from the task id alone: the cancel arm, the durable
@@ -73,7 +86,7 @@ const REPLY_SCAN_LIMIT: i64 = 8;
 /// live scope.
 #[must_use]
 pub fn scope_key(task_id: &str) -> String {
-    format!("task:{task_id}")
+    format!("{TASK_SCOPE_PREFIX}{task_id}")
 }
 
 /// The workspace an ACP session's scope belongs to, or `None` when the scope
@@ -81,10 +94,10 @@ pub fn scope_key(task_id: &str) -> String {
 ///
 /// The one place the `task:<id>` scope convention is read back, so the pool
 /// does not have to know it. An attention row raised by a task's session lands
-/// unscoped without this, and a workspace-filtered inbox — which is every
-/// operator surface — never shows it.
+/// unscoped without this, and a workspace-filtered inbox (which is every
+/// operator surface) never shows it.
 pub async fn workspace_for_scope(pool: &SqlitePool, scope: &str) -> Option<String> {
-    let task_id = scope.strip_prefix("task:")?;
+    let task_id = scope.strip_prefix(TASK_SCOPE_PREFIX)?;
     ainb_hangar_store::repo::task::TaskRepo::get_by_id(pool, task_id)
         .await
         .ok()
@@ -117,11 +130,18 @@ fn task_config_dir(env: &ExecEnv) -> std::path::PathBuf {
 /// Refused rather than defaulted for anything else: silently prompting
 /// `claude-agent-acp` for a task whose agent asked for copilot is the same
 /// class of bug as spawning the headless argv into an interactive pane.
+///
+/// `codex-acp` is deliberately NOT served yet, even though the pool knows how
+/// to spawn it. [`task_adapter`] scopes `CLAUDE_CONFIG_DIR` and nothing else,
+/// while `HOME` rides the base allowlist, so a codex task would read the
+/// operator's `~/.codex`, which is the exact trap `CLAUDE_CONFIG_DIR` exists to
+/// close, and would be denied it under the Linux-default sandbox besides.
+/// Enabling it means scoping codex's own config home and proving it with a
+/// tripwire, which belongs with A8's per-agent provider selection.
 const fn adapter_for(backend: Backend) -> Option<&'static str> {
     match backend {
         Backend::Claude => Some(ainb_acp::config::CLAUDE_ADAPTER),
-        Backend::Codex => Some(ainb_acp::config::CODEX_ADAPTER),
-        Backend::Copilot | Backend::Antigravity => None,
+        Backend::Codex | Backend::Copilot | Backend::Antigravity => None,
     }
 }
 
@@ -249,10 +269,18 @@ pub async fn run_acp(
 
     let (state, detail) = await_leg(pool, &acp, &session_key, &message_id, max_runtime).await;
     let result = build_result(pool, &session_key, &message_id).await;
+    // Stop HOSTING the session. The lease below drops the adapter process, but
+    // the actor is a task of its own that nothing else retires: `ProcessExited`
+    // does not stop it, `retire_actor` only runs from the actor's own exit, and
+    // a per-task adapter key means `evict_if_at_cap` never fires. Without this
+    // every completed run leaks one actor plus a `pool.sessions` entry for the
+    // daemon's lifetime. The `fleet_acp_session` row survives, so a later
+    // resume-across-retry still has something to resume.
+    acp.teardown(&session_key, ConvergeCause::OperatorStop).await;
     Ok(outcome_for(&state, detail.as_deref(), result))
 }
 
-/// `session/cancel` the task's open turn — the ACP analogue of the interactive
+/// `session/cancel` the task's open turn: the ACP analogue of the interactive
 /// arm's `kill_session`.
 ///
 /// Dropping [`run_acp`] stops POLLING; it does not stop the agent, which lives
@@ -265,7 +293,7 @@ pub async fn run_acp(
 /// would mean the adapter never saw the `session/cancel` it is being stopped
 /// by. Bounded, so a wedged actor delays a cancel by seconds rather than
 /// forever.
-pub async fn cancel_run(pool: &SqlitePool, task_id: &str) {
+pub async fn cancel_run(pool: &SqlitePool, events: &EventSink, task_id: &str) {
     let Some(acp) = crate::acp_pool::active_handle().await else {
         return;
     };
@@ -273,19 +301,42 @@ pub async fn cancel_run(pool: &SqlitePool, task_id: &str) {
     let Ok(Some(session)) = session else {
         return;
     };
-    if !acp.cancel(&session.session_key, ConvergeCause::OperatorStop).await {
+    if acp.cancel(&session.session_key, ConvergeCause::OperatorStop).await {
+        await_converged(pool, &session.session_key).await;
         return;
     }
-    let deadline = Instant::now() + Duration::from_secs(2);
+    // No live actor took the cancel, so nothing is going to resolve the leg it
+    // left PENDING. Converge the session here instead of leaving an orphan row
+    // for the next boot scan to find.
+    if let Err(error) = crate::acp_pool::converge_dirty_session(
+        pool,
+        events,
+        &session.session_key,
+        ConvergeCause::OperatorStop,
+    )
+    .await
+    {
+        tracing::warn!(task_id, %error, "could not converge a task session with no live actor");
+    }
+}
+
+/// Wait, bounded, for the pool actor to have HANDLED a cancel rather than
+/// merely received it: its convergence resolves every pending leg on the
+/// session, so an empty pending set is the observable.
+///
+/// Both cancel paths need this and for the same reason. The caller's next act
+/// is the lease drop that kills the adapter process, and killing it first would
+/// mean the adapter never saw the `session/cancel` it is being stopped by.
+async fn await_converged(pool: &SqlitePool, session_key: &str) {
+    let deadline = Instant::now() + CONVERGE_WAIT;
     while Instant::now() < deadline {
-        match FleetMessageRepo::pending_deliveries_for_session(pool, &session.session_key).await {
+        match FleetMessageRepo::pending_deliveries_for_session(pool, session_key).await {
             Ok(legs) if legs.is_empty() => return,
             _ => tokio::time::sleep(Duration::from_millis(20)).await,
         }
     }
     tracing::warn!(
-        task_id,
-        session_key = %session.session_key,
+        %session_key,
         "acp cancel did not converge in time; tearing the adapter down anyway"
     );
 }
@@ -336,6 +387,14 @@ fn task_adapter(
         if let Some(root) = location.extra_root.as_deref() {
             policy = policy.allow_read(root).allow_write(root);
         }
+        // The adapter's OWN binary. Unlike a provider CLI, which the daemon
+        // canonicalises into the system read roots at startup, an ACP adapter is
+        // typically an npm global install or `~/.local/bin`, outside every
+        // system root, so Landlock would deny the exec of the very program this
+        // policy is being built for.
+        if let Some(dir) = adapter.command.parent().filter(|dir| !dir.as_os_str().is_empty()) {
+            policy = policy.allow_read(dir);
+        }
         adapter.sandbox = Some(policy);
     }
     adapter
@@ -353,8 +412,8 @@ fn sandbox_enabled() -> bool {
 /// Poll the delivery leg until it leaves `PENDING`, or the run outlives
 /// `max_runtime`, and answer the `(state, detail)` the outcome mapping reads.
 ///
-/// On the deadline the turn is CANCELLED on the way out — the adapter would
-/// otherwise keep working on a run nobody is waiting for — and the pair
+/// On the deadline the turn is CANCELLED on the way out (the adapter would
+/// otherwise keep working on a run nobody is waiting for) and the pair
 /// returned is the same one the pool's own deadline sweep would have written,
 /// so both routes to a timed-out task map identically.
 async fn await_leg(
@@ -380,6 +439,10 @@ async fn await_leg(
         }
         if Instant::now() >= deadline {
             acp.cancel(session_key, ConvergeCause::TurnDeadline).await;
+            // Same bounded wait the operator-cancel path takes, and for the
+            // same reason: the lease drop that follows kills the adapter, and
+            // killing it first would mean it never saw the `session/cancel`.
+            await_converged(pool, session_key).await;
             return (
                 "UNKNOWN".to_string(),
                 Some(crate::acp_pool::DELIVERY_TURN_DEADLINE.to_string()),
@@ -418,7 +481,7 @@ async fn build_result(pool: &SqlitePool, session_key: &str, message_id: &str) ->
     }
 }
 
-/// [`FailureReason::SpawnError`] with no captured output — the pool or its
+/// [`FailureReason::SpawnError`] with no captured output: the pool or its
 /// registry could not produce an adapter at all.
 fn spawn_error() -> RunOutcome {
     RunOutcome::Failed {
@@ -432,14 +495,14 @@ fn spawn_error() -> RunOutcome {
 ///
 /// The token is the whole answer, and the state is not part of the key. The
 /// pool writes the SAME converge cause under two different states depending on
-/// where the prompt was standing when the session converged — `drain_queue`
+/// where the prompt was standing when the session converged (`drain_queue`
 /// resolves a still-queued prompt `FAILED`, `converge_dirty_session` resolves
-/// an issued one `UNKNOWN` — and `attach_with_one_requeue` writes
+/// an issued one `UNKNOWN`), and `attach_with_one_requeue` writes
 /// `adapter_exit` on a `FAILED` leg while the exit watcher writes it on an
 /// `UNKNOWN` one. Neither difference changes how the task should be retried, so
 /// keying on the pair meant four reachable combinations (`FAILED`+`adapter_exit`,
 /// `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`, `UNKNOWN`+`operator_stop`)
-/// answered `ProviderContractDrift`/NoRetry — burning the retry chain on
+/// answered `ProviderContractDrift`/`NoRetry`, burning the retry chain on
 /// exactly the transient faults that should resume.
 fn outcome_for_token(token: &str, result: &RunnerResult) -> Option<RunOutcome> {
     use crate::acp_pool as tokens;
@@ -474,7 +537,7 @@ fn outcome_for_token(token: &str, result: &RunnerResult) -> Option<RunOutcome> {
 /// success can read `resume=loaded`, a budget stop `stop=max_tokens;
 /// resume=reprimed`, and an adapter exit appends the raw error text after its
 /// token. An unmapped detail is
-/// [`FailureReason::ProviderContractDrift`] on purpose — an unknown token means
+/// [`FailureReason::ProviderContractDrift`] on purpose: an unknown token means
 /// the pool's taxonomy grew, not that the agent succeeded.
 ///
 /// Only two shapes read the STATE: a `DELIVERED` leg, where the stop reason
@@ -553,9 +616,13 @@ mod tests {
     }
 
     #[test]
-    fn only_the_two_acp_backends_are_servable() {
+    fn only_claude_is_servable_over_acp_today() {
         assert_eq!(adapter_for(Backend::Claude), Some("claude-agent-acp"));
-        assert_eq!(adapter_for(Backend::Codex), Some("codex-acp"));
+        // Refused, not defaulted. `codex-acp` waits on a task-scoped codex
+        // config home: `task_adapter` pins `CLAUDE_CONFIG_DIR` only, and `HOME`
+        // rides the base allowlist, so a codex task would read the operator's
+        // `~/.codex`, the exact trap `CLAUDE_CONFIG_DIR` exists to close.
+        assert_eq!(adapter_for(Backend::Codex), None);
         assert_eq!(adapter_for(Backend::Copilot), None);
         assert_eq!(adapter_for(Backend::Antigravity), None);
     }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -46,7 +46,7 @@ use ainb_hangar_store::repo::task::Task;
 use ainb_hangar_store::service::fail::FailureReason;
 use sqlx::SqlitePool;
 
-use crate::acp_pool::{AcpPool, ConvergeCause, SubmitOutcome};
+use crate::acp_pool::{AcpPool, ConvergeCause, DeliveryToken, SubmitOutcome};
 use crate::events::EventSink;
 use crate::execenv::ExecEnv;
 use crate::runner::{Backend, RunLocation, RunOutcome, RunnerResult};
@@ -154,13 +154,31 @@ const fn adapter_for(backend: Backend) -> Option<&'static str> {
 struct AdapterLease {
     pool: Arc<AcpPool>,
     key: String,
+    /// Set once the session exists. The lease is held from BEFORE that, so a
+    /// store fault between registering the adapter and minting the session
+    /// still releases the key.
+    session_key: Option<String>,
 }
 
 impl Drop for AdapterLease {
     fn drop(&mut self) {
         let pool = Arc::clone(&self.pool);
         let key = std::mem::take(&mut self.key);
+        let session_key = self.session_key.take();
         tokio::spawn(async move {
+            // Session actor FIRST, then the process it was talking to. Nothing
+            // else retires the actor: `ProcessExited` does not stop it,
+            // `retire_actor` runs only from the actor's own exit, and a
+            // per-task adapter key means eviction never fires, so every run
+            // that skipped this left a live tokio task ticking `pump()` on the
+            // writer flush interval for the daemon's lifetime. `teardown` is
+            // the only `Control::Shutdown` sender. Doing it HERE rather than at
+            // the normal return is what makes "an actor that exists is torn
+            // down" true by construction: the cancel that drops this future and
+            // the early return on a refused prompt both get it too.
+            if let Some(session_key) = session_key {
+                pool.teardown(&session_key, ConvergeCause::OperatorStop).await;
+            }
             if pool.unregister_adapter(&key).await {
                 tracing::debug!(adapter = %key, "released a task's adapter process");
             }
@@ -232,9 +250,10 @@ pub async fn run_acp(
     );
     // Held from BEFORE the session exists: a store fault below still has to
     // release the key, and an early `?` would otherwise leak a registry entry.
-    let _lease = AdapterLease {
+    let mut lease = AdapterLease {
         pool: Arc::clone(&acp),
         key: key.clone(),
+        session_key: None,
     };
 
     // The session is minted against the TASK's key, not the base adapter, so
@@ -244,6 +263,10 @@ pub async fn run_acp(
         crate::acp_session::ensure(pool, events, &key, &cwd.to_string_lossy(), Some(&scope))
             .await?;
     let session_key = session.session_key;
+    // The lease now owns the session too, so every exit below tears the actor
+    // down: the `Rejected` early return, the `?` on `enqueue`, a panic unwind,
+    // and the cancel that drops this future mid-poll.
+    lease.session_key = Some(session_key.clone());
     // Written the moment it exists, so a run that later fails or is cancelled
     // still points at the transcript it produced; the success path would
     // otherwise be the only one that records it (`CompleteTaskService`).
@@ -269,14 +292,6 @@ pub async fn run_acp(
 
     let (state, detail) = await_leg(pool, &acp, &session_key, &message_id, max_runtime).await;
     let result = build_result(pool, &session_key, &message_id).await;
-    // Stop HOSTING the session. The lease below drops the adapter process, but
-    // the actor is a task of its own that nothing else retires: `ProcessExited`
-    // does not stop it, `retire_actor` only runs from the actor's own exit, and
-    // a per-task adapter key means `evict_if_at_cap` never fires. Without this
-    // every completed run leaks one actor plus a `pool.sessions` entry for the
-    // daemon's lifetime. The `fleet_acp_session` row survives, so a later
-    // resume-across-retry still has something to resume.
-    acp.teardown(&session_key, ConvergeCause::OperatorStop).await;
     Ok(outcome_for(&state, detail.as_deref(), result))
 }
 
@@ -504,30 +519,35 @@ fn spawn_error() -> RunOutcome {
 /// `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`, `UNKNOWN`+`operator_stop`)
 /// answered `ProviderContractDrift`/`NoRetry`, burning the retry chain on
 /// exactly the transient faults that should resume.
-fn outcome_for_token(token: &str, result: &RunnerResult) -> Option<RunOutcome> {
-    use crate::acp_pool as tokens;
-
-    let failed = |reason| {
-        Some(RunOutcome::Failed {
-            reason,
-            result: result.clone(),
-        })
+///
+/// EXHAUSTIVE on [`DeliveryToken`], with no wildcard arm on purpose: a token the
+/// pool grows stops compiling here until someone decides whether it should
+/// retry. The previous shape matched `&str` with a `_ => None` fall-through, so
+/// a new token reached a task run as contract drift and the test that claimed
+/// to guard this could not see it.
+fn outcome_for_token(token: DeliveryToken, result: &RunnerResult) -> RunOutcome {
+    let failed = |reason| RunOutcome::Failed {
+        reason,
+        result: result.clone(),
     };
     match token {
-        tokens::DELIVERY_OPERATOR_STOP => Some(RunOutcome::Cancelled(result.clone())),
+        DeliveryToken::OperatorStop => RunOutcome::Cancelled(result.clone()),
         // Infrastructure, not the work: resume the same conversation.
-        tokens::DELIVERY_ADAPTER_EXIT
-        | tokens::DELIVERY_BREAKER_OPEN
-        | tokens::DELIVERY_PROVIDER_AT_CAPACITY
-        | tokens::DELIVERY_QUEUE_FULL => failed(FailureReason::RuntimeOffline),
-        tokens::DELIVERY_TURN_DEADLINE => failed(FailureReason::Timeout),
-        tokens::DELIVERY_DAEMON_RESTART => failed(FailureReason::RuntimeRecovery),
+        DeliveryToken::AdapterExit
+        | DeliveryToken::BreakerOpen
+        | DeliveryToken::ProviderAtCapacity
+        | DeliveryToken::QueueFull => failed(FailureReason::RuntimeOffline),
+        DeliveryToken::TurnDeadline => failed(FailureReason::Timeout),
+        DeliveryToken::DaemonRestart => failed(FailureReason::RuntimeRecovery),
         // A misconfigured adapter will not self-heal on a re-dispatch.
-        tokens::DELIVERY_SPAWN_FAILED
-        | tokens::DELIVERY_MODE_UNPROVEN
-        | tokens::DELIVERY_TURN_UNRECORDED => failed(FailureReason::SpawnError),
-        tokens::DELIVERY_SESSION_GONE => failed(FailureReason::ProvisionError),
-        _ => None,
+        DeliveryToken::SpawnFailed
+        | DeliveryToken::ModeUnproven
+        | DeliveryToken::TurnUnrecorded => failed(FailureReason::SpawnError),
+        DeliveryToken::SessionGone => failed(FailureReason::ProvisionError),
+        // Handled by the caller's stop-reason arm, which reads this token
+        // POSITIONALLY. Reaching it here means it was not first, which the pool
+        // never writes.
+        DeliveryToken::TurnFailed => failed(FailureReason::ProviderContractDrift),
     }
 }
 
@@ -575,7 +595,11 @@ pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> R
             Some(_) => drift(),
         },
         // The agent ended the turn itself; only the stop reason says how.
-        _ if set.contains(&tokens::DELIVERY_TURN_FAILED) => match stop {
+        // Positional, like every other token read. `finish_turn` writes this
+        // token FIRST or not at all, and an `adapter_exit; <error>` leg whose
+        // free error text happened to carry a `; `-delimited `turn_failed`
+        // would otherwise be hijacked into this arm and answer drift/NoRetry.
+        _ if set.first() == Some(&tokens::DELIVERY_TURN_FAILED) => match stop {
             Some("refusal") => RunOutcome::Failed {
                 reason: FailureReason::AgentError,
                 result,
@@ -583,10 +607,12 @@ pub fn outcome_for(state: &str, detail: Option<&str>, result: RunnerResult) -> R
             Some("cancelled") => RunOutcome::Cancelled(result),
             _ => drift(),
         },
+        // The FIRST token of ours in the set decides. Free error text after a
+        // token (`adapter_exit; <error>`) parses as nothing and is skipped.
         "FAILED" | "UNKNOWN" | "REJECTED" => set
             .iter()
-            .find_map(|token| outcome_for_token(token, &result))
-            .unwrap_or_else(drift),
+            .find_map(|raw| DeliveryToken::parse(raw))
+            .map_or_else(drift, |token| outcome_for_token(token, &result)),
         _ => drift(),
     }
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -930,6 +930,12 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // would cancel every task past half an hour while the same task on the
         // process executor gets 2.5 h. Raise the pool's floor to the task budget
         // rather than leave a 5x cut invisible from the flag.
+        // ponytail: the raise lands AFTER `from_env` has already coupled
+        // `sweep_interval` down to the configured deadline, so
+        // `AINB_ACP_TURN_DEADLINE_MS=2000` with `executor=acp` leaves a raised
+        // deadline and a 1 s sweep that can never match it: harmless (the sweep
+        // is idempotent and only costs one indexed read) and test-only config
+        // today. Recouple the interval to the EFFECTIVE deadline with A6.
         let configured_deadline = acp_config.turn_deadline;
         acp_config.turn_deadline = crate::run_loop::reconcile_turn_deadline(
             configured_deadline,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -921,11 +921,17 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // The ACP agent pool. Installed BEFORE the socket accepts a connection so
         // `fleet/acp_session_create` can never answer "no pool" on a daemon that
         // has one; nothing is spawned until the first prompt reaches it.
-        let acp_pool = crate::acp_pool::AcpPool::new(
-            store.clone(),
-            broker.sink(),
-            crate::acp_pool::PoolConfig::from_env(),
+        let mut acp_config = crate::acp_pool::PoolConfig::from_env();
+        // Under `HANGAR_TASK_EXECUTOR=acp` a TASK turn is a pool turn, and the
+        // pool's deadline sweep exempts no scope, so its 30-minute default
+        // would cancel every task past half an hour while the same task on the
+        // process executor gets 2.5 h. Raise the pool's floor to the task budget
+        // rather than leave a 5x cut invisible from the flag.
+        acp_config.turn_deadline = crate::run_loop::reconcile_turn_deadline(
+            acp_config.turn_deadline,
+            crate::run_loop::acp_turn_budget(),
         );
+        let acp_pool = crate::acp_pool::AcpPool::new(store.clone(), broker.sink(), acp_config);
         let _acp_sweeper = acp_pool.spawn_sweeper();
         crate::acp_pool::install(acp_pool).await;
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -927,10 +927,27 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // would cancel every task past half an hour while the same task on the
         // process executor gets 2.5 h. Raise the pool's floor to the task budget
         // rather than leave a 5x cut invisible from the flag.
+        let configured_deadline = acp_config.turn_deadline;
         acp_config.turn_deadline = crate::run_loop::reconcile_turn_deadline(
-            acp_config.turn_deadline,
+            configured_deadline,
             crate::run_loop::acp_turn_budget(),
         );
+        // Say so when it actually moved. An invisible timeout change triggered
+        // by a flag is the defect class this fix exists to close, and raising
+        // the floor points it the safer way for tasks while opening a smaller
+        // one for CHAT: a wedged chat turn now squats its session slot for the
+        // longer window before the sweep reaps it. Whoever flips the flag
+        // should read that here, not discover it during an incident.
+        if acp_config.turn_deadline > configured_deadline {
+            tracing::warn!(
+                effective_secs = acp_config.turn_deadline.as_secs(),
+                configured_secs = configured_deadline.as_secs(),
+                "HANGAR_TASK_EXECUTOR=acp raised the acp turn deadline to the task runtime \
+                 budget (HANGAR_PROVIDER_MAX_RUNTIME_MS); a wedged CHAT turn on this daemon \
+                 now converges on the longer deadline too. Set AINB_ACP_TURN_DEADLINE_MS at \
+                 or above the task budget to pin it."
+            );
+        }
         let acp_pool = crate::acp_pool::AcpPool::new(store.clone(), broker.sink(), acp_config);
         let _acp_sweeper = acp_pool.spawn_sweeper();
         crate::acp_pool::install(acp_pool).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -24,6 +24,11 @@ pub mod acp_pool;
 /// [`acp_session::enqueue`] puts a prompt on the bus with its PENDING leg.
 /// `fleet/acp_session_create` and a task caller share these two transactions.
 pub mod acp_session;
+/// The ACP task executor (move 1, step A5): the third arm of `execute_claimed`'s
+/// exec-path branch, selected by `HANGAR_TASK_EXECUTOR=acp`. Runs a task's brief
+/// as one ACP turn against a PER-TASK adapter process and maps the delivery leg
+/// onto the same [`runner::RunOutcome`] the process executor returns.
+pub mod acp_task;
 /// Beads CLI adapter — shells out to `bd` and parses `--json` (P2.2).
 ///
 /// The answer router (spec P2): deliver one attention answer from any surface,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5917,6 +5917,21 @@ async fn handle_fleet_acp_session_create(
 
     require_fleet_capability(FLEET_CAPABILITY_ACP_SPAWN)?;
     let params: FleetAcpSessionCreateParams = parse_params(req, "{ provider, cwd, scope_key? }")?;
+    // `task:<id>` belongs to the task executor (`crate::acp_task`). A chat
+    // session minted there would make that task's later run fail `ScopeHeld`
+    // (terminal, `SpawnError`, no retry) and would make the pool stamp this
+    // session's approvals with the task's workspace. Refused at the door, which
+    // is the only untrusted caller of `acp_session::ensure`.
+    if params
+        .scope_key
+        .as_deref()
+        .is_some_and(|scope| scope.trim_start().starts_with(crate::acp_task::TASK_SCOPE_PREFIX))
+    {
+        return Err(invalid_params(&format!(
+            "scope_key {:?} is reserved for task runs",
+            crate::acp_task::TASK_SCOPE_PREFIX
+        )));
+    }
     let row = crate::acp_session::ensure(
         pool,
         events,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -28,6 +28,7 @@
 //! | `HANGAR_SWEEP_DISPATCHED_TTL_MS` | dispatch TTL override (tests) | reference default |
 //! | `HANGAR_DAEMON_DISABLE_CLAIM` | skip the claim loop, run sweepers only (tests) | unset |
 //! | `HANGAR_DAEMON_DISABLE_SANDBOX` | `1` forces providers UNCONFINED (security downgrade); `0` forces the OS sandbox ON | unset (platform default: ON on Linux, OFF on macOS) |
+//! | `HANGAR_TASK_EXECUTOR` | `acp` runs tasks through an ACP adapter ([`crate::acp_task`]); `process` spawns the provider CLI. An unrecognised value warns and falls back | `process` |
 //!
 //! When `HANGAR_DAEMON_RUNTIME_ID` is unset the claim loop is a no-op (the
 //! daemon still sweeps) — a daemon with no runtime has nothing to claim.
@@ -191,7 +192,7 @@ pub struct DaemonConfig {
 /// A second FIRST-CLASS executor, not a mode: `Process` spawns the provider CLI
 /// (`claude -p`, `codex exec`) and keeps its jsonl transcript; `Acp` prompts an
 /// ACP adapter over JSON-RPC and keeps its transcript in `fleet_provider_event`.
-/// Deliberately a different axis from [`Mode`] — executor and interactivity are
+/// Deliberately a different axis from [`Mode`]: executor and interactivity are
 /// two questions, and conflating them is the bug [`interactive_command`] was
 /// extracted to prevent.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -205,6 +206,52 @@ pub enum TaskExecutor {
 
 /// The `HANGAR_TASK_EXECUTOR` value that asks for the ACP path.
 const ACP_EXECUTOR: &str = "acp";
+
+/// The wall-clock ceiling on one provider run (`HANGAR_PROVIDER_MAX_RUNTIME_MS`).
+///
+/// Read through one function because two callers need it: [`DaemonConfig`],
+/// and [`acp_turn_budget`], which is consulted where no `DaemonConfig` exists
+/// yet. Two reads would be two places for the default to drift.
+fn provider_max_runtime_from_env() -> Duration {
+    env_u64_opt("HANGAR_PROVIDER_MAX_RUNTIME_MS")
+        .map_or(PROVIDER_MAX_RUNTIME, Duration::from_millis)
+}
+
+/// How long ONE ACP turn must be allowed to run on this daemon's pool, or
+/// `None` when tasks do not run on it.
+///
+/// Under `HANGAR_TASK_EXECUTOR=acp` a task turn IS a pool turn, and the pool
+/// applies its own [`PoolConfig::turn_deadline`](crate::acp_pool::PoolConfig)
+/// to every scope with no exemption. Its 30-minute default would therefore
+/// cancel every task past half an hour while the identical task on the process
+/// executor gets `HANGAR_PROVIDER_MAX_RUNTIME_MS` (2.5 h by default): a 5x
+/// budget cut that is invisible from the flag that caused it.
+///
+/// Read from the environment rather than a [`DaemonConfig`] because the pool is
+/// built before one exists ([`crate::boot`]); the executor comes through the
+/// same pure resolver the daemon config uses, so the two cannot disagree.
+#[must_use]
+pub fn acp_turn_budget() -> Option<Duration> {
+    let executor =
+        DaemonConfig::resolve_task_executor(std::env::var_os("HANGAR_TASK_EXECUTOR").as_deref());
+    (executor == TaskExecutor::Acp).then(provider_max_runtime_from_env)
+}
+
+/// The turn deadline a pool needs given the task budget riding on it.
+///
+/// Raise only: a deadline an operator lengthened deliberately
+/// (`AINB_ACP_TURN_DEADLINE_MS`) is never shortened, and a daemon whose tasks
+/// run on the process executor keeps the pool's own default untouched. The cost
+/// of raising it is that a wedged CHAT turn on the same daemon converges on the
+/// longer backstop; an operator can still stop one from the fleet surface at
+/// any time, and the alternative is tasks dying silently at 30 minutes.
+#[must_use]
+pub fn reconcile_turn_deadline(pool_deadline: Duration, task_budget: Option<Duration>) -> Duration {
+    match task_budget {
+        Some(budget) => pool_deadline.max(budget),
+        None => pool_deadline,
+    }
+}
 
 impl DaemonConfig {
     /// Build the config from the process environment (see the module table).
@@ -245,8 +292,7 @@ impl DaemonConfig {
         );
         let poll_interval =
             Duration::from_millis(env_u64("HANGAR_DAEMON_POLL_MS", DEFAULT_POLL_MS));
-        let provider_max_runtime = env_u64_opt("HANGAR_PROVIDER_MAX_RUNTIME_MS")
-            .map_or(PROVIDER_MAX_RUNTIME, Duration::from_millis);
+        let provider_max_runtime = provider_max_runtime_from_env();
 
         let mut sweeper = SweeperConfig::default();
         if let Some(ms) = env_u64_opt("HANGAR_SWEEP_INTERVAL_MS") {
@@ -300,8 +346,8 @@ impl DaemonConfig {
     /// Resolve the task executor from the explicit `HANGAR_TASK_EXECUTOR`
     /// value (`None` when unset).
     ///
-    /// `acp` selects the ACP path; anything else — including an unset variable
-    /// and an unrecognised value — resolves to [`TaskExecutor::Process`], the
+    /// `acp` selects the ACP path; anything else (including an unset variable
+    /// and an unrecognised value) resolves to [`TaskExecutor::Process`], the
     /// documented default, with a warning on the typo so a misspelled opt-in is
     /// diagnosable rather than a silent no-op. Split out as a pure function so
     /// the precedence is testable without mutating process env, exactly like
@@ -1236,9 +1282,9 @@ async fn execute_claimed(
     };
 
     // An `interactive` task under the ACP executor is REFUSED, never silently
-    // run headless. There is no attachable pane on the ACP path — the axis
+    // run headless. There is no attachable pane on the ACP path: the axis
     // there is the adapter's `permission_mode` (`default` asks and a human
-    // answers through `attention/answer`, `bypassPermissions` does not) — and
+    // answers through `attention/answer`, `bypassPermissions` does not), and
     // downgrading an operator's explicit "give me a session to drive" into a
     // print-and-exit run is the exact class of bug `interactive_command` was
     // extracted to prevent. Terminalises BEFORE the worktree is provisioned and
@@ -1559,9 +1605,9 @@ async fn execute_claimed(
             if executor == TaskExecutor::Acp {
                 // Dropping `provider_run` stops POLLING; it does not stop the
                 // agent, which lives in an adapter process that has been told
-                // nothing. `session/cancel` it explicitly — the exact analogue
+                // nothing. `session/cancel` it explicitly: the exact analogue
                 // of the interactive arm's `kill_session` below.
-                crate::acp_task::cancel_run(pool, &task.id).await;
+                crate::acp_task::cancel_run(pool, events, &task.id).await;
             } else if mode == Mode::Interactive {
                 // The detached session survives `run_interactive`'s dropped `wait`,
                 // so kill it by its EXACT name and clear the shutdown-reap entry the
@@ -3140,6 +3186,33 @@ mod tests {
         assert!(
             detail.contains("claude"),
             "the synthesized diagnostic must name the provider: {detail}"
+        );
+    }
+
+    /// A5: the pool's turn deadline never cuts a task's runtime budget, and
+    /// never shortens a deadline an operator set deliberately.
+    #[test]
+    fn the_pool_deadline_is_raised_to_the_task_budget_and_never_lowered() {
+        let pool_default = Duration::from_secs(30 * 60);
+        // No tasks on this pool: its own default stands.
+        assert_eq!(
+            reconcile_turn_deadline(pool_default, None),
+            pool_default,
+            "the process executor must not touch the pool's deadline"
+        );
+        // The 5x cut this exists to close: a 2.5h task on a 30min pool.
+        assert_eq!(
+            reconcile_turn_deadline(pool_default, Some(PROVIDER_MAX_RUNTIME)),
+            PROVIDER_MAX_RUNTIME,
+            "an acp task must get its full HANGAR_PROVIDER_MAX_RUNTIME_MS"
+        );
+        // Raise only: an operator who lengthened AINB_ACP_TURN_DEADLINE_MS past
+        // the task budget keeps it.
+        let operator_set = PROVIDER_MAX_RUNTIME * 2;
+        assert_eq!(
+            reconcile_turn_deadline(operator_set, Some(PROVIDER_MAX_RUNTIME)),
+            operator_set,
+            "a longer configured deadline must never be shortened"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -177,7 +177,34 @@ pub struct DaemonConfig {
     /// `=0` forces it ON (used to exercise the profile on macOS). The resolved
     /// posture is logged at daemon startup (see [`log_sandbox_posture`]).
     pub sandbox: bool,
+    /// Which executor a claimed task's provider run takes (move 1).
+    ///
+    /// `HANGAR_TASK_EXECUTOR=acp|process`, defaulting to `process` until the
+    /// ACP path is proven against real adapters. Carried onto
+    /// [`ResolvedDispatch`] so the exec-path branch and the argv can never
+    /// disagree, exactly as `mode` is.
+    pub task_executor: TaskExecutor,
 }
+
+/// Which executor runs a claimed task's provider work.
+///
+/// A second FIRST-CLASS executor, not a mode: `Process` spawns the provider CLI
+/// (`claude -p`, `codex exec`) and keeps its jsonl transcript; `Acp` prompts an
+/// ACP adapter over JSON-RPC and keeps its transcript in `fleet_provider_event`.
+/// Deliberately a different axis from [`Mode`] — executor and interactivity are
+/// two questions, and conflating them is the bug [`interactive_command`] was
+/// extracted to prevent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TaskExecutor {
+    /// Spawn the provider CLI. Today's path, and the default.
+    #[default]
+    Process,
+    /// Prompt an ACP adapter through [`crate::acp_task`].
+    Acp,
+}
+
+/// The `HANGAR_TASK_EXECUTOR` value that asks for the ACP path.
+const ACP_EXECUTOR: &str = "acp";
 
 impl DaemonConfig {
     /// Build the config from the process environment (see the module table).
@@ -248,6 +275,8 @@ impl DaemonConfig {
         // default (ON on Linux, OFF on macOS) unless the env var overrides it.
         let sandbox =
             Self::resolve_sandbox(std::env::var_os("HANGAR_DAEMON_DISABLE_SANDBOX").as_deref());
+        let task_executor =
+            Self::resolve_task_executor(std::env::var_os("HANGAR_TASK_EXECUTOR").as_deref());
 
         Self {
             runtime_id,
@@ -264,6 +293,31 @@ impl DaemonConfig {
             sweeper,
             disable_claim,
             sandbox,
+            task_executor,
+        }
+    }
+
+    /// Resolve the task executor from the explicit `HANGAR_TASK_EXECUTOR`
+    /// value (`None` when unset).
+    ///
+    /// `acp` selects the ACP path; anything else — including an unset variable
+    /// and an unrecognised value — resolves to [`TaskExecutor::Process`], the
+    /// documented default, with a warning on the typo so a misspelled opt-in is
+    /// diagnosable rather than a silent no-op. Split out as a pure function so
+    /// the precedence is testable without mutating process env, exactly like
+    /// [`Self::resolve_sandbox`].
+    #[must_use]
+    pub fn resolve_task_executor(override_val: Option<&std::ffi::OsStr>) -> TaskExecutor {
+        match override_val.and_then(std::ffi::OsStr::to_str).map(str::trim) {
+            Some(value) if value.eq_ignore_ascii_case(ACP_EXECUTOR) => TaskExecutor::Acp,
+            Some(value) if !value.is_empty() && !value.eq_ignore_ascii_case("process") => {
+                tracing::warn!(
+                    value,
+                    "unknown HANGAR_TASK_EXECUTOR; running tasks on the process executor"
+                );
+                TaskExecutor::Process
+            }
+            _ => TaskExecutor::Process,
         }
     }
 
@@ -275,7 +329,8 @@ impl DaemonConfig {
     /// it is otherwise off by default); any other value — or unset — falls back
     /// to [`Self::default_sandbox`]. Split out as a pure function so the
     /// override precedence is testable without mutating process env.
-    fn resolve_sandbox(override_val: Option<&std::ffi::OsStr>) -> bool {
+    #[must_use]
+    pub fn resolve_sandbox(override_val: Option<&std::ffi::OsStr>) -> bool {
         match override_val {
             Some(v) if v == "1" => false,
             Some(v) if v == "0" => true,
@@ -630,10 +685,11 @@ pub async fn run(
                 let events = events.clone();
                 let interactive = interactive.clone();
                 let secrets = secrets.clone();
+                let executor = cfg.task_executor;
                 runs.spawn(async move {
                     let clock = SystemClock;
                     if let Err(e) =
-                        execute_claimed(&pool, &runner, &claimed, &clock, &stats, &events, &interactive, secrets)
+                        execute_claimed(&pool, &runner, &claimed, &clock, &stats, &events, &interactive, secrets, executor)
                             .await
                     {
                         tracing::error!(task_id = %claimed.id, error = %e, "task execution errored");
@@ -1093,6 +1149,7 @@ async fn execute_claimed(
     events: &EventSink,
     interactive: &InteractiveSessions,
     secrets: Arc<dyn ainb_hangar_secrets::SecretBackend + Send + Sync>,
+    executor: TaskExecutor,
 ) -> anyhow::Result<()> {
     let task: Task = TaskRepo::get_by_id(pool, &claimed.id)
         .await?
@@ -1157,19 +1214,44 @@ async fn execute_claimed(
     // branch that picks the exec path and the argv built for it — so the two can
     // never disagree.
     let mode = dispatch_mode(&task.mode);
-    let dispatch =
-        match resolve_dispatch(pool, &task.agent_id, task.issue_id.as_deref(), mode).await {
-            Ok(d) => d,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    task_id = %task.id,
-                    agent_id = %task.agent_id,
-                    "dispatch resolve failed; falling back to the default provider + prompt"
-                );
-                ResolvedDispatch::fallback(mode)
-            }
-        };
+    let dispatch = match resolve_dispatch(
+        pool,
+        &task.agent_id,
+        task.issue_id.as_deref(),
+        mode,
+        executor,
+    )
+    .await
+    {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                task_id = %task.id,
+                agent_id = %task.agent_id,
+                "dispatch resolve failed; falling back to the default provider + prompt"
+            );
+            ResolvedDispatch::fallback(mode, executor)
+        }
+    };
+
+    // An `interactive` task under the ACP executor is REFUSED, never silently
+    // run headless. There is no attachable pane on the ACP path — the axis
+    // there is the adapter's `permission_mode` (`default` asks and a human
+    // answers through `attention/answer`, `bypassPermissions` does not) — and
+    // downgrading an operator's explicit "give me a session to drive" into a
+    // print-and-exit run is the exact class of bug `interactive_command` was
+    // extracted to prevent. Terminalises BEFORE the worktree is provisioned and
+    // before the row leaves `dispatched`, so no tmux session and no checkout
+    // are created for a run that will not happen.
+    if dispatch.executor == TaskExecutor::Acp && mode == Mode::Interactive {
+        let refusal = anyhow::anyhow!(
+            "task mode=interactive is not supported under HANGAR_TASK_EXECUTOR=acp; \
+             run it with HANGAR_TASK_EXECUTOR=process, or use the adapter's \
+             permission_mode for human-in-the-loop under acp"
+        );
+        return finalize_setup_failure(pool, &task, &refusal, clock, stats, events).await;
+    }
 
     // F5: provision the run's working directory from the card's `repo_ref`.
     //
@@ -1276,6 +1358,9 @@ async fn execute_claimed(
     // `provider_run` moves `dispatch` (the async block takes `dispatch.agent_env`
     // by value). The `cancel_guard` was registered up front (before the start).
     let provider = dispatch.backend.name();
+    // Copied out for the same reason `provider` is: the cancel arm below needs
+    // to know which executor to stop, and `provider_run` borrows `dispatch`.
+    let executor = dispatch.executor;
 
     // Doctrine hardening (D-e2e-3): bound EVERY await between the `running` commit
     // and the provider spawn as ONE unit. `resolve_cred_env` already bounds the
@@ -1377,7 +1462,24 @@ async fn execute_claimed(
     // umbrella) so both the timeout terminalise and this run attribute the same
     // backend.
     let provider_run = async {
-        if mode == Mode::Interactive {
+        if executor == TaskExecutor::Acp {
+            // Move 1: no argv, no tmux, no provider subprocess of ours. The
+            // adapter is a per-task process the pool spawns on the first
+            // prompt, carrying this task's cwd, environment, permission mode
+            // and OS confinement; `cred_env` is not threaded because the
+            // adapter authenticates itself (see `acp_task`).
+            crate::acp_task::run_acp(
+                pool,
+                events,
+                &task,
+                &dispatch,
+                &env,
+                &location,
+                task_env,
+                runner.max_runtime(),
+            )
+            .await
+        } else if mode == Mode::Interactive {
             // The interactive path is DELIBERATELY unsandboxed (see
             // `run_interactive`): the attached claude reaches the Keychain and
             // `~/.claude` natively and auto-refreshes, so it needs no injected
@@ -1454,7 +1556,13 @@ async fn execute_claimed(
         // over a provider future that became ready in the same poll.
         biased;
         () = cancel_guard.cancelled() => {
-            if mode == Mode::Interactive {
+            if executor == TaskExecutor::Acp {
+                // Dropping `provider_run` stops POLLING; it does not stop the
+                // agent, which lives in an adapter process that has been told
+                // nothing. `session/cancel` it explicitly — the exact analogue
+                // of the interactive arm's `kill_session` below.
+                crate::acp_task::cancel_run(pool, &task.id).await;
+            } else if mode == Mode::Interactive {
                 // The detached session survives `run_interactive`'s dropped `wait`,
                 // so kill it by its EXACT name and clear the shutdown-reap entry the
                 // dropped future would otherwise leave registered (keeps the set
@@ -2410,9 +2518,14 @@ async fn materialise_agent_profile(
 /// default would carry an empty prompt, which is not a degraded run but a
 /// guaranteed non-run.
 #[derive(Debug, Clone)]
-struct ResolvedDispatch {
+pub struct ResolvedDispatch {
     /// Which provider exec path [`execute_claimed`] routes to.
-    backend: Backend,
+    pub(crate) backend: Backend,
+    /// Which EXECUTOR runs it, resolved once from the daemon config and
+    /// carried here for the same reason `mode` is: the branch that picks the
+    /// exec path reads it from the dispatch, so the executor a task gets and
+    /// the work spawned for it cannot disagree.
+    pub(crate) executor: TaskExecutor,
     /// Which CONTRACT that exec path is spawned for, resolved once from the
     /// task row (see [`dispatch_mode`]) and carried beside `backend`.
     ///
@@ -2422,9 +2535,9 @@ struct ResolvedDispatch {
     /// "interactive"` task spawned `claude -p` ("Print response and exit") into a
     /// pane the operator was meant to attach to and drive. Re-deriving is what
     /// gave that bug somewhere to live.
-    mode: Mode,
+    pub(crate) mode: Mode,
     /// The `model` + `cli_args` the provider threads onto its argv.
-    invocation: ProviderInvocation,
+    pub(crate) invocation: ProviderInvocation,
     /// The agent's per-agent env (`agent_env`), layered onto the child env
     /// after the deny-by-default ambient allowlist.
     ///
@@ -2432,7 +2545,7 @@ struct ResolvedDispatch {
     /// struct's derived `Debug` (a `tracing::debug!(?dispatch)`, an `anyhow`
     /// context, a panic message) masks the VALUES (parity #30). The plaintext
     /// is reached only at the compose seam, via `expose_for_child_env`.
-    agent_env: ainb_hangar_core::agent_env::AgentEnv,
+    pub(crate) agent_env: ainb_hangar_core::agent_env::AgentEnv,
 }
 
 /// The `tasks.mode` column value that asks for an attachable session (ccc / D6,
@@ -2470,9 +2583,10 @@ impl ResolvedDispatch {
     /// `mode` is still the task row's own — a resolve fault says nothing about
     /// which contract the operator asked for, and defaulting it would spawn a
     /// print-and-exit process into an interactive pane.
-    fn fallback(mode: Mode) -> Self {
+    fn fallback(mode: Mode, executor: TaskExecutor) -> Self {
         Self {
             backend: Backend::default(),
+            executor,
             mode,
             invocation: ProviderInvocation {
                 prompt: FALLBACK_PROMPT.to_string(),
@@ -2505,6 +2619,7 @@ async fn resolve_dispatch(
     agent_id: &str,
     issue_id: Option<&str>,
     mode: Mode,
+    executor: TaskExecutor,
 ) -> anyhow::Result<ResolvedDispatch> {
     use ainb_hangar_store::repo::agent::AgentRepo;
     use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
@@ -2519,6 +2634,7 @@ async fn resolve_dispatch(
     let provider = agent.provider.as_deref().unwrap_or(&runtime.provider);
     Ok(ResolvedDispatch {
         backend: Backend::from_provider(provider),
+        executor,
         mode,
         invocation: ProviderInvocation {
             prompt,
@@ -3477,6 +3593,7 @@ mod tests {
             &events,
             &interactive,
             Arc::new(HangingBackend),
+            TaskExecutor::Process,
         )
         .await;
 
@@ -3690,6 +3807,7 @@ mod tests {
                 &events,
                 &interactive,
                 Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
+                TaskExecutor::Process,
             )
             .await
         };
@@ -3732,6 +3850,7 @@ mod tests {
             &events,
             &interactive,
             Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
+            TaskExecutor::Process,
         )
         .await
         .expect("member execute_claimed handles the spawn failure internally");
@@ -4058,9 +4177,15 @@ mod tests {
         .await
         .unwrap();
 
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.invocation.prompt, "Fix the login bug\n\nIt 500s on empty password.",
             "the issue title + description must become the brief"
@@ -4098,11 +4223,21 @@ mod tests {
         )
         .await
         .unwrap();
-        let disp = resolve_dispatch(pool, &instructed.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &instructed.id,
+            None,
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(disp.invocation.prompt, "Triage the inbox.");
 
         // (3) Neither → a non-empty fallback, never a promptless spawn.
-        let disp = resolve_dispatch(pool, &agent.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(pool, &agent.id, None, Mode::Headless, TaskExecutor::Process)
+            .await
+            .unwrap();
         assert!(
             !disp.invocation.prompt.is_empty(),
             "a prompt is never empty"
@@ -4193,9 +4328,15 @@ mod tests {
         .await
         .unwrap();
 
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         let brief = disp.invocation.prompt;
         assert_eq!(
             brief,
@@ -4219,9 +4360,15 @@ mod tests {
             .execute(pool)
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         let brief = disp.invocation.prompt;
         let instr_at = brief.find(INSTRUCTIONS).expect("agent instructions in the brief");
         let stage_at = brief.find(STAGE).expect("stage prompt in the brief");
@@ -4236,9 +4383,15 @@ mod tests {
             .execute(pool)
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(disp.invocation.prompt, INSTRUCTIONS);
     }
 
@@ -4339,9 +4492,15 @@ mod tests {
             .unwrap();
         }
 
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         let brief = disp.invocation.prompt;
         assert!(
             brief.contains(PIPELINE_STAGE),
@@ -4358,9 +4517,15 @@ mod tests {
             .execute(pool)
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agent.id, Some(&issue_id), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&issue_id),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.invocation.prompt, "Fix the login bug",
             "no gating addendum means the brief is the issue body alone"
@@ -4425,9 +4590,15 @@ mod tests {
         CardParityRepo::set_issue_external_ref(pool, &ws, &with_ref, Some("acme/api#42"))
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agent.id, Some(&with_ref), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&with_ref),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.invocation.prompt,
             "Fix login\n\nIt 500s on empty password.\n\nLinked issue: acme/api#42",
@@ -4436,7 +4607,15 @@ mod tests {
 
         // The SAME issue with no ref set: the brief is unchanged (no trailing line).
         let no_ref = seed("Fix login", Some("It 500s on empty password.")).await;
-        let disp = resolve_dispatch(pool, &agent.id, Some(&no_ref), Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&no_ref),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.invocation.prompt, "Fix login\n\nIt 500s on empty password.",
             "no external_ref → no Linked issue line"
@@ -4447,9 +4626,15 @@ mod tests {
         CardParityRepo::set_issue_external_ref(pool, &ws, &title_only, Some("https://x/y/1"))
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agent.id, Some(&title_only), Mode::Headless)
-            .await
-            .unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &agent.id,
+            Some(&title_only),
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.invocation.prompt, "Wire the webhook\n\nLinked issue: https://x/y/1",
             "a linked issue with no brief still hands the agent the ref"
@@ -4499,6 +4684,7 @@ mod tests {
         // exactly as `execute_claimed` resolves it.
         let interactive_dispatch = |backend| ResolvedDispatch {
             backend,
+            executor: TaskExecutor::Process,
             mode: dispatch_mode("interactive"),
             invocation: inv.clone(),
             agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
@@ -4603,6 +4789,7 @@ mod tests {
             &runner,
             &ResolvedDispatch {
                 backend: Backend::Codex,
+                executor: TaskExecutor::Process,
                 mode: dispatch_mode("interactive"),
                 invocation: inv.clone(),
                 agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
@@ -4631,10 +4818,17 @@ mod tests {
 
         // A task whose agent does not exist: resolve MUST fail, which is what
         // drives `execute_claimed` onto the fallback.
-        let err = resolve_dispatch(pool, "agent-that-does-not-exist", None, Mode::Headless).await;
+        let err = resolve_dispatch(
+            pool,
+            "agent-that-does-not-exist",
+            None,
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await;
         assert!(err.is_err(), "a missing agent must fail to resolve");
 
-        let disp = ResolvedDispatch::fallback(Mode::Headless);
+        let disp = ResolvedDispatch::fallback(Mode::Headless, TaskExecutor::Process);
         assert!(
             !disp.invocation.prompt.trim().is_empty(),
             "the fault fallback must carry a real brief, or the provider exits 1 \
@@ -4682,7 +4876,9 @@ mod tests {
 
         // A codex agent on that claude-advertised runtime → codex backend.
         let codex = bootstrap::create_agent(pool, &ws, "coder", "codex", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &codex.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(pool, &codex.id, None, Mode::Headless, TaskExecutor::Process)
+            .await
+            .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Codex,
@@ -4692,7 +4888,15 @@ mod tests {
         // A copilot agent on that claude-advertised runtime → copilot backend
         // (no more silent claude fallback).
         let copilot = bootstrap::create_agent(pool, &ws, "helper", "copilot", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &copilot.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &copilot.id,
+            None,
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Copilot,
@@ -4703,7 +4907,9 @@ mod tests {
         let agy = bootstrap::create_agent(pool, &ws, "gemini_worker", "antigravity", None)
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agy.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(pool, &agy.id, None, Mode::Headless, TaskExecutor::Process)
+            .await
+            .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Antigravity,
@@ -4712,7 +4918,15 @@ mod tests {
 
         // A claude agent on the same runtime → claude backend.
         let claude = bootstrap::create_agent(pool, &ws, "writer", "claude", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &claude.id, None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            &claude.id,
+            None,
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(disp.backend, Backend::Claude);
 
         // An agent with NO provider override falls back to the runtime's provider.
@@ -4729,7 +4943,15 @@ mod tests {
             ..Agent::default()
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
-        let disp = resolve_dispatch(pool, "bare-agent", None, Mode::Headless).await.unwrap();
+        let disp = resolve_dispatch(
+            pool,
+            "bare-agent",
+            None,
+            Mode::Headless,
+            TaskExecutor::Process,
+        )
+        .await
+        .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Claude,

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
@@ -43,10 +43,75 @@ const fn classify(outcome: &RunOutcome) -> Want {
     }
 }
 
+/// EVERY enumerated delivery token, under EVERY terminal state that can carry
+/// it, resolves to something other than contract drift.
+///
+/// The hand-written table below cannot do this job: it lists the pairs someone
+/// thought of, and the four it originally missed (`FAILED`+`adapter_exit`,
+/// `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`,
+/// `UNKNOWN`+`operator_stop`) were all reachable and all answered
+/// `ProviderContractDrift`/NoRetry. This one enumerates the vocabulary from the
+/// pool's own constants, so a token the pool grows without a mapping here fails
+/// the build rather than silently burning a retry chain.
+#[test]
+fn no_state_and_token_the_pool_can_write_falls_through_to_drift() {
+    use ainb_hangar_daemon::acp_pool::{self, ConvergeCause};
+
+    // The enumerated taxonomy at `acp_pool.rs`'s "detail taxonomy" block, plus
+    // every `ConvergeCause::detail()` (which is a subset, listed so a new cause
+    // is caught even if its token is not added to the block above).
+    let tokens: Vec<&str> = [
+        acp_pool::DELIVERY_QUEUE_FULL,
+        acp_pool::DELIVERY_BREAKER_OPEN,
+        acp_pool::DELIVERY_ADAPTER_EXIT,
+        acp_pool::DELIVERY_OPERATOR_STOP,
+        acp_pool::DELIVERY_TURN_DEADLINE,
+        acp_pool::DELIVERY_DAEMON_RESTART,
+        acp_pool::DELIVERY_SPAWN_FAILED,
+        acp_pool::DELIVERY_TURN_UNRECORDED,
+        acp_pool::DELIVERY_SESSION_GONE,
+        acp_pool::DELIVERY_PROVIDER_AT_CAPACITY,
+        acp_pool::DELIVERY_MODE_UNPROVEN,
+    ]
+    .into_iter()
+    .chain(
+        [
+            ConvergeCause::DaemonRestart,
+            ConvergeCause::AdapterExit,
+            ConvergeCause::TurnDeadline,
+            ConvergeCause::OperatorStop,
+        ]
+        .into_iter()
+        .map(ConvergeCause::detail),
+    )
+    .collect();
+
+    // `drain_queue` resolves FAILED, `converge_dirty_session` UNKNOWN, and
+    // `submit_prompt` REJECTED — all three from the same vocabulary.
+    for state in ["FAILED", "UNKNOWN", "REJECTED"] {
+        for token in &tokens {
+            for detail in [(*token).to_string(), format!("{token}; resume=loaded")] {
+                let got = outcome_for(state, Some(&detail), RunnerResult::default());
+                assert_ne!(
+                    classify(&got),
+                    Want::Failed(FailureReason::ProviderContractDrift),
+                    "state={state:?} detail={detail:?} has no mapping"
+                );
+                assert_ne!(
+                    classify(&got),
+                    Want::Success,
+                    "state={state:?} detail={detail:?} must never read as success"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn every_leg_the_pool_can_write_maps_to_a_named_outcome() {
     // (state, detail, expected). Mirrors the table in
-    // `docs/hangar/renovation/move1-acp-tasks.md` section 2f.
+    // `docs/hangar/renovation/move1-acp-tasks.md` section 2f, plus the four
+    // pairs 2f's own table omitted (marked below).
     let table: &[(&str, Option<&str>, Want)] = &[
         // DELIVERED: no `stop=` token IS the ordinary EndTurn. The pool writes
         // the token only when the reason is worth naming.
@@ -138,13 +203,50 @@ fn every_leg_the_pool_can_write_maps_to_a_named_outcome() {
             Some("daemon_restart"),
             Want::Failed(FailureReason::RuntimeRecovery),
         ),
-        // Refused at the door: nothing reached the adapter.
+        // The four 2f's table omitted, all reachable, all previously drift.
+        // `attach_with_one_requeue` writes adapter_exit on a FAILED leg when the
+        // adapter cannot be spawned or the transport dies — the single most
+        // likely ACP failure, and NoRetry would have burned the chain on it.
+        (
+            "FAILED",
+            Some("adapter_exit; spawn refused"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        // `drain_queue` resolves a still-QUEUED prompt FAILED with the converge
+        // cause, so these two arrive under FAILED as well as UNKNOWN.
+        (
+            "FAILED",
+            Some("turn_deadline"),
+            Want::Failed(FailureReason::Timeout),
+        ),
+        (
+            "FAILED",
+            Some("daemon_restart"),
+            Want::Failed(FailureReason::RuntimeRecovery),
+        ),
+        // An operator stopping the session while `await_leg` still polls: the
+        // run is cancelled, not failed, so it neither retries nor moves the card
+        // to a failed column.
+        ("UNKNOWN", Some("operator_stop"), Want::Cancelled),
+        // Refused at the door. The refusal token decides, exactly as it does on
+        // a FAILED leg: a `breaker_open` door refusal is the same transient
+        // condition whichever side of the queue it was seen from. Deliberate
+        // deviation from 2f's "REJECTED | any | SpawnError".
         (
             "REJECTED",
             Some("queue_full"),
-            Want::Failed(FailureReason::SpawnError),
+            Want::Failed(FailureReason::RuntimeOffline),
         ),
-        ("REJECTED", None, Want::Failed(FailureReason::SpawnError)),
+        (
+            "REJECTED",
+            Some("breaker_open"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        (
+            "REJECTED",
+            Some("session_gone"),
+            Want::Failed(FailureReason::ProvisionError),
+        ),
     ];
 
     for (state, detail, want) in table {
@@ -172,6 +274,9 @@ fn an_unmapped_detail_is_contract_drift_and_never_success() {
         ("FAILED", Some("something_new")),
         ("FAILED", Some("turn_failed")),
         ("UNKNOWN", Some("something_new")),
+        // Refused at the door with no reason: `submit_prompt` always names one,
+        // so an empty refusal is the pool's contract changing.
+        ("REJECTED", None),
         // A state the delivery CHECK constraint does not even allow.
         ("PENDING", None),
         ("MISSING", None),
@@ -221,6 +326,20 @@ fn the_retry_disposition_of_each_outcome_is_the_one_the_plan_promised() {
         (
             "UNKNOWN",
             Some("daemon_restart"),
+            RetryDisposition::ResumeRetry,
+        ),
+        // The adapter would not start. THE most likely ACP failure, and the one
+        // NoRetry would have burned the retry chain on.
+        (
+            "FAILED",
+            Some("adapter_exit; spawn refused"),
+            RetryDisposition::ResumeRetry,
+        ),
+        // Refused at the door for a transient reason: the door is not what
+        // makes it terminal.
+        (
+            "REJECTED",
+            Some("breaker_open"),
             RetryDisposition::ResumeRetry,
         ),
         // A misconfigured adapter will not self-heal on a re-dispatch.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
@@ -43,54 +43,56 @@ const fn classify(outcome: &RunOutcome) -> Want {
     }
 }
 
-/// EVERY enumerated delivery token, under EVERY terminal state that can carry
-/// it, resolves to something other than contract drift.
+/// EVERY delivery token the pool can write, under EVERY terminal state that can
+/// carry it, resolves to something other than contract drift.
 ///
 /// The hand-written table below cannot do this job: it lists the pairs someone
 /// thought of, and the four it originally missed (`FAILED`+`adapter_exit`,
 /// `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`,
 /// `UNKNOWN`+`operator_stop`) were all reachable and all answered
-/// `ProviderContractDrift`/NoRetry. This one enumerates the vocabulary from the
-/// pool's own constants, so a token the pool grows without a mapping here fails
-/// the build rather than silently burning a retry chain.
+/// `ProviderContractDrift`/NoRetry.
+///
+/// The vocabulary is read from [`DeliveryToken::ALL`], not copied into a list
+/// here. An earlier version of this test DID copy it, which made the guarantee
+/// it claimed to enforce imaginary: a reviewer added a real
+/// `DELIVERY_RATE_LIMITED` write site to the pool and all four tests still
+/// passed. `DeliveryToken`'s exhaustive `as_str` and `outcome_for_token`'s
+/// wildcard-free match are what now make that a compile error; this test is the
+/// runtime half, covering the states and the `resume=` suffix.
 #[test]
 fn no_state_and_token_the_pool_can_write_falls_through_to_drift() {
-    use ainb_hangar_daemon::acp_pool::{self, ConvergeCause};
+    use ainb_hangar_daemon::acp_pool::{ConvergeCause, DeliveryToken};
 
-    // The enumerated taxonomy at `acp_pool.rs`'s "detail taxonomy" block, plus
-    // every `ConvergeCause::detail()` (which is a subset, listed so a new cause
-    // is caught even if its token is not added to the block above).
-    let tokens: Vec<&str> = [
-        acp_pool::DELIVERY_QUEUE_FULL,
-        acp_pool::DELIVERY_BREAKER_OPEN,
-        acp_pool::DELIVERY_ADAPTER_EXIT,
-        acp_pool::DELIVERY_OPERATOR_STOP,
-        acp_pool::DELIVERY_TURN_DEADLINE,
-        acp_pool::DELIVERY_DAEMON_RESTART,
-        acp_pool::DELIVERY_SPAWN_FAILED,
-        acp_pool::DELIVERY_TURN_UNRECORDED,
-        acp_pool::DELIVERY_SESSION_GONE,
-        acp_pool::DELIVERY_PROVIDER_AT_CAPACITY,
-        acp_pool::DELIVERY_MODE_UNPROVEN,
-    ]
-    .into_iter()
-    .chain(
-        [
-            ConvergeCause::DaemonRestart,
-            ConvergeCause::AdapterExit,
-            ConvergeCause::TurnDeadline,
-            ConvergeCause::OperatorStop,
-        ]
-        .into_iter()
-        .map(ConvergeCause::detail),
-    )
-    .collect();
+    // Every cause's token too. `detail()` still returns `&str`, so a new cause
+    // whose token bypassed the enum would fail to parse and land on drift here.
+    let tokens: Vec<String> = DeliveryToken::ALL
+        .iter()
+        .map(|token| token.as_str().to_string())
+        .chain(
+            [
+                ConvergeCause::DaemonRestart,
+                ConvergeCause::AdapterExit,
+                ConvergeCause::TurnDeadline,
+                ConvergeCause::OperatorStop,
+            ]
+            .into_iter()
+            .map(|cause| cause.detail().to_string()),
+        )
+        .collect();
 
     // `drain_queue` resolves FAILED, `converge_dirty_session` UNKNOWN, and
     // `submit_prompt` REJECTED: all three from the same vocabulary.
     for state in ["FAILED", "UNKNOWN", "REJECTED"] {
         for token in &tokens {
-            for detail in [(*token).to_string(), format!("{token}; resume=loaded")] {
+            // `finish_turn` never writes `turn_failed` without a stop reason,
+            // and the stop reason is what distinguishes a refusal from a
+            // cancellation, so a bare one is genuinely drift.
+            let base = if token == DeliveryToken::TurnFailed.as_str() {
+                format!("{token}; stop=refusal")
+            } else {
+                token.clone()
+            };
+            for detail in [base.clone(), format!("{base}; resume=loaded")] {
                 let got = outcome_for(state, Some(&detail), RunnerResult::default());
                 assert_ne!(
                     classify(&got),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
@@ -1,0 +1,245 @@
+//! Spine A5 / T4: the ACP delivery leg -> `RunOutcome` mapping, table-driven.
+//!
+//! No daemon, no adapter, no database: `outcome_for` is the pure function that
+//! decides whether an ACP run finalizes `done`, `failed` or `cancelled`, and
+//! whether it is retried, so it is worth pinning on its own.
+//!
+//! ```text
+//!   leg.state + leg.detail (a "; "-joined TOKEN SET)
+//!            │
+//!            ▼
+//!   RunOutcome ──▶ finalize_success / finalize_failure / finalize_cancelled
+//!                  RetryService::retry_disposition
+//! ```
+//!
+//! Two properties matter more than any single row.
+//!
+//! **The detail is a SET, never a string.** A plain success can read
+//! `resume=loaded`, a budget stop `stop=max_tokens; resume=reprimed`, and an
+//! adapter exit appends raw error text after its token. Every equality-based
+//! reader of this field would mis-read at least one of those.
+//!
+//! **An unmapped detail is contract DRIFT, not success.** A token the pool grew
+//! and this table has not learned about must not finalize a task `done`.
+
+use ainb_hangar_daemon::acp_task::outcome_for;
+use ainb_hangar_daemon::runner::{RunOutcome, RunnerResult};
+use ainb_hangar_store::service::fail::FailureReason;
+use ainb_hangar_store::service::retry::RetryService;
+
+/// The shorthand each row asserts against.
+#[derive(Debug, PartialEq, Eq)]
+enum Want {
+    Success,
+    Cancelled,
+    Failed(FailureReason),
+}
+
+const fn classify(outcome: &RunOutcome) -> Want {
+    match outcome {
+        RunOutcome::Success(_) => Want::Success,
+        RunOutcome::Cancelled(_) => Want::Cancelled,
+        RunOutcome::Failed { reason, .. } => Want::Failed(*reason),
+    }
+}
+
+#[test]
+fn every_leg_the_pool_can_write_maps_to_a_named_outcome() {
+    // (state, detail, expected). Mirrors the table in
+    // `docs/hangar/renovation/move1-acp-tasks.md` section 2f.
+    let table: &[(&str, Option<&str>, Want)] = &[
+        // DELIVERED: no `stop=` token IS the ordinary EndTurn. The pool writes
+        // the token only when the reason is worth naming.
+        ("DELIVERED", None, Want::Success),
+        ("DELIVERED", Some("resume=loaded"), Want::Success),
+        ("DELIVERED", Some("resume=reprimed"), Want::Success),
+        (
+            "DELIVERED",
+            Some("stop=max_tokens"),
+            Want::Failed(FailureReason::IterationLimit),
+        ),
+        (
+            "DELIVERED",
+            Some("stop=max_tokens; resume=reprimed"),
+            Want::Failed(FailureReason::IterationLimit),
+        ),
+        (
+            "DELIVERED",
+            Some("stop=max_turn_requests"),
+            Want::Failed(FailureReason::IterationLimit),
+        ),
+        // FAILED.
+        (
+            "FAILED",
+            Some("turn_failed; stop=refusal"),
+            Want::Failed(FailureReason::AgentError),
+        ),
+        (
+            "FAILED",
+            Some("turn_failed; stop=cancelled"),
+            Want::Cancelled,
+        ),
+        (
+            "FAILED",
+            Some("turn_failed; stop=cancelled; resume=loaded"),
+            Want::Cancelled,
+        ),
+        ("FAILED", Some("operator_stop"), Want::Cancelled),
+        (
+            "FAILED",
+            Some("spawn_failed"),
+            Want::Failed(FailureReason::SpawnError),
+        ),
+        (
+            "FAILED",
+            Some("mode_unproven"),
+            Want::Failed(FailureReason::SpawnError),
+        ),
+        (
+            "FAILED",
+            Some("turn_unrecorded"),
+            Want::Failed(FailureReason::SpawnError),
+        ),
+        (
+            "FAILED",
+            Some("session_gone"),
+            Want::Failed(FailureReason::ProvisionError),
+        ),
+        (
+            "FAILED",
+            Some("breaker_open"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        (
+            "FAILED",
+            Some("provider_at_capacity"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        (
+            "FAILED",
+            Some("queue_full"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        // UNKNOWN: the request WAS issued, so the outcome is genuinely unknown.
+        // `adapter_exit` carries the raw error text after its token, which is
+        // exactly why the detail is read as a set.
+        (
+            "UNKNOWN",
+            Some("adapter_exit; transport closed while a turn was open"),
+            Want::Failed(FailureReason::RuntimeOffline),
+        ),
+        (
+            "UNKNOWN",
+            Some("turn_deadline"),
+            Want::Failed(FailureReason::Timeout),
+        ),
+        (
+            "UNKNOWN",
+            Some("daemon_restart"),
+            Want::Failed(FailureReason::RuntimeRecovery),
+        ),
+        // Refused at the door: nothing reached the adapter.
+        (
+            "REJECTED",
+            Some("queue_full"),
+            Want::Failed(FailureReason::SpawnError),
+        ),
+        ("REJECTED", None, Want::Failed(FailureReason::SpawnError)),
+    ];
+
+    for (state, detail, want) in table {
+        let got = outcome_for(state, *detail, RunnerResult::default());
+        assert_eq!(
+            &classify(&got),
+            want,
+            "leg state={state:?} detail={detail:?} mapped to {got:?}"
+        );
+    }
+}
+
+#[test]
+fn an_unmapped_detail_is_contract_drift_and_never_success() {
+    // The pool's taxonomy growing a token this table has not learned about must
+    // fail the task loudly, not finalize it `done` on a turn nobody read. Fail
+    // closed, exactly as the runner's own unknown-terminal rule does.
+    let drifted: &[(&str, Option<&str>)] = &[
+        // A stop reason upstream added, or renamed.
+        ("DELIVERED", Some("stop=quota_exhausted")),
+        // `refusal` on a DELIVERED leg contradicts `turn_succeeded`.
+        ("DELIVERED", Some("stop=refusal")),
+        // A FAILED leg carrying nothing at all.
+        ("FAILED", None),
+        ("FAILED", Some("something_new")),
+        ("FAILED", Some("turn_failed")),
+        ("UNKNOWN", Some("something_new")),
+        // A state the delivery CHECK constraint does not even allow.
+        ("PENDING", None),
+        ("MISSING", None),
+    ];
+    for (state, detail) in drifted {
+        let got = outcome_for(state, *detail, RunnerResult::default());
+        assert_eq!(
+            classify(&got),
+            Want::Failed(FailureReason::ProviderContractDrift),
+            "leg state={state:?} detail={detail:?} should be contract drift"
+        );
+    }
+}
+
+#[test]
+fn the_retry_disposition_of_each_outcome_is_the_one_the_plan_promised() {
+    // The mapping is only half the contract: which failures COME BACK is the
+    // other half, and it is decided elsewhere. A row that mapped to a plausible
+    // reason with the wrong disposition would either wedge a card in Todo or
+    // retry a refusal forever.
+    use ainb_hangar_store::service::retry::RetryDisposition;
+
+    let cases: &[(&str, Option<&str>, RetryDisposition)] = &[
+        // The agent ran out of budget: a fresh run has a chance.
+        (
+            "DELIVERED",
+            Some("stop=max_tokens"),
+            RetryDisposition::FreshRetry,
+        ),
+        // The agent refused: running it again refuses again.
+        (
+            "FAILED",
+            Some("turn_failed; stop=refusal"),
+            RetryDisposition::NoRetry,
+        ),
+        // The provider is down, not the work: come back to the same session.
+        (
+            "FAILED",
+            Some("breaker_open"),
+            RetryDisposition::ResumeRetry,
+        ),
+        (
+            "UNKNOWN",
+            Some("adapter_exit; pipe closed"),
+            RetryDisposition::ResumeRetry,
+        ),
+        (
+            "UNKNOWN",
+            Some("daemon_restart"),
+            RetryDisposition::ResumeRetry,
+        ),
+        // A misconfigured adapter will not self-heal on a re-dispatch.
+        ("REJECTED", None, RetryDisposition::NoRetry),
+        ("FAILED", Some("mode_unproven"), RetryDisposition::NoRetry),
+        // Drift is a bug in this table, not a transient fault.
+        ("FAILED", Some("something_new"), RetryDisposition::NoRetry),
+    ];
+
+    for (state, detail, want) in cases {
+        let RunOutcome::Failed { reason, .. } =
+            outcome_for(state, *detail, RunnerResult::default())
+        else {
+            panic!("state={state:?} detail={detail:?} should be a failure");
+        };
+        assert_eq!(
+            RetryService::retry_disposition(reason),
+            *want,
+            "state={state:?} detail={detail:?} reason={reason:?}"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_task_outcome.rs
@@ -87,7 +87,7 @@ fn no_state_and_token_the_pool_can_write_falls_through_to_drift() {
     .collect();
 
     // `drain_queue` resolves FAILED, `converge_dirty_session` UNKNOWN, and
-    // `submit_prompt` REJECTED — all three from the same vocabulary.
+    // `submit_prompt` REJECTED: all three from the same vocabulary.
     for state in ["FAILED", "UNKNOWN", "REJECTED"] {
         for token in &tokens {
             for detail in [(*token).to_string(), format!("{token}; resume=loaded")] {
@@ -205,7 +205,7 @@ fn every_leg_the_pool_can_write_maps_to_a_named_outcome() {
         ),
         // The four 2f's table omitted, all reachable, all previously drift.
         // `attach_with_one_requeue` writes adapter_exit on a FAILED leg when the
-        // adapter cannot be spawned or the transport dies — the single most
+        // adapter cannot be spawned or the transport dies: the single most
         // likely ACP failure, and NoRetry would have burned the chain on it.
         (
             "FAILED",

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -572,6 +572,31 @@ async fn acp_session_create_is_gated_idempotent_and_transactional() {
         "and left the incumbent untouched"
     );
 
+    // A5: `task:` belongs to the task executor. A chat session squatting a real
+    // task's scope would make that task's later run fail `ScopeHeld` - terminal,
+    // no retry - and would make the pool stamp this session's approvals with the
+    // task's workspace.
+    let squat = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            serde_json::json!({
+                "provider": ainb_acp::config::CLAUDE_ADAPTER,
+                "cwd": harness.dir.to_string_lossy(),
+                "scope_key": "task:01JABCDEF",
+            }),
+        )
+        .await;
+    assert_eq!(
+        squat["error"]["code"], -32602,
+        "the task scope namespace is reserved: {squat}"
+    );
+    let squatted: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM fleet_acp_session WHERE scope_key LIKE 'task:%'")
+            .fetch_one(harness.store.pool())
+            .await
+            .expect("count task scopes");
+    assert_eq!(squatted, 0, "and nothing was written under it");
+
     // BOTH rows, under ONE key, from ONE transaction.
     let (provider, cwd, state): (String, String, String) =
         sqlx::query_as("SELECT provider, cwd, state FROM fleet_acp_session WHERE session_key = ?")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
@@ -1,0 +1,574 @@
+//! Spine A5 e2e tripwire: the real daemon binary runs a task over ACP.
+//!
+//! ```text
+//!   HANGAR_TASK_EXECUTOR=acp
+//!         │
+//!   queued ─▶ dispatched ─▶ running ──▶ acp_task::run_acp
+//!                                          │  register claude-agent-acp#task:<id>
+//!                                          │  ensure(scope "task:<id>") ─▶ enqueue ─▶ prompt
+//!                                          ▼
+//!                                   poll the delivery leg
+//!                                          ▼
+//!                                        done   result = the agent's final message
+//!   NEGATIVE, all the way through: no provider process, no *.jsonl, no tmux pane
+//! ```
+//!
+//! Everything runs with no adapter and no credentials: the daemon's
+//! `[acp.adapters.claude-agent-acp]` entry is repointed at
+//! `ainb-acp`'s `fake_acp_adapter` fixture through the same config.toml an
+//! operator edits, and the fixture is SCRIPTED through the agent's own
+//! `agent_env` — which is also the proof that the per-agent environment reaches
+//! a per-task adapter process at all.
+//!
+//! The negative assertions are the ones that stop a silent fallback: a flag
+//! that quietly ran the process executor would leave every positive assertion
+//! about the task row green.
+//!
+//! Skips cleanly (never fails) when tmux is unavailable.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use ainb_hangar_proto::{RpcId, RpcRequest, methods};
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tripwire_support::{
+    DaemonSession, daemon_bin, enqueue_task, fake_acp_adapter, seed_agent_with_env, seed_world,
+    wait_for_db, wait_for_file, write_acp_adapter_config,
+};
+
+/// A task run over ACP reaches `done`, carries the agent's final message, is
+/// keyed to its ACP session, and leaves NO trace of the process executor.
+#[tokio::test]
+async fn an_acp_task_runs_to_done_with_no_process_and_no_tmux() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp task e2e");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    let rpc_log = home.path().join("rpc.log");
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-acp",
+        &serde_json::json!({
+            // The prompt comes back in the final agent message, so the task's
+            // stored `result` is checkable against the brief that produced it.
+            "FAKE_ACP_ECHO_PROMPT": "1",
+            "FAKE_ACP_RPC_LOG": rpc_log.display().to_string(),
+        }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    // A fake `claude` that leaves a MARKER if it is ever spawned. Nothing under
+    // `executor=acp` should reach it; the marker is what makes "no process was
+    // spawned" a positive observation instead of an absence of evidence.
+    let marker = home.path().join("process-executor-ran");
+    let fake_claude = write_marker_binary(home.path(), &marker);
+
+    let session = spawn_acp_daemon(home.path(), &ids, &fake_claude);
+    let task_id = "task-acp-happy";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    let row = wait_for_terminal(&pool, task_id, Duration::from_mins(1)).await;
+    // The daemon writes its tracing to stderr, which is the tmux pane; capture
+    // it BEFORE the session is dropped so a wrong outcome reports WHY.
+    let pane = session.capture_pane();
+    drop(session);
+    assert_eq!(
+        row.get::<String, _>("status"),
+        "done",
+        "the acp run must reach done; reason={:?}\n{}\ndaemon:\n{pane}",
+        row.get::<Option<String>, _>("failure_reason"),
+        dump_legs(&pool).await,
+    );
+
+    // The brief the daemon built from the agent's instructions, echoed back by
+    // the adapter and stored as the run's result.
+    let result: String = row.get::<Option<String>, _>("result").expect("result json");
+    assert!(
+        result.contains("do the agent-acp work"),
+        "the task result must carry the turn's final agent message, got: {result}"
+    );
+
+    // The run is keyed to the ACP session created under its OWN scope, so the
+    // transcript is reachable from the task row.
+    let session_key: String =
+        sqlx::query_scalar("SELECT session_key FROM fleet_acp_session WHERE scope_key = ?")
+            .bind(format!("task:{task_id}"))
+            .fetch_one(&pool)
+            .await
+            .expect("a session under the task scope");
+    assert_eq!(
+        row.get::<Option<String>, _>("session_id").as_deref(),
+        Some(session_key.as_str()),
+        "session_id must be the acp session key"
+    );
+
+    // The durable transcript: `fleet_provider_event`, not a jsonl file.
+    let messages: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM fleet_provider_event \
+         WHERE session_key = ? AND event_type = 'acp.message'",
+    )
+    .bind(&session_key)
+    .fetch_one(&pool)
+    .await
+    .expect("count acp.message rows");
+    assert!(
+        messages > 0,
+        "the run must write acp.message transcript rows"
+    );
+
+    // The adapter spawned once, opened one session and took one prompt.
+    let log = std::fs::read_to_string(&rpc_log).expect("the fixture adapter's rpc log");
+    assert_eq!(
+        log.matches("spawn").count(),
+        1,
+        "one adapter process: {log}"
+    );
+    assert!(
+        log.contains("prompt"),
+        "the adapter must have taken a prompt: {log}"
+    );
+
+    assert_no_process_executor_trace(&row, &marker, task_id);
+}
+
+/// A permission the agent raises lands as an approval row scoped to the task's
+/// WORKSPACE, and answering it through `attention/answer` completes the turn.
+///
+/// The workspace id is the half that used to be missing: `raise_permission`
+/// hardcoded `None`, so the row existed but no workspace-filtered surface — and
+/// every operator surface is one — could show it.
+#[tokio::test]
+async fn a_task_raised_approval_is_workspace_scoped_and_answerable() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp approval e2e");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    let rpc_log = home.path().join("rpc.log");
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-approve",
+        &serde_json::json!({
+            "FAKE_ACP_PERMISSION_SESSIONS": "*",
+            "FAKE_ACP_RPC_LOG": rpc_log.display().to_string(),
+        }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+    let marker = home.path().join("process-executor-ran");
+    let fake_claude = write_marker_binary(home.path(), &marker);
+
+    let session = spawn_acp_daemon(home.path(), &ids, &fake_claude);
+    let task_id = "task-acp-approve";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    // The turn BLOCKS on the parked permission, so the row is observable while
+    // the task is still `running`.
+    let attention = wait_for_attention(&pool, Duration::from_mins(1)).await;
+    let workspace_id: Option<String> = attention.get("workspace_id");
+    assert_eq!(
+        workspace_id.as_deref(),
+        Some(ids.workspace_id.as_str()),
+        "a task-raised approval must carry the task's workspace, or no filtered inbox shows it"
+    );
+    // Rooted in THIS run's directory, not the daemon's cwd. The task row's own
+    // `work_dir` is still NULL here — it is written at finalize — which is
+    // exactly why the approval has to carry the session's cwd itself.
+    let cwd: String = attention.get::<Option<String>, _>("cwd").unwrap_or_default();
+    assert!(
+        cwd.contains(task_id) && cwd.ends_with("/workdir"),
+        "the approval must be rooted in the run's own worktree, got {cwd:?}"
+    );
+
+    // Answer it the way Control Center does — `attention/answer`, not
+    // `fleet/action` — and the turn completes.
+    let attention_id: String = attention.get("id");
+    let payload: String = attention.get("payload");
+    let payload: serde_json::Value = serde_json::from_str(&payload).expect("payload json");
+    let option = payload["options"][0]["optionId"]
+        .as_str()
+        .expect("the adapter offered an option")
+        .to_string();
+
+    let mut client = Client::connect(&home.path().join("hangar.sock")).await;
+    client.auth_from_file(home.path()).await;
+    let resp = client
+        .call(
+            methods::ATTENTION_ANSWER,
+            serde_json::json!({
+                "attention_id": attention_id,
+                "answer": option,
+                "answered_by": "tripwire",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "attention/answer must ack: {resp}");
+
+    let row = wait_for_db(&pool, task_id, "done", Duration::from_mins(1)).await;
+    drop(session);
+
+    let answered: Option<i64> =
+        sqlx::query_scalar("SELECT answered_at FROM attention WHERE id = ?")
+            .bind(&attention_id)
+            .fetch_one(&pool)
+            .await
+            .expect("attention row");
+    assert!(answered.is_some(), "the answered row must be closed");
+
+    let log = std::fs::read_to_string(&rpc_log).expect("rpc log");
+    assert_eq!(
+        log.matches("permission").count(),
+        1,
+        "exactly one permission round trip: {log}"
+    );
+    assert_no_process_executor_trace(&row, &marker, task_id);
+}
+
+/// Cancelling a live ACP task tells the ADAPTER, not just the poll loop.
+///
+/// Dropping `run_acp` stops polling; the agent lives in another process. Without
+/// the explicit `session/cancel` the fixture's hung turn would run on, so the
+/// `cancel` line in its rpc log is the whole assertion.
+#[tokio::test]
+async fn cancelling_an_acp_task_cancels_the_adapter_turn() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp cancel e2e");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    let rpc_log = home.path().join("rpc.log");
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-hang",
+        &serde_json::json!({
+            // The turn NEVER answers, so the cancel below always races a live
+            // turn rather than one that finished on its own.
+            "FAKE_ACP_HANG_SESSIONS": "*",
+            "FAKE_ACP_RPC_LOG": rpc_log.display().to_string(),
+        }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+    let marker = home.path().join("process-executor-ran");
+    let fake_claude = write_marker_binary(home.path(), &marker);
+
+    let issue_id = "issue-acp-cancel";
+    sqlx::query(
+        "INSERT INTO issue (id, workspace_id, title, description, state, creator_type, \
+         creator_id, created_at) VALUES (?, ?, 'cancel me', 'hang forever', 'open', \
+         'member', 'user-trip', 0)",
+    )
+    .bind(issue_id)
+    .bind(&ids.workspace_id)
+    .execute(&pool)
+    .await
+    .expect("insert issue");
+
+    let session = spawn_acp_daemon(home.path(), &ids, &fake_claude);
+    let task_id = "task-acp-cancel";
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, issue_id, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(&agent)
+    .bind(issue_id)
+    .bind(tripwire_support::now_ms())
+    .execute(&pool)
+    .await
+    .expect("enqueue hanging task");
+
+    // The prompt has REACHED the adapter before the cancel, so the cancel below
+    // stops a genuinely open turn.
+    wait_for_file(&rpc_log, Duration::from_mins(1), |log| {
+        log.contains("prompt")
+    });
+
+    let mut client = Client::connect(&home.path().join("hangar.sock")).await;
+    client.auth_from_file(home.path()).await;
+    let resp = client
+        .call(
+            methods::HANGAR_ISSUE_CANCEL_ACTIVE,
+            serde_json::json!({ "workspace_id": ids.workspace_id, "issue_id": issue_id }),
+        )
+        .await;
+    assert!(
+        resp["error"].is_null(),
+        "issue_cancel_active must ack: {resp}"
+    );
+
+    let row = wait_for_db(&pool, task_id, "cancelled", Duration::from_mins(1)).await;
+    drop(session);
+
+    let log = wait_for_file(&rpc_log, Duration::from_secs(10), |log| {
+        log.contains("cancel")
+    });
+    assert!(
+        log.contains("cancel"),
+        "the adapter must be told session/cancel, not merely abandoned: {log}"
+    );
+    assert_no_process_executor_trace(&row, &marker, task_id);
+}
+
+// ------------------------------------------------------------------ helpers
+
+/// Spawn the real daemon under `HANGAR_TASK_EXECUTOR=acp`, with the fixture
+/// adapter already configured and a fake `claude` standing by to prove it is
+/// never reached.
+fn spawn_acp_daemon(
+    home: &Path,
+    ids: &tripwire_support::SeededIds,
+    fake_claude: &Path,
+) -> DaemonSession {
+    let home_str = home.display().to_string();
+    let claude = fake_claude.display().to_string();
+    DaemonSession::spawn(
+        &daemon_bin(),
+        home,
+        &[
+            ("AINB_HANGAR_HOME", &home_str),
+            // The `[acp.adapters]` table is read from $HOME, not the hangar home.
+            ("HOME", &home_str),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_TASK_EXECUTOR", "acp"),
+            ("HANGAR_CLAUDE_PATH", &claude),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+            // The fixture adapter writes its rpc log under the test's tempdir,
+            // which is outside the task tree the policy confines to. The
+            // confinement itself is unit-tested (`acp_task::tests`).
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+        ],
+    )
+}
+
+/// The negative half, asserted on every case: `executor=acp` spawns no provider
+/// process, writes no jsonl transcript and opens no tmux pane.
+fn assert_no_process_executor_trace(row: &sqlx::sqlite::SqliteRow, marker: &Path, task_id: &str) {
+    assert!(
+        !marker.exists(),
+        "executor=acp must spawn NO provider process; the fake claude left {}",
+        marker.display()
+    );
+    if let Some(work_dir) = row.get::<Option<String>, _>("work_dir") {
+        let logs = Path::new(&work_dir).parent().expect("shortID root").join("logs");
+        let jsonl: Vec<_> = std::fs::read_dir(&logs)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "jsonl"))
+            .collect();
+        assert!(
+            jsonl.is_empty(),
+            "executor=acp must write no jsonl, found {jsonl:?}"
+        );
+    }
+    let pane = format!("tmux_hangar-{task_id}");
+    assert!(
+        !tripwire_support::tmux_session_live(&pane),
+        "executor=acp must open no tmux pane, found {pane}"
+    );
+}
+
+/// Write an executable that records having run and exits 0.
+fn write_marker_binary(dir: &Path, marker: &Path) -> std::path::PathBuf {
+    let path = dir.join("fake-claude-marker.sh");
+    std::fs::write(&path, format!("#!/bin/sh\ntouch '{}'\n", marker.display()))
+        .expect("write marker binary");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod marker binary");
+    }
+    path
+}
+
+/// Poll until the task reaches ANY terminal state, so a wrong outcome is
+/// reported with its reason and the leg that produced it rather than as a bare
+/// "did not reach done".
+async fn wait_for_terminal(
+    pool: &SqlitePool,
+    task_id: &str,
+    budget: Duration,
+) -> sqlx::sqlite::SqliteRow {
+    tripwire_support::wait_until(pool, task_id, budget, |row| {
+        matches!(
+            row.get::<String, _>("status").as_str(),
+            "done" | "failed" | "cancelled"
+        )
+    })
+    .await
+}
+
+/// Every delivery leg in the store, for a failure message: the leg's `state`
+/// and `detail` are exactly what the outcome mapping read.
+async fn dump_legs(pool: &SqlitePool) -> String {
+    let rows = sqlx::query(
+        "SELECT d.session_key, d.state, d.detail FROM fleet_message_delivery d \
+         JOIN fleet_message m ON m.id = d.message_id",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("read delivery legs");
+    if rows.is_empty() {
+        return "no delivery legs at all".to_string();
+    }
+    rows.iter()
+        .map(|row| {
+            format!(
+                "leg session={} state={} detail={:?}",
+                row.get::<String, _>("session_key"),
+                row.get::<String, _>("state"),
+                row.get::<Option<String>, _>("detail")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Poll for the one approval attention row this run raises.
+async fn wait_for_attention(pool: &SqlitePool, budget: Duration) -> sqlx::sqlite::SqliteRow {
+    let deadline = Instant::now() + budget;
+    loop {
+        let row = sqlx::query("SELECT * FROM attention WHERE kind = 'approval' LIMIT 1")
+            .fetch_optional(pool)
+            .await
+            .expect("query attention");
+        if let Some(row) = row {
+            return row;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no approval row within {budget:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn open_pool(db_path: &Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}
+
+/// A minimal framed JSON-RPC client over the daemon's `hangar.sock`.
+struct Client {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Client {
+    async fn connect(socket_path: &Path) -> Self {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let stream = loop {
+            match UnixStream::connect(socket_path).await {
+                Ok(c) => break c,
+                Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Err(e) => panic!("never connected to {}: {e}", socket_path.display()),
+            }
+        };
+        let (read_half, writer) = stream.into_split();
+        Self {
+            reader: BufReader::new(read_half),
+            writer,
+        }
+    }
+
+    async fn call(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let req = RpcRequest {
+            jsonrpc: ainb_hangar_proto::jsonrpc_version(),
+            id: RpcId::Number(7),
+            method: method.into(),
+            params,
+        };
+        let body = serde_json::to_vec(&req).expect("encode request");
+        let mut out = format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes();
+        out.extend_from_slice(&body);
+        self.writer.write_all(&out).await.expect("write frame");
+        self.writer.flush().await.expect("flush");
+        loop {
+            let frame = tokio::time::timeout(Duration::from_secs(10), self.read_frame())
+                .await
+                .unwrap_or_else(|_| panic!("no response to {method} within 10s"));
+            if frame.get("id").is_some() {
+                return frame;
+            }
+        }
+    }
+
+    async fn read_frame(&mut self) -> serde_json::Value {
+        use tokio::io::AsyncBufReadExt as _;
+        let mut len: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).await.expect("read header");
+            assert!(n > 0, "connection closed while awaiting a frame");
+            let trimmed = line.trim_end_matches("\r\n");
+            if trimmed.is_empty() {
+                let mut body = vec![0u8; len.expect("Content-Length header")];
+                self.reader.read_exact(&mut body).await.expect("read body");
+                return serde_json::from_slice(&body).expect("decode frame");
+            }
+            if let Some((name, value)) = trimmed.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("Content-Length") {
+                    len = value.trim().parse().ok();
+                }
+            }
+        }
+    }
+
+    async fn auth_from_file(&mut self, dir: &Path) {
+        let token_path = ainb_hangar_proto::auth::token_file_in(dir);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let token = loop {
+            if let Ok(token) = std::fs::read_to_string(&token_path) {
+                break token;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "no daemon token at {}",
+                token_path.display()
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+        let resp = self
+            .call(
+                methods::AUTH_HELLO,
+                serde_json::json!({ "token": token.trim() }),
+            )
+            .await;
+        assert!(resp["error"].is_null(), "auth/hello must ack: {resp}");
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
@@ -17,7 +17,7 @@
 //! `[acp.adapters.claude-agent-acp]` entry is repointed at
 //! `ainb-acp`'s `fake_acp_adapter` fixture through the same config.toml an
 //! operator edits, and the fixture is SCRIPTED through the agent's own
-//! `agent_env` — which is also the proof that the per-agent environment reaches
+//! `agent_env`, which is also the proof that the per-agent environment reaches
 //! a per-task adapter process at all.
 //!
 //! The negative assertions are the ones that stop a silent fallback: a flag
@@ -150,8 +150,8 @@ async fn an_acp_task_runs_to_done_with_no_process_and_no_tmux() {
 /// WORKSPACE, and answering it through `attention/answer` completes the turn.
 ///
 /// The workspace id is the half that used to be missing: `raise_permission`
-/// hardcoded `None`, so the row existed but no workspace-filtered surface — and
-/// every operator surface is one — could show it.
+/// hardcoded `None`, so the row existed but no workspace-filtered surface (and
+/// every operator surface is one) could show it.
 #[tokio::test]
 async fn a_task_raised_approval_is_workspace_scoped_and_answerable() {
     if !tripwire_support::tmux_available() {
@@ -192,7 +192,7 @@ async fn a_task_raised_approval_is_workspace_scoped_and_answerable() {
         "a task-raised approval must carry the task's workspace, or no filtered inbox shows it"
     );
     // Rooted in THIS run's directory, not the daemon's cwd. The task row's own
-    // `work_dir` is still NULL here — it is written at finalize — which is
+    // `work_dir` is still NULL here (it is written at finalize), which is
     // exactly why the approval has to carry the session's cwd itself.
     let cwd: String = attention.get::<Option<String>, _>("cwd").unwrap_or_default();
     assert!(
@@ -200,8 +200,8 @@ async fn a_task_raised_approval_is_workspace_scoped_and_answerable() {
         "the approval must be rooted in the run's own worktree, got {cwd:?}"
     );
 
-    // Answer it the way Control Center does — `attention/answer`, not
-    // `fleet/action` — and the turn completes.
+    // Answer it the way Control Center does (`attention/answer`, not
+    // `fleet/action`) and the turn completes.
     let attention_id: String = attention.get("id");
     let payload: String = attention.get("payload");
     let payload: serde_json::Value = serde_json::from_str(&payload).expect("payload json");
@@ -333,6 +333,78 @@ async fn cancelling_an_acp_task_cancels_the_adapter_turn() {
     assert!(
         log.contains("cancel"),
         "the adapter must be told session/cancel, not merely abandoned: {log}"
+    );
+    assert_no_process_executor_trace(&row, &marker, task_id);
+}
+
+/// A turn that outlives `HANGAR_PROVIDER_MAX_RUNTIME_MS` is cancelled by the
+/// EXECUTOR's own deadline and finalized `timeout`, and the adapter is told.
+///
+/// The task budget is the one the flag does not mention: the pool applies its
+/// own turn deadline to every scope, so without the boot-time reconciliation an
+/// ACP task would instead die on the pool's 30-minute default while the same
+/// task on the process executor ran for 2.5 h. This pins the executor end of
+/// that contract: its poll bound is `max_runtime`, not the pool's.
+#[tokio::test]
+async fn an_acp_turn_past_the_task_budget_times_out_and_tells_the_adapter() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp deadline e2e");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    let rpc_log = home.path().join("rpc.log");
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-deadline",
+        &serde_json::json!({
+            "FAKE_ACP_HANG_SESSIONS": "*",
+            "FAKE_ACP_RPC_LOG": rpc_log.display().to_string(),
+        }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+    let marker = home.path().join("process-executor-ran");
+    let fake_claude = write_marker_binary(home.path(), &marker);
+
+    let home_str = home.path().display().to_string();
+    let claude = fake_claude.display().to_string();
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", &home_str),
+            ("HOME", &home_str),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_TASK_EXECUTOR", "acp"),
+            ("HANGAR_CLAUDE_PATH", &claude),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+            // Far below the pool's 30-minute deadline, so the executor's own
+            // bound is unambiguously the one that fired.
+            ("HANGAR_PROVIDER_MAX_RUNTIME_MS", "4000"),
+        ],
+    );
+    let task_id = "task-acp-deadline";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_mins(1)).await;
+    drop(session);
+
+    assert_eq!(
+        row.get::<Option<String>, _>("failure_reason").as_deref(),
+        Some("timeout"),
+        "a turn past the task budget is a timeout, not drift: {}",
+        dump_legs(&pool).await
+    );
+    let log = std::fs::read_to_string(&rpc_log).expect("rpc log");
+    assert!(
+        log.contains("cancel"),
+        "the deadline path must tell the adapter too, not just stop polling: {log}"
     );
     assert_no_process_executor_trace(&row, &marker, task_id);
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
@@ -409,6 +409,96 @@ async fn an_acp_turn_past_the_task_budget_times_out_and_tells_the_adapter() {
     assert_no_process_executor_trace(&row, &marker, task_id);
 }
 
+/// The pool's own turn deadline does NOT cap a task, because boot raises it to
+/// the task budget.
+///
+/// The 4-second case above proves the executor's poll bound, but the raise is a
+/// no-op there (30 min vs 4 s), so it exercises no reconciliation wiring at all;
+/// the unit test pins the `max()` while touching neither `boot` nor
+/// `sweep_once`. This is the case that fails on the unfixed code: the pool
+/// deadline is 2 s and its sweep runs every 1 s, the task budget is 30 s, and
+/// the turn is paced to about 4 s. Without the raise the sweep cancels the turn
+/// at 2 s and the task finalizes `failed`/`timeout`; with it the turn finishes.
+#[tokio::test]
+async fn the_pool_deadline_does_not_cap_a_task_that_outlives_it() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp deadline reconciliation e2e");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-slow",
+        &serde_json::json!({
+            // About 4 seconds of turn: twice the pool's deadline below, so an
+            // unreconciled sweep has two clean chances to kill it.
+            "FAKE_ACP_CHUNKS": "8",
+            "FAKE_ACP_CHUNK_DELAY_MS": "500",
+        }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+    let marker = home.path().join("process-executor-ran");
+    let fake_claude = write_marker_binary(home.path(), &marker);
+
+    let home_str = home.path().display().to_string();
+    let claude = fake_claude.display().to_string();
+    let session = DaemonSession::spawn(
+        &daemon_bin(),
+        home.path(),
+        &[
+            ("AINB_HANGAR_HOME", &home_str),
+            ("HOME", &home_str),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_TASK_EXECUTOR", "acp"),
+            ("HANGAR_CLAUDE_PATH", &claude),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+            // The pool would cancel this turn at 2 s. Its sweep follows the
+            // deadline down to a 1 s cadence, so it gets two passes inside the
+            // turn: nothing here is a timing near-miss.
+            ("AINB_ACP_TURN_DEADLINE_MS", "2000"),
+            // The task budget the raise must lift the pool deadline to.
+            ("HANGAR_PROVIDER_MAX_RUNTIME_MS", "30000"),
+        ],
+    );
+    let task_id = "task-acp-outlives-pool";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    let row = wait_for_terminal(&pool, task_id, Duration::from_mins(1)).await;
+    // History, not the visible pane: the boot warn asserted below has scrolled
+    // off by the time the run finishes.
+    let pane = session.capture_pane_history();
+    drop(session);
+
+    assert_eq!(
+        row.get::<String, _>("status"),
+        "done",
+        "a turn outliving the POOL deadline but inside the TASK budget must finish; \
+         reason={:?}\n{}\ndaemon:\n{pane}",
+        row.get::<Option<String>, _>("failure_reason"),
+        dump_legs(&pool).await,
+    );
+    assert!(
+        row.get::<Option<String>, _>("failure_reason").is_none(),
+        "and record no failure reason"
+    );
+    // The raise is not silent. This daemon's chat sessions now share the longer
+    // deadline, so boot says so where whoever flipped the flag will read it.
+    // Newlines stripped first: tmux hard-wraps the pane at its width, which
+    // splits the message mid-word.
+    assert!(
+        pane.replace('\n', "").contains("raised the acp turn deadline"),
+        "boot must warn that it raised the deadline:\n{pane}"
+    );
+    assert_no_process_executor_trace(&row, &marker, task_id);
+}
+
 // ------------------------------------------------------------------ helpers
 
 /// Spawn the real daemon under `HANGAR_TASK_EXECUTOR=acp`, with the fixture

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
@@ -732,3 +732,135 @@ async fn fetch_row(pool: &SqlitePool, task_id: &str) -> Option<SqliteRow> {
         .await
         .expect("query task row")
 }
+
+// ----------------------------------------------------------------- ACP (A5)
+
+/// The fixture ACP adapter binary, rebuilt on demand.
+///
+/// `CARGO_BIN_EXE_*` only exists inside the crate that DECLARES the binary, so
+/// this crate resolves it by target-directory convention and builds it. The
+/// build runs UNCONDITIONALLY (a no-op when the fixture is fresh): `cargo test
+/// -p ainb-hangar-daemon` never rebuilds another crate's binary, so building
+/// only when ABSENT leaves a stale executable on disk and every new scripting
+/// knob reads as "the pool ignored it". Same shape as `tests/acp_pool.rs`.
+pub fn fake_acp_adapter() -> PathBuf {
+    static BUILT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    BUILT
+        .get_or_init(|| {
+            let mut dir = std::env::current_exe().expect("test binary path");
+            dir.pop();
+            if dir.ends_with("deps") {
+                dir.pop();
+            }
+            let status = Command::new(env!("CARGO"))
+                .args(["build", "-p", "ainb-acp", "--bin", "fake_acp_adapter"])
+                .status()
+                .expect("build the fixture adapter");
+            assert!(status.success(), "fixture adapter build failed");
+            let binary = dir.join("fake_acp_adapter");
+            assert!(
+                binary.exists(),
+                "fixture adapter missing at {}",
+                binary.display()
+            );
+            binary
+        })
+        .clone()
+}
+
+/// Point the daemon's `claude-agent-acp` adapter at `command`, through the same
+/// `[acp.adapters]` table an operator edits.
+///
+/// Read from `$HOME`, so the caller must export `HOME` into the daemon's
+/// environment alongside `AINB_HANGAR_HOME`.
+pub fn write_acp_adapter_config(home: &Path, command: &Path, permission_mode: &str) {
+    let dir = home.join(".agents-in-a-box").join("config");
+    std::fs::create_dir_all(&dir).expect("create config dir");
+    std::fs::write(
+        dir.join("config.toml"),
+        format!(
+            "[acp.adapters.claude-agent-acp]\ncommand = \"{}\"\npermission_mode = \"{permission_mode}\"\n",
+            command.display()
+        ),
+    )
+    .expect("write config.toml");
+}
+
+/// Seed one more `claude` agent on the ALREADY-SEEDED runtime, carrying
+/// `agent_env` as its per-agent environment.
+///
+/// `agent_env` is the one permitted plaintext escape into the child, so it is
+/// also how a tripwire scripts a per-task ACP adapter: the fake adapter's
+/// `FAKE_ACP_*` knobs ride it, which proves the escape works and configures the
+/// fixture in one move.
+pub async fn seed_agent_with_env(
+    pool: &SqlitePool,
+    ids: &SeededIds,
+    agent_id: &str,
+    agent_env: &serde_json::Value,
+) -> String {
+    sqlx::query(
+        "INSERT INTO agent \
+         (id, workspace_id, name, runtime_id, visibility, owner_id, max_concurrent_tasks, \
+          agent_env, instructions) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(agent_id)
+    .bind(&ids.workspace_id)
+    .bind(agent_id)
+    .bind(&ids.runtime_id)
+    .bind("workspace")
+    .bind("user-trip")
+    .bind(5_i64)
+    .bind(agent_env.to_string())
+    .bind(format!("do the {agent_id} work"))
+    .execute(pool)
+    .await
+    .expect("insert acp agent");
+    agent_id.to_string()
+}
+
+/// Enqueue one task row for `agent_id` on the seeded runtime.
+///
+/// `mode` is the column's own vocabulary (`headless` / `interactive`); the
+/// CHECK constraint rejects anything else, so there is no "unset" spelling to
+/// pass through.
+pub async fn enqueue_task(
+    pool: &SqlitePool,
+    ids: &SeededIds,
+    task_id: &str,
+    agent_id: &str,
+    mode: &str,
+) {
+    sqlx::query(
+        "INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, mode, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(task_id)
+    .bind(&ids.workspace_id)
+    .bind(&ids.runtime_id)
+    .bind(agent_id)
+    .bind(mode)
+    .bind(now_ms())
+    .execute(pool)
+    .await
+    .expect("enqueue task");
+}
+
+/// Poll `path` until it exists and its contents satisfy `pred`, or fail.
+pub fn wait_for_file(path: &Path, budget: Duration, pred: impl Fn(&str) -> bool) -> String {
+    let deadline = Instant::now() + budget;
+    let mut last = String::new();
+    loop {
+        last = std::fs::read_to_string(path).unwrap_or(last);
+        if pred(&last) {
+            return last;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{} did not satisfy the predicate within {budget:?}; contents={last:?}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_support/mod.rs
@@ -573,6 +573,22 @@ impl DaemonSession {
                 |o| String::from_utf8_lossy(&o.stdout).into_owned(),
             )
     }
+
+    /// The pane INCLUDING scrollback (`-S -`).
+    ///
+    /// [`Self::capture_pane`] returns only what is currently visible, so a line
+    /// the daemon logged at BOOT has scrolled off by the time a run finishes.
+    /// Separate rather than a wider default: the existing callers assert on the
+    /// visible pane, and history would let a stale line satisfy them.
+    pub fn capture_pane_history(&self) -> String {
+        Command::new("tmux")
+            .args(["capture-pane", "-p", "-S", "-", "-t", &self.name])
+            .output()
+            .map_or_else(
+                |_| String::new(),
+                |o| String::from_utf8_lossy(&o.stdout).into_owned(),
+            )
+    }
 }
 
 impl Drop for DaemonSession {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
@@ -1,0 +1,344 @@
+//! Spine A5 tripwire: `HANGAR_TASK_EXECUTOR` selects the executor, in BOTH
+//! directions, and the ACP path's per-task isolation actually holds.
+//!
+//! ```text
+//!   =process ─▶ spawns the provider CLI   ─▶ marker + logs/claude.jsonl
+//!               and NO acp session
+//!   =acp     ─▶ spawns an ACP adapter     ─▶ fleet_acp_session + provider events
+//!               and NO process, no jsonl
+//! ```
+//!
+//! Both directions are asserted because a flag that silently fell back to the
+//! process executor would keep every other test in the suite green: the task
+//! still reaches `done`, the card still advances, and only the absence of a
+//! thing nobody looks for gives it away.
+//!
+//! The other two cases are the ones the ACP path can get quietly wrong:
+//! `mode=interactive` under `=acp` must be REFUSED rather than downgraded to a
+//! headless run in a pane nobody can attach to, and each task's adapter is its
+//! OWN process, so one task's `agent_env` must never reach another's — nor the
+//! daemon's ambient environment reach either.
+//!
+//! Skips cleanly (never fails) when tmux is unavailable.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+
+mod tripwire_support;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::{Row, SqlitePool};
+use tripwire_support::{
+    DaemonSession, daemon_bin, enqueue_task, fake_acp_adapter, fake_claude_happy,
+    seed_agent_with_env, seed_world, wait_for_db, wait_for_file, write_acp_adapter_config,
+};
+
+/// A secret only the DAEMON's environment carries. No child of either executor
+/// may see it: it stands in for every ambient credential the daemon holds.
+const AMBIENT_SECRET: &str = "AINB_PLANTED_SECRET";
+
+/// `=process` takes the provider CLI and creates no ACP session.
+#[tokio::test]
+async fn the_process_executor_spawns_a_provider_and_no_acp_session() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping executor-flag tripwire");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let agent = seed_agent_with_env(&pool, &ids, "agent-process", &serde_json::json!({})).await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "process");
+    let task_id = "task-flag-process";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    let row = wait_for_db(&pool, task_id, "done", Duration::from_mins(1)).await;
+    drop(session);
+
+    // POSITIVE: a real provider process ran and left its jsonl transcript.
+    assert_eq!(
+        row.get::<Option<String>, _>("session_id").as_deref(),
+        Some("claude-sid"),
+        "the process executor pins the provider's own session id"
+    );
+    let logs = logs_dir(&row);
+    assert!(
+        logs.join("claude.jsonl").exists(),
+        "the process executor must write logs/claude.jsonl into {}",
+        logs.display()
+    );
+
+    // NEGATIVE: nothing touched the ACP path.
+    assert_eq!(
+        acp_sessions_for(&pool, task_id).await,
+        0,
+        "no acp session under =process"
+    );
+}
+
+/// `=acp` takes the adapter and spawns no provider process.
+#[tokio::test]
+async fn the_acp_executor_spawns_an_adapter_and_no_provider_process() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping executor-flag tripwire");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let rpc_log = home.path().join("rpc.log");
+    let agent = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-acp-flag",
+        &serde_json::json!({ "FAKE_ACP_RPC_LOG": rpc_log.display().to_string() }),
+    )
+    .await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    // The SAME fake claude the process case proves works, so "no jsonl" here is
+    // the flag's doing rather than a provider that could not run anyway.
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "acp");
+    let task_id = "task-flag-acp";
+    enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
+
+    let row = wait_for_db(&pool, task_id, "done", Duration::from_mins(1)).await;
+    drop(session);
+
+    // POSITIVE: an adapter ran and the transcript went to the store.
+    assert_eq!(
+        acp_sessions_for(&pool, task_id).await,
+        1,
+        "one acp session under =acp"
+    );
+    let events: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM fleet_provider_event e \
+         JOIN fleet_acp_session s ON s.session_key = e.session_key WHERE s.scope_key = ?",
+    )
+    .bind(format!("task:{task_id}"))
+    .fetch_one(&pool)
+    .await
+    .expect("count provider events");
+    assert!(events > 0, "the acp run must write provider events");
+    assert!(
+        rpc_log.exists(),
+        "the fixture adapter must have been spawned"
+    );
+
+    // NEGATIVE: the provider CLI never ran, so its transcript is absent and its
+    // session id never reached the row.
+    let logs = logs_dir(&row);
+    assert!(
+        !logs.join("claude.jsonl").exists(),
+        "the acp executor must write NO provider jsonl into {}",
+        logs.display()
+    );
+    assert_ne!(
+        row.get::<Option<String>, _>("session_id").as_deref(),
+        Some("claude-sid"),
+        "the acp run must not be attributed to a provider session it never opened"
+    );
+}
+
+/// `mode=interactive` under `=acp` is refused at dispatch, naming the flag, and
+/// opens no pane.
+///
+/// There is no attachable session on the ACP path, so a silent downgrade would
+/// hand an operator a headless run they asked to drive. Refusing BEFORE the
+/// worktree is provisioned is what makes "no pane" and "no checkout" both true.
+#[tokio::test]
+async fn interactive_under_acp_is_refused_and_opens_no_pane() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping interactive-under-acp refusal");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let agent = seed_agent_with_env(&pool, &ids, "agent-interactive", &serde_json::json!({})).await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "acp");
+    let task_id = "task-flag-interactive";
+    enqueue_task(&pool, &ids, task_id, &agent, "interactive").await;
+
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_mins(1)).await;
+    drop(session);
+
+    assert_eq!(
+        row.get::<Option<String>, _>("failure_reason").as_deref(),
+        Some("provision_error"),
+        "an unsupported mode is a provisioning refusal, not an agent error"
+    );
+    let result: String = row.get::<Option<String>, _>("result").unwrap_or_default();
+    assert!(
+        result.contains("HANGAR_TASK_EXECUTOR"),
+        "the refusal must name the flag that caused it, got: {result}"
+    );
+    let pane = format!("tmux_hangar-{task_id}");
+    assert!(
+        !tripwire_support::tmux_session_live(&pane),
+        "a refused interactive task must open no pane, found {pane}"
+    );
+    assert!(
+        row.get::<Option<String>, _>("work_dir").is_none(),
+        "the refusal must land before the worktree is provisioned"
+    );
+    assert_eq!(
+        acp_sessions_for(&pool, task_id).await,
+        0,
+        "and before any acp session"
+    );
+}
+
+/// Each task's adapter is its own PROCESS, so each sees only its own
+/// `agent_env` and neither sees the daemon's ambient secrets.
+#[tokio::test]
+async fn each_tasks_adapter_sees_only_its_own_environment() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping acp env isolation");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let dump_a = home.path().join("env-a.json");
+    let dump_b = home.path().join("env-b.json");
+    let agent_a = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-tenant-a",
+        &serde_json::json!({
+            "FAKE_ACP_ENV_DUMP": dump_a.display().to_string(),
+            "TENANT_TOKEN": "tenant-a-secret",
+        }),
+    )
+    .await;
+    let agent_b = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-tenant-b",
+        &serde_json::json!({
+            "FAKE_ACP_ENV_DUMP": dump_b.display().to_string(),
+            "TENANT_TOKEN": "tenant-b-secret",
+        }),
+    )
+    .await;
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "acp");
+    enqueue_task(&pool, &ids, "task-tenant-a", &agent_a, "headless").await;
+    enqueue_task(&pool, &ids, "task-tenant-b", &agent_b, "headless").await;
+
+    wait_for_db(&pool, "task-tenant-a", "done", Duration::from_secs(90)).await;
+    wait_for_db(&pool, "task-tenant-b", "done", Duration::from_secs(90)).await;
+    // Written by the adapter's first line of `main`, so it exists by the time
+    // its task is done; polled anyway rather than assumed.
+    let a = wait_for_file(&dump_a, Duration::from_secs(10), |raw| !raw.is_empty());
+    let b = wait_for_file(&dump_b, Duration::from_secs(10), |raw| !raw.is_empty());
+    drop(session);
+
+    let a: serde_json::Value = serde_json::from_str(&a).expect("env dump a");
+    let b: serde_json::Value = serde_json::from_str(&b).expect("env dump b");
+
+    // Each adapter GOT its own agent's value: the per-agent escape reaches a
+    // per-task adapter process at all.
+    assert_eq!(a["TENANT_TOKEN"], "tenant-a-secret");
+    assert_eq!(b["TENANT_TOKEN"], "tenant-b-secret");
+    // And NOT the other tenant's, which a shared pool process would have leaked.
+    let a_raw = a.to_string();
+    let b_raw = b.to_string();
+    assert!(
+        !a_raw.contains("tenant-b-secret"),
+        "task A saw task B's env: {a_raw}"
+    );
+    assert!(
+        !b_raw.contains("tenant-a-secret"),
+        "task B saw task A's env: {b_raw}"
+    );
+    // Nor the daemon's own ambient environment.
+    for (name, raw) in [("a", &a_raw), ("b", &b_raw)] {
+        assert!(
+            !raw.contains("planted-daemon-secret"),
+            "adapter {name} saw the daemon's ambient secret: {raw}"
+        );
+        assert!(
+            a[AMBIENT_SECRET].is_null(),
+            "adapter {name} must not carry {AMBIENT_SECRET}"
+        );
+    }
+    // Pointed at the task's own config tree, so it never merges the operator's
+    // `~/.claude` (whose `settings.json` can refuse `session/new` outright).
+    let config_dir = a["CLAUDE_CONFIG_DIR"].as_str().expect("CLAUDE_CONFIG_DIR is set");
+    assert!(
+        config_dir.contains("task-tenant-a"),
+        "the config dir must be the task's own, got {config_dir}"
+    );
+    assert_ne!(
+        a["CLAUDE_CONFIG_DIR"], b["CLAUDE_CONFIG_DIR"],
+        "two tasks must not share one adapter config tree"
+    );
+}
+
+// ------------------------------------------------------------------ helpers
+
+fn spawn_daemon(
+    home: &Path,
+    ids: &tripwire_support::SeededIds,
+    fake_claude: &Path,
+    executor: &str,
+) -> DaemonSession {
+    let home_str = home.display().to_string();
+    let claude = fake_claude.display().to_string();
+    DaemonSession::spawn(
+        &daemon_bin(),
+        home,
+        &[
+            ("AINB_HANGAR_HOME", &home_str),
+            ("HOME", &home_str),
+            ("HANGAR_DAEMON_RUNTIME_ID", &ids.runtime_id),
+            ("HANGAR_TASK_EXECUTOR", executor),
+            ("HANGAR_CLAUDE_PATH", &claude),
+            ("HANGAR_DAEMON_POLL_MS", "200"),
+            ("HANGAR_DAEMON_DISABLE_SANDBOX", "1"),
+            // The canary the child env must not carry.
+            (AMBIENT_SECRET, "planted-daemon-secret"),
+        ],
+    )
+}
+
+/// How many ACP sessions exist under `task_id`'s scope.
+async fn acp_sessions_for(pool: &SqlitePool, task_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM fleet_acp_session WHERE scope_key = ?")
+        .bind(format!("task:{task_id}"))
+        .fetch_one(pool)
+        .await
+        .expect("count acp sessions")
+}
+
+/// The run's `logs/` dir, beside the work dir the finalize recorded.
+fn logs_dir(row: &sqlx::sqlite::SqliteRow) -> PathBuf {
+    let work_dir: String = row.get::<Option<String>, _>("work_dir").expect("work_dir populated");
+    Path::new(&work_dir).parent().expect("shortID root").join("logs")
+}
+
+async fn open_pool(db_path: &Path) -> SqlitePool {
+    let opts = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+    SqlitePoolOptions::new().connect_with(opts).await.expect("open pool")
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
@@ -16,7 +16,7 @@
 //! The other two cases are the ones the ACP path can get quietly wrong:
 //! `mode=interactive` under `=acp` must be REFUSED rather than downgraded to a
 //! headless run in a pane nobody can attach to, and each task's adapter is its
-//! OWN process, so one task's `agent_env` must never reach another's — nor the
+//! OWN process, so one task's `agent_env` must never reach another's, nor the
 //! daemon's ambient environment reach either.
 //!
 //! Skips cleanly (never fails) when tmux is unavailable.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -297,6 +297,30 @@ impl TaskRepo {
         Ok(res.rows_affected() == 1)
     }
 
+    /// Record the provider `session_id` a run is executing under, mid-run.
+    ///
+    /// The terminal finalize writes it too ([`crate::service::CompleteTaskService`]),
+    /// but only on SUCCESS — so a run that failed or was cancelled kept no
+    /// pointer to the transcript it produced. An ACP run writes it the moment
+    /// its session exists, which is also what makes the session reachable while
+    /// the run is still live. Returns `true` iff exactly one row was updated.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] on a store fault.
+    pub async fn set_session_id(
+        pool: &SqlitePool,
+        id: &str,
+        session_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query("UPDATE agent_task_queue SET session_id = ? WHERE id = ?")
+            .bind(session_id)
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
     /// Record the worktree `branch` (`ainb/<slug>`) a run produced commits on
     /// (tcp T2), written at finalize only when the run left commits ahead of its
     /// base. Returns `true` iff exactly one row was updated.

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -300,7 +300,7 @@ impl TaskRepo {
     /// Record the provider `session_id` a run is executing under, mid-run.
     ///
     /// The terminal finalize writes it too ([`crate::service::CompleteTaskService`]),
-    /// but only on SUCCESS — so a run that failed or was cancelled kept no
+    /// but only on SUCCESS, so a run that failed or was cancelled kept no
     /// pointer to the transcript it produced. An ACP run writes it the moment
     /// its session exists, which is also what makes the session reachable while
     /// the run is still live. Returns `true` iff exactly one row was updated.


### PR DESCRIPTION
Spine A5 (`docs/hangar/renovation/PLAN.md` track A, `move1-acp-tasks.md` step 5). An issue task can now run through the ACP pool instead of spawning a provider CLI, selected by a flag, with the finalize path untouched.

```
  HANGAR_TASK_EXECUTOR=acp
        │
  queued ─▶ dispatched ─▶ running ──▶ acp_task::run_acp
                                         │  register claude-agent-acp#task:<id>   (per-task PROCESS)
                                         │  acp_session::ensure(scope "task:<id>")
                                         │  acp_session::enqueue ─▶ submit_prompt
                                         ▼
                                  poll the delivery leg
                                         ▼
                          leg state + detail TOKEN SET ──▶ RunOutcome
                                         ▼
  finalize_success / finalize_failure / finalize_cancelled   ← UNTOUCHED
```

## What landed

- **Selection.** `DaemonConfig.task_executor` from `HANGAR_TASK_EXECUTOR=acp|process`, default `process`, parsed by `DaemonConfig::resolve_task_executor` — a pure function shaped like `resolve_sandbox`, so precedence is testable without mutating process env. Carried on `ResolvedDispatch` beside `mode`, for the reason that doc comment already gives.
- **The branch.** One new arm at the top of the `provider_run` async block in `execute_claimed`. No `TaskExecutor` trait: a third `if`, as the plan and the reviewer settled. Nothing below `let outcome =` changed.
- **`acp_task::run_acp`** (new `crates/ainb-hangar-daemon/src/acp_task.rs`): resolves the INSTALLED pool via `acp_pool::active_handle` (never a private `AcpPool` — that makes every permission row unanswerable), finds-or-creates the session with `acp_session::ensure` under `scope_key = task:<id>`, writes the session key onto the task row, enqueues with `acp_session::enqueue`, then POLLS the delivery leg bounded by `HANGAR_PROVIDER_MAX_RUNTIME_MS`. No turn-complete future: the pool resolves that leg on every path, and a dropped oneshot is the forever-`running` failure this codebase has the most scar tissue about.
- **Outcome mapping** per 2f, matching on the `; `-joined TOKEN SET rather than string equality. An unmapped detail is `ProviderContractDrift` — fail closed.
- **Per-task adapter process** (plan 5b): registered under `claude-agent-acp#task:<id>` via `AcpPool::register_adapter`, carrying `extra_env` from the same `prepare_spawn_inputs` the process path uses plus the agent's `agent_env`, the base adapter's pinned `permission_mode`, and OS confinement. Released on every exit path, including the cancel that drops the future.
- **Adapter traps, both handled.** `CLAUDE_CONFIG_DIR` points at a task-scoped dir inside the execenv root, so the adapter neither merges the operator's `~/.claude/settings.json` (which refuses `session/new` with `-32603 Invalid permissions.defaultMode` on this box) nor inherits their skills and global `CLAUDE.md`. The operator's own directory is never touched.
- **HITL.** `raise_permission` no longer hardcodes `workspace_id: None`; a task-raised approval carries the raising task's workspace, so a workspace-filtered inbox can see it. This also fixes it for anything else that adopts the `task:` scope.
- **Cancel.** The cancel arm calls `acp_task::cancel_run`, the analogue of the interactive arm's `kill_session`: dropping the future stops polling, not the agent. It waits (bounded 2s) for the actor to have HANDLED the cancel before the lease teardown kills the adapter process, so the adapter always sees the `session/cancel` it is being stopped by.
- **`Mode::Interactive` + `executor=acp` is REFUSED** at dispatch, naming the flag, before the worktree is provisioned and before any pane exists. Never silently downgraded.

`argv_golden_matrix.rs` is untouched and green — A5 adds no argv.

## Verification

Everything below ran on this box with no adapter and no credentials, against the real `ainb-hangar-daemon` binary and `ainb-acp`'s `fake_acp_adapter` fixture.

| | result |
|---|---|
| `acp_task_outcome` (T4, pure table + retry dispositions) | 3 passed |
| `tripwire_acp_task_end_to_end` (T2, the approval variant, T6 cancel) | 3 passed |
| `tripwire_task_executor_flag` (T10 both directions, T5, T9) | 4 passed |
| `argv_golden_matrix` (T9 in the appendix numbering) | 8 passed, file unmodified |
| `acp_pool`, `rpc_acp`, `rpc_acp_no_tmux` | 45 / 12 / 1 passed |
| `ainb-hangar-daemon --lib` | 623 passed |
| `ainb-acp` (all targets) | 45 passed |
| `cargo fmt --all --check`, `cargo clippy` on the touched crates | clean |

**Build trap, worth repeating in the reviewer's own run.** The worktrees share one `CARGO_TARGET_DIR`, and `target/debug/ainb-hangar-daemon` was overwritten by another worktree's build three times during this work. A tripwire that spawns a stale daemon silently takes the PROCESS executor and every assertion reads as a real defect (it first presented as `provider_contract_drift`). Build the binary, then verify it is yours (`strings target/debug/ainb-hangar-daemon | grep -c HANGAR_TASK_EXECUTOR`) both before AND after the run. Every result above is from a run where that check passed on both sides.

## Deliberate scope calls, each smaller than the alternative

1. **No live `TaskMessage` producer for the ACP side.** A2 owns the process executor's producer on another branch and the ACP half belongs with it (the emit point is the pool actor's `ingest`, not this poll loop). A2's follow-up should cover it; T1 is not satisfiable until then.
2. **The sandbox is a POLICY on `AdapterConfig`, not a wrapped command.** The plan expected the launcher to fit `{command, args}`. It does not on Linux: `sandboxed_command` installs Landlock in a `pre_exec` closure that lives on the command object, which no `(command, args)` recipe can carry. So `ainb-acp` gained a `sandbox: Option<SandboxPolicy>` field and builds the command at spawn — ~25 lines, and it keeps `executor=acp` from being a silent confinement downgrade from the Linux-default-on process path.
3. **Usage and PR capture are deferred to A6/A7, as the plan slices them.** `RunnerResult.usage` is `None` rather than a fabricated zero; `stdout_tail` is the turn's final agent message (already persisted as a threaded `agent` reply by `finish_turn`), which is what `parse_gh_pr_create_stdout` scans.
4. **The ACP tripwires set `HANGAR_DAEMON_DISABLE_SANDBOX=1`,** because the fixture adapter writes its rpc log and env dump into the test's tempdir, outside the policy's roots. The policy construction itself is unit-tested (`acp_task::tests::the_sandbox_policy_widens_to_the_run_worktree`).
5. **A finished task's ACP session row stays live.** It costs one row and makes a future resume-across-retry possible; `fleet_retention` already owns the reclaim. Not designed around here.

### Reproducing the two tripwires here

Both new `DaemonSession` files spawn the SHARED `target/debug/ainb-hangar-daemon`, so run each in its OWN invocation and never batched behind another suite — the clobber window opens between cargo's build phase and the spawn:

```
cargo test -p ainb-hangar-daemon --test tripwire_acp_task_end_to_end
cargo test -p ainb-hangar-daemon --test tripwire_task_executor_flag
```

If either fails, hash `target/debug/ainb-hangar-daemon` before believing it: a foreign binary looks exactly like a real regression (it presents as `provider_contract_drift`). Durable fix tracked in #834 (an `AINB_TEST_DAEMON_BIN` override); this PR does not pre-empt it.

---

## Review round 1: all 14 findings closed

Rebased onto `429ca340` first, so every number below is measured against main.

**P1, outcome mapping.** Four reachable `(state, token)` pairs answered `ProviderContractDrift`/NoRetry: `FAILED`+`adapter_exit`, `FAILED`+`turn_deadline`, `FAILED`+`daemon_restart`, `UNKNOWN`+`operator_stop`. Fixed at the key rather than the four instances: the pool writes ONE vocabulary and picks the state by where the prompt was standing, which says nothing about how to retry, so the token decides. Only `DELIVERED` and `turn_failed` still read state, because there the stop reason is the discriminator. `REJECTED` joins the same table, ending the asymmetry where a `breaker_open` at the door was terminal while the identical token on a `FAILED` leg resumed (deliberate deviation from 2f's `REJECTED | any` row).

Fail-closed is preserved and relocated: an unrecognised token makes `find_map` yield nothing and the set falls to `ProviderContractDrift`, as does an unknown `stop=` on a DELIVERED leg and any unknown state.

**P1, deadline.** The pool applied its global 30-minute `turn_deadline` to every scope, so an ACP task died at half an hour while the same task on the process executor got 2.5 h. The pool's deadline is now raised to the task budget at boot, never lowered.

**P2.** The session actor is torn down after the leg resolves (every completed run leaked one actor plus a `pool.sessions` entry). `adapter_for(Backend::Codex)` returns `None` until codex's own config home is scoped and tested. `task:` is reserved at the RPC door.

**P3.** Deadline path takes the same bounded convergence wait as the operator cancel; a cancel with no live actor converges the session instead of orphaning a PENDING leg; `HANGAR_TASK_EXECUTOR` listed in the module env table; `AdapterConfig`'s `Debug` masks `extra_env` values; the sandbox policy grants read on the adapter binary's own directory.

### Verification, rebased tree, provenance-checked

| suite | result |
|---|---|
| `acp_task_outcome` | 4 passed (was 3; one new exhaustive test) |
| `tripwire_acp_task_end_to_end` | 4 passed (was 3; one new deadline case) |
| `tripwire_task_executor_flag` | 4 passed |
| `rpc_acp` / `acp_pool` / `rpc_acp_no_tmux` | 12 / 45 / 1 passed |
| `argv_golden_matrix` | 8 passed, file still unmodified vs main |
| `ainb-hangar-daemon --lib` | 624 passed |
| `ainb-acp` all targets | 46 passed |
| `cargo fmt --all --check`, clippy | clean; 0 em dashes on added lines |

Each daemon tripwire ran in its own `cargo test --test <one>` invocation with the binary-identity check on both sides (issue #834).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an ACP-based task execution option, selectable through configuration.
  - Added per-task filesystem sandboxing for adapter processes.
  - Added task-scoped ACP sessions, cancellation, timeout handling, and delivery status reporting.
  - Added workspace-aware approval requests and protection for reserved task scopes.
  - Added provider session tracking during task execution.

- **Security**
  - Redacted environment variable values from adapter configuration debug output.
  - Isolated task and agent environment variables between adapter processes.

- **Bug Fixes**
  - Corrected task runtime and ACP turn-deadline coordination.
  - Improved delivery outcome classification and retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->