### PR TITLE
feat(hangar): per-agent task executor selection (spine A8)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/hangar/mod.rs
@@ -919,6 +919,9 @@ pub struct AgentCreateArgs {
     /// Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`.
     #[arg(long)]
     pub provider: Option<String>,
+    /// Task executor to record (`process`/`acp`); omitted inherits the daemon's `HANGAR_TASK_EXECUTOR`.
+    #[arg(long)]
+    pub executor: Option<String>,
     /// Optional per-agent model override (e.g. `sonnet`, `gpt-5-codex`).
     #[arg(long)]
     pub model: Option<String>,
@@ -4091,6 +4094,9 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
     }
     let provider = ainb_hangar_store::bootstrap::normalize_provider(args.provider.as_deref())
         .map_err(|e| anyhow::anyhow!(e))?;
+    let task_executor =
+        ainb_hangar_store::bootstrap::normalize_task_executor(args.executor.as_deref())
+            .map_err(|e| anyhow::anyhow!(e))?;
     let description = validated_description(args.description.as_deref())?.unwrap_or_default();
     // An explicit --workspace must exist; the default is ensured (created if absent).
     let workspace_id = match args.workspace.as_deref() {
@@ -4110,6 +4116,7 @@ async fn run_agent_create(store: &Store, args: AgentCreateArgs) -> Result<()> {
         ainb_hangar_store::bootstrap::AgentDraft {
             name: name.to_string(),
             provider,
+            task_executor,
             instructions: args.instructions,
             description,
             avatar_url: args.avatar,

--- a/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
+++ b/ainb-tui/crates/ainb-core/tests/hangar_cli_integration.rs
@@ -663,6 +663,89 @@ fn agent_create_on_fresh_home_inserts_and_lists() {
     );
 }
 
+/// `--executor` records the per-agent task executor (migration 0095) and an
+/// unrecognised one is a clean error, the same shape `--provider` has.
+///
+/// The column is read at DISPATCH, so a value that is silently dropped here is
+/// invisible until a run takes the wrong executor. Asserted on the STORE, not on
+/// the ack: `agent list` renders no executor, so the printed line would look
+/// identical whether the flag landed or was parsed and discarded.
+#[test]
+fn agent_create_records_the_task_executor_and_rejects_an_unknown_one() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "acp-runner",
+            "--executor",
+            "ACP",
+        ],
+    );
+    assert!(ok, "agent create --executor should exit 0; out={out}");
+
+    // An agent that names nothing keeps a NULL column: the daemon-wide default
+    // stays in charge, which is what makes the flag additive.
+    let (ok, out) = run(
+        tmp.path(),
+        &["hangar", "agent", "create", "--name", "inheritor"],
+    );
+    assert!(
+        ok,
+        "agent create without --executor should exit 0; out={out}"
+    );
+
+    let recorded = agent_executors(tmp.path());
+    assert_eq!(
+        recorded,
+        vec![
+            ("acp-runner".to_string(), Some("acp".to_string())),
+            ("inheritor".to_string(), None),
+        ],
+        "the flag must land normalised on the row, and its absence must stay NULL"
+    );
+
+    let (ok, out) = run(
+        tmp.path(),
+        &[
+            "hangar",
+            "agent",
+            "create",
+            "--name",
+            "x",
+            "--executor",
+            "acpp",
+        ],
+    );
+    assert!(!ok, "an unsupported executor must fail; out={out}");
+    assert!(
+        out.contains("unsupported task executor"),
+        "missing executor error:\n{out}"
+    );
+}
+
+/// `(name, task_executor)` for every agent in the home, ordered by name.
+///
+/// `run` points `AINB_HANGAR_HOME` at the tempdir itself, so the database is
+/// `<home>/hangar.db` — not under a nested `.agents-in-a-box/`.
+fn agent_executors(home: &std::path::Path) -> Vec<(String, Option<String>)> {
+    let db = home.join("hangar.db");
+    let conn = rusqlite::Connection::open(&db).expect("open the hangar db");
+    let mut stmt = conn
+        .prepare("SELECT name, task_executor FROM agent ORDER BY name")
+        .expect("prepare");
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .expect("query")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("rows");
+    rows
+}
+
 /// The user-visible proof for migration 0050 (multica gap #23): a description
 /// supplied at `agent create` survives into `agent list --format json`, and a
 /// SECOND create with the same name is REFUSED — a non-zero exit and a clear

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -155,6 +155,8 @@ pub enum DeliveryToken {
     ProviderAtCapacity,
     /// See [`DELIVERY_MODE_UNPROVEN`].
     ModeUnproven,
+    /// See [`DELIVERY_TASK_SCOPE_REFUSED`].
+    TaskScopeRefused,
 }
 
 impl DeliveryToken {
@@ -178,6 +180,7 @@ impl DeliveryToken {
         Self::SessionGone,
         Self::ProviderAtCapacity,
         Self::ModeUnproven,
+        Self::TaskScopeRefused,
     ];
 
     /// The wire spelling persisted in `fleet_message_delivery.detail`.
@@ -196,6 +199,7 @@ impl DeliveryToken {
             Self::SessionGone => "session_gone",
             Self::ProviderAtCapacity => "provider_at_capacity",
             Self::ModeUnproven => "mode_unproven",
+            Self::TaskScopeRefused => "task_scope_refused",
         }
     }
 
@@ -249,6 +253,12 @@ pub const DELIVERY_PROVIDER_AT_CAPACITY: &str = DeliveryToken::ProviderAtCapacit
 /// Terminal, never requeued: retrying an adapter that will not hold the mode
 /// just drives the same session in the wrong permission regime a second time.
 pub const DELIVERY_MODE_UNPROVEN: &str = DeliveryToken::ModeUnproven.as_str();
+/// A CHAT prompt targeted a TASK's session ([`AcpPool::submit_prompt`]).
+///
+/// Terminal: the session belongs to a run, and there is no version of the
+/// request that becomes valid later. See `submit_prompt` for why the refusal
+/// lives at the pool rather than at each RPC door.
+pub const DELIVERY_TASK_SCOPE_REFUSED: &str = DeliveryToken::TaskScopeRefused.as_str();
 /// Prefix of the token a leg carries when the turn stopped for a reason worth
 /// naming: `stop=<reason>`, in the ACP wire spelling ([`stop_reason_token`]),
 /// so `stop=max_tokens`, `stop=max_turn_requests`, `stop=refusal`.
@@ -842,14 +852,57 @@ impl AcpPool {
         }
     }
 
-    /// Hand one prompt to the recipient's OWN session (never a broadcast
+    /// Hand one CHAT prompt to the recipient's OWN session (never a broadcast
     /// scope's, which owns no session). The delivery stays PENDING; the actor
     /// resolves it at turn end.
+    ///
+    /// REFUSES a session whose scope is a task run's
+    /// ([`crate::acp_task::TASK_SCOPE_PREFIX`]), because a task's session is not
+    /// a chat surface: its turns are the run, and a prompt injected into one is
+    /// bounded by nothing an operator can see — `acp_task`'s own poll only
+    /// watches the leg IT submitted, and the pool's deadline sweep deliberately
+    /// exempts task scopes.
+    ///
+    /// The refusal lives HERE, not at each RPC door, for two reasons. This
+    /// function already reads the session row, so the scope costs no extra
+    /// query; and it is the single choke point every prompt to an existing
+    /// session passes through, so a door added later is refused by default
+    /// rather than by remembering. `fleet/acp_session_create` guards the
+    /// creation door with the same constant; `fleet/message_send` and
+    /// `fleet/action` are guarded by this one.
+    ///
+    /// The task executor prompts its own session through
+    /// [`Self::submit_task_prompt`].
     pub async fn submit_prompt(
         self: &Arc<Self>,
         session_key: &str,
         message_id: &str,
         text: &str,
+    ) -> SubmitOutcome {
+        self.submit(session_key, message_id, text, false).await
+    }
+
+    /// [`Self::submit_prompt`] for the run that OWNS a `task:` session.
+    ///
+    /// The one caller is [`crate::acp_task::run_acp`], which submits the brief
+    /// of the task whose scope it is. Named apart from `submit_prompt` so the
+    /// exemption is a deliberate act at one call site instead of a flag every
+    /// chat door could pass by accident.
+    pub async fn submit_task_prompt(
+        self: &Arc<Self>,
+        session_key: &str,
+        message_id: &str,
+        text: &str,
+    ) -> SubmitOutcome {
+        self.submit(session_key, message_id, text, true).await
+    }
+
+    async fn submit(
+        self: &Arc<Self>,
+        session_key: &str,
+        message_id: &str,
+        text: &str,
+        task_run: bool,
     ) -> SubmitOutcome {
         let row = match FleetAcpSessionRepo::get(self.store.pool(), session_key).await {
             Ok(Some(row)) if row.state != "DEAD" => row,
@@ -859,6 +912,16 @@ impl AcpPool {
                 return SubmitOutcome::Rejected(DELIVERY_SESSION_GONE);
             }
         };
+        // `trim_start`, the same shape the create door uses: the two doors read
+        // the scope identically, so neither can be the lenient one.
+        if !task_run && row.scope_key.trim_start().starts_with(crate::acp_task::TASK_SCOPE_PREFIX) {
+            tracing::warn!(
+                %session_key,
+                scope_key = %row.scope_key,
+                "refused a chat prompt aimed at a task's acp session"
+            );
+            return SubmitOutcome::Rejected(DELIVERY_TASK_SCOPE_REFUSED);
+        }
         // The breaker is consulted BEFORE the queue: a provider that is
         // crash-looping must fail every scope routed to it fast, not fill 32
         // queue slots per scope with prompts that will fail anyway.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -912,9 +912,9 @@ impl AcpPool {
                 return SubmitOutcome::Rejected(DELIVERY_SESSION_GONE);
             }
         };
-        // `trim_start`, the same shape the create door uses: the two doors read
-        // the scope identically, so neither can be the lenient one.
-        if !task_run && row.scope_key.trim_start().starts_with(crate::acp_task::TASK_SCOPE_PREFIX) {
+        // One reader for the convention, shared with the create door and the
+        // deadline sweep, so no site can be the lenient one.
+        if !task_run && crate::acp_task::is_task_scope(&row.scope_key) {
             tracing::warn!(
                 %session_key,
                 scope_key = %row.scope_key,
@@ -1205,7 +1205,7 @@ impl AcpPool {
             .await
             .unwrap_or_default();
         for row in overdue {
-            if row.scope_key.starts_with(crate::acp_task::TASK_SCOPE_PREFIX) {
+            if crate::acp_task::is_task_scope(&row.scope_key) {
                 continue;
             }
             tracing::warn!(

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -1122,6 +1122,19 @@ impl AcpPool {
     }
 
     /// One sweep pass: expire overdue turns, then stop idle processes.
+    ///
+    /// TASK-scoped sessions are exempt. A task turn already carries its own
+    /// bound — [`crate::acp_task`]'s poll gives up at
+    /// `HANGAR_PROVIDER_MAX_RUNTIME_MS`, cancels the turn and writes the SAME
+    /// `(UNKNOWN, turn_deadline)` pair this sweep would have — so applying the
+    /// pool's chat-shaped deadline on top can only ever CUT a run short, by
+    /// default 5x (30 min against a 2.5 h budget). That cut used to be papered
+    /// over at boot by raising the whole pool's deadline whenever
+    /// `HANGAR_TASK_EXECUTOR=acp`, which A8 makes unworkable (an agent selects
+    /// the executor per task, so the flag no longer says whether task turns ride
+    /// this pool) and which charged every CHAT turn on the daemon for it.
+    /// Exempting the scope that owns its own deadline is the same fix without
+    /// the collateral.
     pub async fn sweep_once(&self) {
         let deadline_ms = i64::try_from(self.config.turn_deadline.as_millis()).unwrap_or(i64::MAX);
         let cutoff = SystemClock.now_ms().saturating_sub(deadline_ms);
@@ -1129,6 +1142,9 @@ impl AcpPool {
             .await
             .unwrap_or_default();
         for row in overdue {
+            if row.scope_key.starts_with(crate::acp_task::TASK_SCOPE_PREFIX) {
+                continue;
+            }
             tracing::warn!(
                 session_key = %row.session_key,
                 turn_id = ?row.open_turn_id,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -184,7 +184,8 @@ pub async fn ensure(
 ///
 /// One `user` message row in the session's own scope plus its PENDING delivery
 /// leg, in one transaction. Returns the message id the caller hands to
-/// `AcpPool::submit_prompt`.
+/// `AcpPool::submit_prompt` (or, for the run that owns a `task:` scope,
+/// `AcpPool::submit_task_prompt`).
 ///
 /// The leg is what the pool resolves at turn end, so a prompt that skipped
 /// this would have no receipt for anyone to read. `sender` names the door

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -110,6 +110,17 @@ pub async fn ensure(
     );
 
     let session_key = FleetAcpSessionRepo::mint_session_key(&SystemIdGen);
+    // THE ONLY PRODUCTION WRITER of `fleet_acp_session.scope_key`. Nothing
+    // UPDATEs the column afterwards, and the two callers here are the create
+    // door (which refuses a `task:` scope outright) and `acp_task::scope_key`,
+    // which formats one. So no stored scope can carry leading whitespace before
+    // `task:`.
+    //
+    // That is load-bearing, not trivia: `acp_task::is_task_scope` trims before
+    // matching, and at the deadline sweep it gates an EXEMPTION — so a scope
+    // like `"  task:x"` would be skipped by the sweep with only the task's own
+    // poll left to bound it. Unreachable today because of the sentence above.
+    // A SECOND writer makes it reachable, and the sweep is where it would show.
     let scope_key = scope_key.map_or_else(|| format!("session:{session_key}"), str::to_string);
     let now = SystemClock.now_ms();
     let event = NewFleetEvent {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -101,6 +101,17 @@ pub fn scope_key(task_id: &str) -> String {
     format!("{TASK_SCOPE_PREFIX}{task_id}")
 }
 
+/// Whether `scope` belongs to a task run.
+///
+/// Three places refuse or exempt a task's scope — the create door, the prompt
+/// guard and the deadline sweep — and they spelled the test three ways, one of
+/// them without the `trim_start`. Reading it here instead means the next site
+/// cannot be the lenient one.
+#[must_use]
+pub fn is_task_scope(scope: &str) -> bool {
+    scope.trim_start().starts_with(TASK_SCOPE_PREFIX)
+}
+
 /// The workspace an ACP session's scope belongs to, or `None` when the scope
 /// is not a task's.
 ///

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -120,7 +120,10 @@ pub fn is_task_scope(scope: &str) -> bool {
 /// unscoped without this, and a workspace-filtered inbox (which is every
 /// operator surface) never shows it.
 pub async fn workspace_for_scope(pool: &SqlitePool, scope: &str) -> Option<String> {
-    let task_id = scope.strip_prefix(TASK_SCOPE_PREFIX)?;
+    // `trim_start` before the strip, so this agrees with [`is_task_scope`]: a
+    // scope the predicate calls a task's must yield that task's id here, or the
+    // two readers of one convention disagree on the same string.
+    let task_id = scope.trim_start().strip_prefix(TASK_SCOPE_PREFIX)?;
     ainb_hangar_store::repo::task::TaskRepo::get_by_id(pool, task_id)
         .await
         .ok()
@@ -713,6 +716,12 @@ mod tests {
             adapter_key(ainb_acp::config::CLAUDE_ADAPTER, "t-1"),
             "claude-agent-acp#task:t-1"
         );
+        // The predicate the create door, the prompt guard and the deadline
+        // sweep all read. It tolerates leading whitespace, which is the one
+        // behaviour consolidating those three sites changed.
+        assert!(is_task_scope(scope_key("t-1").as_str()));
+        assert!(is_task_scope("  task:t-1"));
+        assert!(!is_task_scope("session:t-1"));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_task.rs
@@ -11,7 +11,7 @@
 //!            ▼
 //!   acp_session::ensure(scope_key = "task:<id>")  ── no spawn, one txn
 //!            ▼
-//!   acp_session::enqueue  ─▶  pool.submit_prompt  ─▶  the adapter's turn
+//!   acp_session::enqueue  ─▶  pool.submit_task_prompt  ─▶  the adapter's turn
 //!            ▼
 //!   POLL the delivery leg (the pool resolves it on EVERY path)
 //!            ▼
@@ -291,8 +291,9 @@ pub async fn run_acp(
     let message_id =
         crate::acp_session::enqueue(pool, &session_key, &scope, &dispatch.invocation.prompt)
             .await?;
-    if let SubmitOutcome::Rejected(detail) =
-        acp.submit_prompt(&session_key, &message_id, &dispatch.invocation.prompt).await
+    if let SubmitOutcome::Rejected(detail) = acp
+        .submit_task_prompt(&session_key, &message_id, &dispatch.invocation.prompt)
+        .await
     {
         tracing::warn!(task_id = %task.id, detail, "the acp pool refused the task's prompt");
         return Ok(outcome_for(
@@ -598,7 +599,14 @@ fn outcome_for_token(token: DeliveryToken, result: &RunnerResult) -> RunOutcome 
         DeliveryToken::SpawnFailed
         | DeliveryToken::ModeUnproven
         | DeliveryToken::TurnUnrecorded => failed(FailureReason::SpawnError),
-        DeliveryToken::SessionGone => failed(FailureReason::ProvisionError),
+        // Unreachable on this path by construction — a task prompts through
+        // `submit_task_prompt`, which is exempt — so reaching it means a task's
+        // leg was resolved by somebody else's refused chat prompt. Terminal for
+        // the same reason `SessionGone` is: the session is not usable for this
+        // prompt and a re-dispatch does not change that.
+        DeliveryToken::SessionGone | DeliveryToken::TaskScopeRefused => {
+            failed(FailureReason::ProvisionError)
+        }
         // Handled by the caller's stop-reason arm, which reads this token
         // POSITIONALLY. Reaching it here means it was not first, which the pool
         // never writes.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_transcript.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_transcript.rs
@@ -81,7 +81,10 @@ pub(crate) async fn bind_task_stream(
     events: EventSink,
     scope_key: String,
 ) -> Option<RunStream> {
-    let task_id = scope_key.strip_prefix(crate::acp_task::TASK_SCOPE_PREFIX)?;
+    // `trim_start` before the strip, so this agrees with
+    // `acp_task::is_task_scope`: a scope the predicate calls a task's must yield
+    // that task's id here, or a run the guard protects streams to nobody.
+    let task_id = scope_key.trim_start().strip_prefix(crate::acp_task::TASK_SCOPE_PREFIX)?;
     let workspace_id = crate::acp_task::workspace_for_scope(&pool, &scope_key).await?;
     RunStream::bind(&events, &workspace_id, task_id)
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -309,6 +309,15 @@ pub mod standup;
 /// The daemon's tokio runtime registers these as periodic tasks; they are also
 /// callable directly (with an injected clock) for deterministic testing.
 pub mod sweeper;
+/// Which executor a claimed task runs on, and the precedence that picks it
+/// (spine A5's flag, A8's per-agent override).
+///
+/// [`task_executor::TaskExecutor`] is the axis (`process` spawns the provider
+/// CLI, `acp` prompts an adapter); [`task_executor::DaemonDefaultExecutor`] is
+/// the daemon-wide `HANGAR_TASK_EXECUTOR` floor, wrapped so it cannot be
+/// mistaken for the executor a TASK was assigned. Pure — the precedence is
+/// testable without mutating process env.
+pub mod task_executor;
 /// `ainb hangar templates use <name>` transactional materialisation (P6.3).
 ///
 /// Turns an embedded curated [`ainb_hangar_core::template::AgentTemplate`] into a
@@ -929,38 +938,16 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // The ACP agent pool. Installed BEFORE the socket accepts a connection so
         // `fleet/acp_session_create` can never answer "no pool" on a daemon that
         // has one; nothing is spawned until the first prompt reaches it.
-        let mut acp_config = crate::acp_pool::PoolConfig::from_env();
-        // Under `HANGAR_TASK_EXECUTOR=acp` a TASK turn is a pool turn, and the
-        // pool's deadline sweep exempts no scope, so its 30-minute default
-        // would cancel every task past half an hour while the same task on the
-        // process executor gets 2.5 h. Raise the pool's floor to the task budget
-        // rather than leave a 5x cut invisible from the flag.
-        //
-        // Through `set_turn_deadline`, which recouples the sweep cadence: the
-        // raise lands after `from_env` may already have shortened it, and the
-        // two together used to leave a raised deadline with a cadence pinned to
-        // the value it replaced (A5 review N3).
-        let configured_deadline = acp_config.turn_deadline;
-        acp_config.set_turn_deadline(crate::run_loop::reconcile_turn_deadline(
-            configured_deadline,
-            crate::run_loop::acp_turn_budget(),
-        ));
-        // Say so when it actually moved. An invisible timeout change triggered
-        // by a flag is the defect class this fix exists to close, and raising
-        // the floor points it the safer way for tasks while opening a smaller
-        // one for CHAT: a wedged chat turn now squats its session slot for the
-        // longer window before the sweep reaps it. Whoever flips the flag
-        // should read that here, not discover it during an incident.
-        if acp_config.turn_deadline > configured_deadline {
-            tracing::warn!(
-                effective_secs = acp_config.turn_deadline.as_secs(),
-                configured_secs = configured_deadline.as_secs(),
-                "HANGAR_TASK_EXECUTOR=acp raised the acp turn deadline to the task runtime \
-                 budget (HANGAR_PROVIDER_MAX_RUNTIME_MS); a wedged CHAT turn on this daemon \
-                 now converges on the longer deadline too. Set AINB_ACP_TURN_DEADLINE_MS at \
-                 or above the task budget to pin it."
-            );
-        }
+        // The pool's turn deadline is the CHAT deadline, and stays exactly what
+        // the operator configured. A task's ACP turn is bounded by the task
+        // budget instead (`HANGAR_PROVIDER_MAX_RUNTIME_MS`, enforced by
+        // `acp_task`'s own poll), and `AcpPool::sweep_once` exempts task scopes
+        // so the two bounds cannot fight. Boot used to raise this whole pool's
+        // deadline to the task budget under `HANGAR_TASK_EXECUTOR=acp`; A8 makes
+        // that trigger meaningless (the executor is chosen per agent, so the
+        // flag no longer predicts whether task turns ride this pool) and the
+        // raise charged every chat turn for a task-path problem.
+        let acp_config = crate::acp_pool::PoolConfig::from_env();
         let acp_pool = crate::acp_pool::AcpPool::new(store.clone(), broker.sink(), acp_config);
         let _acp_sweeper = acp_pool.spawn_sweeper();
         crate::acp_pool::install(acp_pool).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -5962,11 +5962,7 @@ async fn handle_fleet_acp_session_create(
     // (terminal, `SpawnError`, no retry) and would make the pool stamp this
     // session's approvals with the task's workspace. Refused at the door, which
     // is the only untrusted caller of `acp_session::ensure`.
-    if params
-        .scope_key
-        .as_deref()
-        .is_some_and(|scope| scope.trim_start().starts_with(crate::acp_task::TASK_SCOPE_PREFIX))
-    {
+    if params.scope_key.as_deref().is_some_and(crate::acp_task::is_task_scope) {
         return Err(invalid_params(&format!(
             "scope_key {:?} is reserved for task runs",
             crate::acp_task::TASK_SCOPE_PREFIX

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -7985,6 +7985,11 @@ async fn handle_comment_mention_preview(
 /// `provider` is rejected with `INVALID_PARAMS`. The recorded provider is HONOURED
 /// at dispatch (the daemon spawns that backend per task), so a `codex` agent runs
 /// codex even though it binds the single `claude`-advertised runtime.
+///
+/// The optional `task_executor` (`process`/`acp`, migration 0095) is the second
+/// dispatch axis and is validated the same way: absent means the agent inherits
+/// whatever `HANGAR_TASK_EXECUTOR` the daemon was started with, so omitting it
+/// leaves behaviour exactly as it was before the column existed.
 async fn handle_agent_create(
     pool: &SqlitePool,
     req: &RpcRequest,
@@ -7993,8 +7998,8 @@ async fn handle_agent_create(
     // `agent_env` write channel, so it uses the same rule as agent_update.
     let params: ainb_hangar_proto::snapshots::AgentCreateParams = parse_params_secret(
         req,
-        "{ workspace_id?, name, provider?, model?, instructions?, description?, avatar_url?, \
-         service_tier? }",
+        "{ workspace_id?, name, provider?, task_executor?, model?, instructions?, description?, \
+         avatar_url?, service_tier? }",
     )?;
     let name = params.name.trim();
     if name.is_empty() {
@@ -8003,6 +8008,9 @@ async fn handle_agent_create(
     let description = validate_description(params.description.as_deref())?.unwrap_or_default();
     let provider = ainb_hangar_store::bootstrap::normalize_provider(params.provider.as_deref())
         .map_err(|e| invalid_params(&e))?;
+    let task_executor =
+        ainb_hangar_store::bootstrap::normalize_task_executor(params.task_executor.as_deref())
+            .map_err(|e| invalid_params(&e))?;
     let wire = params.workspace_id.as_deref().unwrap_or("").trim();
     let ws = resolve_or_bootstrap_default(pool, wire).await?;
     let created = ainb_hangar_store::bootstrap::create_agent_from(
@@ -8011,6 +8019,7 @@ async fn handle_agent_create(
         ainb_hangar_store::bootstrap::AgentDraft {
             name: name.to_string(),
             provider,
+            task_executor,
             instructions: params.instructions,
             description,
             avatar_url: params.avatar_url,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -28,7 +28,7 @@
 //! | `HANGAR_SWEEP_DISPATCHED_TTL_MS` | dispatch TTL override (tests) | reference default |
 //! | `HANGAR_DAEMON_DISABLE_CLAIM` | skip the claim loop, run sweepers only (tests) | unset |
 //! | `HANGAR_DAEMON_DISABLE_SANDBOX` | `1` forces providers UNCONFINED (security downgrade); `0` forces the OS sandbox ON | unset (platform default: ON on Linux, OFF on macOS) |
-//! | `HANGAR_TASK_EXECUTOR` | `acp` runs tasks through an ACP adapter ([`crate::acp_task`]); `process` spawns the provider CLI. An unrecognised value warns and falls back | `process` |
+//! | `HANGAR_TASK_EXECUTOR` | `acp` runs tasks through an ACP adapter ([`crate::acp_task`]); `process` spawns the provider CLI. An unrecognised value warns and falls back. Only the DEFAULT: an agent's own `task_executor` column overrides it per task ([`crate::task_executor`]) | `process` |
 //!
 //! When `HANGAR_DAEMON_RUNTIME_ID` is unset the claim loop is a no-op (the
 //! daemon still sweeps) — a daemon with no runtime has nothing to claim.
@@ -187,25 +187,15 @@ pub struct DaemonConfig {
     pub task_executor: TaskExecutor,
 }
 
-/// Which executor runs a claimed task's provider work.
+/// The executor axis and the daemon-wide default, re-exported at the path they
+/// have always been imported from.
 ///
-/// A second FIRST-CLASS executor, not a mode: `Process` spawns the provider CLI
-/// (`claude -p`, `codex exec`) and keeps its jsonl transcript; `Acp` prompts an
-/// ACP adapter over JSON-RPC and keeps its transcript in `fleet_provider_event`.
-/// Deliberately a different axis from [`Mode`]: executor and interactivity are
-/// two questions, and conflating them is the bug [`interactive_command`] was
-/// extracted to prevent.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum TaskExecutor {
-    /// Spawn the provider CLI. Today's path, and the default.
-    #[default]
-    Process,
-    /// Prompt an ACP adapter through [`crate::acp_task`].
-    Acp,
-}
-
-/// The `HANGAR_TASK_EXECUTOR` value that asks for the ACP path.
-const ACP_EXECUTOR: &str = "acp";
+/// They live in [`crate::task_executor`] because
+/// [`DaemonDefaultExecutor`](crate::task_executor::DaemonDefaultExecutor)'s
+/// guarantee is module privacy: its inner [`TaskExecutor`] is unreachable from
+/// this file, so nothing here can spawn work for the daemon's default while the
+/// dispatch says a different executor.
+pub use crate::task_executor::{DaemonDefaultExecutor, TaskExecutor};
 
 /// The wall-clock ceiling on one provider run (`HANGAR_PROVIDER_MAX_RUNTIME_MS`).
 ///
@@ -343,8 +333,8 @@ impl DaemonConfig {
         }
     }
 
-    /// Resolve the task executor from the explicit `HANGAR_TASK_EXECUTOR`
-    /// value (`None` when unset).
+    /// Resolve the DAEMON-WIDE task executor from the explicit
+    /// `HANGAR_TASK_EXECUTOR` value (`None` when unset).
     ///
     /// `acp` selects the ACP path; anything else (including an unset variable
     /// and an unrecognised value) resolves to [`TaskExecutor::Process`], the
@@ -352,19 +342,26 @@ impl DaemonConfig {
     /// diagnosable rather than a silent no-op. Split out as a pure function so
     /// the precedence is testable without mutating process env, exactly like
     /// [`Self::resolve_sandbox`].
+    ///
+    /// This is only the FLOOR: an agent carrying its own `task_executor`
+    /// (migration 0095) overrides it per task, through
+    /// [`DaemonDefaultExecutor::for_agent`](crate::task_executor::DaemonDefaultExecutor::for_agent).
     #[must_use]
     pub fn resolve_task_executor(override_val: Option<&std::ffi::OsStr>) -> TaskExecutor {
-        match override_val.and_then(std::ffi::OsStr::to_str).map(str::trim) {
-            Some(value) if value.eq_ignore_ascii_case(ACP_EXECUTOR) => TaskExecutor::Acp,
-            Some(value) if !value.is_empty() && !value.eq_ignore_ascii_case("process") => {
-                tracing::warn!(
-                    value,
-                    "unknown HANGAR_TASK_EXECUTOR; running tasks on the process executor"
-                );
-                TaskExecutor::Process
-            }
-            _ => TaskExecutor::Process,
-        }
+        let Some(value) = override_val
+            .and_then(std::ffi::OsStr::to_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return TaskExecutor::Process;
+        };
+        crate::task_executor::parse(value).unwrap_or_else(|| {
+            tracing::warn!(
+                value,
+                "unknown HANGAR_TASK_EXECUTOR; running tasks on the process executor"
+            );
+            TaskExecutor::Process
+        })
     }
 
     /// Resolve the headless OS FS sandbox posture from the explicit
@@ -731,7 +728,9 @@ pub async fn run(
                 let events = events.clone();
                 let interactive = interactive.clone();
                 let secrets = secrets.clone();
-                let executor = cfg.task_executor;
+                // The daemon-wide FLOOR only: each task's own executor is
+                // resolved from its agent against this (A8).
+                let executor = DaemonDefaultExecutor::new(cfg.task_executor);
                 runs.spawn(async move {
                     let clock = SystemClock;
                     if let Err(e) =
@@ -1195,7 +1194,7 @@ async fn execute_claimed(
     events: &EventSink,
     interactive: &InteractiveSessions,
     secrets: Arc<dyn ainb_hangar_secrets::SecretBackend + Send + Sync>,
-    executor: TaskExecutor,
+    daemon_default: DaemonDefaultExecutor,
 ) -> anyhow::Result<()> {
     let task: Task = TaskRepo::get_by_id(pool, &claimed.id)
         .await?
@@ -1265,7 +1264,7 @@ async fn execute_claimed(
         &task.agent_id,
         task.issue_id.as_deref(),
         mode,
-        executor,
+        daemon_default,
     )
     .await
     {
@@ -1277,7 +1276,7 @@ async fn execute_claimed(
                 agent_id = %task.agent_id,
                 "dispatch resolve failed; falling back to the default provider + prompt"
             );
-            ResolvedDispatch::fallback(mode, executor)
+            ResolvedDispatch::fallback(mode, daemon_default)
         }
     };
 
@@ -1290,11 +1289,18 @@ async fn execute_claimed(
     // extracted to prevent. Terminalises BEFORE the worktree is provisioned and
     // before the row leaves `dispatched`, so no tmux session and no checkout
     // are created for a run that will not happen.
+    //
+    // Read off the DISPATCH, so it refuses per AGENT (A8): an agent whose
+    // `task_executor` is `acp` is refused on a daemon whose default is
+    // `process`, and an agent that pins `process` is NOT refused on a daemon
+    // whose default is `acp` — in both cases the refusal follows the executor
+    // the task was actually assigned.
     if dispatch.executor == TaskExecutor::Acp && mode == Mode::Interactive {
         let refusal = anyhow::anyhow!(
-            "task mode=interactive is not supported under HANGAR_TASK_EXECUTOR=acp; \
-             run it with HANGAR_TASK_EXECUTOR=process, or use the adapter's \
-             permission_mode for human-in-the-loop under acp"
+            "task mode=interactive is not supported on the acp task executor (selected by \
+             this agent's task_executor, or by HANGAR_TASK_EXECUTOR=acp); run it on the \
+             process executor, or use the adapter's permission_mode for human-in-the-loop \
+             under acp"
         );
         return finalize_setup_failure(pool, &task, &refusal, clock, stats, events).await;
     }
@@ -1406,6 +1412,9 @@ async fn execute_claimed(
     let provider = dispatch.backend.name();
     // Copied out for the same reason `provider` is: the cancel arm below needs
     // to know which executor to stop, and `provider_run` borrows `dispatch`.
+    // From the DISPATCH, never from the daemon-wide default: with per-agent
+    // selection (A8) the two differ per task, and the branch that spawns the
+    // work and the arm that cancels it have to agree on which one ran.
     let executor = dispatch.executor;
 
     // Doctrine hardening (D-e2e-3): bound EVERY await between the `running` commit
@@ -2574,10 +2583,15 @@ async fn materialise_agent_profile(
 pub struct ResolvedDispatch {
     /// Which provider exec path [`execute_claimed`] routes to.
     pub(crate) backend: Backend,
-    /// Which EXECUTOR runs it, resolved once from the daemon config and
-    /// carried here for the same reason `mode` is: the branch that picks the
-    /// exec path reads it from the dispatch, so the executor a task gets and
-    /// the work spawned for it cannot disagree.
+    /// Which EXECUTOR runs it, resolved once from the AGENT against the daemon
+    /// default (A8) and carried here for the same reason `mode` is: the branch
+    /// that picks the exec path reads it from the dispatch, so the executor a
+    /// task gets and the work spawned for it cannot disagree.
+    ///
+    /// This is the only place that answer lives once resolution has happened.
+    /// `execute_claimed` holds a [`DaemonDefaultExecutor`], not a
+    /// [`TaskExecutor`], precisely so no branch below can accidentally spawn
+    /// work for the daemon's default while this field says otherwise.
     pub(crate) executor: TaskExecutor,
     /// Which CONTRACT that exec path is spawned for, resolved once from the
     /// task row (see [`dispatch_mode`]) and carried beside `backend`.
@@ -2636,10 +2650,14 @@ impl ResolvedDispatch {
     /// `mode` is still the task row's own — a resolve fault says nothing about
     /// which contract the operator asked for, and defaulting it would spawn a
     /// print-and-exit process into an interactive pane.
-    fn fallback(mode: Mode, executor: TaskExecutor) -> Self {
+    ///
+    /// The executor falls back to the DAEMON default: this path is taken when
+    /// the agent row could not be read, so there is no per-agent override to
+    /// honour and inventing one would route the task on a guess.
+    fn fallback(mode: Mode, daemon_default: DaemonDefaultExecutor) -> Self {
         Self {
             backend: Backend::default(),
-            executor,
+            executor: daemon_default.for_agent(None),
             mode,
             invocation: ProviderInvocation {
                 prompt: FALLBACK_PROMPT.to_string(),
@@ -2663,6 +2681,13 @@ impl ResolvedDispatch {
 /// `cli_args` become the [`ProviderInvocation`]; its `agent_env` is carried
 /// separately.
 ///
+/// A8 adds the second, ORTHOGONAL axis: the agent's own `task_executor`
+/// (migration 0095) decides HOW that backend runs — as a provider subprocess or
+/// as one turn on an ACP adapter — falling back to the daemon-wide
+/// `HANGAR_TASK_EXECUTOR` when the agent names nothing recognised. Resolved
+/// here, in the same read that resolves the backend, so one row read answers
+/// both questions and the pair cannot drift.
+///
 /// # Errors
 ///
 /// Returns an error if the agent id is malformed or the agent / runtime row is
@@ -2672,7 +2697,7 @@ async fn resolve_dispatch(
     agent_id: &str,
     issue_id: Option<&str>,
     mode: Mode,
-    executor: TaskExecutor,
+    daemon_default: DaemonDefaultExecutor,
 ) -> anyhow::Result<ResolvedDispatch> {
     use ainb_hangar_store::repo::agent::AgentRepo;
     use ainb_hangar_store::repo::agent_runtime::AgentRuntimeRepo;
@@ -2685,6 +2710,8 @@ async fn resolve_dispatch(
         .ok_or_else(|| anyhow::anyhow!("runtime {} not found", agent.runtime_id))?;
     // Per-agent provider wins; an agent with no override uses the runtime default.
     let provider = agent.provider.as_deref().unwrap_or(&runtime.provider);
+    // Same shape on the executor axis: per-agent wins, otherwise the daemon's.
+    let executor = daemon_default.for_agent(agent.task_executor.as_deref());
     Ok(ResolvedDispatch {
         backend: Backend::from_provider(provider),
         executor,
@@ -3124,6 +3151,12 @@ fn warn_danger_access(task: &Task, provider: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A daemon started with no `HANGAR_TASK_EXECUTOR`: the floor every test
+    /// below dispatches against, so an agent's own `task_executor` is the only
+    /// thing that can move a task onto the ACP path.
+    const PROCESS_DEFAULT: DaemonDefaultExecutor =
+        DaemonDefaultExecutor::new(TaskExecutor::Process);
 
     /// hangar-e2e-6: a failed run whose runner captured BOTH stdout and stderr
     /// tails must surface BOTH in the persisted failure detail. This is the core
@@ -3673,7 +3706,7 @@ mod tests {
             &events,
             &interactive,
             Arc::new(HangingBackend),
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await;
 
@@ -3887,7 +3920,7 @@ mod tests {
                 &events,
                 &interactive,
                 Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
-                TaskExecutor::Process,
+                PROCESS_DEFAULT,
             )
             .await
         };
@@ -3930,7 +3963,7 @@ mod tests {
             &events,
             &interactive,
             Arc::new(ainb_hangar_secrets::InMemoryBackend::new()),
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .expect("member execute_claimed handles the spawn failure internally");
@@ -4263,7 +4296,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4304,19 +4337,13 @@ mod tests {
         )
         .await
         .unwrap();
-        let disp = resolve_dispatch(
-            pool,
-            &instructed.id,
-            None,
-            Mode::Headless,
-            TaskExecutor::Process,
-        )
-        .await
-        .unwrap();
+        let disp = resolve_dispatch(pool, &instructed.id, None, Mode::Headless, PROCESS_DEFAULT)
+            .await
+            .unwrap();
         assert_eq!(disp.invocation.prompt, "Triage the inbox.");
 
         // (3) Neither → a non-empty fallback, never a promptless spawn.
-        let disp = resolve_dispatch(pool, &agent.id, None, Mode::Headless, TaskExecutor::Process)
+        let disp = resolve_dispatch(pool, &agent.id, None, Mode::Headless, PROCESS_DEFAULT)
             .await
             .unwrap();
         assert!(
@@ -4414,7 +4441,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4446,7 +4473,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4469,7 +4496,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4578,7 +4605,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4603,7 +4630,7 @@ mod tests {
             &agent.id,
             Some(&issue_id),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4676,7 +4703,7 @@ mod tests {
             &agent.id,
             Some(&with_ref),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4693,7 +4720,7 @@ mod tests {
             &agent.id,
             Some(&no_ref),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4712,7 +4739,7 @@ mod tests {
             &agent.id,
             Some(&title_only),
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await
         .unwrap();
@@ -4904,12 +4931,12 @@ mod tests {
             "agent-that-does-not-exist",
             None,
             Mode::Headless,
-            TaskExecutor::Process,
+            PROCESS_DEFAULT,
         )
         .await;
         assert!(err.is_err(), "a missing agent must fail to resolve");
 
-        let disp = ResolvedDispatch::fallback(Mode::Headless, TaskExecutor::Process);
+        let disp = ResolvedDispatch::fallback(Mode::Headless, PROCESS_DEFAULT);
         assert!(
             !disp.invocation.prompt.trim().is_empty(),
             "the fault fallback must carry a real brief, or the provider exits 1 \
@@ -4957,7 +4984,7 @@ mod tests {
 
         // A codex agent on that claude-advertised runtime → codex backend.
         let codex = bootstrap::create_agent(pool, &ws, "coder", "codex", None).await.unwrap();
-        let disp = resolve_dispatch(pool, &codex.id, None, Mode::Headless, TaskExecutor::Process)
+        let disp = resolve_dispatch(pool, &codex.id, None, Mode::Headless, PROCESS_DEFAULT)
             .await
             .unwrap();
         assert_eq!(
@@ -4969,15 +4996,9 @@ mod tests {
         // A copilot agent on that claude-advertised runtime → copilot backend
         // (no more silent claude fallback).
         let copilot = bootstrap::create_agent(pool, &ws, "helper", "copilot", None).await.unwrap();
-        let disp = resolve_dispatch(
-            pool,
-            &copilot.id,
-            None,
-            Mode::Headless,
-            TaskExecutor::Process,
-        )
-        .await
-        .unwrap();
+        let disp = resolve_dispatch(pool, &copilot.id, None, Mode::Headless, PROCESS_DEFAULT)
+            .await
+            .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Copilot,
@@ -4988,7 +5009,7 @@ mod tests {
         let agy = bootstrap::create_agent(pool, &ws, "gemini_worker", "antigravity", None)
             .await
             .unwrap();
-        let disp = resolve_dispatch(pool, &agy.id, None, Mode::Headless, TaskExecutor::Process)
+        let disp = resolve_dispatch(pool, &agy.id, None, Mode::Headless, PROCESS_DEFAULT)
             .await
             .unwrap();
         assert_eq!(
@@ -4999,15 +5020,9 @@ mod tests {
 
         // A claude agent on the same runtime → claude backend.
         let claude = bootstrap::create_agent(pool, &ws, "writer", "claude", None).await.unwrap();
-        let disp = resolve_dispatch(
-            pool,
-            &claude.id,
-            None,
-            Mode::Headless,
-            TaskExecutor::Process,
-        )
-        .await
-        .unwrap();
+        let disp = resolve_dispatch(pool, &claude.id, None, Mode::Headless, PROCESS_DEFAULT)
+            .await
+            .unwrap();
         assert_eq!(disp.backend, Backend::Claude);
 
         // An agent with NO provider override falls back to the runtime's provider.
@@ -5024,15 +5039,9 @@ mod tests {
             ..Agent::default()
         };
         AgentRepo::insert(pool, &bare).await.unwrap();
-        let disp = resolve_dispatch(
-            pool,
-            "bare-agent",
-            None,
-            Mode::Headless,
-            TaskExecutor::Process,
-        )
-        .await
-        .unwrap();
+        let disp = resolve_dispatch(pool, "bare-agent", None, Mode::Headless, PROCESS_DEFAULT)
+            .await
+            .unwrap();
         assert_eq!(
             disp.backend,
             Backend::Claude,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/run_loop.rs
@@ -199,48 +199,13 @@ pub use crate::task_executor::{DaemonDefaultExecutor, TaskExecutor};
 
 /// The wall-clock ceiling on one provider run (`HANGAR_PROVIDER_MAX_RUNTIME_MS`).
 ///
-/// Read through one function because two callers need it: [`DaemonConfig`],
-/// and [`acp_turn_budget`], which is consulted where no `DaemonConfig` exists
-/// yet. Two reads would be two places for the default to drift.
+/// The bound an ACP task's turn is held to as well: [`crate::acp_task`] polls
+/// the delivery leg against this same value, which is why the pool's own
+/// deadline sweep exempts task scopes rather than applying a second, tighter
+/// one.
 fn provider_max_runtime_from_env() -> Duration {
     env_u64_opt("HANGAR_PROVIDER_MAX_RUNTIME_MS")
         .map_or(PROVIDER_MAX_RUNTIME, Duration::from_millis)
-}
-
-/// How long ONE ACP turn must be allowed to run on this daemon's pool, or
-/// `None` when tasks do not run on it.
-///
-/// Under `HANGAR_TASK_EXECUTOR=acp` a task turn IS a pool turn, and the pool
-/// applies its own [`PoolConfig::turn_deadline`](crate::acp_pool::PoolConfig)
-/// to every scope with no exemption. Its 30-minute default would therefore
-/// cancel every task past half an hour while the identical task on the process
-/// executor gets `HANGAR_PROVIDER_MAX_RUNTIME_MS` (2.5 h by default): a 5x
-/// budget cut that is invisible from the flag that caused it.
-///
-/// Read from the environment rather than a [`DaemonConfig`] because the pool is
-/// built before one exists ([`crate::boot`]); the executor comes through the
-/// same pure resolver the daemon config uses, so the two cannot disagree.
-#[must_use]
-pub fn acp_turn_budget() -> Option<Duration> {
-    let executor =
-        DaemonConfig::resolve_task_executor(std::env::var_os("HANGAR_TASK_EXECUTOR").as_deref());
-    (executor == TaskExecutor::Acp).then(provider_max_runtime_from_env)
-}
-
-/// The turn deadline a pool needs given the task budget riding on it.
-///
-/// Raise only: a deadline an operator lengthened deliberately
-/// (`AINB_ACP_TURN_DEADLINE_MS`) is never shortened, and a daemon whose tasks
-/// run on the process executor keeps the pool's own default untouched. The cost
-/// of raising it is that a wedged CHAT turn on the same daemon converges on the
-/// longer backstop; an operator can still stop one from the fleet surface at
-/// any time, and the alternative is tasks dying silently at 30 minutes.
-#[must_use]
-pub fn reconcile_turn_deadline(pool_deadline: Duration, task_budget: Option<Duration>) -> Duration {
-    match task_budget {
-        Some(budget) => pool_deadline.max(budget),
-        None => pool_deadline,
-    }
 }
 
 impl DaemonConfig {
@@ -3226,33 +3191,6 @@ mod tests {
         assert!(
             detail.contains("claude"),
             "the synthesized diagnostic must name the provider: {detail}"
-        );
-    }
-
-    /// A5: the pool's turn deadline never cuts a task's runtime budget, and
-    /// never shortens a deadline an operator set deliberately.
-    #[test]
-    fn the_pool_deadline_is_raised_to_the_task_budget_and_never_lowered() {
-        let pool_default = Duration::from_secs(30 * 60);
-        // No tasks on this pool: its own default stands.
-        assert_eq!(
-            reconcile_turn_deadline(pool_default, None),
-            pool_default,
-            "the process executor must not touch the pool's deadline"
-        );
-        // The 5x cut this exists to close: a 2.5h task on a 30min pool.
-        assert_eq!(
-            reconcile_turn_deadline(pool_default, Some(PROVIDER_MAX_RUNTIME)),
-            PROVIDER_MAX_RUNTIME,
-            "an acp task must get its full HANGAR_PROVIDER_MAX_RUNTIME_MS"
-        );
-        // Raise only: an operator who lengthened AINB_ACP_TURN_DEADLINE_MS past
-        // the task budget keeps it.
-        let operator_set = PROVIDER_MAX_RUNTIME * 2;
-        assert_eq!(
-            reconcile_turn_deadline(operator_set, Some(PROVIDER_MAX_RUNTIME)),
-            operator_set,
-            "a longer configured deadline must never be shortened"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/task_executor.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/task_executor.rs
@@ -1,0 +1,213 @@
+//! Which EXECUTOR a claimed task's provider work takes, and the precedence that
+//! picks it (spine A5's flag, A8's per-agent override).
+//!
+//! ```text
+//!   agent.task_executor  ─▶ recognised?  ─yes─▶ that executor
+//!            │ NULL / blank / unrecognised
+//!            ▼
+//!   HANGAR_TASK_EXECUTOR ─▶ recognised?  ─yes─▶ that executor
+//!            │ unset / blank / unrecognised
+//!            ▼
+//!                              process
+//! ```
+//!
+//! Two shapes here are load-bearing.
+//!
+//! **An agent contributes an executor only when it NAMES a recognised one.** A
+//! NULL column, a blank string and a typo all mean the same thing — no override
+//! — so an agent that says nothing usable dispatches exactly as it did before
+//! migration 0095 existed. The typo warns, because a misspelled opt-in that
+//! silently does nothing is the failure mode this daemon already guards on the
+//! environment variable.
+//!
+//! **[`DaemonDefaultExecutor`] is a distinct TYPE, not another
+//! [`TaskExecutor`].** With per-agent selection the daemon-wide value is only an
+//! INPUT to the decision: the executor a task actually runs on lives on its
+//! `ResolvedDispatch`, and `execute_claimed` has three branches that spawn work
+//! from it. A bare `TaskExecutor` parameter made `daemon_default ==
+//! TaskExecutor::Acp` compile and read plausibly at every one of them, each
+//! routing a task to an executor it was not assigned. Wrapped, and with the
+//! wrapper's field private to THIS module, that comparison does not compile in
+//! `run_loop` at all.
+
+use ainb_hangar_store::bootstrap::{TASK_EXECUTOR_ACP, TASK_EXECUTOR_PROCESS};
+
+/// Which executor runs a claimed task's provider work.
+///
+/// A second FIRST-CLASS executor, not a mode: `Process` spawns the provider CLI
+/// (`claude -p`, `codex exec`) and keeps its jsonl transcript; `Acp` prompts an
+/// ACP adapter over JSON-RPC and keeps its transcript in `fleet_provider_event`.
+/// Deliberately a different axis from [`Mode`](crate::runner::Mode): executor and
+/// interactivity are two questions, and conflating them is the bug
+/// `interactive_command` was extracted to prevent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TaskExecutor {
+    /// Spawn the provider CLI. Today's path, and the default.
+    #[default]
+    Process,
+    /// Prompt an ACP adapter through [`crate::acp_task`].
+    Acp,
+}
+
+impl TaskExecutor {
+    /// Every variant, so a test enumerates the executor axis mechanically
+    /// rather than sampling the two a human happened to think of.
+    pub const ALL: [Self; 2] = [Self::Process, Self::Acp];
+
+    /// The token this executor is spelled with, on the agent row and in
+    /// `HANGAR_TASK_EXECUTOR` alike.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Process => TASK_EXECUTOR_PROCESS,
+            Self::Acp => TASK_EXECUTOR_ACP,
+        }
+    }
+}
+
+/// Parse one executor token, case-insensitively, or `None` when it names
+/// neither executor.
+///
+/// The ONE place a token becomes a [`TaskExecutor`]: the environment variable
+/// and the agent column carry the same vocabulary
+/// ([`ainb_hangar_store::bootstrap::SUPPORTED_TASK_EXECUTORS`]), and two parsers
+/// would be two places for `acp` to stop meaning ACP.
+#[must_use]
+pub fn parse(value: &str) -> Option<TaskExecutor> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case(TASK_EXECUTOR_ACP) {
+        Some(TaskExecutor::Acp)
+    } else if value.eq_ignore_ascii_case(TASK_EXECUTOR_PROCESS) {
+        Some(TaskExecutor::Process)
+    } else {
+        None
+    }
+}
+
+/// The daemon-wide `HANGAR_TASK_EXECUTOR` value: the executor a task takes when
+/// its agent asks for none.
+///
+/// Not a [`TaskExecutor`], on purpose — see the module docs. The only thing that
+/// can be done with one is ask it to resolve a specific agent's executor, which
+/// is the only correct use of it once per-agent selection exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DaemonDefaultExecutor(TaskExecutor);
+
+impl DaemonDefaultExecutor {
+    /// Wrap the daemon-wide default (`DaemonConfig::task_executor`).
+    #[must_use]
+    pub const fn new(default: TaskExecutor) -> Self {
+        Self(default)
+    }
+
+    /// Resolve the executor for one agent: its own `task_executor` when that
+    /// names a recognised executor, else this daemon-wide default.
+    ///
+    /// `None`, blank and unrecognised all inherit, so an agent created before
+    /// migration 0095 — or one whose value was hand-edited into nonsense — runs
+    /// exactly where it ran before. The unrecognised case warns rather than
+    /// failing the task: refusing to dispatch would turn a typo in a cosmetic
+    /// override into an unrunnable agent.
+    #[must_use]
+    pub fn for_agent(self, agent_value: Option<&str>) -> TaskExecutor {
+        let Some(raw) = agent_value.map(str::trim).filter(|v| !v.is_empty()) else {
+            return self.0;
+        };
+        parse(raw).unwrap_or_else(|| {
+            tracing::warn!(
+                value = raw,
+                inherited = self.0.as_str(),
+                "unknown agent.task_executor; inheriting the daemon's HANGAR_TASK_EXECUTOR"
+            );
+            self.0
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DaemonDefaultExecutor, TaskExecutor, parse};
+    use ainb_hangar_store::bootstrap::SUPPORTED_TASK_EXECUTORS;
+
+    /// Every executor the daemon can run is nameable by an operator, and every
+    /// name an operator may write resolves to an executor.
+    ///
+    /// The two sides are enumerated from their own sources — the enum's `ALL`
+    /// and the store constant the create paths validate against — so a variant
+    /// added without a token (an executor nobody can select) and a token added
+    /// without a variant (a value `agent create` accepts and dispatch ignores)
+    /// both fail here. A count would have caught neither.
+    #[test]
+    fn the_token_vocabulary_and_the_executor_set_cover_each_other() {
+        let from_tokens: Vec<TaskExecutor> =
+            SUPPORTED_TASK_EXECUTORS.iter().filter_map(|t| parse(t)).collect();
+        assert_eq!(
+            from_tokens,
+            TaskExecutor::ALL.to_vec(),
+            "every supported token must resolve to a distinct executor, in the same order"
+        );
+        for executor in TaskExecutor::ALL {
+            assert!(
+                SUPPORTED_TASK_EXECUTORS.contains(&executor.as_str()),
+                "{executor:?} has no token an operator can write"
+            );
+        }
+    }
+
+    /// The FULL precedence matrix: every daemon-wide default crossed with every
+    /// shape an agent's column can take.
+    ///
+    /// Both axes are enumerated rather than sampled: the executor axis from
+    /// [`TaskExecutor::ALL`], the "agent asks for X" axis from the same
+    /// [`SUPPORTED_TASK_EXECUTORS`] the write paths validate against (so a new
+    /// token joins this matrix automatically), and the "agent asks for nothing"
+    /// axis from every spelling of absence the column admits.
+    #[test]
+    fn the_agent_wins_when_it_names_an_executor_and_inherits_otherwise() {
+        // Every way the column says "no override": NULL, and the blank shapes a
+        // hand-edited row or a whitespace-only CLI argument can leave behind.
+        let no_override: [Option<&str>; 4] = [None, Some(""), Some("   "), Some("\t")];
+        // Every way it says something the daemon cannot honour.
+        let unrecognised: [&str; 4] = ["acpp", "tmux", "ac p", "0"];
+
+        for daemon_default in TaskExecutor::ALL {
+            let default = DaemonDefaultExecutor::new(daemon_default);
+
+            for absent in no_override {
+                assert_eq!(
+                    default.for_agent(absent),
+                    daemon_default,
+                    "{absent:?} must inherit the daemon default {daemon_default:?}"
+                );
+            }
+
+            for token in SUPPORTED_TASK_EXECUTORS {
+                let asked = parse(token).expect("a supported token parses");
+                assert_eq!(
+                    default.for_agent(Some(token)),
+                    asked,
+                    "the agent's `{token}` must win over the daemon default {daemon_default:?}"
+                );
+                // The same token as an operator may realistically have typed it.
+                assert_eq!(
+                    default.for_agent(Some(&token.to_uppercase())),
+                    asked,
+                    "`{token}` must resolve case-insensitively"
+                );
+                assert_eq!(
+                    default.for_agent(Some(&format!("  {token} "))),
+                    asked,
+                    "`{token}` must resolve with surrounding whitespace"
+                );
+            }
+
+            for garbage in unrecognised {
+                assert_eq!(
+                    default.for_agent(Some(garbage)),
+                    daemon_default,
+                    "`{garbage}` must inherit {daemon_default:?}, not pick an executor"
+                );
+            }
+        }
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/src/task_executor.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/task_executor.rs
@@ -139,8 +139,18 @@ mod tests {
     /// both fail here. A count would have caught neither.
     #[test]
     fn the_token_vocabulary_and_the_executor_set_cover_each_other() {
-        let from_tokens: Vec<TaskExecutor> =
-            SUPPORTED_TASK_EXECUTORS.iter().filter_map(|t| parse(t)).collect();
+        // `map` + panic, never `filter_map`: a token that resolves to NO
+        // executor is the whole failure this direction exists to catch, and
+        // filtering it out is how the guard silently passed with a bogus
+        // `"tmux"` in the vocabulary.
+        let from_tokens: Vec<TaskExecutor> = SUPPORTED_TASK_EXECUTORS
+            .iter()
+            .map(|token| {
+                parse(token).unwrap_or_else(|| {
+                    panic!("`{token}` is offered to operators but resolves to no executor")
+                })
+            })
+            .collect();
         assert_eq!(
             from_tokens,
             TaskExecutor::ALL.to_vec(),

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -1909,6 +1909,59 @@ async fn ensure_refuses_a_blank_cwd_or_scope_before_writing_anything() {
     );
 }
 
+/// A CHAT prompt aimed at a TASK's session is refused, and the task's own
+/// prompt to the same session is not.
+///
+/// `fleet/message_send` and `fleet/action` can both name any live session by
+/// key, and a task's key is deliberately discoverable (`TaskRepo::set_session_id`
+/// records it for transcript viewing). Neither door checks the scope, so the
+/// refusal has to live at the one function both reach — which is also the one
+/// that already read the row the scope is on.
+///
+/// The teeth are the two negatives: the refused prompt must reach NO adapter
+/// process, and the exempt one must still be delivered, so a guard that simply
+/// refused everything would fail the second half.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_chat_prompt_is_refused_for_a_task_scope_and_the_task_run_is_not() {
+    use ainb_hangar_daemon::acp_pool::DELIVERY_TASK_SCOPE_REFUSED;
+    use ainb_hangar_daemon::acp_session::ensure;
+
+    let (_dir, store, pool) = harness(&[("FAKE_ACP_CHUNKS", "1")]).await;
+    let events = EventBroker::new().sink();
+    // Minted the way `acp_task` mints it, through the same reserved prefix the
+    // create door refuses to hand out.
+    let task = ensure(
+        store.pool(),
+        &events,
+        ainb_acp::config::CLAUDE_ADAPTER,
+        "/tmp/acp",
+        Some("task:t-guard"),
+    )
+    .await
+    .expect("mint the task session");
+
+    let chat = seed_message(&store, &task.session_key, "inject").await;
+    assert_eq!(
+        pool.submit_prompt(&task.session_key, &chat, "inject").await,
+        SubmitOutcome::Rejected(DELIVERY_TASK_SCOPE_REFUSED),
+        "a chat door must not prompt a task's session"
+    );
+    assert!(
+        pool.health().await.processes.is_empty(),
+        "the refused prompt must not have started an adapter"
+    );
+
+    // The run that OWNS the scope still gets its turn.
+    let brief = seed_message(&store, &task.session_key, "the brief").await;
+    assert_eq!(
+        pool.submit_task_prompt(&task.session_key, &brief, "the brief").await,
+        SubmitOutcome::Queued,
+        "the task executor is exempt from its own scope's guard"
+    );
+    let (state, detail) = await_terminal(&store, &brief, &task.session_key).await;
+    assert_eq!(state, "DELIVERED", "{detail:?}");
+}
+
 /// A cancel is per SESSION: convergence is idempotent and leaves the scope
 /// reusable without a restart.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -783,6 +783,81 @@ async fn the_deadline_sweep_cancels_only_the_overdue_session() {
     );
 }
 
+/// The deadline sweep expires an overdue CHAT turn and passes over an overdue
+/// TASK turn, in the same pass.
+///
+/// A task's turn is bounded by the TASK budget (`acp_task::await_leg` polls to
+/// `HANGAR_PROVIDER_MAX_RUNTIME_MS`, cancels and writes the same
+/// `UNKNOWN`/`turn_deadline` pair), so the pool's chat-shaped deadline on top
+/// could only ever cut a run short — by default 5x. Boot used to hide that by
+/// raising the WHOLE pool's deadline whenever `HANGAR_TASK_EXECUTOR=acp`, which
+/// per-agent selection makes unworkable and which charged every chat turn for a
+/// task-path problem.
+///
+/// BOTH halves in one pass on purpose. The e2e that replaced the boot raise can
+/// only assert that the task survived, which is equally true if the sweep never
+/// ran at all — "exempt the scope" and "disable the sweep" are indistinguishable
+/// to it. Here the chat leg's cancellation is the proof the sweep was armed and
+/// firing while the task leg went untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_deadline_sweep_expires_a_chat_turn_and_exempts_a_task_turn() {
+    use ainb_hangar_daemon::acp_session::ensure;
+    use ainb_hangar_daemon::acp_task::scope_key;
+
+    let (_dir, store, pool, broker) = harness_with_broker(
+        &[("FAKE_ACP_HANG_SESSIONS", "*"), ("FAKE_ACP_CHUNKS", "1")],
+        |config| config.turn_deadline = Duration::from_millis(1),
+    )
+    .await;
+    let events = broker.sink();
+    let claude = ainb_acp::config::CLAUDE_ADAPTER;
+
+    // Minted through `ensure`, so the scopes are spelled the way production
+    // spells them — `scope_key()` for the task, `session:<key>` for the chat.
+    let chat = ensure(store.pool(), &events, claude, "/tmp/acp", None)
+        .await
+        .expect("mint the chat session");
+    let task = ensure(
+        store.pool(),
+        &events,
+        claude,
+        "/tmp/acp",
+        Some(&scope_key("t-sweep")),
+    )
+    .await
+    .expect("mint the task session");
+
+    let chat_message = seed_message(&store, &chat.session_key, "a").await;
+    let task_message = seed_message(&store, &task.session_key, "bb").await;
+    pool.submit_prompt(&chat.session_key, &chat_message, "a").await;
+    pool.submit_task_prompt(&task.session_key, &task_message, "bb").await;
+    // Both turns are OPEN and both are past the 1 ms deadline, so the only
+    // thing that can separate them is the scope.
+    await_open_turn(&store, &chat.session_key).await;
+    await_open_turn(&store, &task.session_key).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    pool.sweep_once().await;
+
+    let (state, detail) = await_terminal(&store, &chat_message, &chat.session_key).await;
+    assert_eq!(state, "UNKNOWN", "the chat turn must be swept: {detail:?}");
+    assert_eq!(detail.as_deref(), Some("turn_deadline"));
+    assert_eq!(
+        delivery_state(&store, &task_message, &task.session_key).await,
+        Some(("PENDING".to_string(), None)),
+        "the task turn owns its own deadline and must survive the sweep"
+    );
+    assert!(
+        FleetAcpSessionRepo::get(store.pool(), &task.session_key)
+            .await
+            .expect("row")
+            .expect("task session row")
+            .open_turn_id
+            .is_some(),
+        "and must still be holding the turn the sweep passed over"
+    );
+}
+
 /// The deadline sweep is genuinely WIRED, not just callable: the task
 /// `spawn_sweeper` starts expires an overdue turn on its own cadence with no
 /// explicit `sweep_once` in the test.

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -2000,17 +2000,19 @@ async fn ensure_refuses_a_blank_cwd_or_scope_before_writing_anything() {
 async fn a_chat_prompt_is_refused_for_a_task_scope_and_the_task_run_is_not() {
     use ainb_hangar_daemon::acp_pool::DELIVERY_TASK_SCOPE_REFUSED;
     use ainb_hangar_daemon::acp_session::ensure;
+    use ainb_hangar_daemon::acp_task::scope_key;
 
     let (_dir, store, pool) = harness(&[("FAKE_ACP_CHUNKS", "1")]).await;
     let events = EventBroker::new().sink();
-    // Minted the way `acp_task` mints it, through the same reserved prefix the
-    // create door refuses to hand out.
+    // `scope_key`, never a hand-spelled `task:…`: the guard matches on the
+    // production convention, so a test that re-spells it would keep passing if
+    // the convention moved and the guard stopped matching real sessions.
     let task = ensure(
         store.pool(),
         &events,
         ainb_acp::config::CLAUDE_ADAPTER,
         "/tmp/acp",
-        Some("task:t-guard"),
+        Some(&scope_key("t-guard")),
     )
     .await
     .expect("mint the task session");

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/acp_pool.rs
@@ -829,8 +829,17 @@ async fn the_deadline_sweep_expires_a_chat_turn_and_exempts_a_task_turn() {
 
     let chat_message = seed_message(&store, &chat.session_key, "a").await;
     let task_message = seed_message(&store, &task.session_key, "bb").await;
-    pool.submit_prompt(&chat.session_key, &chat_message, "a").await;
-    pool.submit_task_prompt(&task.session_key, &task_message, "bb").await;
+    // Asserted, not discarded: a refused submit would otherwise surface 20 s
+    // later as an `await_open_turn` timeout blaming the turn that never opened
+    // rather than the prompt that was never accepted.
+    assert!(matches!(
+        pool.submit_prompt(&chat.session_key, &chat_message, "a").await,
+        SubmitOutcome::Queued
+    ));
+    assert!(matches!(
+        pool.submit_task_prompt(&task.session_key, &task_message, "bb").await,
+        SubmitOutcome::Queued
+    ));
     // Both turns are OPEN and both are past the 1 ms deadline, so the only
     // thing that can separate them is the scope.
     await_open_turn(&store, &chat.session_key).await;

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_agent_metadata.rs
@@ -399,3 +399,88 @@ async fn agent_update_edits_the_description() {
     let row = actor_row(&mut c, "agent:agent-1").await.expect("agent-1 present");
     assert_eq!(row["description"], "reviews every PR", "the edit persisted");
 }
+
+/// (e) A8: `task_executor` is recorded on the created agent, and an
+/// unrecognised one is `INVALID_PARAMS` with nothing written.
+///
+/// The column is read at DISPATCH, where a wrong value is invisible until a run
+/// takes the wrong executor, so the wire is where a typo has to be refused. The
+/// accepted case is read back from the STORE rather than the roster: the create
+/// reply renders no executor, so only the row proves the param reached the
+/// column rather than being parsed and dropped.
+#[tokio::test]
+async fn agent_create_records_a_task_executor_and_refuses_an_unknown_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket_path, store) = start_server(dir.path()).await;
+    let mut c = Client::connect(&socket_path).await;
+    c.auth_from_file(dir.path()).await;
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "acp-runner",
+                "task_executor": "ACP",
+            }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "create must ack: {resp}");
+    let recorded: Option<String> =
+        sqlx::query_scalar("SELECT task_executor FROM agent WHERE name = ?")
+            .bind("acp-runner")
+            .fetch_one(store.pool())
+            .await
+            .expect("read the created agent");
+    assert_eq!(
+        recorded.as_deref(),
+        Some("acp"),
+        "the create must record the normalised executor on the agent row"
+    );
+
+    // An agent that names nothing keeps a NULL column: the daemon-wide default
+    // stays in charge, which is what makes this field additive.
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({ "workspace_id": WS_SLUG, "name": "inheritor" }),
+        )
+        .await;
+    assert!(resp["error"].is_null(), "create must ack: {resp}");
+    let inherited: Option<String> =
+        sqlx::query_scalar("SELECT task_executor FROM agent WHERE name = ?")
+            .bind("inheritor")
+            .fetch_one(store.pool())
+            .await
+            .expect("read the created agent");
+    assert_eq!(
+        inherited, None,
+        "omitting the field must leave the column NULL, not default it"
+    );
+
+    let resp = c
+        .call(
+            methods::HANGAR_AGENT_CREATE,
+            serde_json::json!({
+                "workspace_id": WS_SLUG,
+                "name": "typo",
+                "task_executor": "acpp",
+            }),
+        )
+        .await;
+    let err = &resp["error"];
+    assert!(
+        !err.is_null(),
+        "an unknown executor must be refused: {resp}"
+    );
+    assert_eq!(err["code"], -32602, "the refusal is INVALID_PARAMS: {err}");
+    assert!(
+        err["message"].as_str().unwrap_or_default().contains("process, acp"),
+        "the message must name the executors it accepts: {err}"
+    );
+    assert_eq!(
+        count_named(&mut c, "typo").await,
+        0,
+        "the rejected create wrote no agent"
+    );
+}

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_acp_task_end_to_end.rs
@@ -340,11 +340,11 @@ async fn cancelling_an_acp_task_cancels_the_adapter_turn() {
 /// A turn that outlives `HANGAR_PROVIDER_MAX_RUNTIME_MS` is cancelled by the
 /// EXECUTOR's own deadline and finalized `timeout`, and the adapter is told.
 ///
-/// The task budget is the one the flag does not mention: the pool applies its
-/// own turn deadline to every scope, so without the boot-time reconciliation an
-/// ACP task would instead die on the pool's 30-minute default while the same
-/// task on the process executor ran for 2.5 h. This pins the executor end of
-/// that contract: its poll bound is `max_runtime`, not the pool's.
+/// The task budget is the one the flag does not mention: the pool's own turn
+/// deadline is the CHAT deadline (30 minutes by default), and an ACP task that
+/// obeyed it would die at half an hour while the same task on the process
+/// executor ran for 2.5 h. The pool's sweep therefore exempts task scopes, and
+/// this pins the bound that remains: the executor's own poll, `max_runtime`.
 #[tokio::test]
 async fn an_acp_turn_past_the_task_budget_times_out_and_tells_the_adapter() {
     if !tripwire_support::tmux_available() {
@@ -409,16 +409,15 @@ async fn an_acp_turn_past_the_task_budget_times_out_and_tells_the_adapter() {
     assert_no_process_executor_trace(&row, &marker, task_id);
 }
 
-/// The pool's own turn deadline does NOT cap a task, because boot raises it to
-/// the task budget.
+/// The pool's own turn deadline does NOT cap a task, because `sweep_once`
+/// exempts task scopes.
 ///
-/// The 4-second case above proves the executor's poll bound, but the raise is a
-/// no-op there (30 min vs 4 s), so it exercises no reconciliation wiring at all;
-/// the unit test pins the `max()` while touching neither `boot` nor
-/// `sweep_once`. This is the case that fails on the unfixed code: the pool
-/// deadline is 2 s and its sweep runs every 1 s, the task budget is 30 s, and
-/// the turn is paced to about 4 s. Without the raise the sweep cancels the turn
-/// at 2 s and the task finalizes `failed`/`timeout`; with it the turn finishes.
+/// The 4-second case above proves the executor's poll bound, but it exercises
+/// the sweep not at all (30 min vs 4 s). This is the case that fails without the
+/// exemption: the pool deadline is 2 s and its sweep runs every 1 s, the task
+/// budget is 30 s, and the turn is paced to about 4 s, so the sweep gets two
+/// clean passes at a turn it must not touch. Unexempted it cancels the turn at
+/// 2 s and the task finalizes `failed`/`timeout`; exempted, the turn finishes.
 #[tokio::test]
 async fn the_pool_deadline_does_not_cap_a_task_that_outlives_it() {
     if !tripwire_support::tmux_available() {
@@ -471,8 +470,8 @@ async fn the_pool_deadline_does_not_cap_a_task_that_outlives_it() {
     enqueue_task(&pool, &ids, task_id, &agent, "headless").await;
 
     let row = wait_for_terminal(&pool, task_id, Duration::from_mins(1)).await;
-    // History, not the visible pane: the boot warn asserted below has scrolled
-    // off by the time the run finishes.
+    // History, not the visible pane: a failure here is diagnosed from the whole
+    // boot log, which has scrolled off by the time the run finishes.
     let pane = session.capture_pane_history();
     drop(session);
 
@@ -488,13 +487,13 @@ async fn the_pool_deadline_does_not_cap_a_task_that_outlives_it() {
         row.get::<Option<String>, _>("failure_reason").is_none(),
         "and record no failure reason"
     );
-    // The raise is not silent. This daemon's chat sessions now share the longer
-    // deadline, so boot says so where whoever flipped the flag will read it.
+    // And the exemption is scoped: the sweep is still ARMED on this daemon (a
+    // 2 s deadline with a 1 s cadence), it simply passed over a `task:` scope.
     // Newlines stripped first: tmux hard-wraps the pane at its width, which
-    // splits the message mid-word.
+    // splits a message mid-word.
     assert!(
-        pane.replace('\n', "").contains("raised the acp turn deadline"),
-        "boot must warn that it raised the deadline:\n{pane}"
+        !pane.replace('\n', "").contains("outlived its deadline"),
+        "the sweep must not have cancelled the task's turn:\n{pane}"
     );
     assert_no_process_executor_trace(&row, &marker, task_id);
 }

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/tripwire_task_executor_flag.rs
@@ -1,11 +1,17 @@
-//! Spine A5 tripwire: `HANGAR_TASK_EXECUTOR` selects the executor, in BOTH
-//! directions, and the ACP path's per-task isolation actually holds.
+//! Spine A5 + A8 tripwire: the executor is selected in BOTH directions by the
+//! daemon-wide `HANGAR_TASK_EXECUTOR` and, per agent, by `agent.task_executor`;
+//! the ACP path's per-task isolation actually holds.
 //!
 //! ```text
 //!   =process ─▶ spawns the provider CLI   ─▶ marker + logs/claude.jsonl
 //!               and NO acp session
 //!   =acp     ─▶ spawns an ACP adapter     ─▶ fleet_acp_session + provider events
 //!               and NO process, no jsonl
+//!
+//!   A8: ONE daemon, two agents, opposite executors
+//!   =process + agent.task_executor='acp'      ─▶ adapter
+//!   =process + agent.task_executor  IS NULL   ─▶ provider CLI  (unchanged)
+//!   =acp     + agent.task_executor='process'  ─▶ provider CLI
 //! ```
 //!
 //! Both directions are asserted because a flag that silently fell back to the
@@ -293,7 +299,229 @@ async fn each_tasks_adapter_sees_only_its_own_environment() {
     );
 }
 
+/// A8: on ONE daemon defaulted to `process`, an agent that asks for `acp` gets
+/// the adapter and an agent that asks for nothing gets the provider CLI.
+///
+/// The whole point of per-agent selection is that these two coexist, so both
+/// halves are asserted against the SAME running daemon rather than two runs
+/// that happen to differ. The inheriting agent is the regression half: it must
+/// dispatch exactly as it did before the column existed, and it would still
+/// reach `done` if per-agent selection leaked onto it — only the absence of an
+/// ACP session and the presence of the provider's jsonl tell the two apart.
+#[tokio::test]
+async fn a_per_agent_acp_override_runs_beside_an_inheriting_agent() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping per-agent executor tripwire");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let rpc_log = home.path().join("rpc.log");
+    let overrider = seed_agent_with_env(
+        &pool,
+        &ids,
+        "agent-wants-acp",
+        &serde_json::json!({ "FAKE_ACP_RPC_LOG": rpc_log.display().to_string() }),
+    )
+    .await;
+    set_agent_executor(&pool, &overrider, "acp").await;
+    // No `task_executor` at all: every agent that predates migration 0095.
+    let inheritor =
+        seed_agent_with_env(&pool, &ids, "agent-inherits", &serde_json::json!({})).await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    // The daemon default is `process`, so ONLY the agent's own column can move
+    // its task onto the adapter.
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "process");
+    enqueue_task(&pool, &ids, "task-agent-acp", &overrider, "headless").await;
+    enqueue_task(&pool, &ids, "task-agent-inherits", &inheritor, "headless").await;
+
+    let acp_row = wait_for_db(&pool, "task-agent-acp", "done", Duration::from_mins(1)).await;
+    let inherit_row =
+        wait_for_db(&pool, "task-agent-inherits", "done", Duration::from_mins(1)).await;
+    drop(session);
+
+    // The overriding agent took the ACP path on a `process` daemon.
+    assert_eq!(
+        acp_sessions_for(&pool, "task-agent-acp").await,
+        1,
+        "agent.task_executor='acp' must run on the adapter even though the daemon defaults \
+         to process"
+    );
+    assert!(
+        rpc_log.exists(),
+        "the fixture adapter must have been spawned for the overriding agent"
+    );
+    assert!(
+        !logs_dir(&acp_row).join("claude.jsonl").exists(),
+        "the overriding agent must spawn no provider CLI"
+    );
+
+    // The inheriting agent is untouched: provider CLI, its jsonl, its session id.
+    assert_eq!(
+        acp_sessions_for(&pool, "task-agent-inherits").await,
+        0,
+        "an agent with no task_executor must NOT be moved onto the adapter"
+    );
+    assert!(
+        logs_dir(&inherit_row).join("claude.jsonl").exists(),
+        "the inheriting agent must still write the provider's jsonl transcript"
+    );
+    assert_eq!(
+        inherit_row.get::<Option<String>, _>("session_id").as_deref(),
+        Some("claude-sid"),
+        "and still pin the provider's own session id"
+    );
+}
+
+/// A8, the other direction: on a daemon defaulted to `acp`, an agent that pins
+/// `process` runs the provider CLI, and its INTERACTIVE task is not refused.
+///
+/// Both halves are the same bug seen twice. If anything downstream of
+/// resolution still reads the daemon-wide value, this agent runs on the adapter
+/// it opted out of; if the interactive refusal reads it, an operator who
+/// deliberately kept an attachable agent on an `acp` daemon loses every session
+/// they try to drive.
+#[tokio::test]
+async fn a_per_agent_process_override_opts_out_of_an_acp_daemon() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping per-agent opt-out tripwire");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let agent =
+        seed_agent_with_env(&pool, &ids, "agent-pins-process", &serde_json::json!({})).await;
+    set_agent_executor(&pool, &agent, "process").await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "acp");
+    enqueue_task(&pool, &ids, "task-pinned-process", &agent, "headless").await;
+    enqueue_task(
+        &pool,
+        &ids,
+        "task-pinned-interactive",
+        &agent,
+        "interactive",
+    )
+    .await;
+
+    let row = wait_for_db(&pool, "task-pinned-process", "done", Duration::from_mins(1)).await;
+    let interactive = tripwire_support::wait_until(
+        &pool,
+        "task-pinned-interactive",
+        Duration::from_mins(1),
+        |row| {
+            matches!(
+                row.get::<String, _>("status").as_str(),
+                "done" | "failed" | "cancelled"
+            )
+        },
+    )
+    .await;
+    drop(session);
+
+    assert_eq!(
+        acp_sessions_for(&pool, "task-pinned-process").await,
+        0,
+        "agent.task_executor='process' must keep its tasks off the adapter on an acp daemon"
+    );
+    assert!(
+        logs_dir(&row).join("claude.jsonl").exists(),
+        "and must spawn the provider CLI, which writes its jsonl transcript"
+    );
+
+    // The refusal follows the TASK's executor, so it must not fire here. Asserted
+    // on the message rather than on the status: this agent's interactive run may
+    // end any number of ways in a test tmux, but "refused for being acp" is the
+    // one outcome that would mean the refusal read the daemon default.
+    let detail: String = interactive.get::<Option<String>, _>("result").unwrap_or_default();
+    assert!(
+        !detail.contains("mode=interactive is not supported"),
+        "an agent pinned to the process executor must not be refused an interactive run: \
+         {detail}"
+    );
+}
+
+/// A8: the interactive refusal fires for an agent that selected `acp` ITSELF,
+/// on a daemon whose default is `process`.
+///
+/// The A5 case above proves the refusal under the flag. This proves it follows
+/// the agent, which is the only way it can still be true once the flag stops
+/// deciding: the task is refused before a pane or a worktree exists, exactly as
+/// under the flag.
+#[tokio::test]
+async fn interactive_is_refused_for_an_agent_that_selected_acp() {
+    if !tripwire_support::tmux_available() {
+        eprintln!("tmux not available; skipping per-agent interactive refusal");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir home");
+    let pool = open_pool(&home.path().join("hangar.db")).await;
+    ainb_hangar_store::apply_migrations(&pool).await.expect("migrate");
+    let ids = seed_world(&pool).await;
+    let agent =
+        seed_agent_with_env(&pool, &ids, "agent-acp-interactive", &serde_json::json!({})).await;
+    set_agent_executor(&pool, &agent, "acp").await;
+    write_acp_adapter_config(home.path(), &fake_acp_adapter(), "default");
+
+    let fake_claude = fake_claude_happy(home.path(), "claude-sid");
+    let session = spawn_daemon(home.path(), &ids, &fake_claude, "process");
+    let task_id = "task-agent-acp-interactive";
+    enqueue_task(&pool, &ids, task_id, &agent, "interactive").await;
+
+    let row = wait_for_db(&pool, task_id, "failed", Duration::from_mins(1)).await;
+    drop(session);
+
+    assert_eq!(
+        row.get::<Option<String>, _>("failure_reason").as_deref(),
+        Some("provision_error"),
+        "an unsupported mode is a provisioning refusal, not an agent error"
+    );
+    let result: String = row.get::<Option<String>, _>("result").unwrap_or_default();
+    assert!(
+        result.contains("task_executor"),
+        "the refusal must name the per-agent setting that caused it, got: {result}"
+    );
+    let pane = format!("tmux_hangar-{task_id}");
+    assert!(
+        !tripwire_support::tmux_session_live(&pane),
+        "a refused interactive task must open no pane, found {pane}"
+    );
+    assert!(
+        row.get::<Option<String>, _>("work_dir").is_none(),
+        "the refusal must land before the worktree is provisioned"
+    );
+    assert_eq!(
+        acp_sessions_for(&pool, task_id).await,
+        0,
+        "and before any acp session"
+    );
+}
+
 // ------------------------------------------------------------------ helpers
+
+/// Record a per-agent executor override on an already-seeded agent (migration
+/// 0095), the way `ainb hangar agent create --executor` does at create time.
+async fn set_agent_executor(pool: &SqlitePool, agent_id: &str, executor: &str) {
+    let updated = sqlx::query("UPDATE agent SET task_executor = ? WHERE id = ?")
+        .bind(executor)
+        .bind(agent_id)
+        .execute(pool)
+        .await
+        .expect("set agent task_executor");
+    assert_eq!(
+        updated.rows_affected(),
+        1,
+        "the seeded agent {agent_id} must exist before its executor is pinned"
+    );
+}
 
 fn spawn_daemon(
     home: &Path,

--- a/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/snapshots.rs
@@ -1622,6 +1622,15 @@ pub struct AgentCreateParams {
     /// advertised default (`claude`). Recorded on the agent row.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// Optional task EXECUTOR (`process`/`acp`); absent = the daemon's own
+    /// `HANGAR_TASK_EXECUTOR` (migration 0095).
+    ///
+    /// The other half of `provider`, not a variant of it: `provider` names which
+    /// agent CLI does the work, this names whether that work runs as a provider
+    /// subprocess or as one turn on an ACP adapter. Append-only field: an old
+    /// client omits it, an old daemon ignores it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_executor: Option<String>,
     /// Optional free-form system prompt / instructions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
@@ -4499,6 +4508,7 @@ mod tests {
             workspace_id: Some("ws-1".into()),
             name: "reviewer".into(),
             provider: Some("codex".into()),
+            task_executor: Some("acp".into()),
             instructions: Some("be terse".into()),
             model: Some("gpt-5-codex".into()),
             token_budget: Some(250_000),
@@ -4514,6 +4524,9 @@ mod tests {
         assert_eq!(minimal.name, "claude");
         assert!(minimal.workspace_id.is_none());
         assert!(minimal.provider.is_none());
+        // Migration-0095's executor override: a payload written before it existed
+        // carries no key and still deserializes as "no override" (append-only).
+        assert!(minimal.task_executor.is_none());
         assert!(minimal.instructions.is_none());
         assert!(minimal.model.is_none());
         // Migration-0050 metadata: a PRE-0050 payload carries none of these keys

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0095_agent_task_executor.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0095_agent_task_executor.sql
@@ -1,0 +1,38 @@
+-- Hangar v1 schema, migration 0095: per-agent task EXECUTOR override (spine A8).
+--
+-- `HANGAR_TASK_EXECUTOR=acp|process` (A5) is daemon-wide: every task on the
+-- daemon takes the same executor. This column makes the choice per agent, so one
+-- agent runs its tasks over an ACP adapter while another spawns a provider CLI
+-- on the same daemon.
+--
+-- WHY NOT `agent.provider` (renovation PLAN.md open question 3). `provider`
+-- answers WHICH agent CLI runs the work, and three consumers depend on it being
+-- exactly one of `claude` / `codex` / `copilot`: the pull's `agent_kind`
+-- derivation (`pull.rs` PULL_SQL hard-codes that IN-list, and the value it
+-- writes is parsed by the closed `AgentKind` enum), `Backend::from_provider`
+-- (whose unknown-token branch silently resolves to Claude), and the daemon's
+-- `adapter_for`, which maps a provider ONTO its ACP adapter. Recording an
+-- adapter token in `provider` would therefore make a mis-set value
+-- indistinguishable from a correct one at all three, and it conflates two
+-- orthogonal questions — which CLI, and how it is run. They are separate
+-- columns because they are separate axes: `provider = codex` with
+-- `task_executor = acp` is a coherent request the single-column shape cannot
+-- express.
+--
+-- NULLABLE TEXT, no default and no backfill. NULL means "no per-agent override —
+-- take the daemon's `HANGAR_TASK_EXECUTOR`", so every pre-existing agent
+-- dispatches exactly as it does today. The recognised values are `process` and
+-- `acp`; the write paths (`hangar/agent_create`, `ainb hangar agent create`)
+-- reject anything else via `bootstrap::normalize_task_executor`, and the daemon
+-- treats an unrecognised stored value as "no override" with a warning rather
+-- than as a reason to strand the task.
+--
+-- Deliberately NOT a CHECK constraint: `agent.provider` (migration 0041) records
+-- its vocabulary the same way — validated at the write boundary, unconstrained
+-- in the schema — and adding a CHECK to an existing table means a full table
+-- rebuild in SQLite. Growth: one nullable TEXT column on a table with one row
+-- per agent (single digits on a real home), and `ALTER TABLE ADD COLUMN` with no
+-- default is metadata-only. No index: the value is read on the agent row that
+-- dispatch already selects by primary key, and is never itself a predicate.
+
+ALTER TABLE agent ADD COLUMN task_executor TEXT;

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -63,6 +63,20 @@ pub const DEFAULT_PROVIDER: &str = "claude";
 /// codex, a `copilot` agent runs copilot.
 pub const SUPPORTED_PROVIDERS: [&str; 3] = ["claude", "codex", "copilot"];
 
+/// The `agent.task_executor` value that spawns the provider CLI (spine A5's
+/// `HANGAR_TASK_EXECUTOR=process`).
+pub const TASK_EXECUTOR_PROCESS: &str = "process";
+/// The `agent.task_executor` value that prompts an ACP adapter (spine A5's
+/// `HANGAR_TASK_EXECUTOR=acp`).
+pub const TASK_EXECUTOR_ACP: &str = "acp";
+
+/// The task executors a per-agent override may name (migration 0095).
+///
+/// The SAME two tokens `HANGAR_TASK_EXECUTOR` accepts, defined once here so the
+/// daemon's env resolver, the daemon's per-agent resolver and the create paths
+/// that validate an operator's spelling cannot drift apart.
+pub const SUPPORTED_TASK_EXECUTORS: [&str; 2] = [TASK_EXECUTOR_PROCESS, TASK_EXECUTOR_ACP];
+
 /// `daemon_id` recorded for the self-registered host runtime. Keyed with
 /// `(workspace_id, daemon_id, provider)` for the runtime's unique index.
 const SELF_DAEMON_ID: &str = "ainb-hangar-daemon";
@@ -104,6 +118,36 @@ pub fn normalize_provider(provider: Option<&str>) -> Result<String, String> {
         Err(format!(
             "unsupported provider `{raw}` (expected one of {})",
             SUPPORTED_PROVIDERS.join(", ")
+        ))
+    }
+}
+
+/// Normalise + validate a caller-supplied task executor: trim, lower-case, and
+/// map an absent/empty value to `None` ("no override — inherit the daemon's
+/// `HANGAR_TASK_EXECUTOR`").
+///
+/// Unlike [`normalize_provider`] there is no default to substitute: the absence
+/// of an override is itself the meaning of a NULL column, and defaulting it to
+/// `process` here would pin every newly created agent to the process executor
+/// even on a daemon started with `HANGAR_TASK_EXECUTOR=acp`.
+///
+/// # Errors
+///
+/// Returns the offending value in an error message when it is not one of
+/// [`SUPPORTED_TASK_EXECUTORS`]. Rejected rather than ignored: a misspelled
+/// opt-in that silently records nothing is the failure mode the daemon's
+/// `HANGAR_TASK_EXECUTOR` warning exists to make diagnosable.
+pub fn normalize_task_executor(executor: Option<&str>) -> Result<Option<String>, String> {
+    let Some(raw) = executor.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let lowered = raw.to_ascii_lowercase();
+    if SUPPORTED_TASK_EXECUTORS.contains(&lowered.as_str()) {
+        Ok(Some(lowered))
+    } else {
+        Err(format!(
+            "unsupported task executor `{raw}` (expected one of {})",
+            SUPPORTED_TASK_EXECUTORS.join(", ")
         ))
     }
 }
@@ -459,6 +503,10 @@ pub struct AgentDraft {
     /// Provider token, already through [`normalize_provider`]. Empty = the
     /// [`DEFAULT_PROVIDER`].
     pub provider: String,
+    /// Task executor token, already through [`normalize_task_executor`]
+    /// (migration 0095). `None` = no per-agent override, so the agent's tasks
+    /// take the daemon's `HANGAR_TASK_EXECUTOR`.
+    pub task_executor: Option<String>,
     /// Free-form system prompt / instructions.
     pub instructions: Option<String>,
     /// Short blurb (multica 060). Trimmed here; the ≤255-char cap is validated by
@@ -563,6 +611,7 @@ pub async fn create_agent_from(
         thinking: None,
         agent_env: ainb_hangar_core::agent_env::AgentEnv::default(),
         provider: Some(provider),
+        task_executor: draft.task_executor,
         token_budget: None,
         description: draft.description.trim().to_string(),
         avatar_url: Some(avatar_url),

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -613,10 +613,21 @@ mod migration_tests {
         // (This assertion read `exists` for exactly as long as 0094 was the head
         // migration and deleting it left a genuinely pending tail; adding any
         // migration above it restores the original, and now stable, condition.)
+        //
+        // Read the DIRECTORY, never `pre-93.bak` by name: the snapshot is named
+        // `pre-{applied}` from `MAX(version)`, which this seed leaves at the head
+        // migration, so a named check for 93 is absent whether the gate fired or
+        // not and would go on passing forever.
+        let snapshots: Vec<String> = std::fs::read_dir(home.path())
+            .expect("read the hangar home")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with("hangar.db.pre-"))
+            .collect();
         assert!(
-            !home.path().join("hangar.db.pre-93.bak").exists(),
+            snapshots.is_empty(),
             "the head migration is still applied, so the numeric gate must see \
-             nothing pending and take no snapshot"
+             nothing pending and take no snapshot; found {snapshots:?}"
         );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -605,17 +605,18 @@ mod migration_tests {
         // Dropped by the repair, then rebuilt by the renumbered 0094 in the
         // same boot. Its absence would mean 94 never applied.
         assert!(index_exists(store.pool(), "idx_fleet_provider_event_retention").await);
-        // On main this asserted the ABSENCE of a snapshot: the gate is numeric,
-        // read MAX(version) = 93 against an embedded max of 93, saw nothing
-        // pending and took none — which is what proved the repair cannot depend
-        // on one. This tree carries 0094, so 94 IS genuinely pending and the
-        // gate fires for that ordinary reason, naming the file after the
-        // applied max. The original property is unchanged and still pinned, by
-        // `a_database_that_ran_the_unmerged_0093_still_upgrades`: it drives
-        // `apply_migrations` directly and never reaches the backup path at all.
+        // NO snapshot, and that absence is the point: it is what proves the
+        // repair cannot depend on one. The gate is numeric and compares MAX
+        // applied against the embedded max, while the seed unwinds only 93 and
+        // 94 — so the HEAD migration is still recorded, the two maxima are
+        // equal, and nothing looks pending even though 94 is about to re-apply.
+        // (This assertion read `exists` for exactly as long as 0094 was the head
+        // migration and deleting it left a genuinely pending tail; adding any
+        // migration above it restores the original, and now stable, condition.)
         assert!(
-            home.path().join("hangar.db.pre-93.bak").exists(),
-            "94 is pending, so the ordinary pre-upgrade snapshot must be taken"
+            !home.path().join("hangar.db.pre-93.bak").exists(),
+            "the head migration is still applied, so the numeric gate must see \
+             nothing pending and take no snapshot"
         );
     }
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -105,6 +105,19 @@ pub struct Agent {
     /// and the daemon spawns THIS provider's backend per task, so a `codex` agent
     /// runs codex.
     pub provider: Option<String>,
+    /// Optional per-agent task EXECUTOR override (`"process"`/`"acp"`, migration
+    /// 0095); `None` = fall back to the daemon's `HANGAR_TASK_EXECUTOR`.
+    ///
+    /// A DIFFERENT axis from [`provider`](Self::provider): `provider` names which
+    /// agent CLI does the work, this names how it is run — as a provider
+    /// subprocess, or as one turn on an ACP adapter. Both are needed, and both
+    /// are honoured at dispatch, so `provider = "codex"` with
+    /// `task_executor = "acp"` asks for codex over ACP.
+    ///
+    /// Free TEXT in the schema (as `provider` is): the create paths validate
+    /// against `bootstrap::SUPPORTED_TASK_EXECUTORS`, and the daemon reads an
+    /// unrecognised stored value as "no override" rather than stranding the task.
+    pub task_executor: Option<String>,
     /// Optional token budget (rtk/headroom) for this agent's runs; `None` =
     /// unlimited (migration 0042). Stored + surfaced only in this milestone —
     /// dispatch-time enforcement is a later feature.
@@ -164,6 +177,7 @@ impl Default for Agent {
             thinking: None,
             agent_env: AgentEnv::default(),
             provider: None,
+            task_executor: None,
             token_budget: None,
             description: String::new(),
             avatar_url: None,
@@ -326,9 +340,9 @@ impl AgentRepo {
             "INSERT INTO agent \
              (id, workspace_id, name, runtime_id, instructions, visibility, permission_mode, \
               owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, provider, \
-              token_budget, description, avatar_url, kind, system_key, service_tier, \
-              disabled_runtime_skills) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              task_executor, token_budget, description, avatar_url, kind, system_key, \
+              service_tier, disabled_runtime_skills) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&agent.id)
         .bind(&agent.workspace_id)
@@ -345,6 +359,7 @@ impl AgentRepo {
         .bind(&agent.thinking)
         .bind(agent.agent_env.to_db_json())
         .bind(&agent.provider)
+        .bind(&agent.task_executor)
         .bind(agent.token_budget)
         .bind(&agent.description)
         .bind(&agent.avatar_url)
@@ -923,8 +938,8 @@ fn is_foreign_key_violation(e: &sqlx::Error) -> bool {
 /// single constant keeps the read queries in lockstep with the `FromRow` impl.
 const SELECT_COLS: &str = "SELECT id, workspace_id, name, runtime_id, instructions, visibility, \
      permission_mode, owner_id, archived, model, cli_args, mcp_config, thinking, agent_env, \
-     provider, token_budget, description, avatar_url, kind, system_key, service_tier, \
-     disabled_runtime_skills, archived_at, archived_by FROM agent";
+     provider, task_executor, token_budget, description, avatar_url, kind, system_key, \
+     service_tier, disabled_runtime_skills, archived_at, archived_by FROM agent";
 
 /// Serialize a CLI-args list into the JSON-array text the `cli_args` column
 /// stores. An empty list yields `"[]"` (the column default).
@@ -1113,6 +1128,7 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Agent {
             thinking: row.try_get("thinking")?,
             agent_env: env_from_json(&row.try_get::<String, _>("agent_env")?)?,
             provider: row.try_get("provider")?,
+            task_executor: row.try_get("task_executor")?,
             token_budget: row.try_get("token_budget")?,
             description: row.try_get("description")?,
             avatar_url: row.try_get("avatar_url")?,

--- a/docs/hangar/renovation/PLAN.md
+++ b/docs/hangar/renovation/PLAN.md
@@ -82,7 +82,7 @@ the hook route for AskUserQuestion.
 | A5 | `acp_task::run_acp` + the flag: one new arm in `execute_claimed` (the shape `run_interactive` already has), per-task adapter process (sandbox, agent_env, permission mode are per process), leg poll bounded by `HANGAR_PROVIDER_MAX_RUNTIME_MS`, outcome mapping table, cancel arm | L | finalize path (success/failure/cancel, board advance, retry) untouched |
 | A6 | Unified durable read: `board_card_timeline` reads `fleet_provider_event` rows for ACP runs; PR URL captured from the transcript | M | |
 | A7 | Usage: `acp.usage` rows into `ProviderUsage` | S | |
-| A8 | Per-agent selection via `agent.provider` = adapter token; no migration | S | |
+| A8 | Per-agent selection via `agent.task_executor` (`process`/`acp`, migration 0095), NULL = the daemon flag; NOT an adapter token on `agent.provider` (open question 3, resolved below) | S | |
 
 Exit criterion, two halves: (A) a card run under each executor shows its transcript growing
 live with the same taxonomy; (B) the Boxtrack P3 leg reproduced with zero tmux: no
@@ -138,4 +138,14 @@ authoring (defects 16, 17).
 
 1. AskUserQuestion under ACP (A0). Owner: first task of track A.
 2. Adapter credential path: passthrough `CLAUDE_CODE_OAUTH_TOKEN` or let the adapter use the keychain? Prove on the first live smoke run, do not hard-wire.
-3. Whether `agent.provider` should carry the executor (A8) or a new column; decided after A5 ships.
+3. ~~Whether `agent.provider` should carry the executor (A8) or a new column; decided after A5 ships.~~
+   **Resolved in A8: a new column, `agent.task_executor` (migration 0095).** `agent.provider`
+   is a CLOSED provider-backend vocabulary with three consumers that assume it —
+   PULL_SQL hard-codes `IN ('claude','codex','copilot')` to derive `agent_kind`, which the
+   closed `AgentKind` enum then parses; `Backend::from_provider` resolves any unrecognised
+   token to Claude *silently*; and `acp_task::adapter_for` maps a provider ONTO its adapter,
+   so naming the adapter in `provider` inverts a mapping the ACP path already relies on.
+   An adapter token there would be indistinguishable from a mis-set one at all three. The
+   axes are also independent: `provider = codex` + `task_executor = acp` is a coherent
+   request the one-column shape cannot express. Cost paid: one nullable `ALTER TABLE ADD
+   COLUMN` (metadata-only, no backfill, NULL = today's behaviour).

--- a/docs/hangar/renovation/move1-acp-tasks.md
+++ b/docs/hangar/renovation/move1-acp-tasks.md
@@ -256,9 +256,9 @@ snapshot re-pull. Do not invert that.
 ### 2d. Executor selection
 
 ```
-┌────────────────┐  agent.provider ends in "-acp"?  ┌──────────────┐
+┌────────────────┐  agent.task_executor recognised? ┌──────────────┐
 │ resolve_dispatch│─────────── else ────────────────▶│ Executor     │
-│ run_loop:1160   │  HANGAR_TASK_EXECUTOR fallback   │ Process | Acp│
+│ run_loop        │  HANGAR_TASK_EXECUTOR fallback   │ Process | Acp│
 └────────────────┘                                   └──────┬───────┘
               ┌──────────────────────────────────────────────┴────────┐
    Process ───▼────────────────┐                     Acp ─────────────▼──────────┐
@@ -268,10 +268,21 @@ snapshot re-pull. Do not invert that.
    └───────────────────────────┘
 ```
 
-- **Per agent (durable):** reuse the existing `agent.provider` column
-  (`crates/ainb-hangar-store/src/repo/agent.rs:107`) with the values `claude-agent-acp` /
-  `codex-acp`, which are already the adapter registry tokens (`config.rs:11-13`).
-  **No migration.**
+- **Per agent (durable):** `agent.task_executor`, a nullable TEXT column carrying
+  `process` / `acp` (migration 0095). NULL means "no override", so every agent that
+  predates it dispatches exactly as before.
+
+  This REPLACES the original plan of reusing `agent.provider` with adapter tokens
+  (`claude-agent-acp` / `codex-acp`), which PLAN.md open question 3 left open until A5
+  shipped. Reading the consumers settled it: `agent.provider` is a closed
+  provider-backend vocabulary, not an open token space. `pull.rs` PULL_SQL hard-codes
+  `a.provider IN ('claude','codex','copilot')` to derive `agent_task_queue.agent_kind`,
+  and that value is parsed by the closed `AgentKind` enum, which has no adapter variant;
+  `Backend::from_provider` resolves ANY unrecognised token to Claude silently; and
+  `acp_task::adapter_for` maps a provider ONTO its adapter, so making the provider name
+  the adapter inverts a mapping the ACP path already depends on. The two are also
+  orthogonal: `provider = codex` with `task_executor = acp` is a coherent request the
+  single-column shape cannot express.
 - **Per task (resolved):** `ResolvedDispatch` gains `executor: Executor`
   (`run_loop.rs:2413-2436`), beside `mode`, for exactly the reason the doc comment there
   gives: it lives on the dispatch so the exec-path branch and the argv cannot disagree.
@@ -280,7 +291,9 @@ snapshot re-pull. Do not invert that.
   like `resolve_sandbox` (`run_loop.rs:278-284`) so precedence is testable without mutating
   process env. Unrecognised value falls back to `process` with a warning, matching the
   sandbox override's documented behaviour.
-- Precedence: agent > daemon default.
+- Precedence: agent > daemon default > `process`. An agent contributes an executor ONLY
+  when it names a recognised one — NULL, blank and a typo all inherit (the typo warns),
+  so no misconfiguration can strand a task.
 - A true per-task override that differs from its agent needs a column on
   `agent_task_queue`. **Deferred**, not designed around. Do NOT overload
   `agent_task_queue.mode` (`""|headless|interactive`, validated `rpc/mod.rs:9661-9669`):

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -5425,6 +5425,7 @@ Options:
       --format <format>              Output format [default: text] [possible values: text, json, csv, markdown]
       --name <NAME>                  The new agent's name
       --provider <PROVIDER>          Provider to record (`claude`/`codex`/`copilot`); defaults to `claude`
+      --executor <EXECUTOR>          Task executor to record (`process`/`acp`); omitted inherits the daemon's `HANGAR_TASK_EXECUTOR`
       --model <MODEL>                Optional per-agent model override (e.g. `sonnet`, `gpt-5-codex`)
       --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
       --description <DESCRIPTION>    Optional short blurb rendered beside the agent (≤255 characters)


### PR DESCRIPTION
Spine **A8**, the last step of track A: `HANGAR_TASK_EXECUTOR=acp|process` stops being daemon-wide. One agent can now run its tasks over an ACP adapter while another spawns a provider subprocess on the same daemon.

## Open question 3, decided: a new column, not `agent.provider`

PLAN.md left this open — *"whether `agent.provider` should carry the executor (A8) or a new column; decided after A5 ships"* — and the A8 row named the first option. **I took the second.** `agent.task_executor` (migration 0095, nullable TEXT, `process`/`acp`).

Reading every consumer of `agent.provider` settled it. It is a **closed provider-backend vocabulary**, not an open token space, and three things depend on that:

| consumer | what an adapter token in `provider` does |
|---|---|
| `pull.rs` `PULL_SQL` | hard-codes `a.provider IN ('claude','codex','copilot')` to derive `agent_task_queue.agent_kind`; an adapter token is filtered out and the `COALESCE` chain falls to the runtime's provider (itself IN-filtered), then the card's `agent_kind`, then the literal `'claude'` — so every run it stamps is mislabelled |
| `AgentKind::parse` | a CLOSED enum that has no adapter variant, so it returns `None` for an adapter token and the value PULL_SQL writes is unparseable. (Its variant set is *not* the IN-list's mirror — `Antigravity` is a variant the IN-list does not admit. That disagreement is pre-existing and out of scope here; it does not change the point, which is that neither vocabulary has room for an adapter name.) |
| `Backend::from_provider` | `_ => Self::Claude`. An unrecognised token resolves to Claude **silently**, so a mis-set value and a correct one are indistinguishable |

And `acp_task::adapter_for` maps a **provider onto its adapter** — putting the adapter in `provider` inverts a mapping the ACP path already depends on. The axes are independent besides: `provider = codex` with `task_executor = acp` is a coherent request one column cannot express, and it is exactly what enabling `codex-acp` will need.

Cost paid: one `ALTER TABLE agent ADD COLUMN task_executor TEXT` — metadata-only in SQLite, no default, no backfill, no index, NULL = today's behaviour. That is cheaper than widening a vocabulary three consumers assume is closed.

## Precedence

Pure function, no process env, so the whole matrix is testable: `DaemonDefaultExecutor::for_agent` (`ainb-tui/crates/ainb-hangar-daemon/src/task_executor.rs`).

| `agent.task_executor` | daemon `HANGAR_TASK_EXECUTOR` | executor | note |
|---|---|---|---|
| `acp` (any case, any padding) | anything | **acp** | agent wins |
| `process` (any case, any padding) | anything | **process** | agent wins, including opting OUT of an `acp` daemon |
| NULL | `acp` | **acp** | inherits |
| NULL | unset / `process` / garbage | **process** | inherits — unchanged from today |
| `""` / whitespace | anything | **the daemon default** | blank is not a selection |
| unrecognised (`acpp`, `tmux`, …) | anything | **the daemon default**, with a warning | a typo must not strand an agent |

**An agent contributes an executor only when it NAMES a recognised one.** NULL, blank and a typo are one case: inherit. So an agent created before 0095 dispatches exactly where it dispatched before — proven on a live daemon, not by inspection (`a_per_agent_acp_override_runs_beside_an_inheriting_agent` runs the inheriting agent beside the overriding one on the same daemon and asserts it still writes `logs/claude.jsonl` and pins the provider's own `session_id`).

The write paths (`ainb hangar agent create --executor`, `hangar/agent_create`) reject an unrecognised token outright, so the tolerant read is a backstop for a hand-edited row, not the operator's error channel.

## The interactive-plus-acp refusal, per agent

Still refused at dispatch, never downgraded, still before the worktree and before the row leaves `dispatched`. It reads `dispatch.executor`, so it follows the agent in both directions:

- agent selected `acp`, daemon default `process` → **refused** (`provision_error`, no pane, no `work_dir`, no ACP session)
- agent pinned `process`, daemon default `acp` → **not refused**, the operator keeps their attachable session

Both are asserted. The message now names both selectors (`this agent's task_executor, or ... HANGAR_TASK_EXECUTOR=acp`) and keeps the `HANGAR_TASK_EXECUTOR` substring A5's tripwire asserts.

## Making the wrong thing impossible

`execute_claimed` has three branches that spawn or cancel work off the executor. With per-agent selection the daemon default and the task's executor differ *per task*, and a bare `TaskExecutor` parameter made `daemon_default == TaskExecutor::Acp` compile and read plausibly at every one of them. It now takes a `DaemonDefaultExecutor` whose field is private **to another module**. Probed rather than asserted:

```
error[E0308]: mismatched types
1290 |     let _probe_compare = daemon_default == TaskExecutor::Acp;
     |            expected `DaemonDefaultExecutor`, found `TaskExecutor`
error[E0616]: field `0` of struct `DaemonDefaultExecutor` is private
1291 |     let _probe_field = daemon_default.0;
```

## One behaviour change beyond selection: the acp turn deadline

**This is the part to look at hardest.** A5 raised the WHOLE pool's turn deadline to the task budget at boot whenever `HANGAR_TASK_EXECUTOR=acp`, because the pool's sweep exempted no scope and would otherwise cut a 2.5 h task at 30 minutes. A8 breaks that trigger: the executor is now chosen per task from a row that can be written after boot, so the flag no longer says whether task turns ride this pool — an agent that selected `acp` on a `process` daemon would have died silently at 30 minutes.

Fixed by exempting `task:` scopes from `AcpPool::sweep_once` instead of raising a global floor. Nothing is unbounded: `acp_task::await_leg` already polls to `HANGAR_PROVIDER_MAX_RUNTIME_MS`, cancels the turn and writes the same `(UNKNOWN, turn_deadline)` pair the sweep would have — A5's own doc calls the two routes identical. The boot raise, `acp_turn_budget` and `reconcile_turn_deadline` go with it (~66 lines deleted), so **chat keeps the deadline its operator configured** rather than paying for a task-path problem, which is a strict improvement over A5's accepted trade-off.

The alternative I rejected: make `acp_turn_budget()` unconditional. Three lines, no pool change — but it widens every daemon's chat wedge window from 30 min to 2.5 h, including daemons that never set a per-agent executor.

A5's e2e that pinned the raise now pins the exemption: same 2 s pool deadline, same 1 s sweep cadence, same ~4 s turn; the sweep must pass over the task scope rather than be lifted above it.

### Re-arguing it against A5's review

A5's reconciler was decided by a second reviewer on the grounds that **a single global deadline cannot disagree with itself, while a per-session map can**, and it shipped with a boot warning. That reasoning is right and this change does not violate it.

**This is not a per-session map.** No second deadline value is introduced and nothing is stored per session. There are still exactly two numbers in the system, and after this change they no longer apply to the same session:

| bound | value | applies to | enforced by |
|---|---|---|---|
| pool turn deadline | `AINB_ACP_TURN_DEADLINE_MS`, 30 min default | chat scopes | `AcpPool::sweep_once` |
| task runtime budget | `HANGAR_PROVIDER_MAX_RUNTIME_MS`, 2.5 h default | `task:` scopes | `acp_task::await_leg` |

The disagreement the reviewer was guarding against is precisely what A5 shipped: **both** bounds applied to a task session, which is why a `max()` reconciler had to exist to stop them contradicting each other. Removing the overlap removes the thing being reconciled. One bound per scope, no arbitration, nothing to drift.

The two other properties of that review survive:

- **Nothing silent.** The boot warning existed because the raise *changed a deadline the operator configured* — chat's — as a side effect of a task flag. There is no longer a raise, so chat's configured value is simply honoured and there is nothing to warn about. The `if acp_config.turn_deadline > configured_deadline` branch could never fire again.
- **A task turn is still bounded, by the same taxonomy.** `await_leg` cancels with `ConvergeCause::TurnDeadline` and returns the same `(UNKNOWN, DELIVERY_TURN_DEADLINE)` pair the sweep writes — A5's own doc comment says both routes "map identically". A daemon that dies mid-turn is covered where it always was, by boot convergence (`list_dirty` selects any session with an open turn), not by a sweep that cannot run in a dead process.

What would falsify this: an ACP task path that reaches an open turn **without** going through `await_leg`. There is one entry point (`run_acp`), it always awaits the leg, and `AdapterLease::drop` tears the session down on every other exit including a mid-poll cancel. If a second entry point is ever added, the exemption becomes wrong and the sweep has to come back.

### The guard the exemption requires

Exempting `task:` scopes removes a cap that was, incidentally, the only bound on a prompt *injected* into a task's session from outside. `fleet/message_send` and `fleet/action` can both name any live session by key, a task's key is deliberately discoverable (`TaskRepo::set_session_id` records it for transcript viewing), and neither door checked the scope. Before the exemption that injected turn was capped by the pool deadline — generous but bounded. After it, it is bounded only by whenever the run's `AdapterLease::drop` teardown happens to converge the session, on a detached `tokio::spawn` with no ordering against the actor picking the prompt up first.

Closed at `AcpPool::submit_prompt` rather than at each door: that function already reads the session row, so the scope costs no extra query, and it is the single choke point every prompt to an existing session passes through — a door added later is refused **by default** rather than by remembering. The task executor prompts its own session through `submit_task_prompt`, named apart so the exemption is one deliberate call site instead of a flag every chat door could pass by accident. Same `TASK_SCOPE_PREFIX` constant and same `trim_start` shape as `fleet/acp_session_create`, so neither door can be the lenient one.

`task_scope_refused` joins `DeliveryToken`, which forces `acp_task::outcome_for_token`'s exhaustive match to decide what it means for a run: terminal `ProvisionError`, alongside `session_gone`.

The chain was then enumerated mechanically rather than argued, and it is the strongest statement available about this seam:

```
set_open_turn  <- record_turn  <- start_turn_inner  <- start_turn
  <- actor loop self.prompts.recv()  <- PromptJob constructed at ONE site
  <- inside submit()  <- THE GUARD
```

`set_open_turn` has exactly one caller, `PromptJob` is constructed at exactly one site, and the `Sender<PromptJob>` is cloned out of the sessions map four lines below the guard. Every other `.prompts` reference is the receiver or capacity telemetry, and the one `try_recv` is the convergence drain, which consumes and never opens. **A turn on any scope requires a `PromptJob`, a `PromptJob` requires `submit`, and `submit` is the guard.** No third door.

Two things stop mattering as a result: the `state != "DEAD"` filter, because the guard sits below it, so there is no state a task session can be in that admits a chat prompt; and the session's `send_prompt: true` capability stamp, because the action is now attempted and cleanly rejected rather than silently allowed — safety moved off a UI affordance and onto the choke point.

Both halves of the new test were shown able to fail: making the guard inert reds the refusal half (`left: Queued`), and making the task path non-exempt reds the delivery half (`left: Rejected("task_scope_refused")`) — so a guard that simply refused everything would not pass.

If the reviewer still prefers the global floor, the smallest way back is `acp_turn_budget()` returning `Some(provider_max_runtime_from_env())` unconditionally — three lines, correct for tasks, at the cost of every daemon's chat wedge window going 30 min → 2.5 h whether or not any agent ever selects `acp`. I did not take it for that reason, but it is a one-commit revert if you disagree.

## Changes

| file | what |
|---|---|
| `migrations/0095_agent_task_executor.sql` | the column, with the open-question-3 reasoning in the migration |
| `store/src/bootstrap.rs` | `TASK_EXECUTOR_{PROCESS,ACP}`, `SUPPORTED_TASK_EXECUTORS`, `normalize_task_executor`, `AgentDraft.task_executor` |
| `store/src/repo/agent.rs` | `Agent.task_executor` + insert / `SELECT_COLS` / `from_row` |
| `store/src/lib.rs` | the 0093-repair test's backup assertion returns to ABSENCE (see below) |
| `daemon/src/task_executor.rs` | **new**: the axis, the daemon default newtype, one parser, the precedence, the matrix |
| `daemon/src/run_loop.rs` | resolve per agent in `resolve_dispatch`; `execute_claimed` takes the newtype; refusal message; deletes the boot budget helpers |
| `daemon/src/acp_pool.rs` | `sweep_once` exempts `task:` scopes |
| `daemon/src/lib.rs` | boot no longer raises the pool deadline |
| `daemon/src/rpc/mod.rs`, `proto/snapshots.rs` | `task_executor` on `hangar/agent_create` |
| `core/src/cli/hangar/mod.rs`, `docs/tui/cli.md` | `agent create --executor`, reference regenerated by `gen-cli-reference.sh` |
| `docs/hangar/renovation/{PLAN,move1-acp-tasks}.md` | the decision recorded where the superseded design lived |

Authoring is **create-time only**, matching `--provider`: neither `agent edit` nor `hangar/agent_update` carries a provider today, so the executor follows the same shape rather than inventing a second convention. The plugin's agent wizard is not touched (track B owns that surface, and its provider list is a separate hard-coded constant).

`store/src/lib.rs`: `the_daemon_boot_path_repairs_the_unmerged_0093` asserted a `hangar.db.pre-93.bak` snapshot EXISTS. Its seed unwinds versions 93 and 94 only, so that held for exactly as long as 0094 was the head migration; with anything above it the head stays applied, the numeric gate sees nothing pending, and no snapshot is taken. That is the ORIGINAL assertion (`!exists`) and the original point — the repair cannot depend on a backup — and it is now the stable one.

## Workspace grep

- `not supported under` (the old refusal phrasing) → **0 hits** repo-wide.
- `acp_turn_budget` / `reconcile_turn_deadline` / `raised the acp turn deadline` → **0 hits** repo-wide.
- `HANGAR_TASK_EXECUTOR` asserted as a STRING in a test → one site, `tripwire_task_executor_flag.rs:191`; the new message still contains it, and that test passes unmodified.
- `AgentCreateParams` / `AgentDraft` / `Agent` struct literals → found via `cargo check --workspace --all-targets`, not by reading: one hit (`proto/snapshots.rs` round-trip fixture), fixed, and the minimal-payload half now pins that a pre-0095 payload still deserializes.

## Test evidence

Every run below: `cargo build -p ainb-acp --bin fake_acp_adapter` → `cargo test … --no-run` → hash → run → hash. **Daemon binary `b1a2bb21…` before and after the tripwire run, unmoved**, and it provably carries this branch's code (`strings target/debug/ainb-hangar-daemon | rg -c "unknown agent.task_executor"` → `1`). Harness provenance after `touch crates/ainb-hangar-daemon/src/lib.rs`: `--list` shows `a_per_agent_acp_override_runs_beside_an_inheriting_agent`, `a_per_agent_process_override_opts_out_of_an_acp_daemon`, `interactive_is_refused_for_an_agent_that_selected_acp`.

```
tripwire_task_executor_flag                7 passed; 0 failed
tripwire_acp_task_end_to_end               5 passed; 0 failed
cargo test -p ainb-hangar-daemon --lib   630 passed; 0 failed; 1 ignored
cargo test -p ainb-hangar-store --lib    318 passed; 0 failed
rpc_agent_metadata / rpc_agent_crud       6 + 6 passed
store: tripwire_migrations_apply, migration_upgrade_full_chain, migration_backup,
       repo_agent, repo_agent_env_redaction, schema_drift, pull_role_gate
                                          5+4+27+9+4+3+26 passed; 0 failed
cargo check --workspace --all-targets     clean
cargo fmt --all --check                   clean
cargo clippy -p ainb-hangar-daemon -p ainb-acp --lib
  -- -D clippy::await_holding_invalid_type   clean
```

**Both new guards were shown able to fail**, not merely to pass:

- Reverting the dispatch to ignore the agent (`for_agent(None)`) turns the three new tripwires RED and leaves A5's four green — the discrimination is real, not incidental.
- Making the agent's value stop winning fails the matrix test; dropping `process` from the parser fails the vocabulary-coverage test. That second guard compares SETS built from `TaskExecutor::ALL` and the store's `SUPPORTED_TASK_EXECUTORS`, so a variant with no token and a token with no variant both fail it. No counts, no lower bounds.

**Ran the thing** — the real `target/debug/ainb` against a scratch home:

```
$ ainb hangar agent create --name acp-agent --executor acp     → created agent acp-agent      (exit 0)
$ ainb hangar agent create --name plain-agent                  → created agent plain-agent    (exit 0)
$ ainb hangar agent create --name broken-agent --executor acpp
Error: unsupported task executor `acpp` (expected one of process, acp)                        (exit 1)

sqlite> SELECT name, provider, task_executor FROM agent;
acp-agent  |claude|acp
plain-agent|claude|<NULL>
```

## Not in scope

- The plugin's agent-create wizard (a 4th step + snapshot churn; track B's surface).
- `agent edit` / `hangar/agent_update` — provider has no update path either.
- `codex-acp`: `adapter_for` still refuses every non-Claude backend. Its blocker is unchanged and named where it lives — the adapter scopes `CLAUDE_CONFIG_DIR` and nothing else, so a codex task would read the operator's `~/.codex`. `provider = codex` + `task_executor = acp` is now *expressible*, and is refused with a clear `ProvisionError` rather than silently served by the wrong adapter.
- A per-TASK override differing from its agent (needs a column on `agent_task_queue`) — deferred by move 1's design and still deferred.

Known-unrelated CI reds on this run (#844): `capture_failed_launch_pane_reads_a_dead_pane`, `acp_pool::two_concurrent_arrivals_never_overshoot_the_session_cap`, `rpc_acp::two_parked_permissions_are_both_answerable_over_the_wire`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose a task executor per agent: `process` or `acp`.
  * Added the `--executor` option to agent creation and support in the agent creation API.
  * Agent-specific settings take precedence over the daemon default; unset settings inherit the configured default.
* **Bug Fixes**
  * ACP task executions are no longer interrupted by chat-session deadline sweeps.
  * Chat prompts cannot be sent to task-scoped sessions.
  * Invalid executor values are rejected with a clear validation error.
* **Documentation**
  * Updated CLI and task-executor configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


