### PR TITLE
fix(tui): enable Antigravity across sessions, presets, onboarding, and icons

### DIFF
--- a/ainb-tui/crates/ainb-cli/src/promote.rs
+++ b/ainb-tui/crates/ainb-cli/src/promote.rs
@@ -63,6 +63,7 @@ const KNOWN_TOOLS: &[&str] = &[
     "codex",
     "copilot",
     "gemini",
+    "antigravity",
     "cursor",
     "amazonq",
     "claude-desktop",

--- a/ainb-tui/crates/ainb-core/src/agents/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/agents/mod.rs
@@ -212,7 +212,7 @@ impl SessionAgent for AntigravityAgent {
         "antigravity"
     }
     fn icon(&self) -> &'static str {
-        "\u{f1a0}"
+        "▲"
     }
     fn name(&self) -> &'static str {
         "Google Antigravity"
@@ -312,7 +312,7 @@ mod tests {
         assert_eq!(r.get("claude").unwrap().name(), "Claude Code");
         assert_eq!(r.get("ssh").unwrap().icon(), "🔐");
         assert_eq!(r.get("ssh").unwrap().name(), "SSH");
-        assert_eq!(r.get("antigravity").unwrap().icon(), "\u{f1a0}");
+        assert_eq!(r.get("antigravity").unwrap().icon(), "▲");
         assert_eq!(r.get("antigravity").unwrap().name(), "Google Antigravity");
         assert_eq!(r.get("kiro").unwrap().icon(), "🔮");
     }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2641,9 +2641,11 @@ impl EventHandler {
                             KeyCode::Char('x') | KeyCode::Char('X') => Some(
                                 AppEvent::OnboardingGenerateScript(crate::setup::Agent::Codex),
                             ),
-                            KeyCode::Char('a') | KeyCode::Char('A') => Some(
-                                AppEvent::OnboardingGenerateScript(crate::setup::Agent::Antigravity),
-                            ),
+                            KeyCode::Char('a') | KeyCode::Char('A') => {
+                                Some(AppEvent::OnboardingGenerateScript(
+                                    crate::setup::Agent::Antigravity,
+                                ))
+                            }
                             KeyCode::Char('p') | KeyCode::Char('P') => Some(
                                 AppEvent::OnboardingGenerateScript(crate::setup::Agent::Copilot),
                             ),

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -2641,6 +2641,9 @@ impl EventHandler {
                             KeyCode::Char('x') | KeyCode::Char('X') => Some(
                                 AppEvent::OnboardingGenerateScript(crate::setup::Agent::Codex),
                             ),
+                            KeyCode::Char('a') | KeyCode::Char('A') => Some(
+                                AppEvent::OnboardingGenerateScript(crate::setup::Agent::Antigravity),
+                            ),
                             KeyCode::Char('p') | KeyCode::Char('P') => Some(
                                 AppEvent::OnboardingGenerateScript(crate::setup::Agent::Copilot),
                             ),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -10107,9 +10107,7 @@ impl AppState {
                 // all continue the most recent session in the worktree cwd.
                 (SessionAgentType::Codex, _)
                 | (SessionAgentType::Copilot, _)
-                | (SessionAgentType::Antigravity, _) => {
-                    "Resuming most recent session".to_string()
-                }
+                | (SessionAgentType::Antigravity, _) => "Resuming most recent session".to_string(),
                 (other, _) => {
                     format!("Started fresh ({} has no resume support)", other.name())
                 }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -8044,11 +8044,12 @@ impl AppState {
             "codex" => SessionAgentType::Codex,
             "gemini" => SessionAgentType::Gemini,
             "copilot" => SessionAgentType::Copilot,
+            "antigravity" => SessionAgentType::Antigravity,
             _ => SessionAgentType::Claude,
         };
         let model = if matches!(
             agent_type,
-            SessionAgentType::Claude | SessionAgentType::Codex
+            SessionAgentType::Claude | SessionAgentType::Codex | SessionAgentType::Antigravity
         ) {
             let model = preset.agent_model.trim();
             (!is_default_model(model)).then(|| model.to_string())
@@ -10102,9 +10103,11 @@ impl AppState {
                         encoded
                     )
                 }
-                // Codex resumes via `codex resume --last`, Copilot via `--continue` —
-                // both continue the most recent session in the worktree cwd.
-                (SessionAgentType::Codex, _) | (SessionAgentType::Copilot, _) => {
+                // Codex resumes via `codex resume --last`, Copilot and Antigravity via `--continue`:
+                // all continue the most recent session in the worktree cwd.
+                (SessionAgentType::Codex, _)
+                | (SessionAgentType::Copilot, _)
+                | (SessionAgentType::Antigravity, _) => {
                     "Resuming most recent session".to_string()
                 }
                 (other, _) => {
@@ -11418,6 +11421,7 @@ impl AppState {
             SessionAgentType::Claude => Some("claude"),
             SessionAgentType::Codex => Some("codex"),
             SessionAgentType::Copilot => Some("copilot"),
+            SessionAgentType::Antigravity => Some("antigravity"),
             _ => None,
         }
     }

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/component.rs
@@ -547,7 +547,7 @@ impl OnboardingComponent {
         // success) > key hints.
         let instr_span = if state.agent_pick_open {
             Span::styled(
-                "Generate installer for:   [c] Claude    [x] Codex    [p] Copilot       Esc cancel",
+                "Generate installer for:   [c] Claude    [x] Codex    [a] Antigravity    [p] Copilot       Esc cancel",
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             )
         } else if let Some(err) = &state.error_message {

--- a/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
+++ b/ainb-tui/crates/ainb-core/src/components/onboarding/state.rs
@@ -433,6 +433,7 @@ pub struct OnboardingState {
 pub enum AuthAgent {
     Claude,
     Codex,
+    Antigravity,
     Gemini,
     Copilot,
 }
@@ -440,13 +441,20 @@ pub enum AuthAgent {
 impl AuthAgent {
     /// The configurable harnesses, in row order.
     pub fn all() -> &'static [AuthAgent] {
-        &[Self::Claude, Self::Codex, Self::Gemini, Self::Copilot]
+        &[
+            Self::Claude,
+            Self::Codex,
+            Self::Antigravity,
+            Self::Gemini,
+            Self::Copilot,
+        ]
     }
 
     pub fn label(&self) -> &'static str {
         match self {
             Self::Claude => "Claude",
             Self::Codex => "Codex",
+            Self::Antigravity => "Antigravity",
             Self::Gemini => "Gemini",
             Self::Copilot => "Copilot",
         }
@@ -459,6 +467,7 @@ impl AuthAgent {
         match self {
             Self::Claude => "System-wide auth",
             Self::Codex => "Sign in with ChatGPT",
+            Self::Antigravity => "Sign in with Google",
             Self::Gemini => "Sign in with Google",
             Self::Copilot => "Sign in with GitHub",
         }
@@ -468,10 +477,13 @@ impl AuthAgent {
     pub fn login_hint(&self) -> &'static str {
         match self {
             Self::Claude => {
-                "Use whatever you set up for Claude at the system level — `claude` /login, a \
+                "Use whatever you set up for Claude at the system level: `claude` /login, a \
                  Pro/Max subscription, or a cloud provider. ainb injects no key."
             }
             Self::Codex => "Run `codex login` and sign in with your ChatGPT account (OAuth).",
+            Self::Antigravity => {
+                "Run `agy` and sign in with Google, or use application-default credentials."
+            }
             Self::Gemini => {
                 "Run `gemini` and sign in with Google, or use application-default credentials."
             }
@@ -486,6 +498,7 @@ impl AuthAgent {
         match self {
             Self::Claude => crate::docs::AUTH_CLAUDE,
             Self::Codex => crate::docs::AUTH_CODEX,
+            Self::Antigravity => crate::docs::AUTH_ANTIGRAVITY,
             Self::Gemini => crate::docs::AUTH_GEMINI,
             Self::Copilot => crate::docs::AUTH_COPILOT,
         }
@@ -497,6 +510,7 @@ impl AuthAgent {
         match self {
             Self::Claude => CredentialKey::AnthropicApiKey,
             Self::Codex => CredentialKey::OpenAiApiKey,
+            Self::Antigravity => CredentialKey::GeminiApiKey,
             Self::Gemini => CredentialKey::GeminiApiKey,
             Self::Copilot => CredentialKey::GithubPat,
         }
@@ -507,6 +521,7 @@ impl AuthAgent {
         match self {
             Self::Claude => "ANTHROPIC_API_KEY",
             Self::Codex => "OPENAI_API_KEY",
+            Self::Antigravity => "GEMINI_API_KEY",
             Self::Gemini => "GEMINI_API_KEY",
             Self::Copilot => "GITHUB_TOKEN",
         }
@@ -518,6 +533,7 @@ impl AuthAgent {
         match self {
             Self::Claude => "sk-ant-",
             Self::Codex => "sk-",
+            Self::Antigravity => "AIza",
             Self::Gemini => "AIza",
             Self::Copilot => "",
         }
@@ -527,6 +543,7 @@ impl AuthAgent {
         match self {
             Self::Claude => "Anthropic API key",
             Self::Codex => "OpenAI API key",
+            Self::Antigravity => "Gemini API key",
             Self::Gemini => "Gemini API key",
             Self::Copilot => "GitHub token (PAT)",
         }
@@ -1114,16 +1131,17 @@ mod tests {
     }
 
     #[test]
-    fn auth_agents_cover_four_harnesses_with_correct_env_vars() {
-        // The env var each harness's stored key is injected as — must match what
+    fn auth_agents_cover_five_harnesses_with_correct_env_vars() {
+        // The env var each harness's stored key is injected as: must match what
         // session_manager::build_env_setup_for_provider actually exports.
         let expected = [
             (AuthAgent::Claude, "ANTHROPIC_API_KEY"),
             (AuthAgent::Codex, "OPENAI_API_KEY"),
+            (AuthAgent::Antigravity, "GEMINI_API_KEY"),
             (AuthAgent::Gemini, "GEMINI_API_KEY"),
             (AuthAgent::Copilot, "GITHUB_TOKEN"),
         ];
-        assert_eq!(AuthAgent::all().len(), 4);
+        assert_eq!(AuthAgent::all().len(), 5);
         for (agent, env) in expected {
             assert_eq!(agent.env_var(), env, "{} env var drift", agent.label());
             assert!(

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -885,6 +885,7 @@ impl SessionRecoveryState {
                     SessionAgentType::Codex => CliProvider::Codex,
                     SessionAgentType::Gemini => CliProvider::Gemini,
                     SessionAgentType::Copilot => CliProvider::Copilot,
+                    SessionAgentType::Antigravity => CliProvider::Antigravity,
                     _ => CliProvider::Claude,
                 };
                 InteractiveSessionManager::build_cli_cmd_parts(

--- a/ainb-tui/crates/ainb-core/src/components/setup_menu.rs
+++ b/ainb-tui/crates/ainb-core/src/components/setup_menu.rs
@@ -61,7 +61,9 @@ impl SetupMenuItem {
             Self::RerunWizard => "Start the full setup wizard from scratch",
             Self::CheckDependencies => "Verify all required tools are installed",
             Self::ConfigureGitPaths => "Update your project directories",
-            Self::AuthenticationSettings => "Configure auth for Claude, Codex, Gemini, Copilot",
+            Self::AuthenticationSettings => {
+                "Configure auth for Claude, Codex, Antigravity, Gemini, Copilot"
+            }
             Self::EditorPreference => "Choose your preferred code editor",
             Self::FactoryReset => "Remove all configuration and start fresh",
         }

--- a/ainb-tui/crates/ainb-core/src/config/presets.rs
+++ b/ainb-tui/crates/ainb-core/src/config/presets.rs
@@ -444,6 +444,22 @@ pub fn install_default_presets(file: &Path) -> Result<()> {
     if !file.exists() {
         fs::write(file, BUNDLED_PRESETS_TOML)
             .with_context(|| format!("Failed to write default presets to {}", file.display()))?;
+    } else {
+        // Backfill any newly bundled default presets (e.g. antigravity-interactive-yolo)
+        // missing from an existing presets.toml, without overwriting existing user presets.
+        if let Ok(mut manager) = PresetManager::with_file(file.to_path_buf()) {
+            if let Ok(parsed) = toml::from_str::<PresetsFile>(BUNDLED_PRESETS_TOML) {
+                for preset in parsed.preset {
+                    if manager.get(&preset.name).is_none() {
+                        tracing::info!(
+                            preset = %preset.name,
+                            "Backfilling newly bundled preset into existing presets.toml",
+                        );
+                        let _ = manager.save_preset(&preset);
+                    }
+                }
+            }
+        }
     }
 
     // Merge any salvaged user-customised legacy presets into the new file.
@@ -790,6 +806,31 @@ mod tests {
         assert!(
             content.contains("my-only"),
             "user preset disappeared on install"
+        );
+        // Missing bundled defaults are backfilled alongside the user preset
+        assert!(
+            content.contains("antigravity-interactive-yolo"),
+            "antigravity preset missing after backfill"
+        );
+    }
+
+    #[test]
+    fn missing_bundled_presets_backfilled_into_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("presets.toml");
+        // Existing user file with only claude preset
+        std::fs::write(
+            &file,
+            "[[preset]]\nname = \"claude-interactive-yolo\"\nagent_provider = \"claude\"\nmode = \"interactive\"\n",
+        )
+        .unwrap();
+        install_default_presets(&file).unwrap();
+        let mgr = PresetManager::with_file(file).unwrap();
+        assert!(mgr.get("claude-interactive-yolo").is_some());
+        assert!(mgr.get("antigravity-interactive-yolo").is_some());
+        assert_eq!(
+            mgr.get("antigravity-interactive-yolo").unwrap().agent_provider,
+            "antigravity"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/docs.rs
+++ b/ainb-tui/crates/ainb-core/src/docs.rs
@@ -39,6 +39,8 @@ pub const AUTH_CODEX: &str = "https://developers.openai.com/codex/auth";
 /// Google Gemini CLI authentication guide.
 pub const AUTH_GEMINI: &str =
     "https://google-gemini.github.io/gemini-cli/docs/get-started/authentication.html";
+/// Google Antigravity authentication guide.
+pub const AUTH_ANTIGRAVITY: &str = "https://github.com/google/antigravity";
 /// GitHub Copilot CLI authentication guide.
 pub const AUTH_COPILOT: &str = "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/authenticate-copilot-cli";
 

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -64,7 +64,7 @@ impl SessionAgentType {
             SessionAgentType::Codex => "✦",
             SessionAgentType::Copilot => "\u{ec1e}", // cod-copilot - real GitHub Copilot logo
             SessionAgentType::Gemini => "\u{f1a0}",  // fa-google - Gemini is a Google product
-            SessionAgentType::Antigravity => "\u{f1a0}", // fa-google - Antigravity is a Google product
+            SessionAgentType::Antigravity => "▲",
             SessionAgentType::Kiro => "\u{e62f}",        // seti-crystal - Kiro crystal motif
             SessionAgentType::Shell => "\u{ea85}",       // cod-terminal
             SessionAgentType::Ssh => "\u{f023}",         // fa-lock
@@ -984,7 +984,7 @@ mod tests {
         let agent = SessionAgentType::Antigravity;
         assert_eq!(agent.id(), "antigravity");
         assert_eq!(agent.name(), "Google Antigravity");
-        assert_eq!(agent.icon(), "\u{f1a0}");
+        assert_eq!(agent.icon(), "▲");
         assert!(agent.is_available());
         assert_eq!(agent.description(), "Google's agentic AI coding assistant");
     }

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -65,9 +65,9 @@ impl SessionAgentType {
             SessionAgentType::Copilot => "\u{ec1e}", // cod-copilot - real GitHub Copilot logo
             SessionAgentType::Gemini => "\u{f1a0}",  // fa-google - Gemini is a Google product
             SessionAgentType::Antigravity => "▲",
-            SessionAgentType::Kiro => "\u{e62f}",        // seti-crystal - Kiro crystal motif
-            SessionAgentType::Shell => "\u{ea85}",       // cod-terminal
-            SessionAgentType::Ssh => "\u{f023}",         // fa-lock
+            SessionAgentType::Kiro => "\u{e62f}", // seti-crystal - Kiro crystal motif
+            SessionAgentType::Shell => "\u{ea85}", // cod-terminal
+            SessionAgentType::Ssh => "\u{f023}",  // fa-lock
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/setup/catalog.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/catalog.rs
@@ -422,6 +422,16 @@ pub fn catalog() -> Vec<Topic> {
                     &[],
                     &[],
                 ),
+                dep(
+                    "antigravity",
+                    "Google Antigravity",
+                    "Google's agentic AI coding assistant",
+                    Optional,
+                    Bin("agy"),
+                    Manual("https://github.com/google/antigravity"),
+                    &[],
+                    &[],
+                ),
             ],
         },
         // ponytail: container runtime topic (docker/colima) removed from the

--- a/ainb-tui/crates/ainb-core/src/setup/installer.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/installer.rs
@@ -378,6 +378,16 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_script_picks_antigravity_cli_not_claude() {
+        let env = MockEnv { present: vec![] };
+        let s = build_script(Agent::Antigravity, &env);
+        assert!(s.contains("Google Antigravity"));
+        assert!(!s.contains("@anthropic-ai/claude-code"));
+        assert!(!s.contains("@openai/codex"));
+        assert!(!s.contains("claude plugin install reflect@agents-in-a-box"));
+    }
+
+    #[test]
     fn satisfied_deps_are_skipped_and_brew_not_bootstrapped() {
         // Everything the script would install is already present.
         let env = MockEnv {

--- a/ainb-tui/crates/ainb-core/src/setup/installer.rs
+++ b/ainb-tui/crates/ainb-core/src/setup/installer.rs
@@ -19,6 +19,7 @@ pub enum Agent {
     Claude,
     Codex,
     Copilot,
+    Antigravity,
 }
 
 impl Agent {
@@ -27,6 +28,7 @@ impl Agent {
             Agent::Claude => "claude",
             Agent::Codex => "codex",
             Agent::Copilot => "copilot",
+            Agent::Antigravity => "antigravity",
         }
     }
 
@@ -35,6 +37,7 @@ impl Agent {
             Agent::Claude => "Claude Code",
             Agent::Codex => "Codex",
             Agent::Copilot => "GitHub Copilot",
+            Agent::Antigravity => "Google Antigravity",
         }
     }
 
@@ -44,6 +47,7 @@ impl Agent {
             "claude" | "c" | "claude-code" | "claudecode" => Some(Agent::Claude),
             "codex" | "x" => Some(Agent::Codex),
             "copilot" | "p" | "gh-copilot" => Some(Agent::Copilot),
+            "antigravity" | "agy" | "a" => Some(Agent::Antigravity),
             _ => None,
         }
     }
@@ -54,6 +58,7 @@ impl Agent {
             Agent::Claude => "claude",
             Agent::Codex => "codex",
             Agent::Copilot => "copilot",
+            Agent::Antigravity => "antigravity",
         }
     }
 
@@ -62,13 +67,13 @@ impl Agent {
         match self {
             Agent::Claude => Some("claudecode-statusline"),
             Agent::Codex => Some("codex-statusline"),
-            Agent::Copilot => None,
+            Agent::Copilot | Agent::Antigravity => None,
         }
     }
 }
 
-/// All AI-CLI dep ids — used to keep only the chosen agent's CLI in the script.
-const AI_CLI_IDS: &[&str] = &["claude", "codex", "gemini", "copilot"];
+/// All AI-CLI dep ids: used to keep only the chosen agent's CLI in the script.
+const AI_CLI_IDS: &[&str] = &["claude", "codex", "gemini", "copilot", "antigravity"];
 /// All statusline dep ids — keep only the chosen agent's.
 const STATUSLINE_IDS: &[&str] = &["claudecode-statusline", "codex-statusline"];
 /// ainb-owned / first-party tools installed by default even when tagged
@@ -302,6 +307,8 @@ mod tests {
         assert_eq!(Agent::parse("claude"), Some(Agent::Claude));
         assert_eq!(Agent::parse("x"), Some(Agent::Codex));
         assert_eq!(Agent::parse("copilot"), Some(Agent::Copilot));
+        assert_eq!(Agent::parse("antigravity"), Some(Agent::Antigravity));
+        assert_eq!(Agent::parse("a"), Some(Agent::Antigravity));
         assert_eq!(Agent::parse("nope"), None);
     }
 

--- a/ainb-tui/crates/ainb-core/tests/challenger_m1_antigravity.rs
+++ b/ainb-tui/crates/ainb-core/tests/challenger_m1_antigravity.rs
@@ -447,7 +447,7 @@ fn test_provider_registry_aliases_and_builtins() {
     let agy_agent = agents.get("antigravity");
     assert!(agy_agent.is_some());
     assert_eq!(agy_agent.as_ref().unwrap().name(), "Google Antigravity");
-    assert_eq!(agy_agent.as_ref().unwrap().icon(), "\u{f1a0}");
+    assert_eq!(agy_agent.as_ref().unwrap().icon(), "▲");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Enables full Antigravity support across the ainb TUI:

- Icon standardization: Standardizes Antigravity icon to ▲ (\u{25b2}) across SessionAgentType, AntigravityAgent, and test suites (matching burndown chart).
- Session launch & configure: Maps "antigravity" to SessionAgentType::Antigravity in create_session_from_configure, propagates custom models via --model, adds Antigravity to resume notification banners, wires inbox hook attention markers, and maps orphan recovery to CliProvider::Antigravity.
- Preset backfill: In install_default_presets, backfills newly bundled default presets (like antigravity-interactive-yolo) into existing presets.toml without modifying user customizations.
- Onboarding wizard & setup catalog: Adds AuthAgent::Antigravity with Gemini API key / Google sign-in support, adds Antigravity to setup catalog ai-clis topic, adds Agent::Antigravity to installer script generation with [a] keybinding, and updates setup menu descriptions and tool promotions.

Closes ai-coder-rules-0xi.