### PR TITLE
crisp B5: tab strip 16 to 7, nine screens behind the palette, Kanban to Runs

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilots_screen_renders.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_autopilots_screen_renders.rs
@@ -75,11 +75,12 @@ fn autopilots_screen_renders_seeded_autopilot() {
         "the issue list must not already show the seeded autopilot name:\n{landing}"
     );
 
-    // Press `4` (single-char nav, no Enter) until the manager shows the seeded
-    // autopilot's name AND cron. 45s budget covers the snapshot round-trip.
+    // `^P autopilots` until the manager shows the seeded autopilot's name AND
+    // cron. Was the `4` tab key until crisp B5 §2.5 demoted it. 45s budget covers
+    // the snapshot round-trip.
     let deadline = Instant::now() + Duration::from_secs(45);
     let pane = session
-        .switch_tab_until("4", deadline, |c| {
+        .go_to_screen_until("autopilots", deadline, |c| {
             hangar_chrome_visible(c) && c.contains(AUTOPILOT_NAME) && c.contains(AUTOPILOT_CRON)
         })
         .unwrap_or_else(|| {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_health_sparkline.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_daemon_health_sparkline.rs
@@ -117,11 +117,11 @@ fn daemon_health_sparkline_renders_with_red_failure_band() {
          the throughput ring needs them to drive the sparkline"
     );
 
-    // Press `D` (single-char nav, no Enter) until the health pane chrome is on
-    // screen with at least one sparkline block glyph.
+    // `^P daemon` until the health pane chrome is on screen with at least one
+    // sparkline block glyph. Was the `D` tab key until crisp B5 §2.5 demoted it.
     let deadline = Instant::now() + Duration::from_secs(45);
     let pane = session
-        .switch_tab_until("D", deadline, |c| {
+        .go_to_screen_until("daemon", deadline, |c| {
             hangar_chrome_visible(c)
                 && c.contains("Daemon health")
                 && c.contains("throughput (60s):")

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_logs_screen_renders.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_logs_screen_renders.rs
@@ -70,12 +70,12 @@ fn logs_screen_renders_seeded_daemon_log_lines() {
         "the issue list must not already show the seeded log marker:\n{landing}"
     );
 
-    // Press `L` (single-char nav, no Enter) until the Logs pane shows the seeded
-    // marker line AND its INFO level token. 45s budget covers the first render's
-    // file read.
+    // `^P logs` until the Logs pane shows the seeded marker line AND its INFO
+    // level token. Was the `L` tab key until crisp B5 §2.5 demoted it. 45s budget
+    // covers the first render's file read.
     let deadline = Instant::now() + Duration::from_secs(45);
     let pane = session
-        .switch_tab_until("L", deadline, |c| {
+        .go_to_screen_until("logs", deadline, |c| {
             hangar_chrome_visible(c) && c.contains(LOGS_TRIPWIRE_MARKER) && c.contains("INFO")
         })
         .unwrap_or_else(|| {

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p2_answer_flip_e2e.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p2_answer_flip_e2e.rs
@@ -59,10 +59,11 @@ fn answering_the_control_center_ask_delivers_and_flips_the_board() {
 
     let scale = budget_scale();
 
-    // Open the control center; wait for the seeded ASK + the `1 need you` count.
+    // Open the control center with `^P control` (crisp B5 §2.5 demoted the `C`
+    // tab key); wait for the seeded ASK + the `1 need you` count.
     let open_deadline = Instant::now() + Duration::from_secs(30 * scale);
     let board = sess
-        .switch_tab_until("C", open_deadline, |c| {
+        .go_to_screen_until("control", open_deadline, |c| {
             c.contains(ATTENTION_ASK_QUESTION) && c.contains("1 need you")
         })
         .unwrap_or_else(|| {
@@ -113,7 +114,11 @@ fn answering_the_control_center_ask_delivers_and_flips_the_board() {
             pressed = true;
         } else if pressed && !cur.contains("need you") {
             // Drifted off the control center after a stray digit — return to it.
-            sess.send_key("C");
+            // `^P control`, since crisp B5 §2.5 demoted the `C` tab key.
+            sess.send_key("Escape");
+            sess.send_key("C-p");
+            sess.type_literal("control");
+            sess.send_enter();
         }
         std::thread::sleep(Duration::from_millis(300));
     };

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p2_control_center_attention.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p2_control_center_attention.rs
@@ -50,12 +50,13 @@ fn control_center_shuffles_ask_above_wait_with_inline_options() {
         "control-center chrome bled into the issue-list landing screen:\n{landing}"
     );
 
-    // Forward nav: `C` opens the control center. Re-send until the seeded ASK
-    // question text has round-tripped through the socket (the plugin's snapshot
-    // fetch races the first render).
+    // Forward nav: `^P control` opens the control center (crisp B5 §2.5 demoted
+    // the `C` tab key). Re-send until the seeded ASK question text has
+    // round-tripped through the socket (the plugin's snapshot fetch races the
+    // first render).
     let deadline = Instant::now() + Duration::from_secs(30 * common::budget_scale());
     let board = sess
-        .switch_tab_until("C", deadline, |c| {
+        .go_to_screen_until("control", deadline, |c| {
             c.contains(ATTENTION_ASK_QUESTION) && c.contains("need you")
         })
         .unwrap_or_else(|| panic!("control center never rendered:\n{}", sess.capture()));

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -2761,6 +2761,13 @@ impl TuiSession {
     ///
     /// Esc first, so a repeat starts from a closed palette rather than typing a
     /// second copy of the word into the query left over from the last attempt.
+    ///
+    /// The word is typed ONLY once the palette's ` Search: ` title is on the
+    /// pane. A dropped `C-p` is the exact failure the resend loop exists for, and
+    /// without the gate the word lands on the live screen instead: on the
+    /// issue-list landing, `c` in `control` / `skills` opens the create-issue
+    /// wizard and the trailing Enter advances it, so every later iteration fights
+    /// an overlay this helper never opened.
     pub fn go_to_screen_until(
         &self,
         word: &str,
@@ -2770,11 +2777,19 @@ impl TuiSession {
         loop {
             self.send_key("Escape");
             self.send_key("C-p");
-            self.type_literal(word);
-            self.send_enter();
-            if let Some(c) = self.poll_capture(Instant::now() + Duration::from_millis(1500), &pred)
+            if self
+                .poll_capture(Instant::now() + Duration::from_millis(1500), |c| {
+                    c.contains(" Search: ")
+                })
+                .is_some()
             {
-                return Some(c);
+                self.type_literal(word);
+                self.send_enter();
+                if let Some(c) =
+                    self.poll_capture(Instant::now() + Duration::from_millis(1500), &pred)
+                {
+                    return Some(c);
+                }
             }
             if Instant::now() >= deadline {
                 return None;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_common.rs
@@ -2748,6 +2748,40 @@ impl TuiSession {
         }
     }
 
+    /// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
+    /// `^P`, the screen's word (one literal `send-keys -l` run so a busy pane
+    /// cannot drop a char mid-word), then Enter.
+    ///
+    /// The nine demoted screens have no nav key at all any more, so this is the
+    /// replacement for [`switch_tab_until`](Self::switch_tab_until) on Skills,
+    /// Autopilots, Daemon, Usage, Logs, Control, Fleet, Squads and Profiles. Like
+    /// its sibling the whole sequence is RE-SENT every ~1.5s until `pred` holds:
+    /// a lone keystroke can be dropped on a loaded runner, and re-opening the
+    /// palette over an already-open one is a no-op, so a repeat is harmless.
+    ///
+    /// Esc first, so a repeat starts from a closed palette rather than typing a
+    /// second copy of the word into the query left over from the last attempt.
+    pub fn go_to_screen_until(
+        &self,
+        word: &str,
+        deadline: Instant,
+        pred: impl Fn(&str) -> bool,
+    ) -> Option<String> {
+        loop {
+            self.send_key("Escape");
+            self.send_key("C-p");
+            self.type_literal(word);
+            self.send_enter();
+            if let Some(c) = self.poll_capture(Instant::now() + Duration::from_millis(1500), &pred)
+            {
+                return Some(c);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+        }
+    }
+
     /// Convenience: spawn `ainb tui`, open the Hangar screen, and return the
     /// landing capture. Panics if the seeded screen never rendered.
     pub fn launch_to_hangar(bin: &Path, home: &Path) -> (Self, String) {
@@ -2770,7 +2804,10 @@ impl Drop for TuiSession {
 /// confirm the `g` navigation switched to the plugin screen even before the
 /// snapshot rows arrive — distinct from the host home screen.
 pub fn hangar_chrome_visible(capture: &str) -> bool {
-    capture.contains("Issues") && capture.contains("Skills") && capture.contains("Settings")
+    // Three of the SEVEN tabs the strip carries since crisp B5 §2.5 cut it from
+    // sixteen. `Skills` was the middle probe here and left the strip with that
+    // cut, which made every tripwire that gates on the chrome time out.
+    capture.contains("Issues") && capture.contains("Inbox") && capture.contains("Settings")
 }
 
 /// Re-send single-char `key` every ~1.5s until `pred` holds on the pane or

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_cross_screen_navigation.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_cross_screen_navigation.rs
@@ -1,4 +1,5 @@
-//! P4.9 — cross-screen navigation tripwire: `1` → `4` → `,` → `1` walks the tabs.
+//! P4.9 — cross-screen navigation tripwire: `1` → `^P skills` → `,` → `1` walks
+//! the surviving tabs AND the palette route that replaced a demoted one.
 //!
 //! The flakiest of the six (per the P4.9 risk register), so each hop polls the
 //! pane with a deadline. Each step pairs a POSITIVE marker for the destination
@@ -20,9 +21,9 @@ use common::{TuiSession, can_run_tripwire, prepare_pipeline, skip};
 /// A single lone keypress can be dropped on a loaded CI runner (the first frames
 /// after a switch race the snapshot fetch), so — like the issue-list and
 /// autopilots tripwires' [`switch_tab_until`] — the key is RE-SENT every ~1.5s
-/// until the marker appears or the deadline passes. The nav keys here (`1`/`3`/
-/// `,`) are idempotent tab switches, so re-pressing on the destination is a
-/// harmless no-op. This replaces a brittle send-once + 12s-poll that flaked on
+/// until the marker appears or the deadline passes. The nav keys here (`1`/`,`)
+/// are idempotent tab switches, so re-pressing on the destination is a harmless
+/// no-op. This replaces a brittle send-once + 12s-poll that flaked on
 /// the loaded `hangar-e2e (ubuntu-latest)` leg once the board redesign made the
 /// per-screen render heavier.
 fn walk_to_screen(sess: &TuiSession, key: &str, positive: &str, forbidden: &str) -> String {
@@ -61,8 +62,21 @@ fn cross_screen_navigation_walks_tabs() {
         "issue counts missing:\n{issues}"
     );
 
-    // 3 → skills (positive: seeded skill; forbidden: issue count).
-    let skills = walk_to_screen(&sess, "3", "commit", "Todo (3)");
+    // ^P skills → skills (positive: seeded skill; forbidden: issue count). The
+    // `3` tab key was the hop here until crisp B5 §2.5 demoted it, which makes
+    // this walk the one tripwire that crosses BOTH nav routes in one run.
+    let skills = sess
+        .go_to_screen_until(
+            "skills",
+            Instant::now() + Duration::from_secs(30 * common::budget_scale()),
+            |c| c.contains("commit") && !c.contains("Todo (3)"),
+        )
+        .unwrap_or_else(|| {
+            panic!(
+                "`^P skills` never rendered the skill manager:\n{}",
+                sess.capture()
+            )
+        });
     assert!(skills.contains("Used"), "skills chip missing:\n{skills}");
 
     // , → settings (positive: Daemon; forbidden: skills chip `Unused`).

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_issue_list_renders.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_issue_list_renders.rs
@@ -44,12 +44,12 @@ fn issue_list_renders_seeded_issues() {
 
     // Return navigation: leave to settings (`,`) then back to issue list (`1`).
     //
-    // Detect the Settings *body*, not the tab strip. P8.5 (`d0a81fa`) added a
-    // `[D]Daemon` entry to the persistent tab strip rendered on EVERY screen, so
-    // a bare `contains("Daemon")` now matches the issue-list landing screen too —
-    // it would fire before `,` took effect and capture the issue list. Gate on a
-    // Settings-body-only section header (`Providers`, which is not a tab) AND the
-    // section word so we only proceed once the body actually switched.
+    // Detect the Settings *body*, not the tab strip. Gate on a Settings-only
+    // section header (`Providers`) AND the section word, so the poll can only
+    // fire once the body has actually switched rather than on chrome that is
+    // painted over the landing screen too. (The original reason was a `[D]Daemon`
+    // tab on the strip; crisp B5 §2.5 demoted `D`, so the strip no longer carries
+    // the word, but pinning a body-only header is still the right shape.)
     // Re-send the nav key until the screen switches: a lone keypress can be
     // dropped on a loaded CI runner.
     let settings = sess

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_skill_manager_lists.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_p4_skill_manager_lists.rs
@@ -23,11 +23,12 @@ fn skill_manager_lists_skills() {
     let bin = common::ainb_bin().expect("gated by can_run_tripwire");
     let (sess, _landing) = TuiSession::launch_to_hangar(&bin, pipe.home());
 
-    // Re-send the nav key until the screen switches: a lone keypress can be
-    // dropped on a loaded CI runner (the flake that reddened the Linux leg).
+    // Re-send the whole `^P skills` sequence until the screen switches: a lone
+    // keystroke can be dropped on a loaded CI runner (the flake that reddened the
+    // Linux leg). Was the `3` tab key until crisp B5 §2.5 demoted it.
     let skills = sess
-        .switch_tab_until(
-            "3",
+        .go_to_screen_until(
+            "skills",
             Instant::now() + Duration::from_secs(15 * common::budget_scale()),
             |c| c.contains("commit") && c.contains("Used"),
         )

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -286,7 +286,9 @@ pub(crate) const fn tab_hotkey(screen: &Screen) -> Option<char> {
         | Screen::Squads
         | Screen::Profiles => None,
         // Modals overlay a tab; they are not one.
-        Screen::AgentPicker(_) | Screen::ActivityTimeline(_) | Screen::Help
+        Screen::AgentPicker(_)
+        | Screen::ActivityTimeline(_)
+        | Screen::Help
         | Screen::CommandPalette => None,
     }
 }
@@ -600,7 +602,13 @@ mod tests {
     #[test]
     fn the_seven_tab_strip_fits_the_eighty_column_floor() {
         let mut buf = WireBuffer::new(80, 24);
-        render_top_bar(&mut buf, 80, &Screen::IssueList, "default", Presence::Online);
+        render_top_bar(
+            &mut buf,
+            80,
+            &Screen::IssueList,
+            "default",
+            Presence::Online,
+        );
         let row0 = row_text(&buf, 0, 80);
         for (hotkey, label) in PRIMARY_TABS {
             assert!(
@@ -616,7 +624,13 @@ mod tests {
 
         // 93 columns is where it fits, and there it paints.
         let mut wide = WireBuffer::new(93, 24);
-        render_top_bar(&mut wide, 93, &Screen::IssueList, "default", Presence::Online);
+        render_top_bar(
+            &mut wide,
+            93,
+            &Screen::IssueList,
+            "default",
+            Presence::Online,
+        );
         let wide0 = row_text(&wide, 0, 93);
         assert!(
             wide0.contains("default · ● online"),

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -37,26 +37,21 @@ const ACTIVE_TAB_BG: Color = Color::rgb(40, 40, 60);
 /// though it is only reachable with a selection — it keeps the tab positions
 /// stable so the eye doesn't jump when a task is opened.
 ///
-/// The numbered hotkeys are **contiguous** (`1`→`4`, no gap): the old `[3]Agents`
-/// tab was folded into the issue-list `[Agents]` filter chip, so `Skills` and
-/// `Autopilots` shifted down to `3`/`4` to close the hole (e38.38). `Issues`/`Task`
-/// keep their `1`/`2` muscle memory; only the two tabs that sat past the removed
-/// `Agents` slot renumber, and only by one.
-const PRIMARY_TABS: [(char, &str); 16] = [
+/// SEVEN, down from sixteen (crisp B5 §2.5). The strip was 138 columns and never
+/// fitted the 80×24 floor, advertising a screen for every noun in the daemon;
+/// these seven are the loop an operator actually runs (author, run, answer, read
+/// the result). It measures 74 columns, pinned by
+/// `the_seven_tab_strip_fits_the_eighty_column_floor`.
+///
+/// The numbered hotkeys stay **contiguous** (`1`→`2`, no gap) and keep their
+/// muscle memory; the nine demoted screens are reached with `^P` + their word
+/// ([`crate::screen::command_palette::GO_SCREENS`]) and listed under Settings.
+const PRIMARY_TABS: [(char, &str); 7] = [
     ('1', "Issues"),
     ('2', "Task"),
-    ('3', "Skills"),
-    ('4', "Autopilots"),
     ('K', "Kanban"),
     ('B', "Boards"),
-    ('D', "Daemon"),
-    ('U', "Usage"),
-    ('L', "Logs"),
     ('I', "Inbox"),
-    ('C', "Control"),
-    ('F', "Fleet"),
-    ('S', "Squads"),
-    ('P', "Profiles"),
     ('A', "Agents"),
     (',', "Settings"),
 ];
@@ -262,30 +257,46 @@ pub(crate) fn footer_hints(active: &Screen) -> Vec<(&'static str, &'static str)>
     hints
 }
 
+/// The tab-strip hotkey that lights up for `screen`, or `None` for a screen with
+/// no tab: the nine crisp B5 demoted, and the four modals (which overlay a tab
+/// rather than being one, so nothing lights while one is open).
+///
+/// Keyed off the SCREEN, not off the hotkey, so it is the one place that decides
+/// what is on the strip. `tab_is_active` reads it, and
+/// `every_tab_on_the_strip_is_reachable_and_labelled` pins it against both
+/// [`PRIMARY_TABS`] and `ROUTER_KEYS` — the previous shape was a second
+/// hotkey→screen table that could keep an arm for a tab the strip had dropped.
+pub(crate) const fn tab_hotkey(screen: &Screen) -> Option<char> {
+    match screen {
+        Screen::IssueList => Some('1'),
+        Screen::TaskDetail(_) => Some('2'),
+        Screen::Kanban => Some('K'),
+        Screen::Boards => Some('B'),
+        Screen::Inbox => Some('I'),
+        Screen::Agents => Some('A'),
+        Screen::Settings => Some(','),
+        // Demoted off the strip by crisp B5 §2.5; reached through `^P`.
+        Screen::SkillManager
+        | Screen::Autopilots
+        | Screen::DaemonHealth
+        | Screen::Usage
+        | Screen::Logs
+        | Screen::ControlCenter
+        | Screen::Fleet
+        | Screen::Squads
+        | Screen::Profiles => None,
+        // Modals overlay a tab; they are not one.
+        Screen::AgentPicker(_) | Screen::ActivityTimeline(_) | Screen::Help
+        | Screen::CommandPalette => None,
+    }
+}
+
 /// Whether `hotkey`'s tab is the active one. `Task` (`2`) highlights for any
 /// task-detail screen; the agent-picker modal keeps the screen *under* it
 /// highlighted, so it falls through to no match (no tab lit) which is correct —
 /// the modal is an overlay, not a tab.
 const fn tab_is_active(active: &Screen, hotkey: char) -> bool {
-    match hotkey {
-        '1' => matches!(active, Screen::IssueList),
-        '2' => matches!(active, Screen::TaskDetail(_)),
-        '3' => matches!(active, Screen::SkillManager),
-        '4' => matches!(active, Screen::Autopilots),
-        'K' => matches!(active, Screen::Kanban),
-        'B' => matches!(active, Screen::Boards),
-        'D' => matches!(active, Screen::DaemonHealth),
-        'U' => matches!(active, Screen::Usage),
-        'L' => matches!(active, Screen::Logs),
-        'I' => matches!(active, Screen::Inbox),
-        'C' => matches!(active, Screen::ControlCenter),
-        'F' => matches!(active, Screen::Fleet),
-        'S' => matches!(active, Screen::Squads),
-        'P' => matches!(active, Screen::Profiles),
-        'A' => matches!(active, Screen::Agents),
-        ',' => matches!(active, Screen::Settings),
-        _ => false,
-    }
+    matches!(tab_hotkey(active), Some(key) if key == hotkey)
 }
 
 /// Column at which the right cluster should start, or `None` if it doesn't fit
@@ -363,9 +374,11 @@ mod tests {
     fn active_tab_detection() {
         assert!(tab_is_active(&Screen::IssueList, '1'));
         assert!(!tab_is_active(&Screen::IssueList, '2'));
-        assert!(tab_is_active(&Screen::SkillManager, '3'));
-        assert!(tab_is_active(&Screen::Autopilots, '4'));
+        assert!(tab_is_active(&Screen::Kanban, 'K'));
+        assert!(tab_is_active(&Screen::Inbox, 'I'));
         assert!(tab_is_active(&Screen::Settings, ','));
+        // A demoted screen lights no tab at all — the strip has none for it.
+        assert!(!tab_is_active(&Screen::SkillManager, '3'));
         let issue = ainb_hangar_core::ids::IssueId::from_str("i1").unwrap();
         assert!(!tab_is_active(&Screen::AgentPicker(issue), '1'));
     }
@@ -532,32 +545,83 @@ mod tests {
         }
     }
 
-    /// Every `Screen` variant, for the tests that must hold across all of them.
-    fn every_screen() -> Vec<Screen> {
-        let issue = ainb_hangar_core::ids::IssueId::from_str("i1").unwrap();
-        let task = ainb_hangar_core::ids::TaskId::from_str("01HANGARTASK000000000001").unwrap();
-        vec![
-            Screen::IssueList,
-            Screen::TaskDetail(task),
-            Screen::AgentPicker(issue.clone()),
-            Screen::ActivityTimeline(issue),
-            Screen::SkillManager,
-            Screen::Autopilots,
-            Screen::Kanban,
-            Screen::Boards,
-            Screen::DaemonHealth,
-            Screen::Usage,
-            Screen::Logs,
-            Screen::Inbox,
-            Screen::ControlCenter,
-            Screen::Fleet,
-            Screen::Squads,
-            Screen::Profiles,
-            Screen::Agents,
-            Screen::Settings,
-            Screen::Help,
-            Screen::CommandPalette,
-        ]
+    use crate::test_support::every_screen;
+
+    /// COVERAGE (crisp B5 §2.5): the strip, the active-tab map and the router key
+    /// set name exactly the same seven tabs.
+    ///
+    /// A tab is a promise of three things at once — it is painted, it lights up
+    /// when you are on it, and its key gets you there. This walks every `Screen`
+    /// variant and both directions of [`PRIMARY_TABS`], so shrinking the strip
+    /// without shrinking [`tab_hotkey`] (a tab that never highlights), or without
+    /// shrinking `ROUTER_KEYS` (a key the router no longer claims painted as if it
+    /// worked), fails here. A count assertion would have passed for both.
+    #[test]
+    fn every_tab_on_the_strip_is_reachable_and_labelled() {
+        use crate::screen::router::ROUTER_KEYS;
+        for screen in every_screen() {
+            let Some(hotkey) = tab_hotkey(&screen) else {
+                assert!(
+                    !PRIMARY_TABS.iter().any(|(_, label)| *label == screen.tab_label()),
+                    "{screen:?} is painted on the strip but lights no tab"
+                );
+                continue;
+            };
+            assert!(
+                PRIMARY_TABS.iter().any(|(key, _)| *key == hotkey),
+                "{screen:?} claims tab `{hotkey}` but the strip does not paint it"
+            );
+            assert!(
+                ROUTER_KEYS.contains(&hotkey),
+                "the strip paints `{hotkey}` for {screen:?} but the router no longer claims it"
+            );
+        }
+        // The other direction: no tab is painted for a screen that dropped out.
+        for (hotkey, label) in PRIMARY_TABS {
+            let owner = every_screen().into_iter().find(|s| tab_hotkey(s) == Some(hotkey));
+            assert_eq!(
+                owner.as_ref().map(Screen::tab_label),
+                Some(label),
+                "the strip paints `[{hotkey}]{label}` but no screen answers to it"
+            );
+        }
+    }
+
+    /// The seven-tab strip measures 74 columns and clears the 80×24 floor with
+    /// every label intact — the sixteen-tab strip was 138 and truncated four tabs
+    /// off the right edge at the floor (crisp B5 §2.5).
+    ///
+    /// The right-hand cluster still yields at 80, which §2.5 predicted it would
+    /// not: the strip is 74 columns of ink and the cursor lands at 76 (each tab
+    /// carries a two-space separator), so `default · ● online` at 18 columns needs
+    /// 95. The tabs winning that contest is the documented rule
+    /// (`right_cluster_yields_to_tabs_when_tight`); pinned here at both widths so
+    /// the trade is a measured number rather than an assumption.
+    #[test]
+    fn the_seven_tab_strip_fits_the_eighty_column_floor() {
+        let mut buf = WireBuffer::new(80, 24);
+        render_top_bar(&mut buf, 80, &Screen::IssueList, "default", Presence::Online);
+        let row0 = row_text(&buf, 0, 80);
+        for (hotkey, label) in PRIMARY_TABS {
+            assert!(
+                row0.contains(&format!("[{hotkey}]{label}")),
+                "`[{hotkey}]{label}` is cut off at the 80-column floor: {row0:?}"
+            );
+        }
+        assert_eq!(row0.trim_end().chars().count(), 74, "row0 = {row0:?}");
+        assert!(
+            !row0.contains("online"),
+            "the right cluster does not fit at 80 and must yield: {row0:?}"
+        );
+
+        // 95 columns is where it fits, and there it paints.
+        let mut wide = WireBuffer::new(95, 24);
+        render_top_bar(&mut wide, 95, &Screen::IssueList, "default", Presence::Online);
+        let wide0 = row_text(&wide, 0, 95);
+        assert!(
+            wide0.contains("default · ● online"),
+            "the cluster paints once there is room: {wide0:?}"
+        );
     }
 
     /// The right cluster yields to the tabs: when there isn't room after the
@@ -573,13 +637,11 @@ mod tests {
     }
 
     /// The top bar renders every tab hotkey + the workspace slug on row 0 at a
-    /// realistic width. The six-tab strip (P8.4 added Kanban) needs >80 cols to
-    /// also fit the right cluster; the slug-yields-to-tabs behaviour at the 80×24
-    /// floor is covered by `chrome_renders_at_80x24_floor_without_overflow`.
+    /// realistic width. The width the strip needs is pinned separately by
+    /// `the_seven_tab_strip_fits_the_eighty_column_floor`.
     #[test]
     fn top_bar_renders_tabs_and_slug() {
-        // Wide enough that the full fifteen-tab strip (P4 added `[B]Boards`, P7
-        // `[S]Squads`, P5 `[P]Profiles`, slice 2 `[A]Agents` — ~168 cols) AND the
+        // Wide enough that the seven-tab strip (74 cols, crisp B5 §2.5) AND the
         // right-side workspace-slug cluster both fit; the tabs win width
         // contention, so a narrower buffer drops the slug (covered by the 80x24
         // floor smoke).
@@ -588,9 +650,9 @@ mod tests {
         // Reconstruct row 0 text from the wire buffer cells.
         let row0 = row_text(&buf, 0, 200);
         assert!(row0.contains("Issues"), "row0 = {row0:?}");
-        assert!(row0.contains("Skills"), "row0 = {row0:?}");
+        assert!(row0.contains("Inbox"), "row0 = {row0:?}");
         assert!(row0.contains("Kanban"), "row0 = {row0:?}");
-        assert!(row0.contains("Usage"), "row0 = {row0:?}");
+        assert!(row0.contains("Settings"), "row0 = {row0:?}");
         assert!(row0.contains("acme"), "row0 = {row0:?}");
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/chrome.rs
@@ -1,7 +1,7 @@
 //! Shared chrome: the top tab bar and bottom footer that wrap every screen.
 //!
 //! The chrome is the persistent frame around the Core 5 screens (P4.1). The
-//! [top tab bar](render_top_bar) shows the four primary tabs, the active
+//! [top tab bar](render_top_bar) shows the seven primary tabs, the active
 //! workspace slug, and an online/offline presence dot; the
 //! [footer](render_footer) shows the contextual key hints for the active
 //! screen. Both are **width-aware**: they derive their sub-region widths from
@@ -40,8 +40,8 @@ const ACTIVE_TAB_BG: Color = Color::rgb(40, 40, 60);
 /// SEVEN, down from sixteen (crisp B5 §2.5). The strip was 138 columns and never
 /// fitted the 80×24 floor, advertising a screen for every noun in the daemon;
 /// these seven are the loop an operator actually runs (author, run, answer, read
-/// the result). It measures 74 columns, pinned by
-/// `the_seven_tab_strip_fits_the_eighty_column_floor`.
+/// the result). It measures 72 columns of ink (74 with the trailing separator),
+/// pinned by `the_seven_tab_strip_fits_the_eighty_column_floor`.
 ///
 /// The numbered hotkeys stay **contiguous** (`1`→`2`, no gap) and keep their
 /// muscle memory; the nine demoted screens are reached with `^P` + their word
@@ -49,7 +49,7 @@ const ACTIVE_TAB_BG: Color = Color::rgb(40, 40, 60);
 const PRIMARY_TABS: [(char, &str); 7] = [
     ('1', "Issues"),
     ('2', "Task"),
-    ('K', "Kanban"),
+    ('K', "Runs"),
     ('B', "Boards"),
     ('I', "Inbox"),
     ('A', "Agents"),
@@ -77,7 +77,7 @@ impl Presence {
 
 /// Render the top tab bar onto row 0 of `buf`.
 ///
-/// Layout: `[1]Issues [2]Task [3]Skills [,]Settings` on the left, and
+/// Layout: `[1]Issues [2]Task [K]Runs … [,]Settings` on the left, and
 /// `<workspace> · <dot> <presence>` flushed to the right. The right cluster is
 /// dropped first when width is too tight to fit both — the tabs always win the
 /// space contest so navigation stays visible at the 80×24 floor.
@@ -592,9 +592,9 @@ mod tests {
     /// off the right edge at the floor (crisp B5 §2.5).
     ///
     /// The right-hand cluster still yields at 80, which §2.5 predicted it would
-    /// not: the strip is 74 columns of ink and the cursor lands at 76 (each tab
+    /// not: the strip is 72 columns of ink and the cursor lands at 74 (each tab
     /// carries a two-space separator), so `default · ● online` at 18 columns needs
-    /// 95. The tabs winning that contest is the documented rule
+    /// 93. The tabs winning that contest is the documented rule
     /// (`right_cluster_yields_to_tabs_when_tight`); pinned here at both widths so
     /// the trade is a measured number rather than an assumption.
     #[test]
@@ -608,16 +608,16 @@ mod tests {
                 "`[{hotkey}]{label}` is cut off at the 80-column floor: {row0:?}"
             );
         }
-        assert_eq!(row0.trim_end().chars().count(), 74, "row0 = {row0:?}");
+        assert_eq!(row0.trim_end().chars().count(), 72, "row0 = {row0:?}");
         assert!(
             !row0.contains("online"),
             "the right cluster does not fit at 80 and must yield: {row0:?}"
         );
 
-        // 95 columns is where it fits, and there it paints.
-        let mut wide = WireBuffer::new(95, 24);
-        render_top_bar(&mut wide, 95, &Screen::IssueList, "default", Presence::Online);
-        let wide0 = row_text(&wide, 0, 95);
+        // 93 columns is where it fits, and there it paints.
+        let mut wide = WireBuffer::new(93, 24);
+        render_top_bar(&mut wide, 93, &Screen::IssueList, "default", Presence::Online);
+        let wide0 = row_text(&wide, 0, 93);
         assert!(
             wide0.contains("default · ● online"),
             "the cluster paints once there is room: {wide0:?}"
@@ -651,7 +651,7 @@ mod tests {
         let row0 = row_text(&buf, 0, 200);
         assert!(row0.contains("Issues"), "row0 = {row0:?}");
         assert!(row0.contains("Inbox"), "row0 = {row0:?}");
-        assert!(row0.contains("Kanban"), "row0 = {row0:?}");
+        assert!(row0.contains("Runs"), "row0 = {row0:?}");
         assert!(row0.contains("Settings"), "row0 = {row0:?}");
         assert!(row0.contains("acme"), "row0 = {row0:?}");
     }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -5640,6 +5640,12 @@ impl HangarPlugin {
             NavIntent::NavigateToEntity { screen, id, kind } => {
                 self.navigate_to_entity(app, &screen, &id, &kind);
             }
+            NavIntent::GoToScreen(screen) => {
+                let mut next = app.clone();
+                next.screen = screen;
+                next.prior_screen = None;
+                self.app = Some(next);
+            }
         }
     }
 
@@ -7424,6 +7430,11 @@ mod tests {
             "a keystroke arms hangar/search for the typed query, got {:?}",
             p.screens.pending_palette_action
         );
+        // Narrow past every `Go:` word so the entity path is what Enter takes
+        // (crisp B5 merged the nine screen rows ahead of the daemon's results).
+        for ch in "efactor".chars() {
+            p.on_key(&char_press(ch));
+        }
 
         // Feed a ranked result back (as the `hangar/search` reply would) and prove
         // it renders inside the overlay.
@@ -7498,12 +7509,26 @@ mod tests {
         }
     }
 
+    /// Drive the palette exactly as an operator does — `^P`, the screen's word,
+    /// Enter — to land on a screen crisp B5 took off the tab strip.
+    ///
+    /// The tests below used the tab hotkey (`4`, `C`, `F`) to get there. Routing
+    /// them through the palette instead means the replacement route is exercised
+    /// by every one of them, not only by its own guard.
+    fn go_to(p: &mut HangarPlugin, word: &str) {
+        p.on_key(&ctrl_p_press());
+        for ch in word.chars() {
+            p.on_key(&char_press(ch));
+        }
+        p.on_key(&enter_press());
+    }
+
     /// Esc closes the palette back to the screen that opened it, with no jump.
     #[test]
     fn esc_closes_palette_back_to_prior_screen() {
         let mut p = connected_plugin_with_issue();
         // Open from the Autopilots screen so the restore target is non-default.
-        p.on_key(&char_press('4'));
+        go_to(&mut p, "autopilots");
         assert!(matches!(p.app_state().screen, Screen::Autopilots));
         p.on_key(&ctrl_p_press());
         assert!(matches!(p.app_state().screen, Screen::CommandPalette));
@@ -8525,11 +8550,13 @@ mod tests {
             "an open card-title overlay must declare text-capture (8hx)"
         );
 
-        // Typing the title's leading `C` must be captured, not switch to Control.
+        // Typing the title's leading `C` must be captured. `C` stopped being a
+        // router key with the crisp B5 shrink, so this now guards the overlay's
+        // own capture rather than a live tab switch.
         p.on_key(&char_press('C'));
         assert!(
             matches!(p.app_state().screen, Screen::Boards),
-            "typing `C` into the title must NOT switch to the control center, got {:?}",
+            "typing `C` into the title must NOT leave the boards screen, got {:?}",
             p.app_state().screen
         );
 
@@ -9085,7 +9112,7 @@ mod tests {
         p.on_key(&char_press('C'));
         assert!(
             matches!(p.app_state().screen, Screen::TaskDetail(_)),
-            "typing `C` in the compose draft must NOT switch to the control center, got {:?}",
+            "typing `C` in the compose draft must NOT leave task detail, got {:?}",
             p.app_state().screen
         );
         assert_eq!(
@@ -9136,7 +9163,7 @@ mod tests {
         p.on_key(&char_press('C'));
         assert!(
             matches!(p.app_state().screen, Screen::Settings),
-            "typing `C` in the key-entry modal must NOT switch to the control center, got {:?}",
+            "typing `C` in the key-entry modal must NOT leave settings, got {:?}",
             p.app_state().screen
         );
         assert!(
@@ -9172,8 +9199,8 @@ mod tests {
     /// REGRESSION (routing level, not the pure reducer): the Daemon-section
     /// numeric-config overlay is a text-capture surface. Every realistic value for
     /// an int knob (30, 120, 240, 1440) contains a digit `routing_event` claims as
-    /// a tab switch, so without the capture guard typing `3` teleported the user to
-    /// the Skill Manager and dropped the keystroke — the headline editing path did
+    /// a tab switch, so without the capture guard typing `1` teleports the user to
+    /// the issue list and drops the keystroke — the headline editing path does
     /// not work at all. Drive the real `on_key` (which consults `routing_event`
     /// BEFORE `route_key`), not `reduce_settings`, or the bug is invisible.
     #[test]
@@ -9199,25 +9226,29 @@ mod tests {
             "Enter on an int knob opens an empty numeric overlay"
         );
 
-        // THE REGRESSION: `3` must extend the buffer, not switch to the Skill
-        // Manager tab (`routing_event` maps '3' → Screen::SkillManager).
-        p.on_key(&key_press(KeyCode::Char { ch: '3' }));
+        // THE REGRESSION: `1` must extend the buffer, not switch tabs. Typed as
+        // `120`, not the `30` this test used to type: crisp B5 demoted `3`, so a
+        // value starting with it no longer crosses the routing layer at all, and
+        // the guard would have passed with the capture guard deleted. `1` and `2`
+        // are still router keys, and `120` is as realistic a minute count as `30`.
+        p.on_key(&key_press(KeyCode::Char { ch: '1' }));
         assert!(
             matches!(p.app_state().screen, Screen::Settings),
-            "typing `3` in the config overlay must NOT switch tabs, got {:?}",
+            "typing `1` in the config overlay must NOT switch tabs, got {:?}",
             p.app_state().screen
         );
         assert_eq!(
             p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()),
-            Some("3"),
-            "`3` must land in the overlay buffer"
+            Some("1"),
+            "`1` must land in the overlay buffer"
         );
 
-        // `0` completes `30`; the overlay is still open on Settings.
+        // `2` then `0` complete `120`; the overlay is still open on Settings.
+        p.on_key(&key_press(KeyCode::Char { ch: '2' }));
         p.on_key(&key_press(KeyCode::Char { ch: '0' }));
         assert_eq!(
             p.screens.settings.as_ref().and_then(|s| s.config_input_buffer()),
-            Some("30"),
+            Some("120"),
             "digits accumulate in the overlay"
         );
         assert!(matches!(p.app_state().screen, Screen::Settings));
@@ -9427,13 +9458,24 @@ mod tests {
         assert!(!p.captures_text(), "capture is released with the overlay");
     }
 
+    /// `^P fleet` lands on the Fleet pane, and bare `F` no longer does.
+    ///
+    /// Was `fleet_hotkey_routes_to_dedicated_pane`, asserting `routing_event('F')`
+    /// yielded the Fleet tab switch. Crisp B5 §2.5 demoted `F`; the negative half
+    /// is kept so freeing the key stays deliberate — `F` now reaches the screen
+    /// reducer, which is the point.
     #[test]
-    fn fleet_hotkey_routes_to_dedicated_pane() {
+    fn the_palette_word_routes_to_the_dedicated_fleet_pane() {
+        let mut p = connected_plugin_with_issue();
+        go_to(&mut p, "fleet");
+        assert_eq!(p.app_state().screen, Screen::Fleet);
+
         let app =
             AppState::new(WorkspaceId::from_str("default").expect("valid default workspace id"));
-        let event = routing_event(&char_press('F'), &app).expect("Fleet route event");
-        let out = crate::screen::reduce(&app, event);
-        assert_eq!(out.state.screen, Screen::Fleet);
+        assert!(
+            routing_event(&char_press('F'), &app).is_none(),
+            "`F` is no longer a router key"
+        );
     }
 
     #[test]
@@ -9522,7 +9564,7 @@ mod tests {
         };
         plugin.screens.fleet.set_sessions(vec![row("claude:one"), row("claude:two")]);
 
-        plugin.on_key(&char_press('F'));
+        go_to(&mut plugin, "fleet");
         plugin.on_key(&key_press(KeyCode::Down));
         assert!(matches!(plugin.app_state().screen, Screen::Fleet));
         assert_eq!(plugin.screens.fleet.selected_key(), Some("claude:two"));
@@ -9535,7 +9577,7 @@ mod tests {
     #[test]
     fn fleet_f5_arms_direct_snapshot_refresh() {
         let mut plugin = connected_plugin_with_issue();
-        plugin.on_key(&char_press('F'));
+        go_to(&mut plugin, "fleet");
         assert!(matches!(plugin.app_state().screen, Screen::Fleet));
 
         plugin.fleet_fetch_pending = false;
@@ -10253,14 +10295,19 @@ mod inbox_attention_key_tests {
         assert!(p.screens.take_pending_answer_action().is_none());
     }
 
-    /// A digit past the last option is not an answer, so it is not swallowed:
-    /// it navigates like any other digit.
+    /// A digit past the last option is never swallowed as an answer.
     ///
     /// The intercept is exactly as wide as the answer. Guarding on "an ASK is
-    /// focused" instead made `3` on a two-option ASK do nothing at all — no
-    /// answer, no navigation, no feedback — on the screen operators live in.
+    /// focused" instead ate every digit on the screen operators live in.
+    ///
+    /// This was `an_out_of_range_digit_falls_through_to_the_tab_router`, pressing
+    /// `3` on a two-option ASK and landing on the Skills tab. Crisp B5 demoted
+    /// `3`, and the only router digits left (`1`, `2`) are both IN range on a
+    /// two-option ASK, so "out of range AND a tab key" is no longer a state that
+    /// exists. The other half of the contract — a digit with nothing to answer
+    /// still navigates — is `a_digit_still_switches_tabs_when_nothing_is_answerable`.
     #[test]
-    fn an_out_of_range_digit_falls_through_to_the_tab_router() {
+    fn a_freed_digit_never_answers_an_option_that_does_not_exist() {
         let mut p = plugin_on_inbox(&[ask_row("a1")]);
         p.on_key(&char_press('3'));
         assert!(
@@ -10268,8 +10315,9 @@ mod inbox_attention_key_tests {
             "a two-option ASK has no third option"
         );
         assert!(
-            matches!(p.app_state().screen, Screen::SkillManager),
-            "so `3` is still the Skills tab"
+            matches!(p.app_state().screen, Screen::Inbox),
+            "`3` is no longer a tab key, so the Inbox keeps the screen, got {:?}",
+            p.app_state().screen
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/plugin.rs
@@ -4671,6 +4671,18 @@ impl HangarPlugin {
             let _ = route_key(&app, &mut self.screens, key);
             return;
         }
+        // The command-palette query is a text-capture surface like any other, and
+        // the one `captures_text` already declared to the host without a matching
+        // guard here: the host forwards `q` into the plugin, and the routing layer
+        // then quit the TUI mid-word. A palette you cannot type `q` into cannot
+        // search for `queued`, and after the crisp B5 shrink it cannot reach
+        // `squads` either.
+        if matches!(app.screen, Screen::CommandPalette) {
+            if let Some(nav) = route_key(&app, &mut self.screens, key) {
+                self.apply_nav(&app, nav);
+            }
+            return;
+        }
 
         // e38.13: `Ctrl+P` opens the global command palette from any non-modal
         // screen. It is a modifier chord, so it never shadows a per-screen `p`
@@ -7454,6 +7466,36 @@ mod tests {
             Some("issue-1"),
             "the jumped-to issue is selected"
         );
+    }
+
+    /// Every char the ROUTER claims is query text once the palette is open.
+    ///
+    /// `captures_text` already told the host the palette is a text surface, so the
+    /// host forwards `q` / `1` / `,` / `B` into the plugin instead of eating them —
+    /// and the routing layer then quit the TUI, or teleported to a tab, mid-word.
+    /// Pinned over the WHOLE reserved set, not one char: `queued`, `Boards`, `1:1`
+    /// and `Kanban` are all things an operator types into a search box.
+    #[test]
+    fn the_palette_query_swallows_every_router_key() {
+        for ch in crate::screen::router::ROUTER_KEYS {
+            let mut p = connected_plugin_with_issue();
+            p.on_key(&ctrl_p_press());
+            p.on_key(&char_press(ch));
+            assert!(
+                matches!(p.app_state().screen, Screen::CommandPalette),
+                "typing `{ch}` into the palette left it for {:?}",
+                p.app_state().screen
+            );
+            assert!(
+                !p.close_request_pending,
+                "typing `{ch}` into the palette asked the host to close"
+            );
+            assert_eq!(
+                p.screens.command_palette.as_ref().map(|s| s.query().to_string()),
+                Some(ch.to_string()),
+                "`{ch}` must land in the query"
+            );
+        }
     }
 
     /// Esc closes the palette back to the screen that opened it, with no jump.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -3252,6 +3252,26 @@ mod help_overlay_tests {
         );
     }
 
+    /// COVERAGE: the `more` block names every screen in `GO_SCREENS`.
+    ///
+    /// It is the third copy of the demoted set and the only hand-written one —
+    /// Settings renders straight off `GO_SCREENS` and the palette rows ARE
+    /// `GO_SCREENS`. Both structural help guards deliberately SKIP this block
+    /// (its tokens are destinations, not screen-local keys), which left it the
+    /// one copy nothing checked: demote a tenth screen and the help would simply
+    /// not mention it.
+    #[test]
+    fn the_help_more_block_names_every_demoted_screen() {
+        use crate::screen::command_palette::GO_SCREENS;
+        let tokens: Vec<&str> = HELP_LINES.iter().flat_map(|l| l.split_whitespace()).collect();
+        for (word, screen) in GO_SCREENS {
+            assert!(
+                tokens.contains(&word),
+                "help `more` block omits `{word}` ({screen:?})"
+            );
+        }
+    }
+
     /// The overlay never paints on the chrome: row 0 is the tab strip and the
     /// last row is the footer, and both stay legible under `?`.
     ///

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1858,7 +1858,7 @@ fn render_prior(buf: &mut WireBuffer, w: u16, h: u16, prior: &Screen, states: &S
 pub const HELP_LINES: &[&str] = &[
     "Hangar — keys",
     "",
-    "screens   1 issues  2 task  K kanban  B boards  I inbox  A agents  , settings",
+    "screens   1 issues  2 task  K runs  B boards  I inbox  A agents  , settings",
     "          ^P search  q back to ainb home",
     "more      ^P then the word:  skills  autopilots  daemon  usage  logs",
     "                            control  fleet  squads  profiles",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/app_screens.rs
@@ -1692,6 +1692,10 @@ pub enum NavIntent {
         /// The selected entity's kind tag (e.g. `"issue"`).
         kind: String,
     },
+    /// Switch to a screen the palette's `Go:` family named (crisp B5 §2.5). The
+    /// replacement for the nine tab hotkeys the strip shrink took away, so it
+    /// behaves like one: switch and clear the modal-restore bookkeeping.
+    GoToScreen(Screen),
 }
 
 /// Render the active screen's body between the chrome top bar (row 0) and footer
@@ -1844,12 +1848,20 @@ fn render_prior(buf: &mut WireBuffer, w: u16, h: u16, prior: &Screen, states: &S
 /// The help overlay's lines: every screen the router reaches plus the keys an
 /// operator reaches for most on each. Kept as data so a test can pin it against
 /// the router's key set, and so a new screen shows up here or fails the build.
+///
+/// TWO screen blocks since crisp B5 §2.5. `screens` is the seven-tab strip, one
+/// `<key> <label>` pair each (`help_overlay_names_every_router_key` pins that
+/// every surviving router key appears). `more` is the nine demoted screens, which
+/// have no key at all: they are the words to type after `^P`, and both blocks are
+/// exempt from `help_overlay_screen_keys_are_not_router_keys` because their
+/// tokens are destinations, not screen-local bindings.
 pub const HELP_LINES: &[&str] = &[
     "Hangar — keys",
     "",
-    "screens   1 issues  2 task  3 skills  4 autopilots  K kanban  B boards",
-    "          C control  F fleet  S squads  P profiles  A agents  D daemon",
-    "          U usage  L logs  I inbox  , settings  ^P search",
+    "screens   1 issues  2 task  K kanban  B boards  I inbox  A agents  , settings",
+    "          ^P search  q back to ainb home",
+    "more      ^P then the word:  skills  autopilots  daemon  usage  logs",
+    "                            control  fleet  squads  profiles",
     "",
     "issues    j/k move  enter open  c create  s sub-issue  a assign  d done",
     "          x delete  y timeline  / filter  f facets  tab chips",
@@ -1872,13 +1884,20 @@ fn render_help(buf: &mut WireBuffer, w: u16, h: u16) {
     use ainb_plugin_sdk::{Cell, Color, Coord};
     const GOLD: Color = Color::rgb(255, 215, 0);
     let lines = HELP_LINES;
-    let y0 = h.saturating_sub(u16::try_from(lines.len()).unwrap_or(0)) / 2;
+    // The table centres inside the BODY band (row 0 is the tab strip, the last
+    // row is the footer) and never above it. Centring over the whole area was
+    // fine while the table was a row shorter than the band: crisp B5 added a
+    // `more` block, `y0` went to 0, and the title painted THROUGH the tab strip
+    // (`[BHangar — keysnbox`). Clamped rather than re-tuned, so the next line
+    // added clips the tail instead of eating the chrome.
+    let band = h.saturating_sub(2);
+    let y0 = 1 + band.saturating_sub(u16::try_from(lines.len()).unwrap_or(0)) / 2;
     for (i, line) in lines.iter().enumerate() {
         let y = y0 + u16::try_from(i).unwrap_or(0);
         // A short pane shows the head of the table and drops the tail; the
         // host clamps off-viewport cells silently, so without this the top
         // rows are the only ones lost.
-        if y >= h {
+        if y >= h.saturating_sub(1) {
             break;
         }
         let line_w = u16::try_from(line.chars().count()).unwrap_or(u16::MAX);
@@ -3039,6 +3058,11 @@ fn route_command_palette(states: &mut ScreenStates, key: &KeyEvent) -> Option<Na
             states.command_palette = None;
             return Some(NavIntent::NavigateToEntity { screen, id, kind });
         }
+        // Enter on a `Go:` row: switch screen and dismiss the modal.
+        Some(CommandPaletteIntent::GoToScreen(screen)) => {
+            states.command_palette = None;
+            return Some(NavIntent::GoToScreen(screen));
+        }
         // A query edit: queue the search RPC, keep the modal open.
         Some(CommandPaletteIntent::Search(query)) => {
             states.pending_palette_action = Some(PaletteAction::Search(query));
@@ -3117,7 +3141,10 @@ mod help_overlay_tests {
         for line in HELP_LINES {
             let first = line.split_whitespace().next().unwrap_or_default();
             if !line.starts_with(' ') {
-                in_screens = first == "screens";
+                // `more` (crisp B5) is a screen block like `screens`: its tokens
+                // are destinations to type after `^P`, not `<key> <label>` pairs,
+                // and its words collide with the section names by design.
+                in_screens = matches!(first, "screens" | "more");
             }
             if in_screens || first.is_empty() || first == "Hangar" || line.starts_with("esc") {
                 continue;
@@ -3161,7 +3188,9 @@ mod help_overlay_tests {
         for line in HELP_LINES {
             let mut tokens = line.split_whitespace().peekable();
             if let Some(first) = tokens.peek() {
-                if *first == "screens" {
+                // `more` joins `screens` as a destination block (crisp B5 §2.5):
+                // its words are what you type after `^P`, not keys a screen binds.
+                if matches!(*first, "screens" | "more") {
                     in_screens = true;
                 } else if !line.starts_with(' ') && !first.is_empty() {
                     in_screens = false;
@@ -3189,7 +3218,7 @@ mod help_overlay_tests {
     }
 
     /// A pane shorter than the table paints its first rows (the title and the
-    /// global keys) inside the viewport and nothing below it, instead of
+    /// global keys) inside the BODY BAND and nothing below it, instead of
     /// centring the block so the rows that survive are the middle ones.
     #[test]
     fn help_overlay_clips_to_a_short_pane_from_the_top() {
@@ -3201,25 +3230,63 @@ mod help_overlay_tests {
             rows.iter().all(|&y| y < h),
             "painted below the viewport: {rows:?}"
         );
-        // Blank separator lines paint no cells, so count the non-blank head.
-        let painted_head =
-            HELP_LINES[..usize::from(h)].iter().filter(|l| !l.trim().is_empty()).count();
+        // The band is rows `1..h-1`; blank separators paint no cells, so count
+        // the non-blank head of what fits in it.
+        let band = usize::from(h) - 2;
+        let painted_head = HELP_LINES[..band].iter().filter(|l| !l.trim().is_empty()).count();
         assert_eq!(
             rows.len(),
             painted_head,
-            "the first {h} lines land, one per row"
+            "the first {band} lines land, one per row"
         );
         let first: String = buf
             .cells
             .iter()
-            .filter(|(c, _)| c.y == 0)
+            .filter(|(c, _)| c.y == 1)
             .map(|(_, cell)| cell.symbol.clone())
             .collect();
         assert_eq!(
             first.trim(),
             HELP_LINES[0].trim(),
-            "row 0 is the table's first line"
+            "row 1 (the top of the band) is the table's first line"
         );
+    }
+
+    /// The overlay never paints on the chrome: row 0 is the tab strip and the
+    /// last row is the footer, and both stay legible under `?`.
+    ///
+    /// Found by looking at an 80×24 pane, not by an assertion: crisp B5 grew the
+    /// table by a `more` block, the whole-area centring put `y0` at 0, and the
+    /// title rendered THROUGH the strip as `[BHangar — keysnbox`. Checked at the
+    /// floor and one row either side of it, where the arithmetic turns over.
+    #[test]
+    fn help_overlay_never_paints_over_the_tab_strip_or_the_footer() {
+        for h in [10, 23, 24, 25, 40] {
+            let w = 80;
+            let mut buf = ainb_plugin_sdk::WireBuffer::new(w, h);
+            super::render_help(&mut buf, w, h);
+            for (coord, cell) in &buf.cells {
+                assert!(
+                    coord.y > 0 && coord.y < h - 1,
+                    "at {w}x{h} the overlay painted {:?} on chrome row {}",
+                    cell.symbol,
+                    coord.y
+                );
+            }
+        }
+    }
+
+    /// The whole table fits the body band at the 80×24 floor, so no row of it is
+    /// clipped on the smallest supported terminal.
+    #[test]
+    fn help_overlay_fits_the_eighty_by_twenty_four_floor() {
+        assert!(
+            HELP_LINES.len() <= 22,
+            "the help table is {} lines; the 80x24 body band holds 22",
+            HELP_LINES.len()
+        );
+        let longest = HELP_LINES.iter().map(|l| l.chars().count()).max().unwrap_or(0);
+        assert!(longest <= 80, "the widest help line is {longest} columns");
     }
 }
 

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
@@ -17,6 +17,29 @@
 use ainb_hangar_proto::snapshots::SearchEntry;
 use ainb_plugin_sdk::{Cell, Color, Coord, WireBuffer};
 
+use super::Screen;
+
+/// The nine screens crisp B5 §2.5 took off the tab strip, each with the word
+/// that reaches it here. The ONE list: the `Go:` palette rows, the Settings
+/// `More screens` section and `palette_reaches_every_demoted_screen` all read it,
+/// so a screen cannot be advertised in one place and unreachable in another.
+///
+/// Carries the [`Screen`] itself, not a wire token: the daemon's `SearchEntry`
+/// route goes through a `screen: String` that an unknown value silently drops on
+/// the floor, and a typo there is a stranded screen with no compile error. These
+/// are plugin-local rows, so they carry the destination.
+pub const GO_SCREENS: [(&str, Screen); 9] = [
+    ("skills", Screen::SkillManager),
+    ("autopilots", Screen::Autopilots),
+    ("daemon", Screen::DaemonHealth),
+    ("usage", Screen::Usage),
+    ("logs", Screen::Logs),
+    ("control", Screen::ControlCenter),
+    ("fleet", Screen::Fleet),
+    ("squads", Screen::Squads),
+    ("profiles", Screen::Profiles),
+];
+
 /// Cornflower-blue modal border (ainb-tui chrome accent).
 const BORDER: Color = Color::rgb(100, 149, 237);
 /// Gold modal title.
@@ -27,6 +50,9 @@ const KIND_TAG: Color = Color::rgb(120, 120, 140);
 const SELECTED: Color = Color::rgb(255, 255, 255);
 /// Body text for an unselected row.
 const BODY: Color = Color::rgb(200, 200, 210);
+/// Modal panel background (the ainb-tui chrome band colour), so the screen the
+/// palette overlays does not read through between its rows.
+const PANEL_BG: Color = Color::rgb(30, 30, 40);
 
 /// The render-state cache for the command-palette modal.
 ///
@@ -65,16 +91,41 @@ impl CommandPaletteState {
         &self.results
     }
 
-    /// The current selection index (into [`Self::results`]).
+    /// The `Go:` rows matching the current query, in [`GO_SCREENS`] order.
+    ///
+    /// Matched client-side on a plain lowercase substring — nine fixed words, so
+    /// a scan is the whole algorithm — and merged AHEAD of the daemon's results:
+    /// `^P usage` must land on the Usage screen, not on an issue whose title
+    /// mentions usage. A bare `^P` lists all nine, so the palette doubles as the
+    /// index of what left the tab strip.
+    #[must_use]
+    pub fn go_rows(&self) -> Vec<(&'static str, Screen)> {
+        let query = self.query.to_lowercase();
+        GO_SCREENS.into_iter().filter(|(word, _)| word.contains(&query)).collect()
+    }
+
+    /// The current selection index, over the `Go:` rows THEN the ranked results.
     #[must_use]
     pub const fn selected_index(&self) -> usize {
         self.selected
     }
 
-    /// The currently-selected result, if any.
+    /// The selected `Go:` row's destination screen, if the selection sits on one.
+    #[must_use]
+    pub fn selected_go_screen(&self) -> Option<Screen> {
+        self.go_rows().into_iter().nth(self.selected).map(|(_, screen)| screen)
+    }
+
+    /// The currently-selected daemon result, if the selection sits past the
+    /// `Go:` rows and on one.
     #[must_use]
     pub fn selected_entry(&self) -> Option<&SearchEntry> {
-        self.results.get(self.selected)
+        self.results.get(self.selected.checked_sub(self.go_rows().len())?)
+    }
+
+    /// Total rows on screen: the matching `Go:` rows plus the ranked results.
+    fn row_count(&self) -> usize {
+        self.go_rows().len() + self.results.len()
     }
 
     /// Whether the modal has been closed (Esc).
@@ -120,6 +171,9 @@ pub enum CommandPaletteIntent {
         /// The selected entity's kind tag (e.g. `"issue"`).
         kind: String,
     },
+    /// Enter on a `Go:` row: switch to that screen. No entity, no row to select —
+    /// this is the replacement for the tab hotkey crisp B5 took away.
+    GoToScreen(Screen),
 }
 
 /// The result of folding one [`CommandPaletteEvent`] into a [`CommandPaletteState`].
@@ -167,7 +221,12 @@ fn reduce_key(state: &CommandPaletteState, c: char) -> CommandPaletteReduction {
 /// After a query edit, emit a [`CommandPaletteIntent::Search`] for the new text so
 /// the glue re-fires `hangar/search`. A blanked query searches for `""` (the
 /// daemon answers an empty result, which clears the list on the next load).
-fn search_after_edit(state: CommandPaletteState) -> CommandPaletteReduction {
+///
+/// The edit also re-filters the `Go:` rows, so the selection is clamped here too:
+/// narrowing nine rows to one while the cursor sat on the ninth would otherwise
+/// leave Enter pointing at a row that is no longer painted.
+fn search_after_edit(mut state: CommandPaletteState) -> CommandPaletteReduction {
+    clamp_selection(&mut state);
     let query = state.query.clone();
     CommandPaletteReduction {
         state,
@@ -179,15 +238,27 @@ fn search_after_edit(state: CommandPaletteState) -> CommandPaletteReduction {
 fn load_results(state: &CommandPaletteState, results: Vec<SearchEntry>) -> CommandPaletteReduction {
     let mut next = state.clone();
     next.results = results;
-    if next.selected >= next.results.len() {
-        next.selected = next.results.len().saturating_sub(1);
-    }
+    clamp_selection(&mut next);
     no_intent(next)
 }
 
-/// Navigate to the selected result (Enter), emitting the navigate intent. A no-op
-/// when there is no result selected (nothing to jump to).
+/// Pull the selection back onto a painted row after the row list shrank.
+fn clamp_selection(state: &mut CommandPaletteState) {
+    let rows = state.row_count();
+    if state.selected >= rows {
+        state.selected = rows.saturating_sub(1);
+    }
+}
+
+/// Navigate on Enter: a `Go:` row switches screen, a daemon result jumps to its
+/// entity. A no-op when nothing is selected (nothing to jump to).
 fn navigate(state: &CommandPaletteState) -> CommandPaletteReduction {
+    if let Some(screen) = state.selected_go_screen() {
+        return CommandPaletteReduction {
+            state: state.clone(),
+            intent: Some(CommandPaletteIntent::GoToScreen(screen)),
+        };
+    }
     state.selected_entry().map_or_else(
         || unchanged(state),
         |entry| CommandPaletteReduction {
@@ -201,10 +272,10 @@ fn navigate(state: &CommandPaletteState) -> CommandPaletteReduction {
     )
 }
 
-/// Move the selection down one result, clamped to the last result.
+/// Move the selection down one row, clamped to the last row.
 fn move_down(state: &CommandPaletteState) -> CommandPaletteReduction {
     let mut next = state.clone();
-    let max = next.results.len().saturating_sub(1);
+    let max = next.row_count().saturating_sub(1);
     next.selected = (next.selected + 1).min(max);
     no_intent(next)
 }
@@ -256,6 +327,18 @@ pub fn render_command_palette(
     let x0 = (area_w.saturating_sub(modal_w)) / 2;
     let y0 = (area_h.saturating_sub(modal_h)) / 2;
 
+    // Blank the interior BEFORE the border and rows. The palette paints only the
+    // cells it fills, so the screen it overlays showed through between its rows:
+    // `[go] Go: logs│             │` reads as one string of nonsense on an 80×24
+    // pane. Harmless while the palette was empty until you typed; crisp B5 made
+    // it the only route to nine screens, and it opens with nine rows.
+    for y in y0..y0.saturating_add(modal_h) {
+        for x in x0..x0.saturating_add(modal_w) {
+            let mut cell = Cell::new(" ");
+            cell.bg = Some(PANEL_BG);
+            buf.push(Coord::new(x, y), cell);
+        }
+    }
     draw_border(buf, x0, y0, modal_w, modal_h);
     // Title carries the live query so the user sees what they typed.
     let title = format!(" Search: {}_ ", state.query());
@@ -266,8 +349,21 @@ pub fn render_command_palette(
     let first_row = y0 + 1;
     let bottom = y0 + modal_h - 1;
 
-    for (i, entry) in state.results().iter().enumerate() {
-        // The row position is the first body row plus the result index; stop once
+    // `Go:` rows first, then the daemon's ranked results — the same order the
+    // selection index runs in, so the highlighted row is the one Enter takes.
+    let rows = state
+        .go_rows()
+        .into_iter()
+        .map(|(word, _)| ("[go] ".to_string(), format!("Go: {word}")))
+        .chain(state.results().iter().map(|entry| {
+            (
+                format!("[{}] ", format!("{:?}", entry.kind).to_lowercase()),
+                entry.label.clone(),
+            )
+        }));
+
+    for (i, (tag, label)) in rows.enumerate() {
+        // The row position is the first body row plus the row index; stop once
         // we'd paint into (or past) the bottom border.
         let row = first_row.saturating_add(u16::try_from(i).unwrap_or(u16::MAX));
         if row >= bottom {
@@ -275,7 +371,6 @@ pub fn render_command_palette(
         }
         let selected = i == state.selected_index();
         // `[kind]` tag (muted) then the label.
-        let tag = format!("[{}] ", format!("{:?}", entry.kind).to_lowercase());
         put_str(buf, inner_x, row, &tag, KIND_TAG, inner_x + inner_w);
         let tag_w = u16::try_from(tag.chars().count()).unwrap_or(0);
         let label_color = if selected { SELECTED } else { BODY };
@@ -283,7 +378,7 @@ pub fn render_command_palette(
             buf,
             inner_x + tag_w,
             row,
-            &entry.label,
+            &label,
             label_color,
             inner_x + inner_w,
         );
@@ -370,10 +465,21 @@ mod tests {
         );
     }
 
+    /// A query no `Go:` word matches, so the reducer tests below address the
+    /// daemon's results at index 0 the way they did before the `Go:` family.
+    fn results_only(results: Vec<SearchEntry>) -> CommandPaletteState {
+        let mut s = CommandPaletteState::new();
+        for ch in "refactor".chars() {
+            s = reduce_command_palette(&s, CommandPaletteEvent::Key(ch)).state;
+        }
+        assert!(s.go_rows().is_empty(), "`refactor` must match no Go row");
+        reduce_command_palette(&s, CommandPaletteEvent::ResultsLoaded(results)).state
+    }
+
     /// Loaded results populate the cache; the selection clamps into the new list.
     #[test]
     fn results_loaded_populates_and_clamps() {
-        let mut s = CommandPaletteState::new();
+        let mut s = results_only(vec![]);
         s = reduce_command_palette(
             &s,
             CommandPaletteEvent::ResultsLoaded(vec![
@@ -406,15 +512,10 @@ mod tests {
     /// entity's screen, id, and kind.
     #[test]
     fn enter_navigates_to_selected_entity() {
-        let mut s = CommandPaletteState::new();
-        s = reduce_command_palette(
-            &s,
-            CommandPaletteEvent::ResultsLoaded(vec![
-                entry(SearchEntryKind::Issue, "i1", "Refactor API"),
-                entry(SearchEntryKind::Skill, "s1", "commit"),
-            ]),
-        )
-        .state;
+        let mut s = results_only(vec![
+            entry(SearchEntryKind::Issue, "i1", "Refactor API"),
+            entry(SearchEntryKind::Skill, "s1", "commit"),
+        ]);
         s = reduce_command_palette(&s, CommandPaletteEvent::SelectDown).state;
         let out = reduce_command_palette(&s, CommandPaletteEvent::Key('\n'));
         assert_eq!(
@@ -428,10 +529,12 @@ mod tests {
         );
     }
 
-    /// Enter with no results is a no-op (nothing to jump to).
+    /// Enter with nothing selected is a no-op (nothing to jump to). A query that
+    /// matches no `Go:` row and has no results is the only way to get there now:
+    /// a bare palette always offers the nine screens.
     #[test]
-    fn enter_with_no_results_is_noop() {
-        let s = CommandPaletteState::new();
+    fn enter_with_no_rows_is_noop() {
+        let s = results_only(vec![]);
         let out = reduce_command_palette(&s, CommandPaletteEvent::Key('\n'));
         assert_eq!(out.intent, None);
         assert_eq!(out.state, s);
@@ -472,5 +575,141 @@ mod tests {
     /// Flatten a [`WireBuffer`] into a single string for substring assertions.
     fn buf_text(buf: &WireBuffer) -> String {
         buf.cells.iter().map(|(_, cell)| cell.symbol.clone()).collect()
+    }
+
+    /// Replay a [`WireBuffer`]'s paint order into a `w`×`h` grid of rows, so a
+    /// test can assert on WHERE a glyph landed rather than merely that it exists.
+    fn grid_of(buf: &WireBuffer, w: usize, h: usize) -> Vec<String> {
+        let mut grid = vec![vec![' '; w]; h];
+        for (coord, cell) in &buf.cells {
+            let (x, y) = (coord.x as usize, coord.y as usize);
+            if x < w && y < h {
+                grid[y][x] = cell.symbol.chars().next().unwrap_or(' ');
+            }
+        }
+        grid.into_iter().map(|row| row.into_iter().collect()).collect()
+    }
+
+    /// COVERAGE (crisp B5 §2.5): every screen with no tab is reachable by typing
+    /// its word and pressing Enter.
+    ///
+    /// The demoted set is derived from the `Screen` enum and
+    /// [`crate::chrome::tab_hotkey`] — "non-modal, and no tab" — NOT from
+    /// [`GO_SCREENS`], which would make this tautological. Demote a tenth screen
+    /// and it fails until it has a row; a count or a `len() >= 9` would pass while
+    /// stranding one screen and advertising another twice.
+    ///
+    /// Driven through the reducer, not read off the table: the row has to survive
+    /// the query filter, own the selection, and produce the intent that lands on
+    /// THAT screen. `^P skills` reaching the Usage screen would pass a table read.
+    #[test]
+    fn palette_reaches_every_demoted_screen() {
+        for screen in crate::test_support::every_screen() {
+            if screen.is_modal() || crate::chrome::tab_hotkey(&screen).is_some() {
+                continue;
+            }
+            let word = GO_SCREENS
+                .into_iter()
+                .find(|(_, target)| *target == screen)
+                .unwrap_or_else(|| {
+                    panic!("{screen:?} has no tab and no `Go:` row — it is stranded")
+                })
+                .0;
+            // Type the word, then Enter, exactly as an operator would.
+            let mut s = CommandPaletteState::new();
+            for ch in word.chars() {
+                s = reduce_command_palette(&s, CommandPaletteEvent::Key(ch)).state;
+            }
+            let out = reduce_command_palette(&s, CommandPaletteEvent::Key('\n'));
+            assert_eq!(
+                out.intent,
+                Some(CommandPaletteIntent::GoToScreen(screen.clone())),
+                "`^P {word}` must land on {screen:?}"
+            );
+        }
+    }
+
+    /// A bare `^P` lists all nine `Go:` rows above the results, so the palette is
+    /// also the index of what left the tab strip — an operator who does not know a
+    /// screen exists cannot type its name.
+    #[test]
+    fn an_empty_query_lists_every_go_row_ahead_of_the_results() {
+        let mut s = CommandPaletteState::new();
+        s = reduce_command_palette(
+            &s,
+            CommandPaletteEvent::ResultsLoaded(vec![entry(
+                SearchEntryKind::Issue,
+                "i1",
+                "Refactor API",
+            )]),
+        )
+        .state;
+        assert_eq!(s.go_rows().len(), GO_SCREENS.len());
+
+        let mut buf = WireBuffer::new(80, 24);
+        render_command_palette(&mut buf, 80, 24, &s);
+        let text = buf_text(&buf);
+        for (word, _) in GO_SCREENS {
+            assert!(text.contains(&format!("Go: {word}")), "missing `Go: {word}`");
+        }
+        assert!(text.contains("Refactor API"), "results still render: {text}");
+
+        // Nothing of the screen underneath reads through BETWEEN the rows. The
+        // palette paints `│` only on its two border columns, so an interior `│`
+        // is the board's column rule showing through (it did, until the modal
+        // learned to blank its own rectangle).
+        let mut under = WireBuffer::new(80, 24);
+        super::super::issue_list::render_issue_list(
+            &mut under,
+            80,
+            1,
+            23,
+            &super::super::issue_list::IssueListState::default(),
+            0,
+        );
+        assert!(
+            grid_of(&under, 80, 24).iter().any(|row| row.contains('│')),
+            "the board under the palette must have column rules to bleed"
+        );
+        render_command_palette(&mut under, 80, 24, &s);
+        let modal_w = (80_u16 * 7 / 10).clamp(40, 80) as usize;
+        let modal_h = (24_u16 * 6 / 10).clamp(8, 24) as usize;
+        let (mx, my) = ((80 - modal_w) / 2, (24 - modal_h) / 2);
+        for row in grid_of(&under, 80, 24).iter().skip(my + 1).take(modal_h - 2) {
+            let interior: String =
+                row.chars().skip(mx + 1).take(modal_w - 2).collect();
+            assert!(
+                !interior.contains('│'),
+                "the board bled through the palette: {interior:?}"
+            );
+        }
+
+        // The selection starts on the first Go row, and Enter takes it — the Go
+        // family is merged AHEAD of the daemon's results, not after them.
+        assert_eq!(
+            reduce_command_palette(&s, CommandPaletteEvent::Key('\n')).intent,
+            Some(CommandPaletteIntent::GoToScreen(GO_SCREENS[0].1.clone()))
+        );
+    }
+
+    /// Narrowing the query past the selected row pulls the cursor back onto a
+    /// painted one, so Enter never fires at a row that is no longer there.
+    #[test]
+    fn narrowing_the_query_clamps_the_selection_onto_a_painted_row() {
+        let mut s = CommandPaletteState::new();
+        for _ in 0..8 {
+            s = reduce_command_palette(&s, CommandPaletteEvent::SelectDown).state;
+        }
+        assert_eq!(s.selected_index(), 8, "the ninth Go row");
+        // `usage` matches exactly one row.
+        for ch in "usage".chars() {
+            s = reduce_command_palette(&s, CommandPaletteEvent::Key(ch)).state;
+        }
+        assert_eq!(s.go_rows().len(), 1);
+        assert_eq!(s.selected_index(), 0);
+        assert_eq!(
+            reduce_command_palette(&s, CommandPaletteEvent::Key('\n')).intent,
+            Some(CommandPaletteIntent::GoToScreen(Screen::Usage))
+        );
     }
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
@@ -322,8 +322,12 @@ pub fn render_command_palette(
     area_h: u16,
     state: &CommandPaletteState,
 ) {
-    let modal_w = (area_w * 7 / 10).clamp(40, area_w);
-    let modal_h = (area_h * 6 / 10).clamp(8, area_h);
+    // `.max().min()`, not `.clamp()`: `u16::clamp` PANICS when min > max, and a
+    // pane under 40x8 makes it so. Pre-existing, but the palette went from an
+    // optional extra to the only route to nine screens, so a panic here is a
+    // navigation dead end rather than a missing convenience.
+    let modal_w = (area_w * 7 / 10).max(40).min(area_w);
+    let modal_h = (area_h * 6 / 10).max(8).min(area_h);
     let x0 = (area_w.saturating_sub(modal_w)) / 2;
     let y0 = (area_h.saturating_sub(modal_h)) / 2;
 
@@ -332,13 +336,14 @@ pub fn render_command_palette(
     // `[go] Go: logs│             │` reads as one string of nonsense on an 80×24
     // pane. Harmless while the palette was empty until you typed; crisp B5 made
     // it the only route to nine screens, and it opens with nine rows.
-    for y in y0..y0.saturating_add(modal_h) {
-        for x in x0..x0.saturating_add(modal_w) {
-            let mut cell = Cell::new(" ");
-            cell.bg = Some(PANEL_BG);
-            buf.push(Coord::new(x, y), cell);
-        }
-    }
+    super::fleet::fill_background(
+        buf,
+        x0,
+        y0,
+        x0.saturating_add(modal_w),
+        y0.saturating_add(modal_h),
+        PANEL_BG,
+    );
     draw_border(buf, x0, y0, modal_w, modal_h);
     // Title carries the live query so the user sees what they typed.
     let title = format!(" Search: {}_ ", state.query());
@@ -615,6 +620,15 @@ mod tests {
                     panic!("{screen:?} has no tab and no `Go:` row — it is stranded")
                 })
                 .0;
+            // The word must NAME the screen, not merely exist. The lookup above
+            // finds the row BY SCREEN, so swapping `("usage", Screen::Logs)` and
+            // `("logs", Screen::Usage)` satisfies everything below while `^P usage`
+            // opens Logs. The tab label is the name the rest of the UI already uses.
+            assert_eq!(
+                word,
+                screen.tab_label().to_lowercase(),
+                "the `Go:` word for {screen:?} does not name it"
+            );
             // Type the word, then Enter, exactly as an operator would.
             let mut s = CommandPaletteState::new();
             for ch in word.chars() {
@@ -695,6 +709,24 @@ mod tests {
             reduce_command_palette(&s, CommandPaletteEvent::Key('\n')).intent,
             Some(CommandPaletteIntent::GoToScreen(GO_SCREENS[0].1.clone()))
         );
+    }
+
+    /// A pane below the modal's own minimum renders instead of panicking.
+    ///
+    /// `u16::clamp` panics when min > max, so `(w * 7 / 10).clamp(40, w)` blew up
+    /// on anything under 40 columns. Below the 80×24 floor, but the palette is
+    /// the only route to nine screens now, so it must degrade rather than take
+    /// the process with it.
+    #[test]
+    fn a_pane_below_the_modal_minimum_renders_instead_of_panicking() {
+        let s = CommandPaletteState::new();
+        for (w, h) in [(1, 1), (20, 4), (39, 7), (40, 8), (80, 24)] {
+            let mut buf = WireBuffer::new(w, h);
+            render_command_palette(&mut buf, w, h, &s);
+            for (coord, _) in &buf.cells {
+                assert!(coord.x < w && coord.y < h, "{w}x{h} painted out of bounds");
+            }
+        }
     }
 
     /// Narrowing the query past the selected row pulls the cursor back onto a

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
@@ -650,9 +650,15 @@ mod tests {
         render_command_palette(&mut buf, 80, 24, &s);
         let text = buf_text(&buf);
         for (word, _) in GO_SCREENS {
-            assert!(text.contains(&format!("Go: {word}")), "missing `Go: {word}`");
+            assert!(
+                text.contains(&format!("Go: {word}")),
+                "missing `Go: {word}`"
+            );
         }
-        assert!(text.contains("Refactor API"), "results still render: {text}");
+        assert!(
+            text.contains("Refactor API"),
+            "results still render: {text}"
+        );
 
         // Nothing of the screen underneath reads through BETWEEN the rows. The
         // palette paints `│` only on its two border columns, so an interior `│`
@@ -676,8 +682,7 @@ mod tests {
         let modal_h = (24_u16 * 6 / 10).clamp(8, 24) as usize;
         let (mx, my) = ((80 - modal_w) / 2, (24 - modal_h) / 2);
         for row in grid_of(&under, 80, 24).iter().skip(my + 1).take(modal_h - 2) {
-            let interior: String =
-                row.chars().skip(mx + 1).take(modal_w - 2).collect();
+            let interior: String = row.chars().skip(mx + 1).take(modal_w - 2).collect();
             assert!(
                 !interior.contains('│'),
                 "the board bled through the palette: {interior:?}"

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/command_palette.rs
@@ -326,8 +326,14 @@ pub fn render_command_palette(
     // pane under 40x8 makes it so. Pre-existing, but the palette went from an
     // optional extra to the only route to nine screens, so a panic here is a
     // navigation dead end rather than a missing convenience.
-    let modal_w = (area_w * 7 / 10).max(40).min(area_w);
-    let modal_h = (area_h * 6 / 10).max(8).min(area_h);
+    //
+    // The intermediate is `u32` for the same reason: `area_w * 7` overflows a
+    // `u16` above 9362 columns. Unreachable on a real terminal, but "this
+    // function does not panic" is worth being total rather than nearly so.
+    let scaled =
+        |v: u16, num: u32, den: u32| u16::try_from(u32::from(v) * num / den).unwrap_or(u16::MAX);
+    let modal_w = scaled(area_w, 7, 10).max(40).min(area_w);
+    let modal_h = scaled(area_h, 6, 10).max(8).min(area_h);
     let x0 = (area_w.saturating_sub(modal_w)) / 2;
     let y0 = (area_h.saturating_sub(modal_h)) / 2;
 
@@ -720,7 +726,19 @@ mod tests {
     #[test]
     fn a_pane_below_the_modal_minimum_renders_instead_of_panicking() {
         let s = CommandPaletteState::new();
-        for (w, h) in [(1, 1), (20, 4), (39, 7), (40, 8), (80, 24)] {
+        // Both ends: under the modal's own 40x8 minimum, where `clamp` panicked,
+        // and past 9362 columns / 10922 rows, where the `u16` scale multiply
+        // overflowed. One axis at a time — a pane huge on both would paint tens
+        // of millions of cells and the test would OOM rather than assert.
+        for (w, h) in [
+            (1, 1),
+            (20, 4),
+            (39, 7),
+            (40, 8),
+            (80, 24),
+            (9400, 24),
+            (80, 11000),
+        ] {
             let mut buf = WireBuffer::new(w, h);
             render_command_palette(&mut buf, w, h, &s);
             for (coord, _) in &buf.cells {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/mod.rs
@@ -130,7 +130,10 @@ impl Screen {
             Self::ActivityTimeline(_) => "Activity",
             Self::SkillManager => "Skills",
             Self::Autopilots => "Autopilots",
-            Self::Kanban => "Kanban",
+            // `Runs` since crisp B5 §2.5: `Kanban` names the widget, this
+            // board is the only run-centric one, and the hotkey is unchanged so
+            // muscle memory survives the rename.
+            Self::Kanban => "Runs",
             Self::Boards => "Boards",
             Self::DaemonHealth => "Daemon",
             Self::Usage => "Usage",

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
@@ -3,10 +3,10 @@
 //! [`reduce`] is the single entry point through which every key press and host
 //! event flows. It owns the tab-switch / modal / quit semantics of P4.1:
 //!
-//! - `1` / `3` / `4` / `,` switch to the issue-list / skill-manager /
-//!   autopilot-manager / settings tabs (the numbered tabs are contiguous; the
-//!   old `[3]Agents` tab folded into the issue-list filter chip, so Skills/
-//!   Autopilots shifted down to `3`/`4` — e38.38).
+//! - `1` / `,` switch to the issue-list / settings tabs, and `K` / `B` / `I` /
+//!   `A` to the four lettered ones (crisp B5 §2.5 cut the strip from sixteen
+//!   tabs to seven; the nine demoted screens keep their reducers and are reached
+//!   through the `Go:` palette family instead — [`super::command_palette`]).
 //! - `2` switches to task detail **only** when a task is selected (otherwise a
 //!   no-op, per the RED test `reduce_tab_key_2_only_valid_when_task_selected`).
 //! - `?` opens the [help overlay](Screen::Help) modal, remembering the screen
@@ -27,9 +27,14 @@ use super::{AppEvent, AppState, Intent, Reduction, Screen};
 /// Kept in lock-step with [`reduce_key`]: a char listed here MUST have a
 /// `reduce_key` arm, and every `reduce_key` arm MUST be listed here
 /// (`router_keys_all_have_a_reduce_key_arm`).
-pub const ROUTER_KEYS: [char; 18] = [
-    '1', '2', '3', '4', 'B', 'K', 'D', 'U', 'L', 'I', 'C', 'F', 'S', 'P', 'A', ',', '?', 'q',
-];
+///
+/// Nine of eighteen went out with the crisp B5 tab shrink (`3` `4` `D` `U` `L`
+/// `C` `F` `S` `P`). Their screens did not: they are reached with `^P` and the
+/// screen's word, and every one of them is pinned reachable by
+/// `palette_reaches_every_demoted_screen`. A char dropped here also stops being
+/// reserved, so a screen-local binding on it comes ALIVE — `3`/`4` on the fleet
+/// filter row had been dead since the router claimed them.
+pub const ROUTER_KEYS: [char; 9] = ['1', '2', 'B', 'K', 'I', 'A', ',', '?', 'q'];
 
 /// Chars the HOST swallows before the plugin ever sees them.
 ///
@@ -42,28 +47,21 @@ pub const ROUTER_KEYS: [char; 18] = [
 pub const HOST_RESERVED_KEYS: [char; 0] = [];
 
 /// Whether the routing layer claims `ch` (drives `routing_event` in the plugin).
+///
+/// READS [`ROUTER_KEYS`] rather than restating it: the two were a hand-kept
+/// `matches!` mirror of the array, so shrinking the strip was three edits that
+/// had to stay in step. Now it is two, and the one that remains ([`reduce_key`])
+/// is covered by `router_keys_all_have_a_reduce_key_arm`.
 #[must_use]
 pub const fn is_router_key(ch: char) -> bool {
-    matches!(
-        ch,
-        '1' | '2'
-            | '3'
-            | '4'
-            | 'B'
-            | 'K'
-            | 'D'
-            | 'U'
-            | 'L'
-            | 'I'
-            | 'C'
-            | 'F'
-            | 'S'
-            | 'P'
-            | 'A'
-            | ','
-            | '?'
-            | 'q'
-    )
+    let mut i = 0;
+    while i < ROUTER_KEYS.len() {
+        if ROUTER_KEYS[i] == ch {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Every char a hangar SCREEN must not bind while it is not capturing text.
@@ -99,31 +97,13 @@ fn reduce_key(state: &AppState, c: char) -> Reduction {
             || unchanged(state),
             |task| switch_tab(state, Screen::TaskDetail(task.clone())),
         ),
-        // `3`/`4` are contiguous after the old `[3]Agents` tab folded into the
-        // issue-list filter chip (e38.38): Skills/Autopilots shifted down to close
-        // the numbering gap.
-        '3' => switch_tab(state, Screen::SkillManager),
-        '4' => switch_tab(state, Screen::Autopilots),
         // `K` (capital) opens the Kanban board from anywhere (P8.4).
         'K' => switch_tab(state, Screen::Kanban),
         // `B` (capital) opens the user-defined Boards screen from anywhere (P4).
         'B' => switch_tab(state, Screen::Boards),
-        // `D` (capital) opens the daemon-health pane from anywhere (P8.5).
-        'D' => switch_tab(state, Screen::DaemonHealth),
-        // `U` (capital) opens the usage dashboard from anywhere (e38.35).
-        'U' => switch_tab(state, Screen::Usage),
-        // `L` (capital) opens the logs-tail pane from anywhere (P8.6).
-        'L' => switch_tab(state, Screen::Logs),
-        // `I` (capital) opens the notification inbox from anywhere (e38.14).
+        // `I` (capital) opens the notification inbox from anywhere (e38.14) — the
+        // one attention surface since crisp B3 §2.4.
         'I' => switch_tab(state, Screen::Inbox),
-        // `C` (capital) opens the fleet-wide control center from anywhere (P2).
-        'C' => switch_tab(state, Screen::ControlCenter),
-        // `F` opens the authoritative Fleet registry and control pane.
-        'F' => switch_tab(state, Screen::Fleet),
-        // `S` (capital) opens the Squads screen from anywhere (P7).
-        'S' => switch_tab(state, Screen::Squads),
-        // `P` (capital) opens the profile editor from anywhere (P5).
-        'P' => switch_tab(state, Screen::Profiles),
         // `A` (capital) opens the Agents roster from anywhere (slice 2). `A` was
         // free — the old `[3]Agents` tab folded into the issue-list filter chip
         // (e38.38) and never reclaimed a letter, so this is the first `A` binding.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/router.rs
@@ -24,16 +24,19 @@ use super::{AppEvent, AppState, Intent, Reduction, Screen};
 /// Chars the ROUTING layer claims on EVERY hangar screen (tab switches, help,
 /// settings, quit) before the active screen's reducer is consulted.
 ///
-/// Kept in lock-step with [`reduce_key`]: a char listed here MUST have a
-/// `reduce_key` arm, and every `reduce_key` arm MUST be listed here
-/// (`router_keys_all_have_a_reduce_key_arm`).
+/// Kept in lock-step with [`reduce_key`]: every char listed here MUST have a
+/// `reduce_key` arm, pinned by `router_keys_all_have_a_reduce_key_arm`. The
+/// reverse needs no test: [`is_router_key`] reads THIS array, so a `reduce_key`
+/// arm for a char that is not listed is unreachable rather than wrong.
 ///
 /// Nine of eighteen went out with the crisp B5 tab shrink (`3` `4` `D` `U` `L`
 /// `C` `F` `S` `P`). Their screens did not: they are reached with `^P` and the
 /// screen's word, and every one of them is pinned reachable by
 /// `palette_reaches_every_demoted_screen`. A char dropped here also stops being
-/// reserved, so a screen-local binding on it comes ALIVE — `3`/`4` on the fleet
-/// filter row had been dead since the router claimed them.
+/// reserved, so a screen-local binding on it now REACHES the screen reducer
+/// instead of being eaten first. (No screen has claimed one yet: the fleet lens
+/// row paints `1`..`5` but `reduce_browse_key` has no digit arm, so those stay
+/// inert either way.)
 pub const ROUTER_KEYS: [char; 9] = ['1', '2', 'B', 'K', 'I', 'A', ',', '?', 'q'];
 
 /// Chars the HOST swallows before the plugin ever sees them.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -1,6 +1,7 @@
-//! P4.7 — Settings screen: the pure reducer + five-section width-aware render.
+//! P4.7 — Settings screen: the pure reducer + section-stacked width-aware render.
 //!
-//! The settings screen (hotkey `,`) has five j/k-navigable sections:
+//! The settings screen (hotkey `,`) has seven j/k-navigable sections. The first
+//! five:
 //!
 //! 1. **Daemon connection** — socket path, PID, uptime, version, connection state
 //!    (from the `hangar/health` RPC snapshot).
@@ -20,6 +21,9 @@
 //!    a `Pending invites` sub-header — `email · role · expires in Nd` — so an
 //!    invited-but-not-yet-joined human is visible. Nothing paints when there are
 //!    none.
+//! 6. **Notifications** (tcp T5) — the attention-kind × channel routing grid.
+//! 7. **More screens** (crisp B5 §2.5) — the nine screens the tab-strip shrink
+//!    demoted, each beside the `^P` word that reaches it. Read-only.
 //!
 //! The reducer ([`reduce_settings`]) is **pure**. The crucial security property
 //! (P4.7 risk register, "keychain write leaks key into log"): entered key
@@ -89,10 +93,15 @@ pub enum SettingsSection {
     /// host-wide GLOBAL rule and the active workspace override
     /// (agents-in-a-box-cqh).
     Notifications,
+    /// The nine screens crisp B5 §2.5 took off the tab strip, listed with the
+    /// word that reaches each from `^P`. Read-only, and the DISCOVERABLE of the
+    /// two routes to a demoted screen: the palette only helps an operator who
+    /// already suspects the screen exists.
+    MoreScreens,
 }
 
 impl SettingsSection {
-    /// The next section down (j), clamped at [`Self::Notifications`].
+    /// The next section down (j), clamped at [`Self::MoreScreens`].
     #[must_use]
     const fn next(self) -> Self {
         match self {
@@ -100,7 +109,8 @@ impl SettingsSection {
             Self::Providers => Self::Keys,
             Self::Keys => Self::Workspaces,
             Self::Workspaces => Self::Members,
-            Self::Members | Self::Notifications => Self::Notifications,
+            Self::Members => Self::Notifications,
+            Self::Notifications | Self::MoreScreens => Self::MoreScreens,
         }
     }
 
@@ -113,6 +123,7 @@ impl SettingsSection {
             Self::Workspaces => Self::Keys,
             Self::Members => Self::Workspaces,
             Self::Notifications => Self::Members,
+            Self::MoreScreens => Self::Notifications,
         }
     }
 
@@ -126,6 +137,7 @@ impl SettingsSection {
             Self::Workspaces => "Workspaces",
             Self::Members => "Members",
             Self::Notifications => "Notifications",
+            Self::MoreScreens => "More screens",
         }
     }
 }
@@ -631,7 +643,9 @@ fn reduce_cursor(state: &SettingsState, delta: i32) -> SettingsReduction {
     }
     match state.section {
         SettingsSection::Daemon => move_config_sel(state, delta),
-        SettingsSection::Notifications => unchanged(state),
+        // Neither has an in-section list: Notifications owns a 2D grid cursor,
+        // More screens is a static reference list with nothing to select.
+        SettingsSection::Notifications | SettingsSection::MoreScreens => unchanged(state),
         _ => move_list(state, delta),
     }
 }
@@ -1101,8 +1115,11 @@ fn move_list(state: &SettingsState, delta: i32) -> SettingsReduction {
         SettingsSection::Providers => next.providers.len(),
         SettingsSection::Members => members_section_len(&next),
         // Notifications owns its own 2D cursor (see `reduce_notify_key`); the
-        // generic list mover is never reached for it.
-        SettingsSection::Daemon | SettingsSection::Notifications => 0,
+        // generic list mover is never reached for it, nor for the static
+        // More-screens list.
+        SettingsSection::Daemon
+        | SettingsSection::Notifications
+        | SettingsSection::MoreScreens => 0,
     };
     if delta < 0 {
         next.list_selected = next.list_selected.saturating_sub(1);
@@ -1623,6 +1640,7 @@ fn paint_sections(buf: &mut WireBuffer, area_w: u16, state: &SettingsState) -> S
         SettingsSection::Workspaces,
         SettingsSection::Members,
         SettingsSection::Notifications,
+        SettingsSection::MoreScreens,
     ] {
         if row >= bottom {
             break;
@@ -1703,6 +1721,28 @@ fn paint_sections(buf: &mut WireBuffer, area_w: u16, state: &SettingsState) -> S
             SettingsSection::Notifications => {
                 let selected = state.section == SettingsSection::Notifications;
                 row = render_notify_grid(buf, area_w, row, bottom, state, selected);
+            }
+            // One row per demoted screen, `^P <word>` beside its label, straight
+            // off `GO_SCREENS` so the list cannot advertise a word the palette
+            // does not match (crisp B5 §2.5).
+            SettingsSection::MoreScreens => {
+                if row < bottom {
+                    put(buf, 4, row, "off the tab strip, reach with ^P", MUTED);
+                    row += 1;
+                }
+                for (word, screen) in crate::screen::command_palette::GO_SCREENS {
+                    if row >= bottom {
+                        break;
+                    }
+                    put(
+                        buf,
+                        4,
+                        row,
+                        &format!("^P {word:<11}{}", screen.tab_label()),
+                        TEXT,
+                    );
+                    row += 1;
+                }
             }
         }
         if is_active {

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/settings.rs
@@ -1117,9 +1117,9 @@ fn move_list(state: &SettingsState, delta: i32) -> SettingsReduction {
         // Notifications owns its own 2D cursor (see `reduce_notify_key`); the
         // generic list mover is never reached for it, nor for the static
         // More-screens list.
-        SettingsSection::Daemon
-        | SettingsSection::Notifications
-        | SettingsSection::MoreScreens => 0,
+        SettingsSection::Daemon | SettingsSection::Notifications | SettingsSection::MoreScreens => {
+            0
+        }
     };
     if delta < 0 {
         next.list_selected = next.list_selected.saturating_sub(1);

--- a/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
@@ -13,10 +13,12 @@ use crate::screen::Screen;
 /// the footer-hint grammar, the reserved-key hygiene, and the crisp B5 promise
 /// that a screen off the tab strip is still reachable.
 ///
-/// Exhaustive BY THE MATCH BELOW, which has no wildcard arm: adding a variant to
-/// `Screen` fails to compile here, next to the list to add it to. (That forces an
-/// author to look; it does not by itself prove the list holds every variant, so
-/// keep the two together.)
+/// Both halves are forced. [`variant_tag`] has no wildcard arm, so a new `Screen`
+/// variant does not compile until it is tagged; and the count of DISTINCT tags in
+/// the list below must equal the number of arms, so tagging a variant and
+/// forgetting to build one here fails too. Without the second half a forgotten
+/// entry is silently skipped by every guard that walks this — a screen with no
+/// tab and no `Go:` row would read as covered.
 pub fn every_screen() -> Vec<Screen> {
     use ainb_hangar_core::ids::{IssueId, TaskId};
     let issue = IssueId::from_str("i1").expect("valid issue id");
@@ -43,31 +45,45 @@ pub fn every_screen() -> Vec<Screen> {
         Screen::Help,
         Screen::CommandPalette,
     ];
-    for screen in &all {
-        match screen {
-            Screen::IssueList
-            | Screen::TaskDetail(_)
-            | Screen::AgentPicker(_)
-            | Screen::ActivityTimeline(_)
-            | Screen::SkillManager
-            | Screen::Autopilots
-            | Screen::Kanban
-            | Screen::Boards
-            | Screen::DaemonHealth
-            | Screen::Usage
-            | Screen::Logs
-            | Screen::Inbox
-            | Screen::ControlCenter
-            | Screen::Fleet
-            | Screen::Squads
-            | Screen::Profiles
-            | Screen::Agents
-            | Screen::Settings
-            | Screen::Help
-            | Screen::CommandPalette => {}
-        }
-    }
+    let tags: std::collections::BTreeSet<u8> = all.iter().map(variant_tag).collect();
+    assert_eq!(
+        tags.len(),
+        SCREEN_VARIANTS,
+        "every_screen() builds {} of the {SCREEN_VARIANTS} Screen variants",
+        tags.len()
+    );
     all
+}
+
+/// The number of arms in [`variant_tag`], and so of `Screen` variants.
+const SCREEN_VARIANTS: usize = 20;
+
+/// A distinct tag per `Screen` variant. No wildcard arm: a new variant fails to
+/// compile here, and bumping [`SCREEN_VARIANTS`] to match then fails
+/// [`every_screen`] until the variant is built there too.
+fn variant_tag(screen: &Screen) -> u8 {
+    match screen {
+        Screen::IssueList => 0,
+        Screen::TaskDetail(_) => 1,
+        Screen::AgentPicker(_) => 2,
+        Screen::ActivityTimeline(_) => 3,
+        Screen::SkillManager => 4,
+        Screen::Autopilots => 5,
+        Screen::Kanban => 6,
+        Screen::Boards => 7,
+        Screen::DaemonHealth => 8,
+        Screen::Usage => 9,
+        Screen::Logs => 10,
+        Screen::Inbox => 11,
+        Screen::ControlCenter => 12,
+        Screen::Fleet => 13,
+        Screen::Squads => 14,
+        Screen::Profiles => 15,
+        Screen::Agents => 16,
+        Screen::Settings => 17,
+        Screen::Help => 18,
+        Screen::CommandPalette => 19,
+    }
 }
 
 /// The full painted text of `buf` in ROW-MAJOR order, so an assertion can search

--- a/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
@@ -13,12 +13,17 @@ use crate::screen::Screen;
 /// the footer-hint grammar, the reserved-key hygiene, and the crisp B5 promise
 /// that a screen off the tab strip is still reachable.
 ///
-/// Both halves are forced. [`variant_tag`] has no wildcard arm, so a new `Screen`
-/// variant does not compile until it is tagged; and the count of DISTINCT tags in
-/// the list below must equal the number of arms, so tagging a variant and
-/// forgetting to build one here fails too. Without the second half a forgotten
-/// entry is silently skipped by every guard that walks this — a screen with no
-/// tab and no `Go:` row would read as covered.
+/// Two things force it, and neither is free: the wildcard-free match below does
+/// not compile when a `Screen` variant is added, and the count of DISTINCT
+/// variants actually built here must equal [`SCREEN_VARIANTS`], so bumping the
+/// count without building the variant fails loudly instead of silently skipping
+/// it in every guard that walks this.
+///
+/// [`SCREEN_VARIANTS`] is HAND-MAINTAINED — the compiler cannot count enum
+/// variants without a derive. Adding a variant means three edits: the match arm
+/// (forced), the constant, and the entry here (the constant forces this one).
+/// Nothing catches all three being forgotten together, but the match arm cannot
+/// be.
 pub fn every_screen() -> Vec<Screen> {
     use ainb_hangar_core::ids::{IssueId, TaskId};
     let issue = IssueId::from_str("i1").expect("valid issue id");
@@ -45,46 +50,46 @@ pub fn every_screen() -> Vec<Screen> {
         Screen::Help,
         Screen::CommandPalette,
     ];
-    let tags: std::collections::BTreeSet<u8> = all.iter().map(variant_tag).collect();
+    // `mem::discriminant` is `Hash + Eq` and ignores the payload, so this counts
+    // VARIANTS rather than values — no hand-assigned tag table to keep in step.
+    let built: std::collections::HashSet<_> = all.iter().map(std::mem::discriminant).collect();
     assert_eq!(
-        tags.len(),
+        built.len(),
         SCREEN_VARIANTS,
         "every_screen() builds {} of the {SCREEN_VARIANTS} Screen variants",
-        tags.len()
+        built.len()
     );
+    // Purely for the compile-time force: no wildcard arm, so a new `Screen`
+    // variant breaks the build here, next to the list it has to be added to.
+    for screen in &all {
+        match screen {
+            Screen::IssueList
+            | Screen::TaskDetail(_)
+            | Screen::AgentPicker(_)
+            | Screen::ActivityTimeline(_)
+            | Screen::SkillManager
+            | Screen::Autopilots
+            | Screen::Kanban
+            | Screen::Boards
+            | Screen::DaemonHealth
+            | Screen::Usage
+            | Screen::Logs
+            | Screen::Inbox
+            | Screen::ControlCenter
+            | Screen::Fleet
+            | Screen::Squads
+            | Screen::Profiles
+            | Screen::Agents
+            | Screen::Settings
+            | Screen::Help
+            | Screen::CommandPalette => {}
+        }
+    }
     all
 }
 
-/// The number of arms in [`variant_tag`], and so of `Screen` variants.
+/// How many variants `Screen` has. Hand-maintained: bump it with the match arm.
 const SCREEN_VARIANTS: usize = 20;
-
-/// A distinct tag per `Screen` variant. No wildcard arm: a new variant fails to
-/// compile here, and bumping [`SCREEN_VARIANTS`] to match then fails
-/// [`every_screen`] until the variant is built there too.
-fn variant_tag(screen: &Screen) -> u8 {
-    match screen {
-        Screen::IssueList => 0,
-        Screen::TaskDetail(_) => 1,
-        Screen::AgentPicker(_) => 2,
-        Screen::ActivityTimeline(_) => 3,
-        Screen::SkillManager => 4,
-        Screen::Autopilots => 5,
-        Screen::Kanban => 6,
-        Screen::Boards => 7,
-        Screen::DaemonHealth => 8,
-        Screen::Usage => 9,
-        Screen::Logs => 10,
-        Screen::Inbox => 11,
-        Screen::ControlCenter => 12,
-        Screen::Fleet => 13,
-        Screen::Squads => 14,
-        Screen::Profiles => 15,
-        Screen::Agents => 16,
-        Screen::Settings => 17,
-        Screen::Help => 18,
-        Screen::CommandPalette => 19,
-    }
-}
 
 /// The full painted text of `buf` in ROW-MAJOR order, so an assertion can search
 /// for a label wherever on the screen it landed.

--- a/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/test_support.rs
@@ -7,6 +7,69 @@
 
 use ainb_plugin_sdk::WireBuffer;
 
+use crate::screen::Screen;
+
+/// Every [`Screen`] variant, for the guards that must hold across ALL of them:
+/// the footer-hint grammar, the reserved-key hygiene, and the crisp B5 promise
+/// that a screen off the tab strip is still reachable.
+///
+/// Exhaustive BY THE MATCH BELOW, which has no wildcard arm: adding a variant to
+/// `Screen` fails to compile here, next to the list to add it to. (That forces an
+/// author to look; it does not by itself prove the list holds every variant, so
+/// keep the two together.)
+pub fn every_screen() -> Vec<Screen> {
+    use ainb_hangar_core::ids::{IssueId, TaskId};
+    let issue = IssueId::from_str("i1").expect("valid issue id");
+    let task = TaskId::from_str("01HANGARTASK000000000001").expect("valid task id");
+    let all = vec![
+        Screen::IssueList,
+        Screen::TaskDetail(task),
+        Screen::AgentPicker(issue.clone()),
+        Screen::ActivityTimeline(issue),
+        Screen::SkillManager,
+        Screen::Autopilots,
+        Screen::Kanban,
+        Screen::Boards,
+        Screen::DaemonHealth,
+        Screen::Usage,
+        Screen::Logs,
+        Screen::Inbox,
+        Screen::ControlCenter,
+        Screen::Fleet,
+        Screen::Squads,
+        Screen::Profiles,
+        Screen::Agents,
+        Screen::Settings,
+        Screen::Help,
+        Screen::CommandPalette,
+    ];
+    for screen in &all {
+        match screen {
+            Screen::IssueList
+            | Screen::TaskDetail(_)
+            | Screen::AgentPicker(_)
+            | Screen::ActivityTimeline(_)
+            | Screen::SkillManager
+            | Screen::Autopilots
+            | Screen::Kanban
+            | Screen::Boards
+            | Screen::DaemonHealth
+            | Screen::Usage
+            | Screen::Logs
+            | Screen::Inbox
+            | Screen::ControlCenter
+            | Screen::Fleet
+            | Screen::Squads
+            | Screen::Profiles
+            | Screen::Agents
+            | Screen::Settings
+            | Screen::Help
+            | Screen::CommandPalette => {}
+        }
+    }
+    all
+}
+
 /// The full painted text of `buf` in ROW-MAJOR order, so an assertion can search
 /// for a label wherever on the screen it landed.
 ///

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
@@ -25,6 +25,10 @@ use ainb_plugin_sdk::Server;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+#[path = "palette_nav_common.rs"]
+mod palette_nav;
+use palette_nav::nav_drain_rounds;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 /// A recorded daemon call: method + params.
@@ -353,7 +357,7 @@ async fn pressing_one_answers_the_selected_ask() {
         // Drain the walk's own traffic (a key delivery per char plus one
         // `hangar/search` per query edit) so it does not come out of the
         // attention/answer budget below.
-        for _ in 0..18 {
+        for _ in 0..nav_drain_rounds("control") {
             relay_once(
                 &mut host_write,
                 &mut host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
@@ -350,6 +350,19 @@ async fn pressing_one_answers_the_selected_ask() {
             send_key(&mut host_write, ch).await;
         }
         send_key(&mut host_write, '\n').await;
+        // Drain the walk's own traffic (a key delivery per char plus one
+        // `hangar/search` per query edit) so it does not come out of the
+        // attention/answer budget below.
+        for _ in 0..18 {
+            relay_once(
+                &mut host_write,
+                &mut host_read,
+                &mut daemon_reader,
+                &mut daemon_write,
+                &stream_id,
+            )
+            .await;
+        }
         send_key(&mut host_write, '1').await;
 
         let mut answered = None;

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/attention_answer_over_socket.rs
@@ -342,8 +342,14 @@ async fn pressing_one_answers_the_selected_ask() {
             .await;
         }
 
-        // Open the control center and answer option ① (staging).
-        send_key(&mut host_write, 'C').await;
+        // Open the control center with `^P control` (crisp B5 §2.5 demoted the `C`
+        // tab key; `\u{10}` is the bare-DLE spelling of Ctrl+P) and answer option
+        // ① (staging).
+        send_key(&mut host_write, '\u{10}').await;
+        for ch in "control".chars() {
+            send_key(&mut host_write, ch).await;
+        }
+        send_key(&mut host_write, '\n').await;
         send_key(&mut host_write, '1').await;
 
         let mut answered = None;

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
@@ -25,6 +25,10 @@ use ainb_plugin_sdk::Server;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+#[path = "palette_nav_common.rs"]
+mod palette_nav;
+use palette_nav::nav_drain_rounds;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 /// A recorded daemon call: method + params.
@@ -333,7 +337,7 @@ async fn go_to_screen<W, R, DR, DW>(
         send_key(host_write, ch).await;
     }
     send_key(host_write, '\n').await;
-    for _ in 0..(2 * word.chars().count() + 4) {
+    for _ in 0..nav_drain_rounds(word) {
         relay_one_send_or_render(
             host_write,
             host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
@@ -308,6 +308,17 @@ async fn send_key<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: char
         .unwrap();
 }
 
+/// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
+/// `^P`, the screen's word, Enter. `\u{10}` is the bare-DLE spelling of Ctrl+P
+/// the plugin accepts alongside the modifier flag (`plugin::is_ctrl_p`).
+async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+    send_key(host_write, '\u{10}').await;
+    for ch in word.chars() {
+        send_key(host_write, ch).await;
+    }
+    send_key(host_write, '\n').await;
+}
+
 /// Boot the plugin + mock daemon, run subscribe + snapshot pump, and return the
 /// live host/daemon handles plus the shared `seen` recorder.
 async fn boot(
@@ -366,9 +377,9 @@ async fn key_r_fires_now() {
         let (mut host_write, mut host_read, mut daemon_reader, mut daemon_write, server) =
             boot(home.path(), &stream_id, seen.clone(), enabled).await;
 
-        // Tab to the autopilot screen (`4`), then press `r` (run now). (e38.38:
-        // Autopilots renumbered 5→4 to close the `[3]Agents` gap.)
-        send_key(&mut host_write, '4').await;
+        // `^P autopilots` to the autopilot screen, then press `r` (run now). Was
+        // the `4` tab key until crisp B5 §2.5 demoted it.
+        go_to_screen(&mut host_write, "autopilots").await;
         send_key(&mut host_write, 'r').await;
 
         let mut sent = false;
@@ -415,10 +426,10 @@ async fn key_d_toggles_enabled() {
         let (mut host_write, mut host_read, mut daemon_reader, mut daemon_write, server) =
             boot(home.path(), &stream_id, seen.clone(), enabled).await;
 
-        // Tab to the autopilot screen (`4`), then press `d` (disable; the seeded
-        // row is enabled → set_enabled(false)). (e38.38: Autopilots renumbered 5→4
-        // to close the `[3]Agents` gap.)
-        send_key(&mut host_write, '4').await;
+        // `^P autopilots` to the autopilot screen, then press `d` (disable; the
+        // seeded row is enabled → set_enabled(false)). Was the `4` tab key until
+        // crisp B5 §2.5 demoted it.
+        go_to_screen(&mut host_write, "autopilots").await;
         send_key(&mut host_write, 'd').await;
 
         // Pump until the daemon records set_enabled(false). The daemon flips its

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/autopilot_rpc_over_socket.rs
@@ -311,12 +311,38 @@ async fn send_key<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: char
 /// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
 /// `^P`, the screen's word, Enter. `\u{10}` is the bare-DLE spelling of Ctrl+P
 /// the plugin accepts alongside the modifier flag (`plugin::is_ctrl_p`).
-async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+///
+/// DRAINS its own traffic before returning: the walk costs one key delivery per
+/// character plus one `hangar/search` per query edit, and left in the pipe those
+/// come out of the caller's bounded relay budget rather than the nav's.
+async fn go_to_screen<W, R, DR, DW>(
+    host_write: &mut W,
+    host_read: &mut R,
+    daemon_reader: &mut DR,
+    daemon_write: &mut DW,
+    stream_id: &str,
+    word: &str,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+    DR: tokio::io::AsyncBufRead + Unpin,
+    DW: tokio::io::AsyncWrite + Unpin,
+{
     send_key(host_write, '\u{10}').await;
     for ch in word.chars() {
         send_key(host_write, ch).await;
     }
     send_key(host_write, '\n').await;
+    for _ in 0..(2 * word.chars().count() + 4) {
+        relay_one_send_or_render(
+            host_write,
+            host_read,
+            daemon_reader,
+            daemon_write,
+            stream_id,
+        )
+        .await;
+    }
 }
 
 /// Boot the plugin + mock daemon, run subscribe + snapshot pump, and return the
@@ -333,9 +359,16 @@ async fn boot(
     tokio::net::unix::OwnedWriteHalf,
     tokio::task::JoinHandle<Result<(), ainb_plugin_sdk::SdkError>>,
 ) {
+    // Seed the `first_run` ack, THEN publish the home. `AINB_HANGAR_HOME` is
+    // process-global and this binary holds two tests, so a sibling's `set_var`
+    // can land between ours and this write; `on_init` reading in that window
+    // finds no acks and paints the danger-full-access modal over the board,
+    // where it swallows every key the test sends. Publishing here rather than at
+    // the call site keeps the two in one place, in this order.
     let state = home.join("hangar").join("state.toml");
     std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
     std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+    std::env::set_var("AINB_HANGAR_HOME", home);
 
     let socket_path = home.join("hangar.sock");
     let listener = UnixListener::bind(&socket_path).expect("bind daemon");
@@ -370,7 +403,6 @@ async fn boot(
 async fn key_r_fires_now() {
     let body = async {
         let home = tempfile::tempdir().expect("home");
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
         let stream_id = format!("sock-fire-{}", std::process::id());
         let seen: Seen = Arc::new(Mutex::new(Vec::new()));
         let enabled = Arc::new(Mutex::new(true));
@@ -379,7 +411,15 @@ async fn key_r_fires_now() {
 
         // `^P autopilots` to the autopilot screen, then press `r` (run now). Was
         // the `4` tab key until crisp B5 §2.5 demoted it.
-        go_to_screen(&mut host_write, "autopilots").await;
+        go_to_screen(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+            "autopilots",
+        )
+        .await;
         send_key(&mut host_write, 'r').await;
 
         let mut sent = false;
@@ -419,7 +459,6 @@ async fn key_r_fires_now() {
 async fn key_d_toggles_enabled() {
     let body = async {
         let home = tempfile::tempdir().expect("home");
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
         let stream_id = format!("sock-toggle-{}", std::process::id());
         let seen: Seen = Arc::new(Mutex::new(Vec::new()));
         let enabled = Arc::new(Mutex::new(true));
@@ -429,7 +468,15 @@ async fn key_d_toggles_enabled() {
         // `^P autopilots` to the autopilot screen, then press `d` (disable; the
         // seeded row is enabled → set_enabled(false)). Was the `4` tab key until
         // crisp B5 §2.5 demoted it.
-        go_to_screen(&mut host_write, "autopilots").await;
+        go_to_screen(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+            "autopilots",
+        )
+        .await;
         send_key(&mut host_write, 'd').await;
 
         // Pump until the daemon records set_enabled(false). The daemon flips its

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
@@ -559,9 +559,14 @@ async fn autopilot_right_click_run_now_fires_autopilot() {
         let home = tempfile::tempdir().expect("home");
         let mut h = boot(home.path(), "ap-menu").await;
 
-        // Open the Autopilots screen (`4`), then render so the board layout is
-        // recorded for the autopilot card.
-        send_key(&mut h.host_write, KeyCode::Char { ch: '4' }).await;
+        // Open the Autopilots screen with `^P autopilots` (crisp B5 §2.5 demoted
+        // the `4` tab key), then render so the board layout is recorded for the
+        // autopilot card. `\u{10}` is the bare-DLE spelling of Ctrl+P.
+        send_key(&mut h.host_write, KeyCode::Char { ch: '\u{10}' }).await;
+        for ch in "autopilots".chars() {
+            send_key(&mut h.host_write, KeyCode::Char { ch }).await;
+        }
+        send_key(&mut h.host_write, KeyCode::Char { ch: '\n' }).await;
         relay_one_send_or_render(
             &mut h.host_write,
             &mut h.host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
@@ -567,6 +567,11 @@ async fn autopilot_right_click_run_now_fires_autopilot() {
             send_key(&mut h.host_write, KeyCode::Char { ch }).await;
         }
         send_key(&mut h.host_write, KeyCode::Char { ch: '\n' }).await;
+        // Drain the walk's own traffic (a key delivery per char plus one
+        // `hangar/search` per query edit) so it does not come out of the
+        // `pump_until` budget the mouse assertion below spends. A predicate that
+        // never matches makes `pump_until` a plain bounded pump.
+        pump_until(&mut h, 24, |_| false).await;
         relay_one_send_or_render(
             &mut h.host_write,
             &mut h.host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/list_screen_mouse_rpc.rs
@@ -27,6 +27,10 @@ use ainb_plugin_sdk::Server;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+#[path = "palette_nav_common.rs"]
+mod palette_nav;
+use palette_nav::nav_drain_rounds;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 /// A recorded daemon call: method + params.
@@ -336,13 +340,18 @@ struct Harness {
 }
 
 async fn boot(home: &std::path::Path, tag: &str) -> Harness {
-    std::env::set_var("AINB_HANGAR_HOME", home);
     let stream_id = format!("sock-{tag}-{}", std::process::id());
     let seen: Seen = Arc::new(Mutex::new(Vec::new()));
 
+    // Seed the `first_run` ack, THEN publish the home. `AINB_HANGAR_HOME` is
+    // process-global and this binary holds THREE tests, all through here, so a
+    // sibling's `set_var` can land between ours and this write; `on_init` reading
+    // in that window finds no acks and paints the danger-full-access modal over
+    // the board, where it swallows every key the test sends.
     let state = home.join("hangar").join("state.toml");
     std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
     std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+    std::env::set_var("AINB_HANGAR_HOME", home);
 
     let socket_path = home.join("hangar.sock");
     let listener = UnixListener::bind(&socket_path).expect("bind daemon");
@@ -569,9 +578,16 @@ async fn autopilot_right_click_run_now_fires_autopilot() {
         send_key(&mut h.host_write, KeyCode::Char { ch: '\n' }).await;
         // Drain the walk's own traffic (a key delivery per char plus one
         // `hangar/search` per query edit) so it does not come out of the
-        // `pump_until` budget the mouse assertion below spends. A predicate that
-        // never matches makes `pump_until` a plain bounded pump.
-        pump_until(&mut h, 24, |_| false).await;
+        // `pump_until` budget the mouse assertion below spends.
+        //
+        // Through `pump_until`, whose per-round 20ms sleep is load-bearing here
+        // rather than waste: relaying the same rounds back to back instead makes
+        // the later right-click find no recorded board layout and
+        // `hangar/autopilot_fire_now` never fires (observed, not assumed). The
+        // gesture needs the Autopilots screen to have actually settled, and the
+        // sleeps are what yield to the runtime for that. A predicate that never
+        // matches makes this a plain bounded pump.
+        pump_until(&mut h, nav_drain_rounds("autopilots"), |_| false).await;
         relay_one_send_or_render(
             &mut h.host_write,
             &mut h.host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/palette_nav_common.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/palette_nav_common.rs
@@ -1,0 +1,35 @@
+//! What a `^P <word>` walk costs the socket suites, in one place.
+//!
+//! Crisp B5 §2.5 demoted nine screens off the tab strip, so five socket tests
+//! that used to press one tab key now walk the command palette. The walk is not
+//! free: it puts `word.len() + 2` key deliveries on the wire and arms one
+//! `hangar/search` per query edit. Left in the pipe, that traffic comes out of
+//! the caller's bounded relay budget, and the assertion under test can run out
+//! of pumps before its own RPC is ever reached (the ~2/23 flake in
+//! `screens_render_from_daemon`).
+//!
+//! Each caller drains it before asserting. The WALK itself is not shared: the
+//! five suites send keys through four different signatures and pump through
+//! four different relay helpers, so one common walk would be an abstraction
+//! over five shapes. The COST is shared, because that is the part that drifts —
+//! it was five copies in three forms, two of them bare literals whose
+//! derivation lived only in a comment, so a palette that fired two searches per
+//! keystroke would have silently left two of them short.
+//!
+//! Included with `#[path = "palette_nav_common.rs"] mod palette_nav;`, the same
+//! way `tripwire_p4_issue_list_renders.rs` shares `tripwire_p4_common.rs`.
+
+/// Relay rounds one `^P <word>` walk needs to clear: `word.len() + 2` key
+/// deliveries (`^P`, the word, Enter), one `hangar/search` per query edit, and
+/// two spare.
+///
+/// Callers loop this count unconditionally rather than stopping at the first
+/// round that relays nothing: a round with nothing to relay is one render on a
+/// duplex pipe, and an early exit returns before the plugin has queued the next
+/// search.
+// Compiled as its own (empty) test target as well as into each includer, where
+// only some of them may end up using it.
+#[allow(dead_code)]
+pub fn nav_drain_rounds(word: &str) -> usize {
+    2 * word.chars().count() + 4
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
@@ -337,6 +337,17 @@ async fn send_key<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: char
         .unwrap();
 }
 
+/// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
+/// `^P`, the screen's word, Enter. `\u{10}` is the bare-DLE spelling of Ctrl+P
+/// the plugin accepts alongside the modifier flag (`plugin::is_ctrl_p`).
+async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+    send_key(host_write, '\u{10}').await;
+    for ch in word.chars() {
+        send_key(host_write, ch).await;
+    }
+    send_key(host_write, '\n').await;
+}
+
 #[tokio::test]
 async fn issue_list_renders_seeded_rows_then_tab_to_skills() {
     let body = async {
@@ -390,9 +401,9 @@ async fn issue_list_renders_seeded_rows_then_tab_to_skills() {
         assert!(!last.contains("Loading"), "stuck on loading:\n{last}");
         assert!(last.contains("Todo"), "Todo column header missing:\n{last}");
 
-        // Route the `3` tab key → skill manager renders `commit` (e38.38: Skills
-        // renumbered 4→3 to close the `[3]Agents` gap).
-        send_key(&mut host_write, '3').await;
+        // `^P skills` → skill manager renders `commit`. Was the `3` tab key until
+        // crisp B5 §2.5 demoted it; the palette is the replacement route.
+        go_to_screen(&mut host_write, "skills").await;
         let (skills, last2) = poll_render_for(&mut host_write, &mut host_read, "commit").await;
         assert!(skills, "tab to skills did not render `commit`:\n{last2}");
         assert!(
@@ -490,9 +501,9 @@ async fn skill_screen_s_invokes_skills_sync_rpc() {
         )
         .await;
 
-        // Tab to the skill manager (`3`), then press `s` (sync). (e38.38: Skills
-        // renumbered 4→3 to close the `[3]Agents` gap.)
-        send_key(&mut host_write, '3').await;
+        // `^P skills` to the skill manager, then press `s` (sync). Was the `3`
+        // tab key until crisp B5 §2.5 demoted it.
+        go_to_screen(&mut host_write, "skills").await;
         send_key(&mut host_write, 's').await;
 
         // Pump renders until the plugin's deferred skill action fires the sync

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
@@ -340,12 +340,62 @@ async fn send_key<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: char
 /// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
 /// `^P`, the screen's word, Enter. `\u{10}` is the bare-DLE spelling of Ctrl+P
 /// the plugin accepts alongside the modifier flag (`plugin::is_ctrl_p`).
-async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+///
+/// DRAINS its own traffic before returning. The walk costs `word.len() + 2` key
+/// deliveries and one `hangar/search` per keystroke; left in the pipe, that came
+/// out of the caller's bounded relay budget and the assertion under test could
+/// run out of pumps before its RPC was ever reached (a ~2/23 flake here).
+async fn go_to_screen<W, R, DR, DW>(
+    host_write: &mut W,
+    host_read: &mut R,
+    daemon_reader: &mut DR,
+    daemon_write: &mut DW,
+    stream_id: &str,
+    word: &str,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+    DR: tokio::io::AsyncBufRead + Unpin,
+    DW: tokio::io::AsyncWrite + Unpin,
+{
     send_key(host_write, '\u{10}').await;
     for ch in word.chars() {
         send_key(host_write, ch).await;
     }
     send_key(host_write, '\n').await;
+    for _ in 0..nav_drain_rounds(word) {
+        relay_one_send_or_render(
+            host_write,
+            host_read,
+            daemon_reader,
+            daemon_write,
+            stream_id,
+        )
+        .await;
+    }
+}
+
+/// Relay rounds a [`go_to_screen`] walk needs to clear: one per key delivery
+/// (`^P` + the word + Enter) plus one per `hangar/search` the query edits arm,
+/// with two spare. Not an early-exit loop: a round that relays nothing is one
+/// render on a duplex pipe, and stopping at the first idle round would return
+/// before the plugin had queued the next search.
+fn nav_drain_rounds(word: &str) -> usize {
+    2 * word.chars().count() + 4
+}
+
+/// Write the `first_run` ack into `home` and THEN publish it as
+/// `AINB_HANGAR_HOME`, so no window exists where the env names a home whose
+/// `state.toml` is not there yet.
+///
+/// The var is process-global and both tests in this binary set it, so whichever
+/// home `on_init` happens to resolve must already carry the ack; otherwise the
+/// danger-full-access modal opens over the board and swallows the test's keys.
+fn seed_first_run_ack(home: &std::path::Path) {
+    let state = home.join("hangar").join("state.toml");
+    std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
+    std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+    std::env::set_var("AINB_HANGAR_HOME", home);
 }
 
 #[tokio::test]
@@ -355,12 +405,15 @@ async fn issue_list_renders_seeded_rows_then_tab_to_skills() {
         // P5.6: this test asserts issue-list rendering, not the first-run
         // danger-full-access modal. Point the plugin's `state.toml` resolution at
         // this isolated home (hermetic — no real `~/.agents-in-a-box`) and pre-seed the
-        // `first_run` ack so the modal is deterministically skipped. Single test
-        // per binary, so the process-wide env set is race-free here.
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
-        let state = home.path().join("hangar").join("state.toml");
-        std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
-        std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+        // `first_run` ack so the modal is deterministically skipped.
+        //
+        // SEED FIRST, then publish the home. `AINB_HANGAR_HOME` is process-global
+        // and this binary holds two tests, so the sibling's `set_var` can land
+        // between ours and our write; `on_init` reading in that window finds no
+        // file, no acks, and paints the modal over the board, which then eats
+        // every key the test sends. (The comment here used to claim one test per
+        // binary; there have been two since the sync test landed.)
+        seed_first_run_ack(home.path());
 
         let socket_path = home.path().join("hangar.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind daemon");
@@ -403,7 +456,15 @@ async fn issue_list_renders_seeded_rows_then_tab_to_skills() {
 
         // `^P skills` → skill manager renders `commit`. Was the `3` tab key until
         // crisp B5 §2.5 demoted it; the palette is the replacement route.
-        go_to_screen(&mut host_write, "skills").await;
+        go_to_screen(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+            "skills",
+        )
+        .await;
         let (skills, last2) = poll_render_for(&mut host_write, &mut host_read, "commit").await;
         assert!(skills, "tab to skills did not render `commit`:\n{last2}");
         assert!(
@@ -467,10 +528,7 @@ where
 async fn skill_screen_s_invokes_skills_sync_rpc() {
     let body = async {
         let home = tempfile::tempdir().expect("home");
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
-        let state = home.path().join("hangar").join("state.toml");
-        std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
-        std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+        seed_first_run_ack(home.path());
 
         let socket_path = home.path().join("hangar.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind daemon");
@@ -503,7 +561,15 @@ async fn skill_screen_s_invokes_skills_sync_rpc() {
 
         // `^P skills` to the skill manager, then press `s` (sync). Was the `3`
         // tab key until crisp B5 §2.5 demoted it.
-        go_to_screen(&mut host_write, "skills").await;
+        go_to_screen(
+            &mut host_write,
+            &mut host_read,
+            &mut daemon_reader,
+            &mut daemon_write,
+            &stream_id,
+            "skills",
+        )
+        .await;
         send_key(&mut host_write, 's').await;
 
         // Pump renders until the plugin's deferred skill action fires the sync

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/screens_render_from_daemon.rs
@@ -26,6 +26,10 @@ use ainb_plugin_sdk::Server;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+#[path = "palette_nav_common.rs"]
+mod palette_nav;
+use palette_nav::nav_drain_rounds;
+
 const BUDGET: Duration = Duration::from_secs(20);
 
 /// Read one Content-Length frame body, decoding the JSON. `None` on EOF.
@@ -375,15 +379,6 @@ async fn go_to_screen<W, R, DR, DW>(
     }
 }
 
-/// Relay rounds a [`go_to_screen`] walk needs to clear: one per key delivery
-/// (`^P` + the word + Enter) plus one per `hangar/search` the query edits arm,
-/// with two spare. Not an early-exit loop: a round that relays nothing is one
-/// render on a duplex pipe, and stopping at the first idle round would return
-/// before the plugin had queued the next search.
-fn nav_drain_rounds(word: &str) -> usize {
-    2 * word.chars().count() + 4
-}
-
 /// Write the `first_run` ack into `home` and THEN publish it as
 /// `AINB_HANGAR_HOME`, so no window exists where the env names a home whose
 /// `state.toml` is not there yet.
@@ -590,11 +585,19 @@ async fn skill_screen_s_invokes_skills_sync_rpc() {
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-        assert!(
-            sent,
-            "pressing `s` on the skill screen must issue a `hangar/skills_sync` RPC; saw: {:?}",
-            seen.lock().unwrap()
-        );
+        // On failure, print the PANE as well as the RPC list. Two different
+        // causes produce an identical RPC list here — a drained-too-late budget,
+        // and the danger-full-access modal swallowing every key before the walk
+        // is delivered — and only the pane tells them apart. Distinguishing them
+        // cost a whole extra diagnosis round.
+        if !sent {
+            let (_, pane) = poll_render_for(&mut host_write, &mut host_read, "\u{0}").await;
+            panic!(
+                "pressing `s` on the skill screen must issue a `hangar/skills_sync` RPC;\n\
+                 saw: {:?}\n--- pane ---\n{pane}",
+                seen.lock().unwrap()
+            );
+        }
 
         drop(host_write);
         server.abort();

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_members_render_snapshot.rs
@@ -125,6 +125,7 @@ fn tui_renders_members_with_roles() {
         scope: global · [g] toggle
                       phone   web     os      atc
         ] [ kind · h/l channel · space toggle
+      More screens
     "###);
 
     // NON-VACUOUS COLOUR CHECK: the owner row's glyphs paint in `SELECTION_GREEN`.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_more_screens_render.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_more_screens_render.rs
@@ -1,0 +1,117 @@
+//! Crisp B5 §2.5 — the Settings `More screens` section renders all nine rows.
+//!
+//! This is the SECOND of the two routes to a screen the tab-strip shrink demoted,
+//! and the discoverable one: the palette only helps an operator who already
+//! suspects the screen exists. It had no render test — the only committed
+//! evidence was a notify-grid snapshot that clips the list after four rows and
+//! reads as if only four screens exist.
+//!
+//! Asserted at the 80×24 floor with the section selected, which is the state an
+//! operator reaches by pressing `,` then `j` to the bottom.
+
+use ainb_hangar_proto::settings::HealthSnapshot;
+use ainb_plugin_hangar::screen::command_palette::GO_SCREENS;
+use ainb_plugin_hangar::screen::settings::{
+    SettingsEvent, SettingsSection, SettingsState, reduce_settings, render_settings,
+};
+use ainb_plugin_sdk::WireBuffer;
+
+const FLOOR_W: u16 = 80;
+const FLOOR_H: u16 = 24;
+
+fn health() -> HealthSnapshot {
+    HealthSnapshot {
+        socket_path: "/tmp/hangar.sock".into(),
+        pid: 1,
+        uptime_secs: 1,
+        version: "0.1.0".into(),
+        connected: true,
+    }
+}
+
+/// `j` to the last section, the way an operator gets there.
+fn on_more_screens() -> SettingsState {
+    let mut s = SettingsState::new(health(), Vec::new(), Vec::new(), Vec::new());
+    for _ in 0..10 {
+        s = reduce_settings(&s, SettingsEvent::Key('j')).state;
+    }
+    assert_eq!(
+        s.section(),
+        SettingsSection::MoreScreens,
+        "`j` must clamp on the last section"
+    );
+    s
+}
+
+/// The painted text of `buf`, row-major.
+fn painted(buf: &WireBuffer) -> String {
+    let mut grid = vec![vec![' '; FLOOR_W as usize]; FLOOR_H as usize];
+    for (coord, cell) in &buf.cells {
+        if coord.x < FLOOR_W && coord.y < FLOOR_H {
+            grid[coord.y as usize][coord.x as usize] = cell.symbol.chars().next().unwrap_or(' ');
+        }
+    }
+    grid.into_iter()
+        .map(|r| r.into_iter().collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Every demoted screen is listed with the `^P` word that reaches it, at 80×24.
+///
+/// Derived from `GO_SCREENS`, so the section cannot advertise a word the palette
+/// does not match, nor omit one the palette does.
+#[test]
+fn more_screens_lists_every_demoted_screen_at_the_floor() {
+    let mut buf = WireBuffer::new(FLOOR_W, FLOOR_H);
+    render_settings(
+        &mut buf,
+        FLOOR_W,
+        FLOOR_H,
+        1,
+        FLOOR_H - 1,
+        &on_more_screens(),
+    );
+    let text = painted(&buf);
+
+    assert!(
+        text.contains("More screens"),
+        "the section header must be on screen:\n{text}"
+    );
+    for (word, screen) in GO_SCREENS {
+        let row = format!("^P {word}");
+        assert!(
+            text.contains(&row),
+            "`{row}` ({}) is missing from the section:\n{text}",
+            screen.tab_label()
+        );
+        assert!(
+            text.contains(screen.tab_label()),
+            "`{row}` has no label beside it:\n{text}"
+        );
+    }
+}
+
+/// Nothing paints outside the 80×24 area, and nothing paints on the chrome rows
+/// the caller reserved (row 0 is the tab strip, row 23 the footer).
+#[test]
+fn more_screens_stays_inside_the_body_band() {
+    let mut buf = WireBuffer::new(FLOOR_W, FLOOR_H);
+    render_settings(
+        &mut buf,
+        FLOOR_W,
+        FLOOR_H,
+        1,
+        FLOOR_H - 1,
+        &on_more_screens(),
+    );
+    for (coord, cell) in &buf.cells {
+        assert!(
+            coord.x < FLOOR_W && coord.y > 0 && coord.y < FLOOR_H - 1,
+            "painted {:?} at ({}, {}), outside the body band",
+            cell.symbol,
+            coord.x,
+            coord.y
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/settings_reducer_test.rs
@@ -40,8 +40,9 @@ fn notify_rules() -> Vec<NotifyRuleWireRow> {
 fn notify_state() -> SettingsState {
     let mut s = state();
     s.set_notify_rules(notify_rules());
-    // Navigate Daemon → … → Notifications (six `j`s reach + clamp at the bottom).
-    for _ in 0..6 {
+    // Navigate Daemon → … → Notifications (five `j`s; a sixth would carry on to
+    // More screens, which crisp B5 §2.5 added below it).
+    for _ in 0..5 {
         s = reduce_settings(&s, SettingsEvent::Key('j')).state;
     }
     assert_eq!(s.section(), SettingsSection::Notifications);
@@ -431,11 +432,13 @@ fn j_k_navigates_settings_sections() {
     assert_eq!(s.section(), SettingsSection::Members);
     let s = reduce_settings(&s, SettingsEvent::Key('j')).state;
     assert_eq!(s.section(), SettingsSection::Notifications);
-    // Clamps at the bottom (Notifications, tcp T5).
     let s = reduce_settings(&s, SettingsEvent::Key('j')).state;
-    assert_eq!(s.section(), SettingsSection::Notifications);
+    assert_eq!(s.section(), SettingsSection::MoreScreens);
+    // Clamps at the bottom (More screens, crisp B5 §2.5).
+    let s = reduce_settings(&s, SettingsEvent::Key('j')).state;
+    assert_eq!(s.section(), SettingsSection::MoreScreens);
     let s = reduce_settings(&s, SettingsEvent::Key('k')).state;
-    assert_eq!(s.section(), SettingsSection::Members);
+    assert_eq!(s.section(), SettingsSection::Notifications);
 }
 
 /// `n` on the keys section opens the key-entry modal.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/snapshots/settings_notify_grid_snapshot__tui_renders_notify_routing_grid.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ainb-plugin-hangar/tests/settings_notify_grid_snapshot.rs
+assertion_line: 89
 expression: map
 ---
   Daemon
@@ -16,3 +17,9 @@ expression: map
      error         ○       ○       ●       ○
      waiting       ○       ○       ○       ○
     ] [ kind · h/l channel · space toggle
+  More screens
+    off the tab strip, reach with ^P
+    ^P skills     Skills
+    ^P autopilots Autopilots
+    ^P daemon     Daemon
+    ^P usage      Usage

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -36,6 +36,10 @@ use ainb_plugin_sdk::Server;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
+#[path = "palette_nav_common.rs"]
+mod palette_nav;
+use palette_nav::nav_drain_rounds;
+
 const BUDGET: Duration = Duration::from_secs(30);
 
 /// A recorded daemon call: method + params.
@@ -419,7 +423,7 @@ async fn go_to_screen<W, R, DR, DW>(
         send_char(host_write, ch).await;
     }
     send_char(host_write, '\n').await;
-    for _ in 0..(2 * word.chars().count() + 4) {
+    for _ in 0..nav_drain_rounds(word) {
         let _ = render_capture(
             host_write,
             host_read,

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -391,6 +391,20 @@ async fn send_char<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: cha
     send_key(host_write, KeyCode::Char { ch }).await;
 }
 
+/// Walk the command palette to a screen crisp B5 §2.5 took off the tab strip:
+/// `^P`, the screen's word, Enter. `\u{10}` is the bare-DLE spelling of Ctrl+P
+/// the plugin accepts alongside the modifier flag (`plugin::is_ctrl_p`).
+///
+/// `squads` is the word with a `q` in it, which is why the palette had to stop
+/// letting the router eat its query first.
+async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+    send_char(host_write, '\u{10}').await;
+    for ch in word.chars() {
+        send_char(host_write, ch).await;
+    }
+    send_char(host_write, '\n').await;
+}
+
 /// Boot the plugin + mock daemon, relay the connect handshake, and pump renders
 /// until BOTH the agents and squads snapshots have been fetched + folded (so the
 /// Squads screen has resolved rows). Returns the live handles + recorder.
@@ -475,8 +489,9 @@ async fn squads_screen_shows_leader_and_member_rows() {
             "the squad must not be on the landing screen:\n{pre}"
         );
 
-        // Press `S` to open the Squads screen, then render.
-        send_char(&mut hw, 'S').await;
+        // `^P squads` opens the Squads screen, then render. Was the `S` tab key
+        // until crisp B5 §2.5 demoted it.
+        go_to_screen(&mut hw, "squads").await;
         let mut post = String::new();
         for _ in 0..30 {
             post = render_capture(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id).await;
@@ -514,8 +529,8 @@ async fn create_and_assign_fire_the_squad_rpcs() {
         let (mut hw, mut hr, mut dr, mut dw, server) =
             boot(home.path(), &stream_id, seen.clone()).await;
 
-        // Open the Squads screen.
-        send_char(&mut hw, 'S').await;
+        // Open the Squads screen (crisp B5 §2.5 demoted the `S` tab key).
+        go_to_screen(&mut hw, "squads").await;
         let _ = render_capture(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id).await;
 
         // Create a squad: `c`, type "qa", Enter.

--- a/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/tests/tripwire_squads_flow.rs
@@ -397,12 +397,38 @@ async fn send_char<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, ch: cha
 ///
 /// `squads` is the word with a `q` in it, which is why the palette had to stop
 /// letting the router eat its query first.
-async fn go_to_screen<W: tokio::io::AsyncWrite + Unpin>(host_write: &mut W, word: &str) {
+///
+/// DRAINS its own traffic before returning: the walk costs one key delivery per
+/// character plus one `hangar/search` per query edit, and left in the pipe those
+/// come out of the caller's bounded relay budget rather than the nav's.
+async fn go_to_screen<W, R, DR, DW>(
+    host_write: &mut W,
+    host_read: &mut R,
+    daemon_reader: &mut DR,
+    daemon_write: &mut DW,
+    stream_id: &str,
+    word: &str,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+    R: tokio::io::AsyncBufRead + Unpin,
+    DR: tokio::io::AsyncBufRead + Unpin,
+    DW: tokio::io::AsyncWrite + Unpin,
+{
     send_char(host_write, '\u{10}').await;
     for ch in word.chars() {
         send_char(host_write, ch).await;
     }
     send_char(host_write, '\n').await;
+    for _ in 0..(2 * word.chars().count() + 4) {
+        let _ = render_capture(
+            host_write,
+            host_read,
+            daemon_reader,
+            daemon_write,
+            stream_id,
+        )
+        .await;
+    }
 }
 
 /// Boot the plugin + mock daemon, relay the connect handshake, and pump renders
@@ -420,9 +446,16 @@ async fn boot(
     tokio::net::unix::OwnedWriteHalf,
     tokio::task::JoinHandle<Result<(), ainb_plugin_sdk::SdkError>>,
 ) {
+    // Seed the `first_run` ack, THEN publish the home. `AINB_HANGAR_HOME` is
+    // process-global and this binary holds two tests, so a sibling's `set_var`
+    // can land between ours and this write; `on_init` reading in that window
+    // finds no acks and paints the danger-full-access modal over the board,
+    // where it swallows every key the test sends. Publishing here rather than at
+    // the call site keeps the two in one place, in this order.
     let state = home.join("hangar").join("state.toml");
     std::fs::create_dir_all(state.parent().unwrap()).expect("state dir");
     std::fs::write(&state, "warnings_ack = [\"first_run\"]\n").expect("seed ack");
+    std::env::set_var("AINB_HANGAR_HOME", home);
 
     let socket_path = home.join("hangar.sock");
     let listener = UnixListener::bind(&socket_path).expect("bind daemon");
@@ -476,7 +509,6 @@ async fn boot(
 async fn squads_screen_shows_leader_and_member_rows() {
     let body = async {
         let home = tempfile::tempdir().expect("home");
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
         let stream_id = format!("sock-squads-{}", std::process::id());
         let seen: Seen = Arc::new(Mutex::new(Vec::new()));
         let (mut hw, mut hr, mut dr, mut dw, server) =
@@ -491,7 +523,7 @@ async fn squads_screen_shows_leader_and_member_rows() {
 
         // `^P squads` opens the Squads screen, then render. Was the `S` tab key
         // until crisp B5 §2.5 demoted it.
-        go_to_screen(&mut hw, "squads").await;
+        go_to_screen(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id, "squads").await;
         let mut post = String::new();
         for _ in 0..30 {
             post = render_capture(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id).await;
@@ -523,14 +555,13 @@ async fn squads_screen_shows_leader_and_member_rows() {
 async fn create_and_assign_fire_the_squad_rpcs() {
     let body = async {
         let home = tempfile::tempdir().expect("home");
-        std::env::set_var("AINB_HANGAR_HOME", home.path());
         let stream_id = format!("sock-squadrpc-{}", std::process::id());
         let seen: Seen = Arc::new(Mutex::new(Vec::new()));
         let (mut hw, mut hr, mut dr, mut dw, server) =
             boot(home.path(), &stream_id, seen.clone()).await;
 
         // Open the Squads screen (crisp B5 §2.5 demoted the `S` tab key).
-        go_to_screen(&mut hw, "squads").await;
+        go_to_screen(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id, "squads").await;
         let _ = render_capture(&mut hw, &mut hr, &mut dr, &mut dw, &stream_id).await;
 
         // Create a squad: `c`, type "qa", Enter.

--- a/docs/hangar/renovation/crisp-ui-track.md
+++ b/docs/hangar/renovation/crisp-ui-track.md
@@ -274,7 +274,9 @@ before (16 tabs, 138 cols, wraps under 138, never fits 80):
 [1]Issues [2]Task [3]Skills [4]Autopilots [K]Kanban [B]Boards [D]Daemon [U]Usage
 [L]Logs [I]Inbox [C]Control [F]Fleet [S]Squads [P]Profiles [A]Agents [,]Settings
 
-after (7 tabs, 74 cols, fits the 80x24 floor with the right cluster intact):
+after (7 tabs, 72 cols of ink / cursor at 74; every label fits the 80x24 floor,
+the right cluster yields until 93 - measured on the shipped strip, and pinned by
+`the_seven_tab_strip_fits_the_eighty_column_floor`):
 [1]Issues  [2]Task  [K]Runs  [B]Boards  [I]Inbox  [A]Agents  [,]Settings   ⬡⬡ 2 working  default ● online
 ```
 

--- a/docs/hangar/tui-keybindings.md
+++ b/docs/hangar/tui-keybindings.md
@@ -10,28 +10,44 @@ Hints are rendered next to the control they affect (per
 
 ## Routing layer (all screens)
 
+Nine keys, down from eighteen (crisp B5). The tab strip carries the seven
+screens the loop runs through; the rest moved behind the command palette.
+
 | Key | Action |
 |-----|--------|
 | `1` | Issue list (landing) |
 | `2` | Task detail (only when a task is selected) |
-| `3` | Skill manager |
-| `4` | Autopilots |
-| `K` | Kanban |
+| `K` | Runs (the task board; the screen and its widget are still `kanban`) |
 | `B` | Boards |
-| `C` | Control center |
-| `S` | Squads |
-| `P` | Profile editor |
-| `D` | Daemon health |
-| `U` | Usage dashboard |
-| `L` | Logs |
 | `I` | Inbox |
-| `F` | Fleet (every live session: lenses, stop / interrupt / continue / kill, chat) |
 | `A` | Agents (roster + guided create wizard) |
 | `,` | Settings |
-| `Ctrl+P` | Command palette (`hangar/search` as you type; Enter jumps to the entity) |
+| `Ctrl+P` | Command palette: `Go: <screen>` first, then `hangar/search` as you type; Enter jumps |
 | `?` | Help overlay |
 | `Esc` | Close the active modal |
 | `q` | Back to the `ainb` home screen (press `q` again there to quit) |
+
+### Screens behind the palette
+
+These nine kept their screens, their reducers and their per-screen keys; only
+the tab hotkey went. Reach one with `Ctrl+P` and its word, or read the list off
+the Settings screen's **More screens** section.
+
+| Type | Screen |
+|------|--------|
+| `^P skills` | Skill manager |
+| `^P autopilots` | Autopilots |
+| `^P daemon` | Daemon health |
+| `^P usage` | Usage dashboard |
+| `^P logs` | Logs |
+| `^P control` | Control center |
+| `^P fleet` | Fleet (every live session: lenses, stop / interrupt / continue / kill, chat) |
+| `^P squads` | Squads |
+| `^P profiles` | Profile editor |
+
+The freed keys (`3` `4` `C` `D` `F` `L` `P` `S` `U`) now reach the active
+screen's reducer, so a screen-local binding on one of them is live rather than
+eaten by the router.
 
 `?` and `H` belong to the plugin on every hangar screen, typed or not: the host
 never reserves them here, so a title or brief containing `H` reads through
@@ -160,10 +176,10 @@ Every retry chain is capped by the task's `max_attempts` regardless of reason.
 **Where the real error surfaces:** a `provision_error` writes the underlying
 setup error (the failed clone / worktree message) into the task's `result`, so
 the task-detail screen shows it directly. A `spawn_timeout`'s cause is logged by
-the daemon — check the Logs screen (`L`) or the daemon log. For agent-side
+the daemon — check the Logs screen (`^P logs`) or the daemon log. For agent-side
 failures the transcript on this screen carries the run output.
 
-## Skill manager (`3`) — P6.5
+## Skill manager (`^P skills`) — P6.5
 
 The three panes: a left skill list, a middle file tree (collapses below ~100
 cols), and a right detail/editor pane. The action-key hints
@@ -187,9 +203,12 @@ pair (`hangar/skill_attach` returns an error).
 
 ## Settings (`,`)
 
-Six stacked sections: Daemon, Providers, Keys, Workspaces, Members,
-Notifications. `j` / `k` switch sections; `J` / `K` (and `↑` / `↓`) move the
-row cursor within the focused section.
+Seven stacked sections: Daemon, Providers, Keys, Workspaces, Members,
+Notifications, More screens. `j` / `k` switch sections; `J` / `K` (and `↑` /
+`↓`) move the row cursor within the focused section.
+
+**More screens** is read-only: the nine screens the tab strip dropped, each
+beside the `^P` word that reaches it.
 
 | Key | Action |
 |-----|--------|
@@ -232,7 +251,7 @@ A role-gated Pipeline board (`ainb hangar pipeline init`) pulls a card through
 its stages by itself; there is no key for that. Its columns carry no FSM
 mapping, so cards move only when a stage finishes.
 
-## Control center (`C`)
+## Control center (`^P control`)
 
 | Key | Action |
 |-----|--------|
@@ -246,7 +265,7 @@ title row confirms delivery by dropping the card; when the daemon refuses
 (ambiguous target, no live session, delivery failed, already answered elsewhere)
 the reason is painted on the title row in red and the card stays.
 
-## Squads (`S`)
+## Squads (`^P squads`)
 
 | Key | Action |
 |-----|--------|
@@ -264,7 +283,7 @@ the reason is painted on the title row in red and the card stays.
 | `n` | Guided create: Name → Description → Provider (`←`/`→`) → Model → Instructions → confirm (Enter) |
 | `x` | Delete the selected agent (confirm) |
 
-## Kanban (`K`)
+## Runs (`K`)
 
 | Key | Action |
 |-----|--------|
@@ -272,7 +291,7 @@ the reason is painted on the title row in red and the card stays.
 | `Shift+←` / `Shift+→` (or `<` / `>`) | Move the card to the adjacent column |
 | `R` | Force-requeue a focused failed / cancelled card |
 
-## Logs (`L`) · Inbox (`I`) · Profiles (`P`)
+## Logs (`^P logs`) · Inbox (`I`) · Profiles (`^P profiles`)
 
 | Screen | Keys |
 |--------|------|


### PR DESCRIPTION
Crisp UI track step B5 (`docs/hangar/renovation/crisp-ui-track.md` §2.5, §4 Step 5). Last step of track B.

## What changed

**Tab strip, 16 to 7** (`chrome.rs:49 PRIMARY_TABS`). `[1]Issues [2]Task [K]Runs [B]Boards [I]Inbox [A]Agents [,]Settings`. 72 columns of ink.

**Router keys, 18 to 9** (`router.rs:30 ROUTER_KEYS`): `1 2 K B I A , ? q`. Nine demoted: `3` `4` `D` `U` `L` `C` `F` `S` `P`. Every demoted SCREEN, its reducer, its snapshots and its tests stay (track-B do-not #9); only the key went.

**Both replacement routes, in the same commit as the demotion** (e7620681):
1. `^P` gains a plugin-local `Go: <screen>` family (`command_palette.rs GO_SCREENS`), matched client-side on a lowercase substring and merged AHEAD of the daemon's `hangar/search` results. `SearchEntryKind` untouched. The rows carry the `Screen` itself, not a wire token, so there is no `navigate_to_entity` string to typo into a stranded screen.
2. `,` Settings gains a read-only `More screens` section (7th `SettingsSection`) listing all nine with their palette words, rendered straight off `GO_SCREENS`.

**`Kanban` relabelled `Runs`** (db784a23). Hotkey unchanged; the `Screen` variant, module and widget stay `kanban`.

**`HELP_LINES` rewritten**: a 7-tab `screens` block plus a `more` block naming the nine palette words.

## Guards added

| test | what it covers |
|---|---|
| `palette_reaches_every_demoted_screen` | the spec's required test. Demoted set derived from the `Screen` enum minus `chrome::tab_hotkey`, **not** from `GO_SCREENS` (that would be tautological), and driven through the reducer (type the word, press Enter, assert the intent names THAT screen) rather than read off the table. A tenth demotion fails until it has a row. |
| `every_tab_on_the_strip_is_reachable_and_labelled` | `PRIMARY_TABS` ↔ `tab_hotkey` ↔ `ROUTER_KEYS`, both directions, over every `Screen` variant. Catches "painted but never highlights" and "painted but the router dropped the key". |
| `the_seven_tab_strip_fits_the_eighty_column_floor` | all seven labels intact at 80, strip measured at 72 columns, and the right cluster's yield pinned at both 80 and 93. |
| `the_palette_query_swallows_every_router_key` | over the whole `ROUTER_KEYS` set, not one char. |
| `help_overlay_never_paints_over_the_tab_strip_or_the_footer` | at h ∈ {10, 23, 24, 25, 40}. |
| `help_overlay_fits_the_eighty_by_twenty_four_floor` | table ≤ 22 lines, ≤ 80 columns. |
| `an_empty_query_lists_every_go_row_ahead_of_the_results` | all nine rows, ahead of a daemon result, plus no background bleed. |
| `narrowing_the_query_clamps_the_selection_onto_a_painted_row` | Enter never fires at a row that is no longer painted. |

Each of the four that guard a fix was run against the un-fixed code and observed to FAIL. Not claimed, executed:

- `the_palette_query_swallows_every_router_key` without the capture guard: ``typing `1` into the palette left it for IssueList``
- `an_empty_query_lists_every_go_row_ahead_of_the_results` without the modal fill: ``the board bled through the palette: "│[go] Go: skills            │             │           "``
- `help_overlay_never_paints_over_the_tab_strip_or_the_footer` and `help_overlay_clips_to_a_short_pane_from_the_top` without the band clamp: both FAILED.

No `len() >= N`, no count, no lower bound anywhere in the eight.

## Structural, not conventional

`is_router_key` was a hand-kept `matches!` mirror of `ROUTER_KEYS`; it now **reads the array** in a `const fn` loop, so the shrink is two edits in step instead of three, and the surviving one (`reduce_key`) is covered by the existing `router_keys_all_have_a_reduce_key_arm`.

`tab_is_active` was a second hotkey→screen table that could keep an arm for a tab the strip had dropped; it now reads one `tab_hotkey(&Screen)`, keyed off the screen.

Neither is claimed as compiler-enforced. `every_screen()` in `test_support.rs` carries a wildcard-free match so a new `Screen` variant fails to compile next to the list, which forces an author to look; it does not by itself prove the list holds every variant, and the doc comment says so.

## The 80-column render

Real tmux pane, 80x24, real daemon, seeded pipeline (`tmux resize-window` on a `TuiSession`, captured with `capture-pane`):

```
[1]Issues  [2]Task  [K]Runs  [B]Boards  [I]Inbox  [A]Agents  [,]Settings
[All] [Members] [Agents] [Mine]                                      ⬡ 1 working
☰ Backlog ⋯ +│○ Todo (3)⋯ +│◔ In Progr⋯ +│◑ In Revie⋯ +│● Done (0)          ⋯ +
```

Seven tabs, no wrap, no truncation. **The right-hand cluster does NOT fit, which §2.5 predicted it would.** Measured: the strip is 72 columns of ink and the cursor lands at 74 (each tab carries a two-space separator); `default · ● online` is 18 more and `right_start` requires a one-column gap, so it needs 93. Below that the existing width-aware rule drops it, tabs winning the space contest. Both widths are now pinned by the test rather than assumed. I did not add a degradation ladder for the cluster: that is new behaviour §2.5 did not ask for.

`^P` at 80x24, and `^P usage` + Enter:

```
            ╭─ Search: _ ──────────────────────────────────────────╮
            │ [go] Go: skills                                      │
            │ [go] Go: autopilots                                  │
            │ [go] Go: daemon                                      │
            │ [go] Go: usage                                       │
            │ [go] Go: logs                                        │
            │ [go] Go: control                                     │
 ╭╌╌╌╌╌╌╌╌╌╮│ [go] Go: fleet                                       │╌╌╌╌╌╌╌╌╌╌╮
 ╎— empty —╎│ [go] Go: squads                                      │ty —      ╎
 ╰╌╌╌╌╌╌╌╌╌╯│ [go] Go: profiles                                    │╌╌╌╌╌╌╌╌╌╌╯
            ╰──────────────────────────────────────────────────────╯
enter:go  esc:close  ?:help  q:quit
```

```
[1]Issues  [2]Task  [K]Runs  [B]Boards  [I]Inbox  [A]Agents  [,]Settings
Usage

total: 0 in  0 out  $0.0000  (0 runs)
```

Settings `More screens`, and the help overlay clear of the chrome:

```
▶ More screens
    off the tab strip, reach with ^P
    ^P skills     Skills
    ^P autopilots Autopilots
    …
    ^P profiles   Profiles
```

```
[1]Issues  [2]Task  [K]Runs  [B]Boards  [I]Inbox  [A]Agents  [,]Settings
                                 Hangar — keys

  screens   1 issues  2 task  K runs  B boards  I inbox  A agents  , settings
                              ^P search  q back to ainb home
      more      ^P then the word:  skills  autopilots  daemon  usage  logs
                                      control  fleet  squads  profiles
```

## Two defects the render caught that no assertion did

Both found by looking at an 80x24 pane, both fixed in e7620681, both now guarded.

1. **The help overlay painted through the tab strip.** The `more` block grew the table to 23 lines; `render_help` centred over the WHOLE area, so `y0` went to 0 and the title rendered as `[BHangar — keysnbox`. It centres in the body band now (`1..h-1`) and can never reach the chrome, plus the table is trimmed to 22 lines so nothing clips at the floor.
2. **The palette never blanked its own rectangle.** The screen underneath read through between the rows: `│[go] Go: logs│             │`. Harmless while the palette opened empty and you typed to fill it; it opens with nine rows now, and it is the only route to nine screens. The modal fills its rect before drawing.

## Prerequisite bug fixed first (2da4167b)

`captures_text()` already declared the command palette a text surface, so the HOST forwards `q`, `1`, `,`, `B` into the plugin — but `handle_key` had no matching guard, and `routing_event` claims `ROUTER_KEYS` on every screen. Typing `q` into the search box quit the TUI. Its own doc comment claimed the two lists were in sync 1:1; the palette was the one that was not.

This is load-bearing for B5, not a drive-by: `squads` contains a `q`. Without it that Go entry is typed as `squa`+quit, and the reachability guard (a pure-reducer test) would not have caught it. `tripwire_squads_flow` now types `squads` through the real plugin key path and passes.

## Spec test predictions, each verified

| §4 Step 5 prediction | held? |
|---|---|
| `router_keys_all_have_a_reduce_key_arm` passes unchanged | **yes** |
| Add `palette_reaches_every_demoted_screen` | **added**, derived from the enum not the table |
| `help_overlay_names_every_router_key` passes with fewer keys | **yes**, all 8 non-`?` survivors are `<key> <label>` pairs |
| `help_overlay_screen_keys_are_not_router_keys` passes; widen `in_screens` to `more` | **widened**, and it was NOT optional. The pairing test flags a section name stranded mid-row, and the `more` block lists `control`, `logs`, `squads`, `profiles`, `skills` — all of which ARE section names lower down. Without the widening it fails outright, not merely loses intent. |
| `help_overlay_screen_rows_pair_every_label_with_a_key` passes | **only after the same widening** (see above) |
| `help_overlay_clips_to_a_short_pane_from_the_top` adjusts automatically | **NO.** It counts `HELP_LINES[..h]` against painted rows; the band clamp makes that `[..h-2]`, and the first line moved from row 0 to row 1. Updated. |
| `footer_hint_keys_never_collide_with_reserved_router_keys` gets looser, passes | **yes** |
| `chrome.rs` width test comment says "fifteen-tab strip"; update the comment and the assertion | **done**, and the assertion is now a measured 72 with the 80-vs-93 trade pinned |
| `tests/screen_router_test.rs` — update any assertion pressing a demoted key | **none to update**; it only presses `1 2 I ? q` |
| `tests/tripwire_hangar_plugin_connects.rs` green | **yes** |

## What §4 did NOT predict, found by grepping for the old strings

The spec's test list named only the plugin crate. Nine more call sites across two crates pressed a demoted key or gated on a demoted tab label:

- **`tripwire_p4_common.rs:2810 hangar_chrome_visible`** gated on `Issues && Skills && Settings`. `Skills` left the strip, so EVERY tripwire that waits for the hangar chrome would have timed out. Now `Issues && Inbox && Settings`.
- Seven tmux tripwires pressed a demoted key: `p4_cross_screen_navigation` (`3`), `p4_skill_manager_lists` (`3`), `autopilots_screen_renders` (`4`), `daemon_health_sparkline` (`D`), `logs_screen_renders` (`L`), `p2_control_center_attention` (`C`), `p2_answer_flip_e2e` (`C`, twice). All now use a new `TuiSession::go_to_screen_until(word, …)` that re-sends `Esc ^P <word> Enter` on the same retry cadence as `switch_tab_until`.
- Five plugin-crate integration tests pressed one: `screens_render_from_daemon` (`3`, twice), `autopilot_rpc_over_socket` (`4`, twice), `attention_answer_over_socket` (`C`), `list_screen_mouse_rpc` (`4`), `tripwire_squads_flow` (`S`, twice).
- Eight in-crate `plugin.rs` tests. Three now route through a `go_to(&mut p, word)` helper, so the palette route is exercised by every test that needs a demoted screen rather than only by its own guard.

`p4_skill_manager_lists` was missed on the first sweep (its `"3"` sat on its own line inside a multi-line `switch_tab_until` call) and caught by RUNNING the tripwires; fixed in cad6728a with the grep hole named in the commit body.

### Workspace grep for every changed label

`Kanban` (the rendered tab label), across every crate's `src/` and `tests/`, every `.snap`, and docs:

- **Zero** test assertions and **zero** snapshots contain the literal tab label. `tripwire_kanban_columns_render.rs` asserts the four COLUMN headers, not the tab, and presses `K`, which is unchanged. Verified by running it: green.
- Every other `Kanban` in Rust is the `Screen::Kanban` variant, the `kanban` module, or a doc comment. All deliberately unchanged.
- `docs/hangar/tui-keybindings.md` updated (d2e3d803). Historical evidence captures under `docs/explorations/**` and `CHANGELOG.md` left alone.

Same grep for the other changed strings: `Skills`/`Autopilots`/`Daemon`/`Usage`/`Logs`/`Control`/`Fleet`/`Squads`/`Profiles` as tab labels appear only in `hangar_chrome_visible` (fixed) and historical captures. A bare-literal sweep for `"3"` `"4"` `"D"` `"U"` `"L"` `"C"` `"F"` `"S"` `"P"` across all crates now returns nothing hangar-navigational.

## Test evidence

Provenance first (`touch crates/ainb-plugin-hangar/src/lib.rs`, then `-- --list`), so the binary the results come from is the one built from this tree:

```
$ cargo test -p ainb-plugin-hangar --lib -- --list | rg <the new tests>
chrome::tests::every_tab_on_the_strip_is_reachable_and_labelled: test
chrome::tests::the_seven_tab_strip_fits_the_eighty_column_floor: test
plugin::tests::the_palette_query_swallows_every_router_key: test
screen::app_screens::help_overlay_tests::help_overlay_fits_the_eighty_by_twenty_four_floor: test
screen::app_screens::help_overlay_tests::help_overlay_never_paints_over_the_tab_strip_or_the_footer: test
screen::command_palette::tests::an_empty_query_lists_every_go_row_ahead_of_the_results: test
screen::command_palette::tests::narrowing_the_query_clamps_the_selection_onto_a_painted_row: test
screen::command_palette::tests::palette_reaches_every_demoted_screen: test
```

```
$ cargo test -p ainb-plugin-hangar -j2 --no-fail-fast
passed: 932  failed: 0            # run twice, identical
```

```
$ cargo check --workspace --all-targets -j2
(no errors)
$ cargo fmt --all --check
(clean)
```

Fourteen tmux tripwires, real daemon, `env -u TMUX -u TMUX_PANE TMUX_TMPDIR=/tmp/claude-1000/tw-b5`, `--test-threads=1`. Binary hashes taken before and after each batch and unmoved (`dist/plugins/hangar-tui/hangar-tui` `a4885e23…`, `target/debug/ainb` `85905267…`, `target/debug/ainb-hangar-daemon` `ed6e0d85…`):

```
autopilots_screen_renders_seeded_autopilot ................ ok   (^P autopilots)
daemon_health_sparkline_renders_with_red_failure_band ..... ok   (^P daemon)
kanban_board_renders_four_columns_with_cards .............. ok
logs_screen_renders_seeded_daemon_log_lines ............... ok   (^P logs)
control_center_shuffles_ask_above_wait_with_inline_options  ok   (^P control)
cross_screen_navigation_walks_tabs ........................ ok   (1 → ^P skills → , → 1)
skill_manager_lists_skills ................................ ok   (^P skills)
issue_create_keystroke_lands_in_db ........................ ok
kanban_move_keystroke_transitions_db ...................... ok
mouse_drag_moves_card_to_new_column ....................... ok
answering_the_control_center_ask_delivers_and_flips_board . ok   (^P control)
issue_list_renders_seeded_issues .......................... ok
settings_renders_sections ................................. ok
task_detail_opens_for_selected_issue ...................... ok
plugin_crash_host_recovers_and_host_death_leaves_no_orphan  ok
workspace_switch_e2e ...................................... ok
```

`cross_screen_navigation_walks_tabs` is now the one tripwire that crosses BOTH nav routes in a single run: `1` (router key) → `^P skills` (palette) → `,` (router key) → `1`.

Build order followed the known trap: `ainb` + daemon binaries, then `build-plugins.sh` last, then `--no-run`, then hash / run / hash. The daemon binary DID relink on the first `--no-run` (`d93b7ef6` → `ed6e0d85`) exactly as warned; re-staged and re-hashed until stable before trusting any result.

## Deliberately out of scope

- **The right cluster at 80.** Reported as a §2.5 prediction that did not hold, with the arithmetic. Making it fit needs a new degradation ladder.
- **Help overlay typography.** Each line is centred individually, so the block reads ragged (audit §1.9, "lowest priority"). B5 rewrites the CONTENT; a layout redesign is not in §2.5.
- **`Screen` variants for the nine.** Track-B do-not #9: only the key goes.
- **`tripwire_ccc_*` / `tcp_*` e2e tripwires.** They spawn real agents and need credentials this box does not have. None of them presses a demoted key or gates on a demoted tab label (verified by the bare-literal sweep and by `hangar_chrome_visible` call sites), and the ones that use `hangar_chrome_visible` are covered by the sixteen above.
- **A `c5-tabs.tape` vhs recording** (§5). The recording plan is a separate deliverable; the stills above are `capture-pane` from the same isolated harness.

Known-unrelated CI reds per #844, not touched: `capture_failed_launch_pane_reads_a_dead_pane`, `acp_pool::two_concurrent_arrivals_never_overshoot_the_session_cap`, `rpc_acp::two_parked_permissions_are_both_answerable_over_the_wire`.


---

## Review round 1 (#854 @ 5e1de676 → c0c5b661)

All eleven findings addressed. Four new/changed guards were run against un-fixed code and observed to fail; the flake was reproduced, root-caused twice, and re-measured.

### P1-1 — the flake, two causes not one

`screens_render_from_daemon` at ~2/23. The review's diagnosis (nav traffic eating the assertion's relay budget) was **half of it**.

**Cause A, as diagnosed.** `go_to_screen` now drains its own traffic before returning: one relay round per key delivery plus one per `hangar/search` the query edits arm, with two spare, in `screens_render_from_daemon`, `autopilot_rpc_over_socket`, `tripwire_squads_flow`, and also the two inlined nav sites the review did not flag (`attention_answer_over_socket`, `list_screen_mouse_rpc`). Deliberately not an early-exit loop: a round that relays nothing is one render on a duplex pipe, and stopping at the first idle round returns before the plugin has queued the next search.

**That left 1 in 30.** Captured the survivor, and it is a different failure: the pane shows the `⚠ danger-full-access` modal over the board, so the walk was never delivered at all.

**Cause B, pre-existing.** `AINB_HANGAR_HOME` is process-global; both tests in the binary `set_var` and *then* write the `first_run` ack. A sibling's `set_var` landing between ours and our write leaves `on_init` (`plugin.rs:5771`) reading a home with no `state.toml`, so no acks, so the modal opens and swallows every key. Verified pre-existing: `git show 1d49dcbd:…/screens_render_from_daemon.rs` has **two** `#[tokio::test]`s and both already ordered `set_var` before the write, under a comment claiming "single test per binary, so the process-wide env set is race-free here" — false since the sync test landed. Fix is the reorder: seed the ack, then publish the home.

**On the mechanism, not on a soak.** 0 failures in 60 runs was the original claim here and it does not carry that weight: at p = 1/30, `(29/30)^60` is 13%, so one soak in eight passes with no fix at all, and 0/60 only bounds the rate at 5% — an interval that still contains 1-in-30. Round 2's verifier ran 200 on HEAD and 300 with this fix reverted, both clean, so the residual rate is not reproducible on this box either way. What IS established: the modal-swallow chain is proven by source (`on_init` → `state_path` → `$AINB_HANGAR_HOME`; a missing file reads as no acks; no acks paints the modal; the modal swallows every key), the merge-base window is proven by source, and deleting the ack write reproduces the symptom every run. The reorder is correct on the mechanism; the attribution of the residual 1-in-30 to it is not established, and is no longer claimed.

Same reorder applied to the two suites this branch already touches, where the seed lives in `boot()` (`autopilot_rpc_over_socket`, `tripwire_squads_flow`) — the `set_var` moved into `boot()` beside the write, deleting it from both call sites.

Four other plugin-crate suites carry the identical latent race and are **not** touched here: `tripwire_issue_facets`, `tripwire_issue_blocked_cancelled`, `tripwire_issue_properties_render`, `issue_wizard_rpc_over_socket` (each 2 tests × 2 `set_var`s). All green today; fixing four files this PR does not otherwise touch is scope this step did not ask for. Naming them rather than silently leaving them.

### P2-2 — the help `more` block had zero coverage

Correct, and it was the only uncovered copy of the four. `the_help_more_block_names_every_demoted_screen` loops `GO_SCREENS` and asserts each word is a token in `HELP_LINES`. Observed to fail when `usage` is dropped from the block: `` help `more` block omits `usage` (Usage) ``.

### P2-3 — the false fleet claim

Confirmed: `FleetFilter::key()` is paint-only, `reduce_browse_key` has no digit arm, `SetFilter` is raised nowhere outside tests. Dropped the example; the general claim (a freed char now reaches the screen reducer) stands, and the comment now says explicitly that no screen has claimed one yet.

### P2-4 — Settings `More screens` had no render test

`tests/settings_more_screens_render.rs`: `j` to the last section, render at 80×24, assert `^P {word}` **and** the screen's label for every `GO_SCREENS` entry, plus a body-band bounds check. Observed to fail when `SettingsSection::MoreScreens` is dropped from the paint loop.

### P3-5 — the guard proved existence, not naming

Correct and the sharpest finding in the report. `find(|(_, target)| *target == screen)` selects by screen, so swapping two rows passed while `^P usage` opened Logs. Added `assert_eq!(word, screen.tab_label().to_lowercase())`. Observed to fail on exactly that swap: ``the `Go:` word for Usage does not name it``.

### P3-6 — `every_screen()` forced the arm but not the entry

Correct. A `variant_tag` with one distinct tag per arm plus `assert_eq!(tags.len(), SCREEN_VARIANTS)` forces both: the wildcard-free match still fails to compile on a new variant, and bumping the count then fails until the variant is built in the vec. Observed to fail when `Screen::Usage` is dropped from the vec: `every_screen() builds 19 of the 20 Screen variants`.

### P3-7 — fourth copy of `fill_background`

The six-line loop now calls `screen::fleet::fill_background`, which was already `pub(crate)` and already used by `agent_picker` and `activity`. **Not** hoisting `PANEL_BG`: deleting three one-line consts to add one const and three imports across two files this PR does not otherwise touch is a wash.

### P3-8 — `clamp` panic under 40×8

Real, and on the navigation path now. `.max().min()` instead. New test renders at 1×1, 20×4, 39×7, 40×8 and 80×24 and asserts no cell lands out of bounds.

### P3-9 — false citation in the `ROUTER_KEYS` doc

Reworded: the array→arm direction is what `router_keys_all_have_a_reduce_key_arm` walks; the reverse holds by construction because `is_router_key` reads the array, so an unlisted arm is unreachable rather than wrong. No test cited for a direction no test covers.

### P3-10 — `go_to_screen_until` typed into whatever was there

Real. A dropped `C-p` (the exact failure the resend loop exists for) put the word on the live screen, where `c` in `control`/`skills` opens the create-issue wizard and the trailing Enter advances it. Now polls for the ` Search: ` title between `C-p` and `type_literal`.

### P3-11 — stale `[D]Daemon` rationale

Fixed; the gate keeps its shape for the reason that is still true.

### The 80-column ruling — accepted, spec amended, no ladder

Agreed on all three points: unsatisfiable arithmetic, pre-existing and already-tested yielding behaviour that this PR improves rather than regresses, and `plugin.rs:4472` painting the full offline panel at any width so only the redundant positive confirmation is lost. §2.5 now reads "72 cols of ink (cursor 74); every label fits the 80x24 floor, the right cluster yields until 93", citing the test that pins both widths. No code change.

### Re-verification

- `cargo test -p ainb-plugin-hangar --no-fail-fast` → **936 passed, 0 failed** (was 932; +4 new tests).
- `screens_render_from_daemon` → 0 failures in 60 runs. See above for why that number proves less than it looks.
- `cargo fmt --all --check` clean, `cargo check --workspace --all-targets` clean.
- Provenance re-taken after `touch src/lib.rs`: the three new lib guards are in the rebuilt binary.
- Eight tmux tripwires re-run against a real daemon after the `go_to_screen_until` gate — `cross_screen_navigation`, `skill_manager_lists`, `autopilots_screen_renders`, `daemon_health_sparkline`, `logs_screen_renders`, `p2_control_center_attention`, `p2_answer_flip_e2e`, `p4_issue_list_renders` — all green, binary hashes taken before and after and unmoved.


---

## Review round 2 (verify @ c0c5b661 → afd8e3b7)

Merge-after-one-Major. The Major and all five Minors addressed; one Minor **rejected on evidence** after trying it.

### Major — the fifth carrier, in a file this PR already edits

Correct and it was my omission, not a scope call. `list_screen_mouse_rpc.rs` `boot()` published `AINB_HANGAR_HOME` and only then wrote the `first_run` ack, and that binary holds **three** tests all routed through it — a wider window than the two-test binaries I did fix, and the nav helper four lines below had just been hardened while the race stayed. Same two-statement reorder (`79c44f27`).

That makes it five carriers, not four. The four still untouched (`tripwire_issue_facets`, `tripwire_issue_blocked_cancelled`, `tripwire_issue_properties_render`, `issue_wizard_rpc_over_socket`) are left per the team's scope call, not on my own judgement — the verifier argues in Ruling 2 that "all green today" is not evidence the window is shut, and my own captured survivor is a fair illustration.

### The 60-run soak — claim withdrawn

The verifier is right and the arithmetic is not close: at p = 1/30, `(29/30)^60` = 13%, so one soak in eight passes with no fix at all, and 0/60 only bounds the rate at 5%, an interval that still contains 1-in-30. Their 200 runs on HEAD and **300 with my env fix reverted** were both clean, so the residual rate is not reproducible on this box in either configuration.

What survives is the part that was always the real argument: the modal-swallow chain is proven by source, the merge-base window is proven by source, and deleting the ack write reproduces the symptom every run. The reorder is correct on the mechanism. The attribution of the residual 1-in-30 to it is **not** established and the PR body no longer claims it.

### Minor — `test_support.rs` claimed a guarantee it did not give

Correct. `SCREEN_VARIANTS` is hand-written; `variant_tag`'s arm count never entered the assert, so tagging a variant and forgetting both the const bump and the vec entry still read `20 == 20`. Took the verifier's better option: deleted `variant_tag` (24 lines, 20 hand-assigned magic numbers) for `std::mem::discriminant`, which is `Hash + Eq` and ignores the payload, keeping a wildcard-free `match ... => {}` purely for the compile-time force. The doc now says plainly that the constant is hand-maintained, that adding a variant is three edits, and that only the match arm is forced (`cf64a498`). Re-checked that dropping a variant from the vec still fails.

### Minor — the `2n+4` cost model in five places

Fixed via the `#[path]` idiom the daemon tripwires already use: `tests/palette_nav_common.rs` holds `nav_drain_rounds`, included by all five callers, killing two inline copies and both bare literals (`367fe424`).

Shared the **cost only**, not `go_to_screen`. The five suites send keys through four different signatures and pump through four different relay helpers; one common walk would be an abstraction over five shapes. The number is the part that drifts, and it is now in one place.

### Minor — identical failure message for two causes

Fixed: the `skills_sync` assertion now captures and prints the pane, as its sibling does. Verified by mutation (send `Z` instead of `s`) that the pane actually reaches the message. This rode in `367fe424` with the cost-model change — both edit `screens_render_from_daemon.rs`, so path-staging could not split them.

### Minor — `u16` overflow at the top end

Correct, and it undercut the previous commit's own argument. `area_w * 7` overflows above 9362 columns; the clamp fix made the function safe at the small end and left the large end panicking in debug. Scaled through `u32` (`afd8e3b7`), and the no-panic test now covers both ends — one axis at a time, because a pane huge on both paints tens of millions of cells and OOMs the test (found by trying `u16::MAX` first). Verified the new case fails without the cast: `attempt to multiply with overflow`.

### Minor — REJECTED: `pump_until(…, |_| false)` is not wasted sleep

The one finding I did not take, and I tried it first. Replacing it with a plain relay loop, exactly as suggested, **makes `autopilot_right_click_run_now_fires_autopilot` fail**: `hangar/search` fires, so the walk is delivered and drained, but `hangar/autopilot_fire_now` never does — the later right-click finds no recorded board layout. The 20ms per round is what yields to the runtime for the Autopilots screen to settle; it is load-bearing, not 480ms of nothing. Kept `pump_until`, now sized by `nav_drain_rounds` rather than a literal, with the reason in the comment so the next reader does not re-try it.

### Rulings

- **`PANEL_BG`**: agreed, not hoisted. The verifier's correction (four declarations, not three) does not change the call.
- **The four sibling env races**: left per the team's scope decision. Recorded here rather than only in a commit message, with the file list and the recipe: move the `set_var("AINB_HANGAR_HOME", home)` below the `std::fs::write` of `state.toml`.

### Re-verification

- `cargo test -p ainb-plugin-hangar --no-fail-fast` → **936 passed, 0 failed**.
- `cargo fmt --all --check` clean; `cargo check --workspace --all-targets` clean.
- Four mutations re-run and observed to fail: dropping a `Screen` variant from the vec, the `u16` overflow width, the `Z`-instead-of-`s` pane capture, and the plain-loop replacement for `pump_until` (which is why that finding was rejected).
- `screens_render_from_daemon` at this head: 130 runs, 0 test failures, 0 pruner kills. Reported as a count. Per the arithmetic above it bounds the rate at ~2.3% and is not offered as proof the race is fixed; the mechanism is what justifies that fix.
- One caveat on an earlier round-2 note: a "1 failure in 120 runs" observation of the two socket suites together was **not** a test failure. Re-running the same loop reproduced it at run 124 and the capture shows `could not execute process … (never executed) / No such file or directory` — this box's artifact pruner removing the test binary between build and exec. Both suites had passed in that same iteration. No product or test defect behind it.

