### PR TITLE
fix(update): let the running binary decide who owns the install

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/update.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/update.rs
@@ -412,26 +412,49 @@ enum InstallOwner {
 }
 
 impl InstallOwner {
+    /// Which installation owns the binary the user actually invoked.
+    ///
+    /// The RUNNING executable decides, and every check is keyed on it. This used
+    /// to probe `brew list --versions ainb` first and answer `Homebrew` on
+    /// success, without consulting `exe` at all — so on a machine where Homebrew
+    /// owns one copy and a second copy shadows it on `PATH`, `ainb update`
+    /// upgraded Homebrew's, reported success, and left the binary the user ran
+    /// untouched. The shadowing copy could never be updated by the updater, no
+    /// matter how many times it was run, and it stayed stale silently.
+    ///
+    /// That is not hypothetical: a `~/.local/bin/ainb` source build shadowed a
+    /// Homebrew 1.24.0 and pinned the whole machine to 1.23.2, which surfaced
+    /// only when its embedded migrations were too old to open a database a
+    /// newer build had already migrated forward.
+    ///
+    /// Homebrew is still the answer when the running exe IS Homebrew's, and it
+    /// remains the fallback for an exe that matches nothing known — but that
+    /// fallback now says out loud which binary it is about to upgrade, because
+    /// it is not the one that is running.
     fn detect() -> Result<Self> {
         let exe = std::env::current_exe().context("resolving ainb executable")?;
-        if Command::new("brew")
-            .args(["list", "--versions", "ainb"])
-            .output()
-            .ok()
-            .is_some_and(|out| out.status.success())
-        {
+        let brew_owns = || {
+            Command::new("brew")
+                .args(["list", "--versions", "ainb"])
+                .output()
+                .ok()
+                .is_some_and(|out| out.status.success())
+        };
+
+        if let Some(owner) = classify_exe(
+            &exe,
+            brew_prefix_binary().as_deref(),
+            dirs::home_dir().as_deref(),
+        ) {
+            return Ok(owner);
+        }
+        if brew_owns() {
+            eprintln!(
+                "warning: upgrading the Homebrew ainb, but you are running {}. \
+                 That copy shadows Homebrew's on PATH and will stay at this version.",
+                exe.display()
+            );
             return Ok(Self::Homebrew);
-        }
-        if exe.parent().is_some_and(|parent| parent.ends_with(".cargo/bin")) {
-            return Ok(Self::Cargo);
-        }
-        let home = dirs::home_dir();
-        let direct = [
-            PathBuf::from("/usr/local/bin/ainb"),
-            home.unwrap_or_default().join(".local/bin/ainb"),
-        ];
-        if direct.iter().any(|path| canonical_eq(path, &exe)) {
-            return Ok(Self::Direct);
         }
         bail!(
             "ainb installation is unmanaged; reinstall with the curl installer or use your package manager"
@@ -679,8 +702,60 @@ impl DirectPluginSwap {
     }
 }
 
+/// Which installation owns `exe`, by path alone. `None` when it matches nothing
+/// known, which is the only case that may fall back to a probe.
+///
+/// Split out of [`InstallOwner::detect`] so the ORDER is testable without a
+/// Homebrew on the machine: the regression this guards is a `Direct` exe being
+/// answered `Homebrew` merely because Homebrew also had a copy somewhere.
+fn classify_exe(
+    exe: &Path,
+    brew_binary: Option<&Path>,
+    home: Option<&Path>,
+) -> Option<InstallOwner> {
+    if brew_binary.is_some_and(|brewed| canonical_eq(brewed, exe)) {
+        return Some(InstallOwner::Homebrew);
+    }
+    if exe.parent().is_some_and(|parent| parent.ends_with(".cargo/bin")) {
+        return Some(InstallOwner::Cargo);
+    }
+    let direct = [
+        PathBuf::from("/usr/local/bin/ainb"),
+        home.unwrap_or(Path::new("")).join(".local/bin/ainb"),
+    ];
+    direct
+        .iter()
+        .any(|path| canonical_eq(path, exe))
+        .then_some(InstallOwner::Direct)
+}
+
+/// The `ainb` binary Homebrew owns, if Homebrew has it.
+///
+/// `brew --prefix ainb` names the keg; the symlink on `PATH` resolves into it,
+/// so `canonical_eq` against this is what distinguishes "you are running
+/// Homebrew's ainb" from "Homebrew merely has one somewhere".
+fn brew_prefix_binary() -> Option<PathBuf> {
+    let out = Command::new("brew").args(["--prefix", "ainb"]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let prefix = String::from_utf8(out.stdout).ok()?;
+    let prefix = prefix.trim();
+    (!prefix.is_empty()).then(|| PathBuf::from(prefix).join("bin").join("ainb"))
+}
+
+/// Whether two paths name the same existing file.
+///
+/// Both sides must resolve. Comparing `canonicalize(..).ok()` instead made two
+/// paths that BOTH fail to resolve compare equal, so an exe that does not exist
+/// matched a `/usr/local/bin/ainb` that does not exist either and was reported
+/// as a Direct install. `current_exe` always resolves, so this never misfired in
+/// production, but "neither of these exists" is not "these are the same binary".
 fn canonical_eq(left: &Path, right: &Path) -> bool {
-    std::fs::canonicalize(left).ok() == std::fs::canonicalize(right).ok()
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 fn launchd_path() -> Option<PathBuf> {
@@ -789,6 +864,52 @@ pub fn cached_state() -> Option<ReleaseState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_shadowing_direct_exe_is_not_claimed_by_homebrew() {
+        // Real files: `canonical_eq` requires both sides to resolve, so a fake
+        // path matches nothing — which is itself pinned by the last case here.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home = tmp.path().join("home");
+        let local_bin = home.join(".local/bin");
+        let brew_bin = tmp.path().join("brew/bin");
+        let cargo_bin = home.join(".cargo/bin");
+        for dir in [&local_bin, &brew_bin, &cargo_bin] {
+            std::fs::create_dir_all(dir).expect("create dir");
+            std::fs::write(dir.join("ainb"), b"binary").expect("write binary");
+        }
+        let brewed = brew_bin.join("ainb");
+
+        // The regression. Homebrew HAS an ainb, but the running exe is the
+        // ~/.local/bin copy that shadows it on PATH. Answering Homebrew here is
+        // what let `ainb update` upgrade a binary the user was not running,
+        // report success, and leave the shadowing copy stale forever.
+        assert_eq!(
+            classify_exe(&local_bin.join("ainb"), Some(&brewed), Some(&home)),
+            Some(InstallOwner::Direct),
+            "a shadowing ~/.local/bin exe owns itself even when Homebrew has a copy"
+        );
+
+        assert_eq!(
+            classify_exe(&brewed, Some(&brewed), Some(&home)),
+            Some(InstallOwner::Homebrew),
+            "running Homebrew's own binary is still Homebrew"
+        );
+        assert_eq!(
+            classify_exe(&cargo_bin.join("ainb"), Some(&brewed), Some(&home)),
+            Some(InstallOwner::Cargo),
+            "a ~/.cargo/bin exe is Cargo's, not Homebrew's"
+        );
+        assert_eq!(
+            classify_exe(
+                &tmp.path().join("elsewhere/ainb"),
+                Some(&brewed),
+                Some(&home)
+            ),
+            None,
+            "an exe matching nothing known must fall through to the probe"
+        );
+    }
 
     #[test]
     fn homebrew_update_refreshes_formula_metadata_before_upgrade() {

--- a/ainb-tui/crates/ainb-core/src/cli/update.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/update.rs
@@ -414,44 +414,37 @@ enum InstallOwner {
 impl InstallOwner {
     /// Which installation owns the binary the user actually invoked.
     ///
-    /// The RUNNING executable decides, and every check is keyed on it. This used
-    /// to probe `brew list --versions ainb` first and answer `Homebrew` on
-    /// success, without consulting `exe` at all — so on a machine where Homebrew
-    /// owns one copy and a second copy shadows it on `PATH`, `ainb update`
-    /// upgraded Homebrew's, reported success, and left the binary the user ran
-    /// untouched. The shadowing copy could never be updated by the updater, no
-    /// matter how many times it was run, and it stayed stale silently.
+    /// The RUNNING executable decides. This used to probe
+    /// `brew list --versions ainb` first and answer `Homebrew` on success
+    /// without consulting `exe` at all, so on a machine where Homebrew owns one
+    /// copy and a second copy shadows it on `PATH`, `ainb update` upgraded
+    /// Homebrew's, reported success, and left the binary the user ran
+    /// untouched. That copy could never be updated by the updater however many
+    /// times it was run.
     ///
-    /// That is not hypothetical: a `~/.local/bin/ainb` source build shadowed a
-    /// Homebrew 1.24.0 and pinned the whole machine to 1.23.2, which surfaced
-    /// only when its embedded migrations were too old to open a database a
-    /// newer build had already migrated forward.
-    ///
-    /// Homebrew is still the answer when the running exe IS Homebrew's, and it
-    /// remains the fallback for an exe that matches nothing known — but that
-    /// fallback now says out loud which binary it is about to upgrade, because
-    /// it is not the one that is running.
+    /// Not hypothetical: a `~/.local/bin/ainb` source build shadowed a Homebrew
+    /// 1.24.0 and pinned the machine to 1.23.2, surfacing only when its
+    /// embedded migrations were too old to open a database a newer build had
+    /// already migrated forward.
     fn detect() -> Result<Self> {
         let exe = std::env::current_exe().context("resolving ainb executable")?;
-        let brew_owns = || {
-            Command::new("brew")
-                .args(["list", "--versions", "ainb"])
-                .output()
-                .ok()
-                .is_some_and(|out| out.status.success())
-        };
-
-        if let Some(owner) = classify_exe(
-            &exe,
-            brew_prefix_binary().as_deref(),
-            dirs::home_dir().as_deref(),
-        ) {
+        if let Some(owner) = classify_exe(&exe, dirs::home_dir().as_deref()) {
             return Ok(owner);
         }
-        if brew_owns() {
-            eprintln!(
-                "warning: upgrading the Homebrew ainb, but you are running {}. \
-                 That copy shadows Homebrew's on PATH and will stay at this version.",
+        if Command::new("brew")
+            .args(["list", "--versions", "ainb"])
+            .output()
+            .ok()
+            .is_some_and(|out| out.status.success())
+        {
+            // Printed on stdout, beside the completion line `apply_command`
+            // writes, NOT on stderr. A caller capturing only stdout would
+            // otherwise read an unqualified success for an upgrade that did not
+            // touch the running binary, which is the same silent
+            // wrong-binary failure this function exists to remove.
+            println!(
+                "warning: upgrading the Homebrew ainb, but you are running {}, \
+                 which is not it. That copy stays at its current version.",
                 exe.display()
             );
             return Ok(Self::Homebrew);
@@ -708,40 +701,44 @@ impl DirectPluginSwap {
 /// Split out of [`InstallOwner::detect`] so the ORDER is testable without a
 /// Homebrew on the machine: the regression this guards is a `Direct` exe being
 /// answered `Homebrew` merely because Homebrew also had a copy somewhere.
-fn classify_exe(
-    exe: &Path,
-    brew_binary: Option<&Path>,
-    home: Option<&Path>,
-) -> Option<InstallOwner> {
-    if brew_binary.is_some_and(|brewed| canonical_eq(brewed, exe)) {
+///
+/// Homebrew is recognised by a `Cellar` ancestor, not by asking
+/// `brew --prefix ainb` where its binary is. The formula installs the real
+/// executable at `<keg>/libexec/ainb` and writes `<keg>/bin/ainb` as a shell
+/// wrapper that `exec`s it, so `current_exe` under Homebrew reports the libexec
+/// path and never equals the prefix's `bin/ainb`. Comparing against that
+/// wrapper made the Homebrew arm unreachable and gave every ordinary Homebrew
+/// user a warning naming their own live binary as a stale shadow. The ancestor
+/// walk is the same rule `ainb_plugin_notifyd::install::homebrew_launcher`
+/// uses, and it costs no subprocess.
+///
+/// Checked BEFORE the direct paths on purpose: a brew-managed
+/// `/usr/local/bin/ainb` is a symlink into the Cellar, and canonicalising it
+/// reaches the keg, so answering `Direct` there would let
+/// `apply_direct_release` replace a Homebrew-owned link with an unmanaged file.
+fn classify_exe(exe: &Path, home: Option<&Path>) -> Option<InstallOwner> {
+    let resolved = std::fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    if resolved
+        .ancestors()
+        .any(|path| path.file_name().is_some_and(|name| name == "Cellar"))
+    {
         return Some(InstallOwner::Homebrew);
     }
-    if exe.parent().is_some_and(|parent| parent.ends_with(".cargo/bin")) {
+    if resolved.parent().is_some_and(|parent| parent.ends_with(".cargo/bin")) {
         return Some(InstallOwner::Cargo);
     }
-    let direct = [
-        PathBuf::from("/usr/local/bin/ainb"),
-        home.unwrap_or(Path::new("")).join(".local/bin/ainb"),
-    ];
+    // `home` guarded rather than defaulted: an empty base yields the RELATIVE
+    // `.local/bin/ainb`, which `canonicalize` resolves against the process
+    // working directory, so an unrelated binary under the cwd could be
+    // classified `Direct` and then overwritten.
+    let mut direct = vec![PathBuf::from("/usr/local/bin/ainb")];
+    if let Some(home) = home {
+        direct.push(home.join(".local/bin/ainb"));
+    }
     direct
         .iter()
-        .any(|path| canonical_eq(path, exe))
+        .any(|path| canonical_eq(path, &resolved))
         .then_some(InstallOwner::Direct)
-}
-
-/// The `ainb` binary Homebrew owns, if Homebrew has it.
-///
-/// `brew --prefix ainb` names the keg; the symlink on `PATH` resolves into it,
-/// so `canonical_eq` against this is what distinguishes "you are running
-/// Homebrew's ainb" from "Homebrew merely has one somewhere".
-fn brew_prefix_binary() -> Option<PathBuf> {
-    let out = Command::new("brew").args(["--prefix", "ainb"]).output().ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let prefix = String::from_utf8(out.stdout).ok()?;
-    let prefix = prefix.trim();
-    (!prefix.is_empty()).then(|| PathBuf::from(prefix).join("bin").join("ainb"))
 }
 
 /// Whether two paths name the same existing file.
@@ -867,47 +864,72 @@ mod tests {
 
     #[test]
     fn a_shadowing_direct_exe_is_not_claimed_by_homebrew() {
-        // Real files: `canonical_eq` requires both sides to resolve, so a fake
-        // path matches nothing — which is itself pinned by the last case here.
+        // Real files throughout: `canonical_eq` requires both sides to resolve,
+        // and the Cellar walk runs on the CANONICAL exe, so fake paths would
+        // prove nothing.
         let tmp = tempfile::tempdir().expect("tempdir");
         let home = tmp.path().join("home");
         let local_bin = home.join(".local/bin");
-        let brew_bin = tmp.path().join("brew/bin");
         let cargo_bin = home.join(".cargo/bin");
-        for dir in [&local_bin, &brew_bin, &cargo_bin] {
+        let elsewhere = tmp.path().join("elsewhere");
+        // The real formula shape: the executable lives in `<keg>/libexec` and
+        // `<keg>/bin/ainb` is a shell wrapper that execs it, so a Homebrew run
+        // reports the LIBEXEC path. Modelling both as one path is what let the
+        // first version of this test pass while the production arm was dead.
+        let keg = tmp.path().join("Cellar/ainb/1.24.0");
+        let brew_libexec = keg.join("libexec");
+        let brew_bin = keg.join("bin");
+        for dir in [&local_bin, &cargo_bin, &elsewhere, &brew_libexec, &brew_bin] {
             std::fs::create_dir_all(dir).expect("create dir");
             std::fs::write(dir.join("ainb"), b"binary").expect("write binary");
         }
-        let brewed = brew_bin.join("ainb");
 
-        // The regression. Homebrew HAS an ainb, but the running exe is the
-        // ~/.local/bin copy that shadows it on PATH. Answering Homebrew here is
+        // The regression. Homebrew has a copy, but the running exe is the
+        // ~/.local/bin one that shadows it on PATH. Answering Homebrew here is
         // what let `ainb update` upgrade a binary the user was not running,
         // report success, and leave the shadowing copy stale forever.
         assert_eq!(
-            classify_exe(&local_bin.join("ainb"), Some(&brewed), Some(&home)),
+            classify_exe(&local_bin.join("ainb"), Some(&home)),
             Some(InstallOwner::Direct),
-            "a shadowing ~/.local/bin exe owns itself even when Homebrew has a copy"
+            "a shadowing ~/.local/bin exe owns itself"
+        );
+
+        // The arm that was unreachable in production: the libexec binary, not
+        // the wrapper, is what `current_exe` reports under Homebrew.
+        assert_eq!(
+            classify_exe(&brew_libexec.join("ainb"), Some(&home)),
+            Some(InstallOwner::Homebrew),
+            "the real Homebrew binary lives in libexec and must classify as Homebrew"
+        );
+        assert_eq!(
+            classify_exe(&brew_bin.join("ainb"), Some(&home)),
+            Some(InstallOwner::Homebrew),
+            "the wrapper is Homebrew's too"
         );
 
         assert_eq!(
-            classify_exe(&brewed, Some(&brewed), Some(&home)),
-            Some(InstallOwner::Homebrew),
-            "running Homebrew's own binary is still Homebrew"
-        );
-        assert_eq!(
-            classify_exe(&cargo_bin.join("ainb"), Some(&brewed), Some(&home)),
+            classify_exe(&cargo_bin.join("ainb"), Some(&home)),
             Some(InstallOwner::Cargo),
-            "a ~/.cargo/bin exe is Cargo's, not Homebrew's"
+            "a ~/.cargo/bin exe is Cargo's"
         );
         assert_eq!(
-            classify_exe(
-                &tmp.path().join("elsewhere/ainb"),
-                Some(&brewed),
-                Some(&home)
-            ),
+            classify_exe(&elsewhere.join("ainb"), Some(&home)),
             None,
-            "an exe matching nothing known must fall through to the probe"
+            "a real binary in an unrecognised directory falls through to the probe"
+        );
+
+        // No home: the `~/.local/bin` candidate must not degrade to the
+        // relative `.local/bin/ainb`, which canonicalises against the process
+        // working directory.
+        assert_eq!(
+            classify_exe(&local_bin.join("ainb"), None),
+            None,
+            "without a home there is no ~/.local/bin candidate to match"
+        );
+        assert_eq!(
+            classify_exe(&brew_libexec.join("ainb"), None),
+            Some(InstallOwner::Homebrew),
+            "Homebrew is decided by the Cellar ancestor, with or without a home"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/install.rs
@@ -269,8 +269,17 @@ fn is_executable(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether two paths name the same existing file.
+///
+/// Both sides must resolve. Comparing `canonicalize(..).ok()` made two paths
+/// that BOTH fail to resolve compare equal, so "neither of these exists" read
+/// as "these are the same binary". The `is_executable` guard on the calling
+/// side masks it today; the next caller would inherit it.
 fn canonical_eq(left: &Path, right: &Path) -> bool {
-    std::fs::canonicalize(left).ok() == std::fs::canonicalize(right).ok()
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 /// Return the unversioned Homebrew launcher for a Cellar executable.


### PR DESCRIPTION
## The bug

`InstallOwner::detect` probed `brew list --versions ainb` **first** and answered `Homebrew` on success, without consulting the running executable at all:

```rust
let exe = std::env::current_exe()?;           // resolved, then ignored
if brew list --versions ainb succeeds {
    return Ok(Self::Homebrew);
}
if exe.parent().ends_with(".cargo/bin") { ... }   // never reached when brew has a copy
if direct.iter().any(|p| canonical_eq(p, &exe)) { ... }
```

On a machine where Homebrew owns one copy and a second copy shadows it on `PATH`, every `ainb update` upgraded Homebrew's, reported success, and left the binary the user actually ran untouched. The shadowing copy is invisible to the updater by construction.

## How it surfaced

A `~/.local/bin/ainb` source build (`1.23.2 (429ca340-dirty, source)`) shadowed a Homebrew `1.24.0 (649f3e7, ci)`. `ainb update -y` had been run and reported success throughout.

The symptom appeared nowhere near the updater:

```
hangar daemon · start failed
Error: daemon exited immediately (exit status: 1)

$ ainb hangar daemon run
Error: run hangar daemon (foreground)
Caused by:
    migration 94 was previously applied but is missing in the resolved migrations
```

`0094_fleet_provider_event_retention.sql` shipped in 1.24.0. A newer build had migrated the database to 94; the shadowing 1.23.2 stops at 93, and sqlx refuses to open a database ahead of the binary. Removing the stale copy fixed it instantly — `/opt/homebrew/bin/ainb` opened the same database cleanly.

## The change

Homebrew now means "the running exe **is** Homebrew's", matched against `brew --prefix ainb`. An exe matching nothing known still falls back to Homebrew when it has a copy, but prints which binary it is upgrading, because it is not the one running.

Carries a second fix it cannot be tested without. `canonical_eq` compared `canonicalize(..).ok()`, so two paths that BOTH fail to resolve compared **equal** — a non-existent exe matched a non-existent `/usr/local/bin/ainb` and was reported as `Direct`. `current_exe` always resolves so this never misfired in production, but "neither exists" is not "same binary".

The ordering is extracted into `classify_exe(exe, brew_binary, home)` so it is testable without a Homebrew on the machine.

## Verification

`a_shadowing_direct_exe_is_not_claimed_by_homebrew` pins all four arms against real files in a tempdir (fake paths would be meaningless — that is what the `canonical_eq` fix is about):

| exe | brew has a copy | expected |
|---|---|---|
| `~/.local/bin/ainb` | yes, elsewhere | `Direct` — the regression |
| brew's own binary | yes | `Homebrew` |
| `~/.cargo/bin/ainb` | yes | `Cargo` |
| unknown path | yes | `None`, falls through to the probe |

```
cargo test -p ainb --lib cli::update     4 passed
cargo fmt --all --check                  clean
```

Full lib suite: 2260 passed, 3 failed — all in the known env-race set that also fails on main, and each passes when run alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installation-source detection during updates to correctly identify the active executable.
  - Prevented updates from targeting a Homebrew installation when a direct installation is being used.
  - Added a warning when another installation may be shadowing the one being upgraded.
  - Improved path comparison reliability when resolving installation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->