### PR TITLE
test(tmux): stop the dead-pane tests racing the pane

### DIFF
--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -3046,9 +3046,27 @@ mod tests {
             ])
             .output()
             .await;
-        tokio::time::sleep(std::time::Duration::from_millis(700)).await;
-
-        let captured = super::capture_failed_launch_pane(&target).await;
+        // Poll, do not sleep a guessed interval. `remain-on-exit` keeps the
+        // pane, but the echo and the death are two separate events and a loaded
+        // runner can put the capture between them: the marker is drawn, the
+        // program's line is not readable yet, and the assertion below reports a
+        // pane holding nothing but `Pane is dead (status 1, ...)`. That is a
+        // race in the TEST, not in `capture_failed_launch_pane`, and it went red
+        // once on ubuntu while macOS passed the same commit.
+        //
+        // On timeout, fall through with the last capture so the assertion still
+        // prints what the pane actually held.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let captured = loop {
+            let attempt = super::capture_failed_launch_pane(&target).await;
+            if attempt.as_deref().is_some_and(|text| text.contains("codex-startup-failed")) {
+                break attempt;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break attempt;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        };
 
         let _ = TokioCommand::new("tmux").args(["kill-session", "-t", &target]).output().await;
 

--- a/ainb-tui/crates/ainb-core/tests/behavioral/tmux_lifecycle.rs
+++ b/ainb-tui/crates/ainb-core/tests/behavioral/tmux_lifecycle.rs
@@ -451,8 +451,27 @@ async fn test_keeping_dead_pane_survives_an_immediate_exit() -> Result<()> {
     session.start(temp_dir.path()).await?;
     let live = session.name().to_string();
 
-    // Let the program run and exit.
-    tokio::time::sleep(Duration::from_millis(800)).await;
+    // Poll for the program's own output, do not sleep a guessed interval. The
+    // echo and the exit are two separate events, and a loaded runner can put
+    // the capture between them: the dead-pane marker is drawn while the line is
+    // not readable yet. The sibling assertion in `session_manager` went red on
+    // ubuntu that way while macOS passed the same commit.
+    //
+    // On timeout, fall through and let the assertions below report what the
+    // pane actually held.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let seen = tokio::process::Command::new("tmux")
+            .args(["capture-pane", "-p", "-S", "-", "-t", &format!("={live}:")])
+            .output()
+            .await?;
+        if String::from_utf8_lossy(&seen.stdout).contains("codex-startup-failed")
+            || tokio::time::Instant::now() >= deadline
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     assert!(
         tmux_session_exists(&live),


### PR DESCRIPTION
Both dead-pane tests waited a fixed interval and then captured. `remain-on-exit` keeps the pane, but the program's `echo` and its exit are two separate events, and a loaded runner can land the capture between them: the marker is drawn, the program's line is not readable yet, and the assertion reports a pane holding nothing but `Pane is dead (status 1, ...)`.

The race is in the tests, not in `capture_failed_launch_pane`.

## Observed, both ubuntu-only

| test | where | outcome |
|---|---|---|
| `test_keeping_dead_pane_survives_an_immediate_exit` | #790's CI | failed once, passed on rerun of the identical commit |
| `capture_failed_launch_pane_reads_a_dead_pane` | main `3af14abb` | failed once, passed on rerun of the identical commit |

macOS passed both commits. The test that failed on main landed there at 16:22 today with #790 and had passed on four main commits before going red on the fifth, so this is a load-dependent race rather than a regression or a pre-existing break.

## Change

Poll for the program's own output with a 10s bound instead of sleeping 700ms / 800ms. On timeout each test falls through with the last capture, so a genuine failure still prints what the pane actually held rather than a bare timeout.

Nothing in the production path changes: `capture_failed_launch_pane` and `TmuxSession::keeping_dead_pane` are untouched.

## Verification

```
cargo test -p ainb --lib interactive::session_manager::tests::capture_failed_launch_pane   1 passed
cargo test -p ainb --test behavioral tmux_lifecycle                                       10 passed
cargo test -p ainb --test behavioral tmux_lifecycle::test_keeping_dead_pane  x3            2 passed each
cargo fmt --all --check                                                                   clean
```
