### PR TITLE
docs(hangar): add the zero-tmux ACP leg to the fullstack explainer

### DIFF
--- a/scripts/hangar/build-fullstack-explainer.py
+++ b/scripts/hangar/build-fullstack-explainer.py
@@ -22,7 +22,7 @@ ROOT = Path(__file__).resolve().parents[2]
 REPORT = ROOT / "docs/hangar/proofs/fullstack/REPORT.md"
 TEMPLATE = Path.home() / ".claude/skills/explain-to-me/assets/templates/11-status-report.html"
 OUT = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "explainers/prove-hangar-fullstack.html"
-BRANCH = "f/prove-hangar"
+BRANCH = "main"
 RAW = f"https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/{BRANCH}/docs/hangar/proofs/fullstack"
 PR = "https://github.com/stevengonsalvez/agents-in-a-box/pull/815"
 COMMIT = "https://github.com/stevengonsalvez/agents-in-a-box/commit"
@@ -98,14 +98,17 @@ def main() -> None:
         ("p2-pipeline", "P2 · role-gated pipeline, Triage → Done", range(1, 10)),
         ("p3-human-loop", "P3 · live AskUserQuestion answered from Control Center", range(1, 8)),
         ("p4-levers", "P4 · levers + observability after real runs", range(1, 13)),
+        ("p3-acp-human-loop", "P3-ACP · the same loop with zero tmux, answered from the Inbox", range(1, 9)),
     ):
         gif = ROOT / f"docs/hangar/proofs/fullstack/{slug}.gif"
         if not gif.exists():
             continue
-        prefix = slug.split("-")[0]
+        # rsplit, not split: the ACP leg's prefix is "p3-acp", and a bare
+        # split would hand it "p3" and glob the tmux leg's stills instead.
+        prefix = slug.rsplit("-", 2)[0]
         pngs = sorted(
             (ROOT / "docs/hangar/proofs/fullstack").glob(f"{prefix}-[0-9]*-*.png"),
-            key=lambda q: int(q.name.split("-")[1]),
+            key=lambda q: int(q.name[len(prefix) + 1:].split("-")[0]),
         )
         recordings.append((slug, title, pngs))
 


### PR DESCRIPTION
The explainer's recordings list is hardcoded, so the P3-ACP leg's gif and its eight stills never reached the page, even though the leg row itself was already picked up from `REPORT.md`.

Two latent assumptions in the still-globbing broke on the new slug and are fixed here:

- `prefix = slug.split("-")[0]` handed `p3-acp-human-loop` the prefix `p3`, which globs the **tmux** leg's stills. `rsplit("-", 2)[0]` keeps `p3-acp` and is unchanged for the other four slugs.
- the sort key `int(name.split("-")[1])` would have parsed `acp` as the still index.

`BRANCH` moves to `main`, where all fifteen renovation PRs landed, so the raw asset URLs resolve for every leg rather than pointing at the old run's branch.

Verified on the published page: eight ACP stills in order, gif and mp4 linked, the original P3 leg still globbing `p3-1..8` with no ACP contamination, and all five recordings present.

https://explainers.stevengonsalvez.com/prove-hangar/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a P3-ACP recording to the full-stack explainer content.

- **Bug Fixes**
  - Corrected explainer references and commit information to use the main content branch.
  - Improved recording image matching and ordering for multi-part entries, including P3-ACP content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->