### PR TITLE
fix(disk-cleaner): close fourteen holes, three of them destructive

### DIFF
--- a/.claude/skills/disk-space-cleaner/SKILL.md
+++ b/.claude/skills/disk-space-cleaner/SKILL.md
@@ -2,13 +2,14 @@
 name: disk-space-cleaner
 description: |
   Reclaim disk by deleting regenerable build and dependency directories
-  (target, node_modules, .next, dist, build, .gradle, .turbo, .venv), biggest
-  first, skipping any whose owning directory shows a live process. Dry-run by
-  default. Only the build directory is ever removed, never the worktree or repo
-  containing it. Use when disk is low, when `df` shows the volume near full, or
-  when the user says "clean disk", "free up space", "disk-space-cleaner", or
-  "what's eating my disk".
-version: "0.2.0"
+  (target, node_modules, .next, build, .turbo, .venv), biggest first, skipping
+  any whose owning directory shows a live process, a live tmux session, or a
+  git worktree lock. Dry-run by default, and the dry-run runs every check the
+  apply does. Only the build directory is ever removed, never the worktree or
+  repo containing it. Use when disk is low, when `df` shows the volume near
+  full, or when the user says "clean disk", "free up space",
+  "disk-space-cleaner", or "what's eating my disk".
+version: "0.3.0"
 user-invocable: true
 ---
 
@@ -17,22 +18,29 @@ user-invocable: true
 Free disk by deleting only **regenerable** build and dependency directories.
 Never touches source, never removes a worktree.
 
-## The two rules
+## The three rules
 
 **1. Only the build directory, never its parent.** Clearing a worktree's
 `target/` must leave the worktree itself, with all its source and any
-uncommitted work, exactly where it was. The script verifies the owning
-directory still exists after each deletion rather than assuming it.
+uncommitted work, exactly where it was. The script asserts this **before** the
+`rm`: the candidate must still be a directory, must live under its scan root,
+and its basename must be one of the target names. A check that runs after the
+deletion cannot prevent anything.
 
-**2. Decide by liveness, not by age.** This is the correction that matters. A
-`target/` rebuilt an hour ago by a session that has since finished is safe to
-clear. One untouched for a month can belong to a session running right now.
-mtime cannot tell those apart, so it is not used as a safety signal at all.
+**2. Decide by liveness, not by age.** A `target/` rebuilt an hour ago by a
+session that has since finished is safe to clear. One untouched for a month can
+belong to a session running right now. mtime cannot tell those apart, so it is
+not used as a safety signal at all.
 
 An age gate looks prudent and is actively misleading: on a busy machine every
 large build directory is recently touched, so an age-gated sweep skips exactly
 the directories worth reclaiming while offering no protection to the ones in
 use.
+
+**3. Fail closed.** A signal that could not be collected is not the same as a
+signal that came back empty. If `ps`, `tmux`, `lsof` or `git` is missing or
+unreadable, `--apply` refuses and reports `held (liveness incomplete)` rather
+than deleting blind. `--ignore-live` overrides, deliberately and loudly.
 
 ## Step 1: see where the space went
 
@@ -59,10 +67,16 @@ scripts/clean.sh ~/some/dir --apply
 ```
 
 Flags: `--min-size MB` (default 500), `--names a,b,c`, `--max-depth N`,
-`--top N`, `--apply`, `--ignore-live`.
+`--top N`, `--apply`, `--no-protect-locked`, `--ignore-live`.
 
-Output marks each candidate `would rm` / `rm`, or `skip` with the reason it is
-considered in use.
+Output marks each candidate `would rm` / `rm`, `skip` with the reason it is
+considered in use, `hold` when liveness could not be established, or `REFUSED`
+when the pre-flight assertion rejected the path.
+
+Exit status is `1` if any deletion failed or any candidate was held, `0`
+otherwise. A partially-deleted tree counts as a failure: `rm -rf` can remove
+part of a directory and then error, and a caller checking `$?` must not read
+that as a clean run.
 
 ## How "in use" is decided
 
@@ -70,22 +84,46 @@ A candidate is skipped if any of these hold for its owning directory:
 
 | signal | why it matters |
 |---|---|
-| a `cargo` or `rustc` process has the path in its command line | a build is running; clearing `target/` breaks it mid-compile |
-| a tmux session name contains a path component below the scan root | an agent session is live in that worktree |
-| any process has its cwd inside the directory | something is working there |
+| the owner sits under a git worktree marked `locked` | an explicit human "do not touch" that outlives the session which set it |
+| a build process has the owner's path, or the candidate's own path, in its command line | a build is running; clearing `target/` breaks it mid-compile |
+| a tmux session name contains a path component of the owner | an agent session is live in that worktree |
+| any process has its cwd inside the owner | something is working there |
 
-Only components **below the scan root** are used for the tmux test. Components
-at or above it (a username, `worktrees`, the repo name shared by every
-worktree) appear in unrelated session names and would mark everything as in
-use.
+Build processes matched: `cargo`, `rustc`, `node`, `npm`, `pnpm`, `yarn`,
+`next`, `vite`, `webpack`, `tsc`, `esbuild`, `turbo`, `gradle`, `java`,
+`python`, `pip`, `uv`, `go build`, `go run`. The default target names are not
+all Rust, so a Rust-only pattern left every other build undetectable.
 
-`lsof -d cwd` is only collected when `--apply` is passed, because it is slow on
-a near-full disk and a dry-run does not need it to be authoritative.
+Both the owner path and the candidate path are matched, because they catch
+different invocations. `cd <worktree> && cargo build` has no path in its own
+argv at all; the `rustc` calls underneath it carry
+`--out-dir .../target/debug/deps`, which names the candidate rather than the
+owner.
 
-## Two traps this script had to be fixed for
+For the tmux test, components **below the scan root** are used. Components at
+or above it (a username, `worktrees`, the repo name shared by every worktree)
+appear in unrelated session names and would mark everything as in use. When the
+owner *is* the scan root, which is what `clean.sh <worktree>` and the default
+`.` produce, there are no components below it, so the root's own basename is
+used instead: the operator named that directory explicitly.
 
-Both were found by dry-running against real worktrees and checking the verdicts
-against reality. Keep them in mind if you edit the liveness logic.
+Components shorter than **3 characters** are ignored, since one or two
+characters match almost any session name by accident. Real worktree names like
+`api`, `web`, `ainb` and `hangar` are therefore covered.
+
+Every check runs in dry-run and under `--apply` alike, `lsof` included. A
+preview produced with one of the guards switched off is not a preview of
+anything.
+
+Under `--apply` the `ps` and `tmux` pictures are re-read immediately before each
+deletion. Sizing dozens of multi-GB trees takes minutes, and a build started
+inside that window is invisible to a snapshot taken before it. `lsof` is not
+re-read: it is the slow one, and per-candidate reruns would cost more than the
+sweep saves.
+
+## Three traps this script had to be fixed for
+
+Keep them in mind if you edit the liveness logic.
 
 **`ps` shows the checker.** A probe whose own command line contains both
 `cargo` and a worktree path matches itself, reporting a live build that does not
@@ -98,6 +136,13 @@ measure yourself.
 upstream process in the pipeline takes SIGPIPE, and with `pipefail` set the
 whole pipeline reports failure, so the check silently never fires. Use counting
 greps (`grep -c`, test `-gt 0`) in any pipeline whose result gates a deletion.
+
+**A delimited text record splits on the data.** Candidates were once written to
+a temp file as `kb<TAB>dir<TAB>root` and read back with `IFS=$'\t' read`. A path
+containing a TAB or a newline field-split on the way back in, `dir` became a
+truncated prefix, and the `rm -rf` ran against the source directory while the
+real build directory survived. Reproduced, confirmed. Paths now live in bash
+arrays and only the sort keys, two integers, ever round-trip through text.
 
 ## Step 3: extras, ask first
 
@@ -120,14 +165,21 @@ Desktop's own disk-space tooling.
 
 ## Safety notes
 
+- **`dist` and `.gradle` are not default targets.** `dist/` is routinely a
+  deployed artifact directory with no source, no package.json and nothing local
+  able to rebuild it; `~/.gradle` is a tool home holding `jdks/`, `native/` and
+  the daemon registry rather than project output. Both are still available
+  through `--names` when you know your layout.
 - A `build/` directory is usually generated but can occasionally be
   source-controlled. Review the dry-run list; drop it from `--names` if a
   project keeps source there.
 - `.venv` is in the default names because Python virtualenvs are large and
   regenerable, but recreating one is slower than a rebuild. Drop it from
   `--names` if that trade is wrong for you.
-- Everything this skill deletes is rebuilt by `cargo build`,
-  `npm/pnpm/yarn install`, or the next build. No permanent loss.
+- **Most of what this deletes is rebuilt by the next build, but not all of it,
+  and the script cannot tell which is which.** It matches directory names, not
+  provenance. Read the dry-run list before applying, and treat any hit outside
+  a project you recognise as suspect.
 - **Uncommitted work is not protected by anything here.** The script preserves
   it by never touching the worktree, but if a worktree holds uncommitted changes
   the real protection is committing them.

--- a/.claude/skills/disk-space-cleaner/SKILL.md
+++ b/.claude/skills/disk-space-cleaner/SKILL.md
@@ -40,7 +40,12 @@ use.
 **3. Fail closed.** A signal that could not be collected is not the same as a
 signal that came back empty. If `ps`, `tmux`, `lsof` or `git` is missing or
 unreadable, `--apply` refuses and reports `held (liveness incomplete)` rather
-than deleting blind. `--ignore-live` overrides, deliberately and loudly.
+than deleting blind. This is re-evaluated after every re-read, not decided once
+at startup: a `ps` that succeeds before the sizing pass and fails during it must
+stop the run, not ride the verdict it had before. An installed tool that exits
+with an error counts as unreadable; only the exit status that genuinely means
+"nothing found" is treated as an empty answer. `--ignore-live` overrides,
+deliberately and loudly.
 
 ## Step 1: see where the space went
 
@@ -70,13 +75,25 @@ Flags: `--min-size MB` (default 500), `--names a,b,c`, `--max-depth N`,
 `--top N`, `--apply`, `--no-protect-locked`, `--ignore-live`.
 
 Output marks each candidate `would rm` / `rm`, `skip` with the reason it is
-considered in use, `hold` when liveness could not be established, or `REFUSED`
-when the pre-flight assertion rejected the path.
+considered in use, `hold` when liveness could not be established, `gone` when
+the directory disappeared before the delete, or `REFUSED` when the pre-flight
+assertion rejected the path.
 
-Exit status is `1` if any deletion failed or any candidate was held, `0`
-otherwise. A partially-deleted tree counts as a failure: `rm -rf` can remove
-part of a directory and then error, and a caller checking `$?` must not read
-that as a clean run.
+Exit status is `1` if any deletion failed, any candidate was refused, or any
+candidate was held; `2` for a bad argument; `0` otherwise. A partially-deleted
+tree counts as a failure: `rm -rf` can remove part of a directory and then
+error, and a caller checking `$?` must not read that as a clean run. A directory
+that simply vanished is *not* a failure — another cleaner or a `cargo clean`
+got there first, and the outcome is the one that was wanted.
+
+The pre-flight refuses a path that is not under its scan root, whose basename
+does not match the target names, or that is a **mountpoint** — another
+filesystem borrowing the path, whose contents `rm -rf` would happily descend
+into and destroy.
+
+Counts are validated: `--top one` used to make the cap test print "integer
+expression expected", evaluate false, and delete everything. Bad numbers now
+exit 2.
 
 ## How "in use" is decided
 
@@ -84,10 +101,22 @@ A candidate is skipped if any of these hold for its owning directory:
 
 | signal | why it matters |
 |---|---|
-| the owner sits under a git worktree marked `locked` | an explicit human "do not touch" that outlives the session which set it |
+| the owner is, or sits under, a git worktree marked `locked` | an explicit human "do not touch" that outlives the session which set it |
 | a build process has the owner's path, or the candidate's own path, in its command line | a build is running; clearing `target/` breaks it mid-compile |
-| a tmux session name contains a path component of the owner | an agent session is live in that worktree |
+| a tmux **session name** contains a path component of the owner | an agent session is live in that worktree |
 | any process has its cwd inside the owner | something is working there |
+
+The lock is asked of the **candidate's own directory**, by looking for a
+`locked` file in its gitdir. Enumerating from the scan roots instead meant
+`git -C <worktrees parent> worktree list` exited 128 with "not a git
+repository" for the canonical sweep-the-parent invocation, and the protection
+was silently off in exactly the case it exists for. Reading the gitdir also
+avoids parsing `worktree list --porcelain`, whose path field is
+whitespace-delimited and truncated any locked worktree whose path contained a
+space.
+
+A lock is a human decision, not a liveness signal, so **`--ignore-live` does not
+lift it**. Only `--no-protect-locked` does.
 
 Build processes matched: `cargo`, `rustc`, `node`, `npm`, `pnpm`, `yarn`,
 `next`, `vite`, `webpack`, `tsc`, `esbuild`, `turbo`, `gradle`, `java`,
@@ -111,17 +140,29 @@ Components shorter than **3 characters** are ignored, since one or two
 characters match almost any session name by accident. Real worktree names like
 `api`, `web`, `ainb` and `hangar` are therefore covered.
 
-Every check runs in dry-run and under `--apply` alike, `lsof` included. A
-preview produced with one of the guards switched off is not a preview of
-anything.
+Every check runs in dry-run and under `--apply` alike, `lsof` and the rule-1
+pre-flight included. A preview produced with one of the guards switched off is
+not a preview of anything, and a preview that lists a path the apply will refuse
+is worse than none.
+
+Paths are matched in several spellings, because the processes being searched for
+do not use ours. The canonical physical path, the logical path (macOS `/tmp` is a
+symlink to `/private/tmp`, so a live `node /tmp/wt/server.js` contains no
+`/private/tmp/wt`), and the spelling the operator typed on the command line are
+all tested.
 
 Under `--apply` the `ps` and `tmux` pictures are re-read immediately before each
 deletion. Sizing dozens of multi-GB trees takes minutes, and a build started
-inside that window is invisible to a snapshot taken before it. `lsof` is not
-re-read: it is the slow one, and per-candidate reruns would cost more than the
-sweep saves.
+inside that window is invisible to a snapshot taken before it.
 
-## Three traps this script had to be fixed for
+**Known limit:** `lsof` is *not* re-read per candidate. It is the slow one, and
+per-candidate reruns would cost more than the sweep saves, so a shell that `cd`s
+into a worktree during the sizing pass is not detected unless it also shows up
+in `ps` or tmux. **Known limit:** the mountpoint check compares device ids, so
+it catches a genuinely separate volume but not an APFS firmlink, which shares
+one.
+
+## Traps this script had to be fixed for
 
 Keep them in mind if you edit the liveness logic.
 
@@ -143,6 +184,20 @@ containing a TAB or a newline field-split on the way back in, `dir` became a
 truncated prefix, and the `rm -rf` ran against the source directory while the
 real build directory survived. Reproduced, confirmed. Paths now live in bash
 arrays and only the sort keys, two integers, ever round-trip through text.
+
+The same class bit twice more, so treat any path-carrying text channel as
+hostile. `git worktree list --porcelain` is whitespace-delimited, so an awk
+field-split truncated locked worktrees whose path contained a space; the lock is
+now read from the gitdir with nothing to parse. And `du -sk` echoes the path it
+sized, so a path with a newline made its output span lines and `cut -f1`
+returned a multi-line "size" that then rode the integer-only sort channel and
+could order a 1 KiB candidate ahead of a 10 GiB one. Sizes are validated as
+plain integers before they are trusted.
+
+**A fixed-string exclusion is a fail-open filter.** The process snapshot drops
+this script's own subshells, and matching the bare string `clean.sh` also
+dropped any unrelated live build whose command line happened to contain it, on
+the one signal that matters most. It matches the script's absolute path now.
 
 ## Step 3: extras, ask first
 

--- a/.claude/skills/disk-space-cleaner/scripts/clean.sh
+++ b/.claude/skills/disk-space-cleaner/scripts/clean.sh
@@ -10,13 +10,17 @@
 #      node_modules/ is. Checked BEFORE the rm, not after: a check that runs
 #      after the deletion cannot prevent anything, and if the path was already
 #      corrupted the check derives from the same corrupted value and passes.
+#      The same check runs in dry-run, so the preview cannot offer a path the
+#      apply would refuse.
 #   2. Decide by LIVENESS, not by age. A target rebuilt an hour ago by a session
 #      that has since finished is safe to clear; one untouched for a month can
 #      belong to a session that is running right now. mtime cannot tell those
 #      apart, so it is not used as a safety signal.
 #   3. Fail CLOSED. A liveness signal that could not be collected is not the
 #      same as a signal that came back empty. If ps, tmux or lsof is missing or
-#      unreadable, deletions are refused rather than performed blind.
+#      unreadable, deletions are refused rather than performed blind. This is
+#      re-evaluated after every re-read, not decided once at startup: a signal
+#      that dies mid-run must stop the run, not ride the verdict it had before.
 set -uo pipefail
 
 # ---- defaults ----
@@ -55,10 +59,11 @@ Options:
   --names a,b,c       Directory names to target
                       (default: target,node_modules,.next,build,.turbo,.venv).
   --max-depth N       How deep to search (default: 8).
-  --top N             Only act on the N largest ACTIONABLE candidates. Ones
-                      skipped as in use do not consume a slot.
+  --top N             Only report on the N largest candidates.
   --apply             Actually delete. Without this, only prints.
-  --no-protect-locked Do NOT skip git worktrees marked `locked` (not recommended).
+  --no-protect-locked Do NOT skip git worktrees marked `locked`. This is the
+                      ONLY flag that lifts that protection; --ignore-live does
+                      not, because a lock is a human decision, not a signal.
   --ignore-live       Delete even where a live process was detected, and even
                       when a liveness signal could not be collected. Dangerous:
                       these are the checks that stop a running build losing its
@@ -66,11 +71,11 @@ Options:
   -h, --help          Show this help.
 
 A directory is treated as IN USE, and skipped, if any of these hold:
-  - it sits under a git worktree marked `locked`
+  - it sits in, or under, a git worktree marked `locked`
   - a build process (cargo, rustc, node, npm/pnpm/yarn, next, vite, webpack,
     tsc, esbuild, turbo, gradle, java, python/pip/uv, go) has the owning
     directory OR the candidate itself in its command line
-  - a tmux session name contains a path component of the owning directory
+  - a tmux SESSION NAME contains a path component of the owning directory
   - any process has its cwd inside the owning directory
 
 The same checks run in dry-run and under --apply, so the preview is never more
@@ -78,18 +83,29 @@ permissive than the action. Under --apply the process and tmux signals are
 re-read immediately before each deletion, because the snapshot taken before the
 sizing pass is minutes stale by the time the rm happens.
 
-Only the named build directories are ever removed. The directory containing
-them is never touched, so a git worktree survives having its target/ cleared.
+Exit status is 1 if any deletion failed, any candidate was refused by the
+pre-flight, or any candidate was held for incomplete liveness. A directory that
+simply vanished before the rm is not a failure: the outcome wanted was that it
+be gone.
 EOF
 }
 
 # ---- parse args ----
+# A non-numeric count silently disables the guard it was meant to tighten:
+# `--top one` made `[ "$TOP" -gt 0 ]` print "integer expression expected", the
+# test evaluated false, the cap never fired, and every candidate was deleted.
+require_int() {
+  case "$2" in
+    ''|*[!0-9]*) echo "$1 needs a non-negative integer, got: $2" >&2; exit 2 ;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --min-size) MIN_SIZE_MB="$2"; shift 2 ;;
+    --min-size) require_int --min-size "$2"; MIN_SIZE_MB="$2"; shift 2 ;;
     --names) IFS=',' read -r -a NAMES <<< "$2"; shift 2 ;;
-    --max-depth) MAXDEPTH="$2"; shift 2 ;;
-    --top) TOP="$2"; shift 2 ;;
+    --max-depth) require_int --max-depth "$2"; MAXDEPTH="$2"; shift 2 ;;
+    --top) require_int --top "$2"; TOP="$2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
     --no-protect-locked) PROTECT_LOCKED=0; shift ;;
     --ignore-live) IGNORE_LIVE=1; shift ;;
@@ -100,19 +116,49 @@ while [ $# -gt 0 ]; do
 done
 [ ${#ROOTS[@]} -eq 0 ] && ROOTS=(".")
 
-# Canonicalise every root to an absolute physical path.
+# Canonicalise every root to an absolute physical path, keeping the logical one.
 #
-# The default root is `.`, and with a relative root every candidate is `./target`
-# and every owner is `.`. A fixed-string search for "." matches essentially every
-# ps and lsof line, so the liveness verdict was decided by an unrelated
-# substring: `--apply` skipped everything while the dry-run, which did not
-# collect lsof, offered to delete the same directories.
-abs_dir() { (cd "$1" 2>/dev/null && pwd -P) || return 1; }
+# Absolute, because with a relative root every candidate is `./target` and every
+# owner is `.`: a fixed-string search for "." matches essentially every ps and
+# lsof line, so the liveness verdict was decided by an unrelated substring.
+#
+# Both forms, because `pwd -P` resolves symlinks and the processes we are
+# searching for usually do not. On macOS /tmp is a symlink to /private/tmp, so a
+# live `node /tmp/wt/server.js` contains no substring `/private/tmp/wt` and all
+# three liveness greps miss a worktree that is plainly in use.
+#
+# `cd -P --`, not a bare `cd`: a bare cd honours CDPATH, which both resolves a
+# relative root to somewhere else entirely and echoes the destination on stdout,
+# so the captured value came back as two lines.
+abs_dir() { (cd -P -- "$1" >/dev/null 2>&1 && pwd -P) || return 1; }
+logical_dir() { (cd -- "$1" >/dev/null 2>&1 && pwd) || return 1; }
+
+# Trailing slashes are stripped so containment tests never build `//*`, a
+# pattern no path matches. Without this `clean.sh /` refused every candidate.
+strip_slash() {
+  local p="$1"
+  while [ "${#p}" -gt 1 ] && [ "${p%/}" != "$p" ]; do p="${p%/}"; done
+  printf '%s' "$p"
+}
+
+# The prefix to build a `<root>/*` glob from. Empty for the filesystem root,
+# because "/" + "/*" is `//*`, which matches nothing: `clean.sh /` refused every
+# candidate on the disk and exited 1 after a full-disk du.
+glob_prefix() { [ "$1" = "/" ] && printf '' || printf '%s' "$1"; }
 
 ABS_ROOTS=()
+ORIG_ROOTS=()   # the spelling the operator typed, kept for liveness matching
 for r in "${ROOTS[@]}"; do
+  # Command substitution strips trailing newlines, so a root that genuinely ends
+  # in one cannot survive `$(pwd)`: `clean.sh $'/tmp/repo\n'` would resolve to
+  # the SIBLING `/tmp/repo` and delete its target instead. There is no encoding
+  # that fixes this, so it is refused rather than silently redirected.
+  case "$r" in
+    *$'\n') echo "refusing a root whose path ends in a newline: $(printf '%q' "$r")" >&2; exit 2 ;;
+  esac
   if a="$(abs_dir "$r")"; then
-    ABS_ROOTS+=("$a")
+    ABS_ROOTS+=("$(strip_slash "$a")")
+    ORIG_ROOTS+=("$(strip_slash "$r")")
   else
     echo "skipping unreadable root: $r" >&2
   fi
@@ -120,8 +166,6 @@ done
 [ ${#ABS_ROOTS[@]} -eq 0 ] && { echo "no readable roots" >&2; exit 2; }
 
 # ---- liveness signals ----
-# Collected once up front for the sizing pass; ps and tmux are re-read per
-# deletion (see refresh_volatile_snapshots).
 
 # Commands whose presence in a command line means something is building. The
 # previous version matched only `cargo ` and `rustc `, while the default target
@@ -131,8 +175,27 @@ BUILD_PROCESS_RE='cargo |rustc |node |npm |pnpm |yarn |next |vite |webpack |tsc 
 
 # Reasons a signal could not be collected. Non-empty means fail closed.
 DEGRADED=""
+REFUSE_DELETE=0
 
 have() { command -v "$1" >/dev/null 2>&1; }
+
+note_degraded() {
+  case "$DEGRADED" in
+    *"$1"*) : ;;
+    *) DEGRADED="${DEGRADED}$1; " ;;
+  esac
+  # Re-evaluated here, not once before the loop. A signal that dies mid-run used
+  # to keep the verdict computed at startup, so --apply carried on deleting with
+  # an empty process table and reported a clean run.
+  [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ] && REFUSE_DELETE=1
+  return 0
+}
+
+# This script's own path, used to drop our own subshells from the process table.
+# Matching the bare string "clean.sh" also deleted unrelated live builds whose
+# argv merely contained it (`node /tmp/clean.sh-project/build.js ...`), which is
+# a fail-OPEN filter on the primary liveness signal.
+SELF_PATH="$(abs_dir "$(dirname -- "$0")" 2>/dev/null)/$(basename -- "$0")"
 
 collect_ps() {
   # Exclude grep/ripgrep lines and this script's own process. `ps` shows the
@@ -142,14 +205,29 @@ collect_ps() {
   ps -Awwo pid,command 2>/dev/null \
     | grep -v -E '(^| )[0-9]+ +(grep|rg|egrep|fgrep) ' \
     | grep -v -E "^ *$$ " \
-    | grep -vF "clean.sh"
+    | grep -vF -- "$SELF_PATH"
 }
 
-# `tmux ls` exits non-zero when no server is running, which is a legitimate
-# "no sessions" and NOT a collection failure. A missing binary is a failure.
-collect_tmux() { tmux ls 2>/dev/null || true; }
+# SESSION NAMES ONLY. `tmux ls` renders `name: 1 windows (created ...)`, and a
+# fixed-string search over that whole line matches the boilerplate: with a
+# three-character floor, path components like `win`, `dow`, `ate` and `cre` hit
+# every session on the host and the sweep protected everything while reporting
+# it as safety.
+#
+# Exit 1 with no output means "no server running", which is a real answer.
+# Anything else (an unreadable socket dir, a permission failure) is a collection
+# FAILURE and must degrade, not read as "no sessions".
+collect_tmux() {
+  local out status
+  out="$(tmux ls -F '#{session_name}' 2>/dev/null)"; status=$?
+  if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+    note_degraded "tmux unreadable"
+  fi
+  printf '%s' "$out"
+}
 
 PS_SNAPSHOT=""
+PS_BUILD_LINES=""
 TMUX_SNAPSHOT=""
 LSOF_SNAPSHOT=""
 
@@ -157,19 +235,20 @@ refresh_volatile_snapshots() {
   PS_SNAPSHOT="$(collect_ps || true)"
   if [ -z "$PS_SNAPSHOT" ]; then
     # ps always reports at least this script, so empty means it did not run.
-    case "$DEGRADED" in *"ps"*) : ;; *) DEGRADED="${DEGRADED}ps unreadable; " ;; esac
+    note_degraded "ps unreadable"
   fi
+  # Filtered once per refresh rather than once per candidate: live_reason used
+  # to re-scan the whole process table for every directory it looked at.
+  PS_BUILD_LINES="$(printf '%s\n' "$PS_SNAPSHOT" | grep -E "$BUILD_PROCESS_RE" || true)"
   if have tmux; then
     TMUX_SNAPSHOT="$(collect_tmux)"
   else
     TMUX_SNAPSHOT=""
-    case "$DEGRADED" in *"tmux"*) : ;; *) DEGRADED="${DEGRADED}tmux not installed; " ;; esac
+    note_degraded "tmux not installed"
   fi
 }
 
-if ! have ps; then
-  DEGRADED="${DEGRADED}ps not installed; "
-fi
+have ps || note_degraded "ps not installed"
 refresh_volatile_snapshots
 
 # `lsof -d cwd` is the expensive one, and it used to be collected only under
@@ -178,36 +257,45 @@ refresh_volatile_snapshots
 # switched off. A preview must be at least as protective as the action it
 # previews, so it is now always collected.
 if have lsof; then
-  LSOF_SNAPSHOT="$(lsof -d cwd 2>/dev/null || true)"
+  # An installed lsof that FAILS is not an empty process table. lsof exits 1
+  # when it merely found nothing, so only other statuses degrade.
+  LSOF_SNAPSHOT="$(lsof -d cwd 2>/dev/null)"; lsof_status=$?
+  if [ "$lsof_status" -ne 0 ] && [ "$lsof_status" -ne 1 ]; then
+    note_degraded "lsof unreadable"
+  fi
 else
-  DEGRADED="${DEGRADED}lsof not installed; "
+  note_degraded "lsof not installed"
 fi
+
+have git || note_degraded "git not installed (locked worktrees unknown)"
 
 # ---- locked git worktrees ----
 # An explicit, deterministic human "do not touch" marker that outlives the
 # session that set it. The process and tmux signals only see what is running at
 # snapshot time, so a locked worktree that is mid-rebase, paused, or whose
 # terminal was closed has no other protection.
-LOCKED=()
-if [ "$PROTECT_LOCKED" -eq 1 ]; then
-  if have git; then
-    for r in "${ABS_ROOTS[@]}"; do
-      while IFS= read -r wt; do
-        [ -n "$wt" ] && LOCKED+=("$wt")
-      done < <(git -C "$r" worktree list --porcelain 2>/dev/null \
-               | awk '/^worktree /{p=$2} /^locked/{print p}' || true)
-    done
-  else
-    DEGRADED="${DEGRADED}git not installed (locked worktrees unknown); "
-  fi
-fi
-
+#
+# Asked of the CANDIDATE's own directory, not of the scan roots. Enumerating
+# from the roots meant `git -C <worktrees parent> worktree list` exited 128 with
+# "not a git repository" for the canonical sweep-the-parent invocation, stderr
+# went to /dev/null, and the protection was silently off in exactly the case it
+# exists for.
+#
+# Read from the gitdir rather than parsed out of `worktree list --porcelain`:
+# that porcelain path is whitespace-delimited, so an awk field-split truncated
+# any locked worktree whose path contains a space and let it through. A locked
+# worktree simply has a `locked` file in its gitdir; there is nothing to parse.
 is_locked() {
-  local d="$1" l
-  for l in "${LOCKED[@]:-}"; do
-    [ -z "$l" ] && continue
-    case "$d" in "$l"|"$l"/*) return 0 ;; esac
-  done
+  local d="$1" gitdir common
+  have git || return 1
+  gitdir="$(git -C "$d" rev-parse --absolute-git-dir 2>/dev/null)" || return 1
+  [ -n "$gitdir" ] || return 1
+  # A linked worktree's gitdir is <main>/.git/worktrees/<name>, and its lock is
+  # <that>/locked. A main worktree cannot be locked at all.
+  [ -f "$gitdir/locked" ] && return 0
+  # A candidate can also sit under a locked worktree without being its root.
+  common="$(git -C "$d" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$common" ] && [ "$gitdir" != "$common" ] && [ -f "$gitdir/locked" ] && return 0
   return 1
 }
 
@@ -216,10 +304,17 @@ is_locked() {
 # $2 = the absolute scan root this candidate was found under
 # $3 = the candidate directory itself
 live_reason() {
-  local owner="$1" root="$2" cand="$3"
-
-  if is_locked "$owner"; then
-    echo "locked git worktree"; return
+  local owner="$1" root="$2" cand="$3" oroot="${4:-}"
+  # The same directory as the operator spelled it. Roots are canonicalised for
+  # our own bookkeeping, but a process started as
+  # `node /srv/repos/team/../team/app/x` carries the operator's spelling in its
+  # argv and nothing else. Testing only the canonical form was a regression:
+  # the previous version passed the root through to find unresolved, so that
+  # argv matched.
+  local owner_orig="" cand_orig=""
+  if [ -n "$oroot" ] && [ "$oroot" != "$root" ]; then
+    owner_orig="$oroot${owner#"$root"}"
+    cand_orig="$oroot${cand#"$root"}"
   fi
 
   # Match the owning path OR the candidate path anywhere in a build command
@@ -227,19 +322,22 @@ live_reason() {
   # argv at all, while the rustc invocations underneath it carry
   # `--out-dir .../target/debug/deps`, which names the candidate, not the owner.
   #
+  # Each path is tested in both its physical and its logical form, since the
+  # process may have been started through a symlink we have already resolved.
+  #
   # NOTE: `grep -q` must not be used in these pipelines. It exits on the first
   # match, the upstream grep takes SIGPIPE, and with `pipefail` set the whole
   # pipeline then reports failure, so the check silently never fires. Counting
   # greps read all input and cannot lose that way.
-  local build_lines
-  build_lines="$(printf '%s\n' "$PS_SNAPSHOT" | grep -E "$BUILD_PROCESS_RE" || true)"
-  if [ -n "$build_lines" ]; then
-    if [ "$(printf '%s\n' "$build_lines" | grep -cF -- "$owner")" -gt 0 ]; then
-      echo "live build process"; return
-    fi
-    if [ "$(printf '%s\n' "$build_lines" | grep -cF -- "$cand")" -gt 0 ]; then
-      echo "live build process (writing this directory)"; return
-    fi
+  if [ -n "$PS_BUILD_LINES" ]; then
+    local p
+    for p in "$owner" "$(logical_dir "$owner" 2>/dev/null)" "$owner_orig" \
+             "$cand" "$cand_orig"; do
+      [ -z "$p" ] && continue
+      if [ "$(printf '%s\n' "$PS_BUILD_LINES" | grep -cF -- "$p")" -gt 0 ]; then
+        echo "live build process"; return
+      fi
+    done
   fi
 
   # tmux names sessions after the worktree, not after the crate subdirectory, so
@@ -248,14 +346,19 @@ live_reason() {
   # "worktrees" directory, the repo name shared by every worktree) appears in
   # unrelated session names and would mark every candidate as in use.
   if [ -n "$TMUX_SNAPSHOT" ]; then
-    local rel part
-    rel="${owner#"$root"}"
-    # When the owner IS the scan root there are no components below it, which
-    # used to disable the tmux test entirely for the most natural invocation
-    # (`clean.sh <worktree>`, or the default `.` from inside one). Fall back to
-    # the root's own basename: the operator named this directory explicitly, so
-    # testing its name is exactly what they asked for.
-    [ -z "${rel//\//}" ] && rel="$(basename "$root")"
+    local rel part pref
+    pref="$(glob_prefix "$root")"
+    case "$owner" in
+      "$pref"/*) rel="${owner#"$pref"}" ;;
+      # The owner is the scan root, or the root is deeper than the owner (which
+      # happens when the operator points straight at a build directory). Either
+      # way there is nothing below the root to test, so use the owner's own
+      # basename: that is the directory the operator named. Stripping nothing
+      # and testing the whole absolute path instead would match the username and
+      # every shared parent, which is the false positive this block avoids.
+      *) rel="$(basename "$owner")" ;;
+    esac
+    [ -z "${rel//\//}" ] && rel="$(basename "$owner")"
     while IFS= read -r part; do
       [ ${#part} -lt "$MIN_TMUX_COMPONENT" ] && continue
       if [ "$(printf '%s\n' "$TMUX_SNAPSHOT" | grep -cF -- "$part")" -gt 0 ]; then
@@ -264,23 +367,57 @@ live_reason() {
     done < <(printf '%s\n' "$rel" | tr '/' '\n')
   fi
 
-  if [ -n "$LSOF_SNAPSHOT" ] && [ "$(printf '%s\n' "$LSOF_SNAPSHOT" | grep -cF -- "$owner")" -gt 0 ]; then
-    echo "process cwd inside"; return
+  if [ -n "$LSOF_SNAPSHOT" ]; then
+    local p
+    for p in "$owner" "$(logical_dir "$owner" 2>/dev/null)" "$owner_orig"; do
+      [ -z "$p" ] && continue
+      if [ "$(printf '%s\n' "$LSOF_SNAPSHOT" | grep -cF -- "$p")" -gt 0 ]; then
+        echo "process cwd inside"; return
+      fi
+    done
   fi
   echo ""
 }
 
-# Rule 1, asserted BEFORE the deletion. Every condition here is about the path
-# we are one command away from passing to `rm -rf`.
+# Rule 1, asserted BEFORE the deletion and in dry-run alike. Every condition
+# here is about the path we would be one command away from passing to `rm -rf`.
+#
+# Echoes "" when safe, "gone" when the directory has simply vanished (a benign
+# race with another cleaner or a `cargo clean`, whose outcome is what we wanted
+# anyway), or a reason string when it is a genuine rule-1 violation.
 safe_to_delete() {
-  local dir="$1" root="$2" base ok n
-  [ -d "$dir" ] || { echo "not a directory"; return; }
-  case "$dir" in "$root"/*) : ;; *) echo "outside its scan root"; return ;; esac
+  local dir="$1" root="$2" base ok n pref
+  [ -d "$dir" ] || { echo "gone"; return; }
+  # `dir == root` is legitimate: the operator pointed straight at a build
+  # directory. Only a path OUTSIDE the root is a violation.
+  pref="$(glob_prefix "$root")"
+  case "$dir" in
+    "$root"|"$pref"/*) : ;;
+    *) echo "outside its scan root"; return ;;
+  esac
   base="$(basename "$dir")"
   ok=0
-  for n in "${NAMES[@]}"; do [ "$base" = "$n" ] && ok=1; done
+  # Glob-matched, not compared literally, so this agrees with the `find -name`
+  # predicate that produced the candidate. A literal test rejected every
+  # candidate found through a pattern (`--names 'target*'`), turning a working
+  # sweep into an all-REFUSED run.
+  for n in "${NAMES[@]}"; do
+    case "$base" in $n) ok=1 ;; esac
+  done
   [ "$ok" -eq 1 ] || { echo "basename '$base' is not a target name"; return; }
   [ "$(dirname "$dir")" = "$dir" ] && { echo "has no parent"; return; }
+  # A mountpoint is another filesystem borrowing this path. `rm -rf` descends
+  # into it and destroys data that has nothing to do with this build tree, and
+  # nothing above would notice: the basename is still `target`, and it is still
+  # under the scan root.
+  if [ -d "$dir" ] && [ -d "$dir/.." ]; then
+    local dev_self dev_parent
+    dev_self="$(stat -f '%d' "$dir" 2>/dev/null || stat -c '%d' "$dir" 2>/dev/null)"
+    dev_parent="$(stat -f '%d' "$dir/.." 2>/dev/null || stat -c '%d' "$dir/.." 2>/dev/null)"
+    if [ -n "$dev_self" ] && [ -n "$dev_parent" ] && [ "$dev_self" != "$dev_parent" ]; then
+      echo "is a mountpoint"; return
+    fi
+  fi
   echo ""
 }
 
@@ -297,12 +434,21 @@ done
 # the way back in: `dir` became a truncated prefix, and the rm ran against the
 # SOURCE directory rather than the build directory. Only the sort keys (an
 # integer size and an integer index) ever round-trip through text now.
-C_KB=(); C_DIR=(); C_ROOT=()
+C_KB=(); C_DIR=(); C_ROOT=(); C_OROOT=()
 
-for r in "${ABS_ROOTS[@]}"; do
+for ri in "${!ABS_ROOTS[@]}"; do
+  r="${ABS_ROOTS[$ri]}"; oroot="${ORIG_ROOTS[$ri]}"
   while IFS= read -r -d '' d; do
-    kb=$(du -sk "$d" 2>/dev/null | cut -f1)
-    [ -z "$kb" ] && continue
+    d="$(strip_slash "$d")"
+    # `du -sk` echoes the path it sized, so a path containing a NEWLINE makes
+    # its output span lines and `cut -f1` returns a multi-line value. That value
+    # then rides the integer-only sort channel and can order a 1 KiB candidate
+    # ahead of a 10 GiB one, which under `--top 1 --apply` deletes the wrong
+    # directory. Anything that is not a plain integer is not a size.
+    kb=$(du -sk "$d" 2>/dev/null | head -1 | cut -f1)
+    case "$kb" in
+      ''|*[!0-9]*) echo "skipping (unreadable size): $(printf '%q' "$d")" >&2; continue ;;
+    esac
     [ "$kb" -lt $((MIN_SIZE_MB * 1024)) ] && continue
 
     # Overlapping roots find the same directory twice with different scan roots,
@@ -316,11 +462,13 @@ for r in "${ABS_ROOTS[@]}"; do
       [ "${C_DIR[$i]}" = "$d" ] && { dup=$i; break; }
     done
     if [ "$dup" -ge 0 ]; then
-      [ ${#r} -lt ${#C_ROOT[$dup]} ] && C_ROOT[$dup]="$r"
+      if [ ${#r} -lt ${#C_ROOT[$dup]} ]; then
+        C_ROOT[$dup]="$r"; C_OROOT[$dup]="$oroot"
+      fi
       continue
     fi
 
-    C_KB+=("$kb"); C_DIR+=("$d"); C_ROOT+=("$r")
+    C_KB+=("$kb"); C_DIR+=("$d"); C_ROOT+=("$r"); C_OROOT+=("$oroot")
   done < <(find "$r" -maxdepth "$MAXDEPTH" \( -type d \( "${NAME_ARGS[@]}" \) \) -prune -print0 2>/dev/null)
 done
 
@@ -330,24 +478,22 @@ echo "== disk-space-cleaner =="
 echo "roots:   ${ABS_ROOTS[*]}"
 echo "targets: ${NAMES[*]}"
 echo "min-size: ${MIN_SIZE_MB}MB | apply: $([ "$APPLY" -eq 1 ] && echo yes || echo 'NO (dry-run)')"
-[ "${#LOCKED[@]}" -gt 0 ] && echo "protected (locked worktrees): ${#LOCKED[@]}"
-[ "$IGNORE_LIVE" -eq 1 ] && echo "WARNING: --ignore-live set, liveness checks disabled"
+[ "$PROTECT_LOCKED" -eq 0 ] && echo "WARNING: --no-protect-locked set, locked worktrees are eligible"
+[ "$IGNORE_LIVE" -eq 1 ] && echo "WARNING: --ignore-live set, liveness checks disabled (locked worktrees still protected)"
 
 # Fail closed. An uncollectable signal reads identically to a quiet one, and the
 # summary would report "0 skipped as in use" as though everything had been
 # checked.
-REFUSE_DELETE=0
 if [ -n "$DEGRADED" ]; then
   echo "WARNING: liveness incomplete: ${DEGRADED%; }"
-  if [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ]; then
+  if [ "$REFUSE_DELETE" -eq 1 ]; then
     echo "REFUSING to delete with an incomplete liveness picture."
     echo "Install the missing tool, or re-run with --ignore-live to override."
-    REFUSE_DELETE=1
   fi
 fi
 echo
 
-TOTAL_KB=0; COUNT=0; SKIPPED=0; ACTED=0; FAILED=0; BLOCKED=0
+TOTAL_KB=0; COUNT=0; SKIPPED=0; LOCKED_N=0; SHOWN=0; FAILED=0; BLOCKED=0; VANISHED=0
 
 # Sort by size, biggest first, carrying only integers through the pipe.
 ORDER=()
@@ -357,51 +503,90 @@ done < <(for i in "${!C_KB[@]}"; do printf '%s %s\n' "${C_KB[$i]}" "$i"; done | 
 
 for idx in "${ORDER[@]:-}"; do
   [ -z "${idx:-}" ] && continue
-  kb="${C_KB[$idx]}"; dir="${C_DIR[$idx]}"; root="${C_ROOT[$idx]}"
+  kb="${C_KB[$idx]}"; dir="${C_DIR[$idx]}"; root="${C_ROOT[$idx]}"; oroot="${C_OROOT[$idx]}"
 
-  # --top caps the candidates ACTED ON, not the ones looked at. Counting skipped
-  # ones against the cap meant `--top 3` with three busy directories did nothing
-  # at all and never reached the fourth, largest reclaimable one.
-  [ "$TOP" -gt 0 ] && [ "$ACTED" -ge "$TOP" ] && break
+  # --top caps the candidates REPORTED ON, including the ones held or refused.
+  # Keying it on successful actions alone meant a degraded run walked every
+  # candidate on the disk emitting two lines each, and `--top 3` with three busy
+  # directories did nothing and never reached the fourth.
+  [ "$TOP" -gt 0 ] && [ "$SHOWN" -ge "$TOP" ] && break
 
   owner="$(dirname "$dir")"
+
+  # A lock is a human decision, not a liveness signal, so it is tested outside
+  # live_reason and --ignore-live does not lift it. Only --no-protect-locked
+  # does, which is what its help text says.
+  if [ "$PROTECT_LOCKED" -eq 1 ] && is_locked "$owner"; then
+    SHOWN=$((SHOWN + 1)); LOCKED_N=$((LOCKED_N + 1)); SKIPPED=$((SKIPPED + 1))
+    printf 'skip  %8s  %s\n         (locked git worktree)\n' "$(human_gb "$kb")" "$dir"
+    continue
+  fi
 
   # Under --apply the process and tmux pictures are re-read here rather than
   # reused from before the du pass. Sizing dozens of multi-GB trees takes
   # minutes, and a build started inside that window was invisible to all three
-  # checks. lsof is not re-read: it is the slow one, and re-running it per
-  # candidate would cost more than the sweep saves.
-  [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ] && refresh_volatile_snapshots
+  # checks. Skipped once REFUSE_DELETE is set: every remaining candidate is
+  # going to be held regardless, so the process table need not be dumped again.
+  # lsof is not re-read: it is the slow one, and re-running it per candidate
+  # would cost more than the sweep saves.
+  [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ] && [ "$REFUSE_DELETE" -eq 0 ] \
+    && refresh_volatile_snapshots
 
   reason=""
-  [ "$IGNORE_LIVE" -eq 0 ] && reason="$(live_reason "$owner" "$root" "$dir")"
+  [ "$IGNORE_LIVE" -eq 0 ] && reason="$(live_reason "$owner" "$root" "$dir" "$oroot")"
 
   if [ -n "$reason" ]; then
+    SHOWN=$((SHOWN + 1)); SKIPPED=$((SKIPPED + 1))
     printf 'skip  %8s  %s\n         (%s)\n' "$(human_gb "$kb")" "$dir" "$reason"
-    SKIPPED=$((SKIPPED + 1))
     continue
   fi
 
+  # Rule 1 runs for every candidate, in dry-run too, so the preview cannot list
+  # a path the apply would then refuse.
+  unsafe="$(safe_to_delete "$dir" "$root")"
+  if [ "$unsafe" = "gone" ]; then
+    # Not a failure. Another cleaner, or a `cargo clean`, got there first during
+    # the multi-minute sizing pass, and the outcome is the one we wanted.
+    SHOWN=$((SHOWN + 1)); VANISHED=$((VANISHED + 1))
+    printf 'gone  %8s  %s\n' "$(human_gb "$kb")" "$dir"
+    continue
+  fi
+  if [ -n "$unsafe" ]; then
+    SHOWN=$((SHOWN + 1)); FAILED=$((FAILED + 1))
+    printf 'REFUSED %6s  %s\n         (%s)\n' "$(human_gb "$kb")" "$dir" "$unsafe" >&2
+    continue
+  fi
+
+  if [ "$APPLY" -eq 1 ] && [ "$REFUSE_DELETE" -eq 1 ]; then
+    SHOWN=$((SHOWN + 1)); BLOCKED=$((BLOCKED + 1))
+    printf 'hold  %8s  %s\n         (liveness incomplete)\n' "$(human_gb "$kb")" "$dir"
+    continue
+  fi
+
+  SHOWN=$((SHOWN + 1))
   if [ "$APPLY" -eq 1 ]; then
-    if [ "$REFUSE_DELETE" -eq 1 ]; then
-      printf 'hold  %8s  %s\n         (liveness incomplete)\n' "$(human_gb "$kb")" "$dir"
-      BLOCKED=$((BLOCKED + 1))
+    # Last look before the destructive call. `rm -rf` on a path that no longer
+    # exists succeeds, so without this a directory renamed out from under us
+    # between the pre-flight and here was reported as a reclaim of its full
+    # size while every byte survived under the new name.
+    if [ ! -d "$dir" ]; then
+      VANISHED=$((VANISHED + 1))
+      printf 'gone  %8s  %s\n' "$(human_gb "$kb")" "$dir"
       continue
     fi
-    unsafe="$(safe_to_delete "$dir" "$root")"
-    if [ -n "$unsafe" ]; then
-      printf 'REFUSED %6s  %s\n         (%s)\n' "$(human_gb "$kb")" "$dir" "$unsafe" >&2
-      FAILED=$((FAILED + 1))
-      continue
-    fi
-    ACTED=$((ACTED + 1))
     if rm -rf "$dir"; then
-      printf 'rm    %8s  %s\n' "$(human_gb "$kb")" "$dir"
       # Belt and braces. The pre-flight assertion above is the one that can
       # actually prevent the mistake; this only catches an rm that went wider
-      # than its argument.
-      [ -d "$owner" ] || { echo "         ERROR: owning directory disappeared: $owner" >&2; FAILED=$((FAILED + 1)); }
-      TOTAL_KB=$((TOTAL_KB + kb)); COUNT=$((COUNT + 1))
+      # than its argument. It is NOT counted as a reclaim: folding the worst
+      # outcome this script guards against into the freed total would let a
+      # destroyed worktree read as a successful 0.6G sweep.
+      if [ -d "$owner" ]; then
+        printf 'rm    %8s  %s\n' "$(human_gb "$kb")" "$dir"
+        TOTAL_KB=$((TOTAL_KB + kb)); COUNT=$((COUNT + 1))
+      else
+        echo "         RULE 1 VIOLATED: the owning directory was destroyed: $owner" >&2
+        FAILED=$((FAILED + 1))
+      fi
     else
       # rm -rf can delete part of a tree and then fail. Counting it, and exiting
       # non-zero, is the difference between a caller seeing a partial deletion
@@ -410,7 +595,6 @@ for idx in "${ORDER[@]:-}"; do
       FAILED=$((FAILED + 1))
     fi
   else
-    ACTED=$((ACTED + 1))
     printf 'would rm %6s  %s\n' "$(human_gb "$kb")" "$dir"
     TOTAL_KB=$((TOTAL_KB + kb)); COUNT=$((COUNT + 1))
   fi
@@ -420,6 +604,8 @@ echo
 printf 'summary: %d dirs %s %s, %d skipped as in use' \
   "$COUNT" "$([ "$APPLY" -eq 1 ] && echo removed || echo 'would free')" \
   "$(human_gb "$TOTAL_KB")" "$SKIPPED"
+[ "$LOCKED_N" -gt 0 ] && printf ' (%d locked)' "$LOCKED_N"
+[ "$VANISHED" -gt 0 ] && printf ', %d already gone' "$VANISHED"
 [ "$BLOCKED" -gt 0 ] && printf ', %d held (liveness incomplete)' "$BLOCKED"
 [ "$FAILED" -gt 0 ] && printf ', %d FAILED' "$FAILED"
 printf '\n'

--- a/.claude/skills/disk-space-cleaner/scripts/clean.sh
+++ b/.claude/skills/disk-space-cleaner/scripts/clean.sh
@@ -4,24 +4,40 @@
 #
 # Deletes NOTHING by default (dry-run). Pass --apply to actually remove.
 #
-# Two rules this script exists to enforce:
+# Three rules this script exists to enforce:
 #   1. Only ever delete a build/dependency directory. Never the directory that
 #      contains it. A worktree is never removed, only its target/ or
-#      node_modules/ is.
+#      node_modules/ is. Checked BEFORE the rm, not after: a check that runs
+#      after the deletion cannot prevent anything, and if the path was already
+#      corrupted the check derives from the same corrupted value and passes.
 #   2. Decide by LIVENESS, not by age. A target rebuilt an hour ago by a session
 #      that has since finished is safe to clear; one untouched for a month can
 #      belong to a session that is running right now. mtime cannot tell those
 #      apart, so it is not used as a safety signal.
+#   3. Fail CLOSED. A liveness signal that could not be collected is not the
+#      same as a signal that came back empty. If ps, tmux or lsof is missing or
+#      unreadable, deletions are refused rather than performed blind.
 set -uo pipefail
 
 # ---- defaults ----
 ROOTS=()
-NAMES=(target node_modules .next dist build .gradle .turbo .venv)
+# `dist` and `.gradle` are deliberately NOT default targets. `dist` is routinely
+# a deployed artifact directory with nothing local able to rebuild it, and
+# `~/.gradle` is a tool home holding jdks/, native/ and the daemon registry
+# rather than project output. Both remain available through --names.
+NAMES=(target node_modules .next build .turbo .venv)
 MIN_SIZE_MB=500        # ignore anything smaller; the long tail is not worth the risk
 MAXDEPTH=8
 APPLY=0
 IGNORE_LIVE=0          # escape hatch, documented as dangerous
+PROTECT_LOCKED=1       # skip anything under a `locked` git worktree
 TOP=0                  # 0 = no limit
+
+# The shortest path component the tmux test will consider. Two characters and
+# below match almost any session name by accident. Real worktree names like
+# `api`, `web`, `ainb` and `hangar` are protected; an earlier 8-character floor
+# silently exempted every one of them.
+MIN_TMUX_COMPONENT=3
 
 usage() {
   cat <<'EOF'
@@ -37,19 +53,30 @@ Positional:
 Options:
   --min-size MB       Ignore directories smaller than this (default: 500).
   --names a,b,c       Directory names to target
-                      (default: target,node_modules,.next,dist,build,.gradle,.turbo,.venv).
+                      (default: target,node_modules,.next,build,.turbo,.venv).
   --max-depth N       How deep to search (default: 8).
-  --top N             Only act on the N largest candidates.
+  --top N             Only act on the N largest ACTIONABLE candidates. Ones
+                      skipped as in use do not consume a slot.
   --apply             Actually delete. Without this, only prints.
-  --ignore-live       Delete even where a live process was detected. Dangerous:
-                      this is the check that stops a running build losing its
+  --no-protect-locked Do NOT skip git worktrees marked `locked` (not recommended).
+  --ignore-live       Delete even where a live process was detected, and even
+                      when a liveness signal could not be collected. Dangerous:
+                      these are the checks that stop a running build losing its
                       artifacts mid-compile. Do not use casually.
   -h, --help          Show this help.
 
 A directory is treated as IN USE, and skipped, if any of these hold:
-  - a `cargo` or `rustc` process has its path in the command line
-  - a tmux session name contains the owning directory's name
+  - it sits under a git worktree marked `locked`
+  - a build process (cargo, rustc, node, npm/pnpm/yarn, next, vite, webpack,
+    tsc, esbuild, turbo, gradle, java, python/pip/uv, go) has the owning
+    directory OR the candidate itself in its command line
+  - a tmux session name contains a path component of the owning directory
   - any process has its cwd inside the owning directory
+
+The same checks run in dry-run and under --apply, so the preview is never more
+permissive than the action. Under --apply the process and tmux signals are
+re-read immediately before each deletion, because the snapshot taken before the
+sizing pass is minutes stale by the time the rm happens.
 
 Only the named build directories are ever removed. The directory containing
 them is never touched, so a git worktree survives having its target/ cleared.
@@ -64,6 +91,7 @@ while [ $# -gt 0 ]; do
     --max-depth) MAXDEPTH="$2"; shift 2 ;;
     --top) TOP="$2"; shift 2 ;;
     --apply) APPLY=1; shift ;;
+    --no-protect-locked) PROTECT_LOCKED=0; shift ;;
     --ignore-live) IGNORE_LIVE=1; shift ;;
     -h|--help) usage; exit 0 ;;
     -*) echo "unknown option: $1" >&2; usage; exit 2 ;;
@@ -72,42 +100,146 @@ while [ $# -gt 0 ]; do
 done
 [ ${#ROOTS[@]} -eq 0 ] && ROOTS=(".")
 
-# ---- liveness signals ----
-# Collected once up front: walking every candidate would re-run ps and lsof per
-# directory, and lsof in particular is slow on a near-full disk.
+# Canonicalise every root to an absolute physical path.
+#
+# The default root is `.`, and with a relative root every candidate is `./target`
+# and every owner is `.`. A fixed-string search for "." matches essentially every
+# ps and lsof line, so the liveness verdict was decided by an unrelated
+# substring: `--apply` skipped everything while the dry-run, which did not
+# collect lsof, offered to delete the same directories.
+abs_dir() { (cd "$1" 2>/dev/null && pwd -P) || return 1; }
 
-# Exclude grep/ripgrep lines and this script's own process. `ps` shows the
-# command line of whatever is doing the checking, and a probe that mentions both
-# "cargo" and a worktree path will match itself, reporting a live build that does
-# not exist. That false positive protects directories forever.
-PS_SNAPSHOT="$(ps -Awwo pid,command 2>/dev/null \
-  | grep -v -E '(^| )[0-9]+ +(grep|rg|egrep|fgrep) ' \
-  | grep -v -E "^ *$$ " \
-  | grep -vF "clean.sh" || true)"
-TMUX_SNAPSHOT="$(tmux ls 2>/dev/null || true)"
-# `lsof -d cwd` is the expensive one. Skipped entirely when nothing will be
-# deleted, since a dry-run does not need it to be authoritative.
-if [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ]; then
+ABS_ROOTS=()
+for r in "${ROOTS[@]}"; do
+  if a="$(abs_dir "$r")"; then
+    ABS_ROOTS+=("$a")
+  else
+    echo "skipping unreadable root: $r" >&2
+  fi
+done
+[ ${#ABS_ROOTS[@]} -eq 0 ] && { echo "no readable roots" >&2; exit 2; }
+
+# ---- liveness signals ----
+# Collected once up front for the sizing pass; ps and tmux are re-read per
+# deletion (see refresh_volatile_snapshots).
+
+# Commands whose presence in a command line means something is building. The
+# previous version matched only `cargo ` and `rustc `, while the default target
+# list covered node_modules, .next and .venv, so every non-Rust build was
+# invisible to the one signal advertised as primary.
+BUILD_PROCESS_RE='cargo |rustc |node |npm |pnpm |yarn |next |vite |webpack |tsc |esbuild |turbo |gradle |java |python|pip |uv |go build|go run'
+
+# Reasons a signal could not be collected. Non-empty means fail closed.
+DEGRADED=""
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+collect_ps() {
+  # Exclude grep/ripgrep lines and this script's own process. `ps` shows the
+  # command line of whatever is doing the checking, and a probe that mentions
+  # both "cargo" and a worktree path will match itself, reporting a live build
+  # that does not exist. That false positive protects directories forever.
+  ps -Awwo pid,command 2>/dev/null \
+    | grep -v -E '(^| )[0-9]+ +(grep|rg|egrep|fgrep) ' \
+    | grep -v -E "^ *$$ " \
+    | grep -vF "clean.sh"
+}
+
+# `tmux ls` exits non-zero when no server is running, which is a legitimate
+# "no sessions" and NOT a collection failure. A missing binary is a failure.
+collect_tmux() { tmux ls 2>/dev/null || true; }
+
+PS_SNAPSHOT=""
+TMUX_SNAPSHOT=""
+LSOF_SNAPSHOT=""
+
+refresh_volatile_snapshots() {
+  PS_SNAPSHOT="$(collect_ps || true)"
+  if [ -z "$PS_SNAPSHOT" ]; then
+    # ps always reports at least this script, so empty means it did not run.
+    case "$DEGRADED" in *"ps"*) : ;; *) DEGRADED="${DEGRADED}ps unreadable; " ;; esac
+  fi
+  if have tmux; then
+    TMUX_SNAPSHOT="$(collect_tmux)"
+  else
+    TMUX_SNAPSHOT=""
+    case "$DEGRADED" in *"tmux"*) : ;; *) DEGRADED="${DEGRADED}tmux not installed; " ;; esac
+  fi
+}
+
+if ! have ps; then
+  DEGRADED="${DEGRADED}ps not installed; "
+fi
+refresh_volatile_snapshots
+
+# `lsof -d cwd` is the expensive one, and it used to be collected only under
+# --apply. That made the dry-run a strict superset of what --apply would touch,
+# so the list the operator approved was produced with one of three guards
+# switched off. A preview must be at least as protective as the action it
+# previews, so it is now always collected.
+if have lsof; then
   LSOF_SNAPSHOT="$(lsof -d cwd 2>/dev/null || true)"
 else
-  LSOF_SNAPSHOT=""
+  DEGRADED="${DEGRADED}lsof not installed; "
 fi
 
-# Why is this directory in use? Echoes a reason, or nothing if it looks idle.
-# $1 = the directory that OWNS the build dir (the worktree, not the target).
-live_reason() {
-  local owner="$1"
+# ---- locked git worktrees ----
+# An explicit, deterministic human "do not touch" marker that outlives the
+# session that set it. The process and tmux signals only see what is running at
+# snapshot time, so a locked worktree that is mid-rebase, paused, or whose
+# terminal was closed has no other protection.
+LOCKED=()
+if [ "$PROTECT_LOCKED" -eq 1 ]; then
+  if have git; then
+    for r in "${ABS_ROOTS[@]}"; do
+      while IFS= read -r wt; do
+        [ -n "$wt" ] && LOCKED+=("$wt")
+      done < <(git -C "$r" worktree list --porcelain 2>/dev/null \
+               | awk '/^worktree /{p=$2} /^locked/{print p}' || true)
+    done
+  else
+    DEGRADED="${DEGRADED}git not installed (locked worktrees unknown); "
+  fi
+fi
 
-  # A rust build names paths under the project in nearly every rustc argv, so a
-  # fixed-string match of the owning directory anywhere in a cargo/rustc command
-  # line is the reliable signal. Matching the path, not a basename: basenames
-  # like "ainb-tui" repeat across every worktree and would be useless here.
+is_locked() {
+  local d="$1" l
+  for l in "${LOCKED[@]:-}"; do
+    [ -z "$l" ] && continue
+    case "$d" in "$l"|"$l"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# Why is this directory in use? Echoes a reason, or nothing if it looks idle.
+# $1 = the directory that OWNS the build dir (the worktree, not the target)
+# $2 = the absolute scan root this candidate was found under
+# $3 = the candidate directory itself
+live_reason() {
+  local owner="$1" root="$2" cand="$3"
+
+  if is_locked "$owner"; then
+    echo "locked git worktree"; return
+  fi
+
+  # Match the owning path OR the candidate path anywhere in a build command
+  # line. Both are needed: `cd <worktree> && cargo build` has no path in its own
+  # argv at all, while the rustc invocations underneath it carry
+  # `--out-dir .../target/debug/deps`, which names the candidate, not the owner.
+  #
   # NOTE: `grep -q` must not be used in these pipelines. It exits on the first
   # match, the upstream grep takes SIGPIPE, and with `pipefail` set the whole
   # pipeline then reports failure, so the check silently never fires. Counting
   # greps read all input and cannot lose that way.
-  if [ "$(printf '%s\n' "$PS_SNAPSHOT" | grep -E 'cargo |rustc ' | grep -cF -- "$owner")" -gt 0 ]; then
-    echo "live cargo/rustc"; return
+  local build_lines
+  build_lines="$(printf '%s\n' "$PS_SNAPSHOT" | grep -E "$BUILD_PROCESS_RE" || true)"
+  if [ -n "$build_lines" ]; then
+    if [ "$(printf '%s\n' "$build_lines" | grep -cF -- "$owner")" -gt 0 ]; then
+      echo "live build process"; return
+    fi
+    if [ "$(printf '%s\n' "$build_lines" | grep -cF -- "$cand")" -gt 0 ]; then
+      echo "live build process (writing this directory)"; return
+    fi
   fi
 
   # tmux names sessions after the worktree, not after the crate subdirectory, so
@@ -117,9 +249,15 @@ live_reason() {
   # unrelated session names and would mark every candidate as in use.
   if [ -n "$TMUX_SNAPSHOT" ]; then
     local rel part
-    rel="${owner#"$2"}"
+    rel="${owner#"$root"}"
+    # When the owner IS the scan root there are no components below it, which
+    # used to disable the tmux test entirely for the most natural invocation
+    # (`clean.sh <worktree>`, or the default `.` from inside one). Fall back to
+    # the root's own basename: the operator named this directory explicitly, so
+    # testing its name is exactly what they asked for.
+    [ -z "${rel//\//}" ] && rel="$(basename "$root")"
     while IFS= read -r part; do
-      [ ${#part} -lt 8 ] && continue
+      [ ${#part} -lt "$MIN_TMUX_COMPONENT" ] && continue
       if [ "$(printf '%s\n' "$TMUX_SNAPSHOT" | grep -cF -- "$part")" -gt 0 ]; then
         echo "live tmux session"; return
       fi
@@ -132,6 +270,20 @@ live_reason() {
   echo ""
 }
 
+# Rule 1, asserted BEFORE the deletion. Every condition here is about the path
+# we are one command away from passing to `rm -rf`.
+safe_to_delete() {
+  local dir="$1" root="$2" base ok n
+  [ -d "$dir" ] || { echo "not a directory"; return; }
+  case "$dir" in "$root"/*) : ;; *) echo "outside its scan root"; return ;; esac
+  base="$(basename "$dir")"
+  ok=0
+  for n in "${NAMES[@]}"; do [ "$base" = "$n" ] && ok=1; done
+  [ "$ok" -eq 1 ] || { echo "basename '$base' is not a target name"; return; }
+  [ "$(dirname "$dir")" = "$dir" ] && { echo "has no parent"; return; }
+  echo ""
+}
+
 # ---- find candidates ----
 NAME_ARGS=()
 for i in "${!NAMES[@]}"; do
@@ -139,36 +291,90 @@ for i in "${!NAMES[@]}"; do
   NAME_ARGS+=(-name "${NAMES[$i]}")
 done
 
-CANDIDATES="$(mktemp)"
-trap 'rm -f "$CANDIDATES"' EXIT
+# Candidates live in parallel arrays, never in a delimited text record.
+# They used to be written to a temp file as `kb<TAB>dir<TAB>root` and read back
+# with `IFS=$'\t' read`, so a path containing a TAB or a newline field-split on
+# the way back in: `dir` became a truncated prefix, and the rm ran against the
+# SOURCE directory rather than the build directory. Only the sort keys (an
+# integer size and an integer index) ever round-trip through text now.
+C_KB=(); C_DIR=(); C_ROOT=()
 
-for r in "${ROOTS[@]}"; do
+for r in "${ABS_ROOTS[@]}"; do
   while IFS= read -r -d '' d; do
     kb=$(du -sk "$d" 2>/dev/null | cut -f1)
     [ -z "$kb" ] && continue
     [ "$kb" -lt $((MIN_SIZE_MB * 1024)) ] && continue
-    printf '%s\t%s\t%s\n' "$kb" "$d" "$r" >> "$CANDIDATES"
+
+    # Overlapping roots find the same directory twice with different scan roots,
+    # which produced two contradictory verdicts for one path and double-counted
+    # the totals. Keep the record whose root is SHORTEST: it yields the longest
+    # relative path, so the tmux test gets the most components to check, which
+    # is the more protective of the two.
+    # ponytail: linear scan, candidates are the >500MB minority so n is tiny.
+    dup=-1
+    for i in "${!C_DIR[@]}"; do
+      [ "${C_DIR[$i]}" = "$d" ] && { dup=$i; break; }
+    done
+    if [ "$dup" -ge 0 ]; then
+      [ ${#r} -lt ${#C_ROOT[$dup]} ] && C_ROOT[$dup]="$r"
+      continue
+    fi
+
+    C_KB+=("$kb"); C_DIR+=("$d"); C_ROOT+=("$r")
   done < <(find "$r" -maxdepth "$MAXDEPTH" \( -type d \( "${NAME_ARGS[@]}" \) \) -prune -print0 2>/dev/null)
 done
 
 human_gb() { awk -v k="$1" 'BEGIN{printf "%.1fG", k/1024/1024}'; }
 
 echo "== disk-space-cleaner =="
-echo "roots:   ${ROOTS[*]}"
+echo "roots:   ${ABS_ROOTS[*]}"
 echo "targets: ${NAMES[*]}"
 echo "min-size: ${MIN_SIZE_MB}MB | apply: $([ "$APPLY" -eq 1 ] && echo yes || echo 'NO (dry-run)')"
+[ "${#LOCKED[@]}" -gt 0 ] && echo "protected (locked worktrees): ${#LOCKED[@]}"
 [ "$IGNORE_LIVE" -eq 1 ] && echo "WARNING: --ignore-live set, liveness checks disabled"
+
+# Fail closed. An uncollectable signal reads identically to a quiet one, and the
+# summary would report "0 skipped as in use" as though everything had been
+# checked.
+REFUSE_DELETE=0
+if [ -n "$DEGRADED" ]; then
+  echo "WARNING: liveness incomplete: ${DEGRADED%; }"
+  if [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ]; then
+    echo "REFUSING to delete with an incomplete liveness picture."
+    echo "Install the missing tool, or re-run with --ignore-live to override."
+    REFUSE_DELETE=1
+  fi
+fi
 echo
 
-TOTAL_KB=0; COUNT=0; SKIPPED=0; N=0
-while IFS=$'\t' read -r kb dir SCAN_ROOT; do
-  [ -z "$dir" ] && continue
-  N=$((N + 1))
-  [ "$TOP" -gt 0 ] && [ "$N" -gt "$TOP" ] && break
+TOTAL_KB=0; COUNT=0; SKIPPED=0; ACTED=0; FAILED=0; BLOCKED=0
+
+# Sort by size, biggest first, carrying only integers through the pipe.
+ORDER=()
+while IFS=' ' read -r _kb idx; do
+  ORDER+=("$idx")
+done < <(for i in "${!C_KB[@]}"; do printf '%s %s\n' "${C_KB[$i]}" "$i"; done | sort -rn)
+
+for idx in "${ORDER[@]:-}"; do
+  [ -z "${idx:-}" ] && continue
+  kb="${C_KB[$idx]}"; dir="${C_DIR[$idx]}"; root="${C_ROOT[$idx]}"
+
+  # --top caps the candidates ACTED ON, not the ones looked at. Counting skipped
+  # ones against the cap meant `--top 3` with three busy directories did nothing
+  # at all and never reached the fourth, largest reclaimable one.
+  [ "$TOP" -gt 0 ] && [ "$ACTED" -ge "$TOP" ] && break
 
   owner="$(dirname "$dir")"
+
+  # Under --apply the process and tmux pictures are re-read here rather than
+  # reused from before the du pass. Sizing dozens of multi-GB trees takes
+  # minutes, and a build started inside that window was invisible to all three
+  # checks. lsof is not re-read: it is the slow one, and re-running it per
+  # candidate would cost more than the sweep saves.
+  [ "$APPLY" -eq 1 ] && [ "$IGNORE_LIVE" -eq 0 ] && refresh_volatile_snapshots
+
   reason=""
-  [ "$IGNORE_LIVE" -eq 0 ] && reason="$(live_reason "$owner" "$SCAN_ROOT")"
+  [ "$IGNORE_LIVE" -eq 0 ] && reason="$(live_reason "$owner" "$root" "$dir")"
 
   if [ -n "$reason" ]; then
     printf 'skip  %8s  %s\n         (%s)\n' "$(human_gb "$kb")" "$dir" "$reason"
@@ -177,23 +383,48 @@ while IFS=$'\t' read -r kb dir SCAN_ROOT; do
   fi
 
   if [ "$APPLY" -eq 1 ]; then
+    if [ "$REFUSE_DELETE" -eq 1 ]; then
+      printf 'hold  %8s  %s\n         (liveness incomplete)\n' "$(human_gb "$kb")" "$dir"
+      BLOCKED=$((BLOCKED + 1))
+      continue
+    fi
+    unsafe="$(safe_to_delete "$dir" "$root")"
+    if [ -n "$unsafe" ]; then
+      printf 'REFUSED %6s  %s\n         (%s)\n' "$(human_gb "$kb")" "$dir" "$unsafe" >&2
+      FAILED=$((FAILED + 1))
+      continue
+    fi
+    ACTED=$((ACTED + 1))
     if rm -rf "$dir"; then
       printf 'rm    %8s  %s\n' "$(human_gb "$kb")" "$dir"
-      # Rule 1, verified rather than assumed: the owning directory must survive.
-      [ -d "$owner" ] || echo "         ERROR: owning directory disappeared: $owner" >&2
+      # Belt and braces. The pre-flight assertion above is the one that can
+      # actually prevent the mistake; this only catches an rm that went wider
+      # than its argument.
+      [ -d "$owner" ] || { echo "         ERROR: owning directory disappeared: $owner" >&2; FAILED=$((FAILED + 1)); }
       TOTAL_KB=$((TOTAL_KB + kb)); COUNT=$((COUNT + 1))
     else
-      echo "         FAILED to remove $dir" >&2
+      # rm -rf can delete part of a tree and then fail. Counting it, and exiting
+      # non-zero, is the difference between a caller seeing a partial deletion
+      # and a caller seeing a clean run.
+      echo "         FAILED to remove $dir (may be partially deleted)" >&2
+      FAILED=$((FAILED + 1))
     fi
   else
+    ACTED=$((ACTED + 1))
     printf 'would rm %6s  %s\n' "$(human_gb "$kb")" "$dir"
     TOTAL_KB=$((TOTAL_KB + kb)); COUNT=$((COUNT + 1))
   fi
-done < <(sort -rn "$CANDIDATES")
+done
 
 echo
-printf 'summary: %d dirs %s %s, %d skipped as in use\n' \
+printf 'summary: %d dirs %s %s, %d skipped as in use' \
   "$COUNT" "$([ "$APPLY" -eq 1 ] && echo removed || echo 'would free')" \
   "$(human_gb "$TOTAL_KB")" "$SKIPPED"
+[ "$BLOCKED" -gt 0 ] && printf ', %d held (liveness incomplete)' "$BLOCKED"
+[ "$FAILED" -gt 0 ] && printf ', %d FAILED' "$FAILED"
+printf '\n'
 [ "$APPLY" -eq 0 ] && echo "(dry-run, re-run with --apply to delete)"
+
+[ "$FAILED" -gt 0 ] && exit 1
+[ "$BLOCKED" -gt 0 ] && exit 1
 exit 0


### PR DESCRIPTION
A review with reproductions found fourteen defects in the disk-space-cleaner
skill as it stands on `main`. Three are destructive, and all three are
reproduced below rather than argued.

## The three that destroy or lie

**It deleted the source directory.** Candidates were written to a temp file as
`kb<TAB>dir<TAB>root` and read back with `IFS=$'\t' read`, so a path containing
a TAB or newline field-split on the way in: `dir` became a truncated prefix and
the `rm -rf` ran against the source directory while the real build directory
survived. Reproduced against a `proj<TAB>old` worktree, which lost
`proj/main.rs` and kept its `target/`. Paths now live in bash arrays; only the
two integer sort keys round-trip through text.

**The locked-worktree guard was dropped.** Removed in the same commit that
replaced the age gate, with nothing re-establishing it and no mention in the
message. A `git worktree lock` outlives the session that set it, which is
exactly the case the process and tmux signals cannot see. Restored.

**A partial deletion reported success.** No `set -e`, and an unconditional
`exit 0`. `rm -rf` can remove part of a tree and then fail; the summary said
`0 dirs removed` and the exit status said clean. Failures and holds are now
counted, and the script exits 1.

## The other eleven, all ways the liveness check answered without looking

- Roots are canonicalised. With the default root every owner was `.`, and a
  fixed-string search for `.` matched nearly every `ps` and `lsof` line.
- When the owner *is* the scan root the relative path is empty, which silently
  disabled the tmux test for `clean.sh <worktree>`. Falls back to the root's
  basename.
- tmux component floor drops from 8 characters to 3, so `api`, `web`, `ainb`
  and `hangar` are covered rather than exempt.
- Signals that could not be collected are no longer read as quiet. `--apply`
  refuses and reports `held`.
- The build-process pattern covers node, npm, pnpm, yarn, next, vite, webpack,
  tsc, esbuild, turbo, gradle, java, python, pip, uv and go. The default
  targets were never Rust-only.
- It matches the candidate path as well as the owner, so a `rustc --out-dir`
  counts even when the parent `cargo build` has no path in its argv.
- `ps` and `tmux` are re-read immediately before each `rm`, not reused from
  before the multi-minute sizing pass.
- `lsof` is collected in dry-run too, so the preview is never more permissive
  than the action.
- Overlapping roots deduplicate instead of yielding two contradictory verdicts
  and a doubled total.
- `--top` counts candidates acted on, not skipped ones.
- Rule 1 is asserted *before* the `rm`, where it can prevent something, instead
  of after it from the same corrupted path.

`dist` and `.gradle` leave the default names: `dist` is routinely a deployed
artifact with nothing local able to rebuild it, and `~/.gradle` is a tool home.
Both stay available through `--names`. SKILL.md loses the claim that everything
deleted is rebuilt by the next build, which was false for those defaults.

## Verification

Each fix has a reproduction run against both the old and new script:

| behaviour | old | new |
|---|---|---|
| TAB in path, `--apply` | deleted `proj/main.rs`, kept `target/` | source survives, correct target deleted |
| partial `rm` failure | `0 dirs removed`, exit 0 | `1 FAILED`, exit 1 |
| locked worktree | `would rm` | `skip (locked git worktree)` |
| owner is scan root, live tmux | `would rm` | `skip (live tmux session)` |
| 3-char worktree name `api`, live session | `would rm` | skipped |
| no lsof and no tmux, `--apply` | deleted blind, exit 0 | `REFUSING`, `1 held`, exit 1 |
| process cwd inside, dry-run | `would rm` | skipped |
| overlapping roots | same path twice, 1.2G double-count | one record, protective verdict |
| `--top 1`, largest is live | freed 0.0G, never reached the next | reached it, 0.7G |

Real-world dry run over the worktree tree reports 45.2G reclaimable and
correctly skips a live-tmux worktree (34.1G) and one with a process cwd inside
(16.5G).

https://claude.ai/code/session_01PQVMcoVN4cgjT4ZNuMQw8i