### PR TITLE
docs(hangar): label which UI era each recording was made on

### DIFF
--- a/scripts/hangar/build-fullstack-explainer.py
+++ b/scripts/hangar/build-fullstack-explainer.py
@@ -92,13 +92,19 @@ def main() -> None:
     fixed = sum(1 for d in defects if d[3].upper().startswith("FIXED"))
     now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
+    # `era` is load-bearing, not decoration: the first four legs were recorded
+    # against the 16-tab UI that the renovation replaced, so an unlabelled page
+    # implies they show today's product. PRE renders a warning badge ABOVE the
+    # player, where it is read before anyone presses play.
+    PRE = ("pre", "recorded on the pre-renovation UI (16-tab strip)")
+    NEW = ("new", "renovated UI · 7-tab strip, nine screens behind the palette")
     recordings = []
-    for slug, title, stills in (
-        ("p1-happy-path", "P1 · single-issue happy path", range(1, 7)),
-        ("p2-pipeline", "P2 · role-gated pipeline, Triage → Done", range(1, 10)),
-        ("p3-human-loop", "P3 · live AskUserQuestion answered from Control Center", range(1, 8)),
-        ("p4-levers", "P4 · levers + observability after real runs", range(1, 13)),
-        ("p3-acp-human-loop", "P3-ACP · the same loop with zero tmux, answered from the Inbox", range(1, 9)),
+    for slug, title, era in (
+        ("p1-happy-path", "P1 · single-issue happy path", PRE),
+        ("p2-pipeline", "P2 · role-gated pipeline, Triage → Done", PRE),
+        ("p3-human-loop", "P3 · live AskUserQuestion answered from Control Center", PRE),
+        ("p4-levers", "P4 · levers + observability after real runs", PRE),
+        ("p3-acp-human-loop", "P3-ACP · the same loop with zero tmux, answered from the Inbox", NEW),
     ):
         gif = ROOT / f"docs/hangar/proofs/fullstack/{slug}.gif"
         if not gif.exists():
@@ -110,7 +116,7 @@ def main() -> None:
             (ROOT / "docs/hangar/proofs/fullstack").glob(f"{prefix}-[0-9]*-*.png"),
             key=lambda q: int(q.name[len(prefix) + 1:].split("-")[0]),
         )
-        recordings.append((slug, title, pngs))
+        recordings.append((slug, title, era, pngs))
 
     tpl = TEMPLATE.read_text()
     head = tpl.split("<body>")[0]
@@ -121,6 +127,14 @@ def main() -> None:
   .legs td:nth-child(3) { font-size: 12.5px; line-height: 1.45; }
   .rec { margin: 18px 0 28px; }
   .rec img.gif { width: 100%; border-radius: 10px; border: 1px solid #E3DACC; }
+  .era { display: block; font-size: 12.5px; font-weight: 600; padding: 7px 11px;
+         border-radius: 7px; margin: 6px 0 9px; border-left: 3px solid; }
+  .era-pre { background: #F6E7DF; color: #8A3D1E; border-left-color: #D97757; }
+  .era-new { background: #E8EDE0; color: #3F4C2C; border-left-color: #788C5D; }
+  .era-banner { margin: 0 0 6px; padding: 12px 14px; border-radius: 9px;
+                background: #F6E7DF; border-left: 3px solid #D97757;
+                color: #5C3524; font-size: 13.5px; line-height: 1.5; }
+  .era-banner strong { color: #8A3D1E; }
   .stills { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 8px; }
   .stills a img { width: 100%; border-radius: 6px; border: 1px solid #E3DACC; }
   .ledger td:nth-child(2) { font-size: 12.5px; line-height: 1.45; }
@@ -131,6 +145,22 @@ def main() -> None:
   .env td:first-child { white-space: nowrap; color:#87867F; }
   .notes li { margin: 6px 0; font-size: 13.5px; }
 </style>
+"""
+    # Name the pre-renovation legs from the data, so the banner cannot drift
+    # out of step with the badges the way a hand-written sentence would.
+    pre_legs = [t.split("·")[0].strip() for _, t, e, _ in recordings if e is PRE]
+    new_legs = [t.split("·")[0].strip() for _, t, e, _ in recordings if e is NEW]
+    era_banner = ""
+    if pre_legs and new_legs:
+        era_banner = f"""
+    <div class="era-banner">
+      <strong>Two UI eras on this page.</strong> The hangar was renovated after most of
+      these legs were recorded: the tab strip went from 16 entries to 7, nine screens
+      moved behind the command palette, and Kanban became Runs.
+      {", ".join(html.escape(n) for n in pre_legs)} predate that work and show the old
+      interface; only {", ".join(html.escape(n) for n in new_legs)} shows the current one.
+      The older legs are kept because each still proves what it was recorded to prove.
+    </div>
 """
     body = [f"""
 <body>
@@ -146,7 +176,7 @@ def main() -> None:
         &nbsp;&middot;&nbsp; {total_commits} commits on the branch
       </div>
     </header>
-
+{era_banner}
     <section>
       <div class="summary-band">
         <div class="stat-card"><div class="stat-num">{green}/{len(legs)}</div><div class="stat-label">legs green</div><div class="stat-delta flat">TUI-driven, real agents</div></div>
@@ -175,8 +205,10 @@ def main() -> None:
     body.append('<section><h2>Recordings</h2><hr class="rule">\n')
     if not recordings:
         body.append("<p>No green recording yet.</p>")
-    for slug, title, pngs in recordings:
+    for slug, title, era, pngs in recordings:
+        era_cls, era_text = era
         body.append(f'<div class="rec"><h3>{html.escape(title)}</h3>'
+                    f'<div class="era era-{era_cls}">{html.escape(era_text)}</div>'
                     f'<a href="{RAW}/{slug}.mp4"><img class="gif" src="{RAW}/{slug}.gif" alt="{html.escape(title)}"></a>'
                     f'<div class="chart-caption">gif linked from the branch; <a href="{RAW}/{slug}.mp4">mp4</a> · tape: <code>docs/hangar/proofs/fullstack/{slug}.tape</code></div>')
         if pngs:


### PR DESCRIPTION
Four of the five legs on the explainer were recorded against the 16-tab interface the renovation replaced, so the page implied all five show the product as it stands. P1, P2, P3 and P4 predate the crisp-UI track; only P3-ACP was recorded after it.

- **Per-recording badge, above the player.** Each leg carries its era where it is read before anyone presses play, not in a caption underneath. Pre-renovation legs get a warning-toned badge, the renovated leg a green one.
- **Banner at the top of the page** naming the change (16 tabs to 7, nine screens behind the palette, Kanban to Runs) and which legs predate it.
- The banner derives its leg names from the recordings list rather than restating them, so it cannot drift out of step with the badges.

No recording is removed or re-recorded. Each older leg still proves what it was recorded to prove.

Verified on the published page: banner present, 4 pre badges and 1 new badge, and in all five `rec` blocks the badge precedes the player.

https://explainers.stevengonsalvez.com/prove-hangar/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recording summaries now identify whether each leg represents the pre-renovation or renovated interface.
  - Added era badges beneath recording titles for quick reference.
  - Added an era banner above the summary when recordings from both interface eras are included.
  - Updated the explainer presentation to make comparisons between the two interface versions clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->