### PR TITLE
feat(tui): preserve tmux preview fidelity

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -546,8 +546,17 @@ impl AppState {
             self.observer_pending = None;
             return false;
         }
+        if !crate::tmux::EmbedClient::read_only_observer_supported() {
+            self.release_interactive_pane();
+            self.observer_failed_target = Some((name, now, MAX_OBSERVER_FAILURES));
+            self.add_warning_notification(
+                "Live preview requires tmux client ignore-size support".to_string(),
+            );
+            return false;
+        }
         if let Some((failed, retry_at, attempts)) = &self.observer_failed_target {
             if failed == &name && (*attempts >= MAX_OBSERVER_FAILURES || now < *retry_at) {
+                self.release_interactive_pane();
                 return false;
             }
         }
@@ -692,15 +701,7 @@ impl AppState {
                 self.add_info_notification("Live session ended, released".to_string());
             } else if exited {
                 if let Some(session) = session {
-                    if crate::tmux::session_alive(&session) == Some(false) {
-                        // A normally-ended session is not an observer fault.
-                        // Suppress reconnects until the user changes rows.
-                        self.observer_failed_target =
-                            Some((session, Instant::now(), MAX_OBSERVER_FAILURES));
-                        self.add_info_notification("Live session ended, released".to_string());
-                    } else {
-                        self.record_observer_failure(session);
-                    }
+                    self.record_observer_failure(session);
                 }
             }
             return true;

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -455,6 +455,7 @@ pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 const OBSERVER_SETTLE_DELAY: Duration = Duration::from_millis(250);
 const OBSERVER_RETRY_DELAY: Duration = Duration::from_secs(2);
+const OBSERVER_SUCCESS_GRACE: Duration = Duration::from_millis(250);
 const MAX_OBSERVER_FAILURES: u8 = 3;
 
 fn host_tmux_session_name() -> Option<&'static str> {
@@ -560,7 +561,11 @@ impl AppState {
             Ok(client) => {
                 self.embed = Some(client);
                 self.embed_session = Some(name);
-                self.observer_failed_target = None;
+                // `attach-session` can spawn successfully then immediately
+                // fail (for example, if tmux rejects a client flag). Keep a
+                // prior retry count until this client survives one grace
+                // period so failed spawns cannot reset the retry cap.
+                self.observer_started_at = Some(now);
                 true
             }
             Err(e) => {
@@ -626,6 +631,7 @@ impl AppState {
             client.shutdown();
         }
         self.embed_session = None;
+        self.observer_started_at = None;
         self.embed_pane_area = None;
         if self.focused_pane == FocusedPane::Preview {
             self.focused_pane = FocusedPane::Sessions;
@@ -686,10 +692,26 @@ impl AppState {
                 self.add_info_notification("Live session ended, released".to_string());
             } else if exited {
                 if let Some(session) = session {
-                    self.record_observer_failure(session);
+                    if crate::tmux::session_alive(&session) == Some(false) {
+                        // A normally-ended session is not an observer fault.
+                        // Suppress reconnects until the user changes rows.
+                        self.observer_failed_target =
+                            Some((session, Instant::now(), MAX_OBSERVER_FAILURES));
+                        self.add_info_notification("Live session ended, released".to_string());
+                    } else {
+                        self.record_observer_failure(session);
+                    }
                 }
             }
             return true;
+        }
+        if !interactive
+            && self
+                .observer_started_at
+                .is_some_and(|started| started.elapsed() >= OBSERVER_SUCCESS_GRACE)
+        {
+            self.observer_started_at = None;
+            self.observer_failed_target = None;
         }
         false
     }
@@ -3343,6 +3365,9 @@ pub struct AppState {
     observer_pending: Option<(String, Instant)>,
     // A read-only observer that dies waits before the next retry.
     observer_failed_target: Option<(String, Instant, u8)>,
+    // A spawned observer must survive briefly before it clears a prior retry
+    // count. `tmux attach-session` reports some startup failures asynchronously.
+    observer_started_at: Option<Instant>,
     // Interior screen rect (inside the border) the embed's PseudoTerminal
     // occupies, published by the interactive render branch each frame. Drives
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
@@ -3982,6 +4007,7 @@ impl Default for AppState {
             embed_session: None,
             observer_pending: None,
             observer_failed_target: None,
+            observer_started_at: None,
             embed_pane_area: None,
             menu_bar_area: None,
             sessions_pane_state,
@@ -11501,6 +11527,15 @@ impl AppState {
     /// Add an info notification
     pub fn add_info_notification(&mut self, message: String) {
         self.add_notification(Notification::info(message));
+    }
+
+    /// Explain that a read-only preview cannot provide tmux copy-mode without
+    /// filling the notification queue while a scroll key repeats.
+    pub fn notify_live_preview_no_scrollback(&mut self) {
+        const MESSAGE: &str = "Live preview has no scrollback. Press A to interact.";
+        if !self.notifications.iter().any(|notification| notification.message == MESSAGE) {
+            self.add_info_notification(MESSAGE.to_string());
+        }
     }
 
     /// Add a warning notification

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -454,22 +454,13 @@ pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 
 impl AppState {
-    /// Enter interactive mode: attach a live embed client to the selected
-    /// session's tmux session and focus the preview pane. Returns false (no-op)
-    /// if the selection has no tmux session or the attach fails — the pane stays
-    /// on the read-only preview.
+    /// Enter interactive mode by replacing the selected read-only tmux client
+    /// with a writable client feeding the same terminal parser path.
     pub fn enter_interactive_pane(&mut self, rows: u16, cols: u16) -> bool {
         if self.embed.is_some() {
-            if self.selected_tmux_name() == self.embed_session {
-                // Self-healing re-entry on the SAME row: a live embed with
-                // focus drifted off the preview pane is a leaked state —
-                // restore the mode invariant instead of silently no-opping.
-                self.focused_pane = FocusedPane::Preview;
+            if self.selected_tmux_name() == self.embed_session && self.is_interactive_pane() {
                 return true;
             }
-            // Different row: the user means "attach HERE" — release the stale
-            // client and fall through to a fresh attach, instead of
-            // refocusing an embed that renders some other session.
             self.release_interactive_pane();
         }
         let Some(name) = self.selected_tmux_name() else {
@@ -500,6 +491,37 @@ impl AppState {
         }
     }
 
+    /// Keep one read-only tmux client on the selected terminal. The observer
+    /// consumes the same PTY byte stream as interactive attach, but input stays
+    /// host-owned until [`Self::is_interactive_pane`] becomes true.
+    ///
+    /// Returns true when the observed target changes.
+    pub fn sync_terminal_observer(&mut self, rows: u16, cols: u16) -> bool {
+        let target = self.selected_tmux_name();
+        if self.embed_session == target && self.embed.is_some() {
+            if let Some(client) = self.embed.as_mut() {
+                let _ = client.resize(rows, cols);
+            }
+            return false;
+        }
+
+        self.release_interactive_pane();
+        let Some(name) = target else {
+            return false;
+        };
+        match crate::tmux::EmbedClient::observe(&name, rows, cols) {
+            Ok(client) => {
+                self.embed = Some(client);
+                self.embed_session = Some(name);
+                true
+            }
+            Err(e) => {
+                tracing::debug!("failed to observe terminal {name}: {e}");
+                false
+            }
+        }
+    }
+
     /// Whether the current selection's tmux session already has another client
     /// attached. Every kind that tracks attachment reports it (Claude and SSH
     /// rows via `is_attached`, other-tmux rows via tmux's attached flag);
@@ -516,8 +538,7 @@ impl AppState {
         }
     }
 
-    /// Release interactive mode: kill the ephemeral embed client (NEVER the tmux
-    /// session) and return focus to the session list.
+    /// Release the ephemeral client. Read-only preview reconnects next loop.
     pub fn release_interactive_pane(&mut self) {
         if let Some(mut client) = self.embed.take() {
             client.shutdown();
@@ -553,10 +574,8 @@ impl AppState {
         self.embed.is_some() && self.focused_pane == FocusedPane::Preview
     }
 
-    /// If the embed has ended (detach / session gone / EOF), auto-release so the
-    /// pane reverts to the read-only preview rather than a dead screen. Also
-    /// releases defensively when the current screen is no longer the session
-    /// list — keys must never be forwarded to an invisible PTY.
+    /// If the observer has ended or become invisible, stop it. Keys can never
+    /// be forwarded to an invisible PTY.
     ///
     /// Returns true when it released (the layout changed → repaint needed).
     pub fn poll_embed_exit(&mut self) -> bool {
@@ -568,7 +587,7 @@ impl AppState {
         if exited || invisible {
             self.release_interactive_pane();
             if exited {
-                self.add_info_notification("Live session ended — released".to_string());
+                self.add_info_notification("Live session ended, released".to_string());
             }
             return true;
         }
@@ -11630,12 +11649,10 @@ impl AppState {
 
             let is_selected = selected_session_id == Some(*session_id);
 
-            // While the interactive embed is live, the selected session's
-            // pane renders straight from the embed's vt100 screen — the full
-            // capture would be pure subprocess waste. Fall through to the
-            // cheap status-dot check instead (the collapsed rail still needs
-            // those for every session).
-            if is_selected && !self.is_interactive_pane() {
+            // The selected session renders from the observer's vt100 screen,
+            // so a parallel capture would waste work and rebuild terminal
+            // text through the lossy legacy path.
+            if is_selected && self.embed_session.as_deref() != Some(tmux_session.name()) {
                 // Selected session: capture last 200 lines (not full history)
                 // Full history can be megabytes for long-running sessions
                 let opts = CaptureOptions {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -452,11 +452,15 @@ pub const MIN_SESSIONS_SIDEBAR_WIDTH: u16 = 24;
 pub const SESSIONS_PREVIEW_RESERVE: u16 = 50;
 pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
+const OBSERVER_SETTLE_DELAY: Duration = Duration::from_millis(250);
 
 impl AppState {
     /// Enter interactive mode by replacing the selected read-only tmux client
     /// with a writable client feeding the same terminal parser path.
     pub fn enter_interactive_pane(&mut self, rows: u16, cols: u16) -> bool {
+        let attached_elsewhere = self.selected_session_attached_elsewhere();
+        self.observer_pending = None;
+        self.observer_failed_target = None;
         if self.embed.is_some() {
             if self.selected_tmux_name() == self.embed_session && self.is_interactive_pane() {
                 return true;
@@ -470,7 +474,6 @@ impl AppState {
         // tmux mirrors a session to every attached client, but all clients
         // fight over its size — attaching alongside an existing client is the
         // user's call, so allow it and warn (never block).
-        let attached_elsewhere = self.selected_session_attached_elsewhere();
         match crate::tmux::EmbedClient::attach(&name, rows, cols) {
             Ok(client) => {
                 self.embed = Some(client);
@@ -498,17 +501,28 @@ impl AppState {
     /// Returns true when the observed target changes.
     pub fn sync_terminal_observer(&mut self, rows: u16, cols: u16) -> bool {
         let target = self.selected_tmux_name();
-        if self.embed_session == target && self.embed.is_some() {
-            if let Some(client) = self.embed.as_mut() {
-                let _ = client.resize(rows, cols);
-            }
+        let Some(name) = target else {
+            self.observer_pending = None;
+            self.observer_failed_target = None;
+            self.release_interactive_pane();
+            return false;
+        };
+        if self.observer_failed_target.as_deref() != Some(name.as_str()) {
+            self.observer_failed_target = None;
+        }
+        if self.embed_session.as_deref() == Some(name.as_str()) && self.embed.is_some() {
+            self.observer_pending = None;
+            return false;
+        }
+        if self.observer_failed_target.as_deref() == Some(name.as_str()) {
+            return false;
+        }
+        if !self.observer_target_settled(&name, Instant::now()) {
+            self.release_interactive_pane();
             return false;
         }
 
         self.release_interactive_pane();
-        let Some(name) = target else {
-            return false;
-        };
         match crate::tmux::EmbedClient::observe(&name, rows, cols) {
             Ok(client) => {
                 self.embed = Some(client);
@@ -517,6 +531,21 @@ impl AppState {
             }
             Err(e) => {
                 tracing::debug!("failed to observe terminal {name}: {e}");
+                self.observer_failed_target = Some(name);
+                false
+            }
+        }
+    }
+
+    fn observer_target_settled(&mut self, target: &str, now: Instant) -> bool {
+        match self.observer_pending.as_ref() {
+            Some((pending, ready_at)) if pending == target && now >= *ready_at => {
+                self.observer_pending = None;
+                true
+            }
+            Some((pending, _)) if pending == target => false,
+            _ => {
+                self.observer_pending = Some((target.to_string(), now + OBSERVER_SETTLE_DELAY));
                 false
             }
         }
@@ -574,6 +603,18 @@ impl AppState {
         self.embed.is_some() && self.focused_pane == FocusedPane::Preview
     }
 
+    /// True when the selected terminal has a read-only observer client.
+    pub fn is_observing_selected_terminal(&self) -> bool {
+        self.selected_tmux_name()
+            .is_some_and(|name| self.is_observing_tmux_session(&name))
+    }
+
+    fn is_observing_tmux_session(&self, session: &str) -> bool {
+        !self.is_interactive_pane()
+            && self.embed.is_some()
+            && self.embed_session.as_deref() == Some(session)
+    }
+
     /// If the observer has ended or become invisible, stop it. Keys can never
     /// be forwarded to an invisible PTY.
     ///
@@ -584,10 +625,16 @@ impl AppState {
         }
         let exited = self.embed.as_ref().is_some_and(|e| e.has_exited());
         let invisible = self.current_screen != screen_ids::SESSION_LIST;
+        let interactive = self.is_interactive_pane();
+        let session = self.embed_session.clone();
         if exited || invisible {
             self.release_interactive_pane();
-            if exited {
+            if exited && interactive {
                 self.add_info_notification("Live session ended, released".to_string());
+            } else if exited {
+                if let Some(session) = session {
+                    self.observer_failed_target = Some(session);
+                }
             }
             return true;
         }
@@ -3228,7 +3275,7 @@ pub struct AppState {
     // Enforced invariants (focus can drift, so none of these are assumed):
     //  - Input forwards to the PTY only while `is_interactive_pane()` holds
     //    (embed Some AND focused_pane == Preview).
-    //  - Ctrl+Q releases whenever the embed exists, regardless of focus/mode.
+    //  - Ctrl+Q releases only while interactive focus owns the terminal.
     //  - `poll_embed_exit` (run before every draw) releases on client death
     //    or when the session-list screen is no longer current, so keys are
     //    never forwarded to an invisible PTY.
@@ -3239,6 +3286,10 @@ pub struct AppState {
     // attaches to the new target instead of silently refocusing the stale
     // one (see `enter_interactive_pane`).
     pub embed_session: Option<String>,
+    // A changed selection must settle before starting a read-only client.
+    observer_pending: Option<(String, Instant)>,
+    // A read-only observer that dies stays suppressed until selection changes.
+    observer_failed_target: Option<String>,
     // Interior screen rect (inside the border) the embed's PseudoTerminal
     // occupies, published by the interactive render branch each frame. Drives
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
@@ -3876,6 +3927,8 @@ impl Default for AppState {
             focused_pane: FocusedPane::Sessions,
             embed: None,
             embed_session: None,
+            observer_pending: None,
+            observer_failed_target: None,
             embed_pane_area: None,
             menu_bar_area: None,
             sessions_pane_state,
@@ -5856,7 +5909,9 @@ impl AppState {
                     continue;
                 }
 
-                let attached = parts[parts.len() - 2] == "1";
+                let attached_clients = parts[parts.len() - 2].parse::<usize>().unwrap_or(0);
+                let attached =
+                    attached_clients > usize::from(self.is_observing_tmux_session(name.as_str()));
                 let windows = parts[parts.len() - 1].parse().unwrap_or_else(|e| {
                     warn!(
                         "Failed to parse window count for tmux session '{}': {}. Defaulting to 1.",

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -20,6 +20,7 @@ use crate::docker::LogStreamingCoordinator;
 use crate::models::{Session, SessionAgentType, Workspace, is_default_model};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use chrono;
@@ -454,6 +455,26 @@ pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 const OBSERVER_SETTLE_DELAY: Duration = Duration::from_millis(250);
 const OBSERVER_RETRY_DELAY: Duration = Duration::from_secs(2);
+const MAX_OBSERVER_FAILURES: u8 = 3;
+
+fn host_tmux_session_name() -> Option<&'static str> {
+    static HOST_TMUX_SESSION: OnceLock<Option<String>> = OnceLock::new();
+    HOST_TMUX_SESSION
+        .get_or_init(|| {
+            std::env::var_os("TMUX")?;
+            let output = std::process::Command::new("tmux")
+                .args(["display-message", "-p", "#{session_name}"])
+                .output()
+                .ok()?;
+            output
+                .status
+                .success()
+                .then(|| String::from_utf8(output.stdout).ok())
+                .flatten()
+                .map(|name| name.trim().to_string())
+        })
+        .as_deref()
+}
 
 impl AppState {
     /// Enter interactive mode by replacing the selected read-only tmux client
@@ -508,19 +529,26 @@ impl AppState {
             self.release_interactive_pane();
             return false;
         };
+        if host_tmux_session_name() == Some(name.as_str()) {
+            self.release_interactive_pane();
+            return false;
+        }
         let now = Instant::now();
-        if self.observer_failed_target.as_ref().is_some_and(|(failed, _)| failed != &name) {
+        if self
+            .observer_failed_target
+            .as_ref()
+            .is_some_and(|(failed, _, _)| failed != &name)
+        {
             self.observer_failed_target = None;
         }
         if self.embed_session.as_deref() == Some(name.as_str()) && self.embed.is_some() {
             self.observer_pending = None;
             return false;
         }
-        if let Some((failed, retry_at)) = &self.observer_failed_target {
-            if failed == &name && now < *retry_at {
+        if let Some((failed, retry_at, attempts)) = &self.observer_failed_target {
+            if failed == &name && (*attempts >= MAX_OBSERVER_FAILURES || now < *retry_at) {
                 return false;
             }
-            self.observer_failed_target = None;
         }
         if !self.observer_target_settled(&name, now) {
             self.release_interactive_pane();
@@ -536,9 +564,28 @@ impl AppState {
             }
             Err(e) => {
                 tracing::debug!("failed to observe terminal {name}: {e}");
-                self.observer_failed_target = Some((name, now + OBSERVER_RETRY_DELAY));
+                self.record_observer_failure(name);
                 false
             }
+        }
+    }
+
+    fn record_observer_failure(&mut self, session: String) {
+        let attempts = self
+            .observer_failed_target
+            .as_ref()
+            .filter(|(failed, _, _)| failed == &session)
+            .map_or(1, |(_, _, attempts)| attempts.saturating_add(1))
+            .min(MAX_OBSERVER_FAILURES);
+        self.observer_failed_target = Some((
+            session.clone(),
+            Instant::now() + OBSERVER_RETRY_DELAY.saturating_mul(attempts.into()),
+            attempts,
+        ));
+        if attempts == MAX_OBSERVER_FAILURES {
+            self.add_warning_notification(format!(
+                "Live preview unavailable for '{session}'. Select another row to retry."
+            ));
         }
     }
 
@@ -638,8 +685,7 @@ impl AppState {
                 self.add_info_notification("Live session ended, released".to_string());
             } else if exited {
                 if let Some(session) = session {
-                    self.observer_failed_target =
-                        Some((session, Instant::now() + OBSERVER_RETRY_DELAY));
+                    self.record_observer_failure(session);
                 }
             }
             return true;
@@ -3295,7 +3341,7 @@ pub struct AppState {
     // A changed selection must settle before starting a read-only client.
     observer_pending: Option<(String, Instant)>,
     // A read-only observer that dies waits before the next retry.
-    observer_failed_target: Option<(String, Instant)>,
+    observer_failed_target: Option<(String, Instant, u8)>,
     // Interior screen rect (inside the border) the embed's PseudoTerminal
     // occupies, published by the interactive render branch each frame. Drives
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
@@ -5897,19 +5943,6 @@ impl AppState {
             .filter_map(|s| s.tmux_session_name.as_deref())
             .collect();
 
-        let current_tmux_session = if std::env::var_os("TMUX").is_some() {
-            Command::new("tmux")
-                .args(["display-message", "-p", "#{session_name}"])
-                .output()
-                .await
-                .ok()
-                .filter(|output| output.status.success())
-                .and_then(|output| String::from_utf8(output.stdout).ok())
-                .map(|session| session.trim().to_string())
-        } else {
-            None
-        };
-
         let sessions_output = String::from_utf8_lossy(&output.stdout);
         let mut other_sessions = Vec::new();
         let mut ssh_sessions = Vec::new();
@@ -5919,12 +5952,6 @@ impl AppState {
             if parts.len() >= 3 {
                 // Session name may contain colons, so reconstruct from all parts except last two
                 let name = parts[..parts.len() - 2].join(":");
-
-                // A live observer of ainb's own tmux client would consume each
-                // repaint and trigger another repaint forever.
-                if current_tmux_session.as_deref() == Some(name.as_str()) {
-                    continue;
-                }
 
                 // Skip shell sessions (ainb-ws-*, ainb-sh-*, ainb-shell-*)
                 if name.starts_with("ainb-ws-")

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -560,6 +560,7 @@ impl AppState {
             Ok(client) => {
                 self.embed = Some(client);
                 self.embed_session = Some(name);
+                self.observer_failed_target = None;
                 true
             }
             Err(e) => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -453,6 +453,7 @@ pub const SESSIONS_PREVIEW_RESERVE: u16 = 50;
 pub const COLLAPSED_SESSIONS_SIDEBAR_WIDTH: u16 = 5;
 pub const SESSIONS_ROW_DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(300);
 const OBSERVER_SETTLE_DELAY: Duration = Duration::from_millis(250);
+const OBSERVER_RETRY_DELAY: Duration = Duration::from_secs(2);
 
 impl AppState {
     /// Enter interactive mode by replacing the selected read-only tmux client
@@ -507,17 +508,21 @@ impl AppState {
             self.release_interactive_pane();
             return false;
         };
-        if self.observer_failed_target.as_deref() != Some(name.as_str()) {
+        let now = Instant::now();
+        if self.observer_failed_target.as_ref().is_some_and(|(failed, _)| failed != &name) {
             self.observer_failed_target = None;
         }
         if self.embed_session.as_deref() == Some(name.as_str()) && self.embed.is_some() {
             self.observer_pending = None;
             return false;
         }
-        if self.observer_failed_target.as_deref() == Some(name.as_str()) {
-            return false;
+        if let Some((failed, retry_at)) = &self.observer_failed_target {
+            if failed == &name && now < *retry_at {
+                return false;
+            }
+            self.observer_failed_target = None;
         }
-        if !self.observer_target_settled(&name, Instant::now()) {
+        if !self.observer_target_settled(&name, now) {
             self.release_interactive_pane();
             return false;
         }
@@ -531,7 +536,7 @@ impl AppState {
             }
             Err(e) => {
                 tracing::debug!("failed to observe terminal {name}: {e}");
-                self.observer_failed_target = Some(name);
+                self.observer_failed_target = Some((name, now + OBSERVER_RETRY_DELAY));
                 false
             }
         }
@@ -633,7 +638,8 @@ impl AppState {
                 self.add_info_notification("Live session ended, released".to_string());
             } else if exited {
                 if let Some(session) = session {
-                    self.observer_failed_target = Some(session);
+                    self.observer_failed_target =
+                        Some((session, Instant::now() + OBSERVER_RETRY_DELAY));
                 }
             }
             return true;
@@ -3288,8 +3294,8 @@ pub struct AppState {
     pub embed_session: Option<String>,
     // A changed selection must settle before starting a read-only client.
     observer_pending: Option<(String, Instant)>,
-    // A read-only observer that dies stays suppressed until selection changes.
-    observer_failed_target: Option<String>,
+    // A read-only observer that dies waits before the next retry.
+    observer_failed_target: Option<(String, Instant)>,
     // Interior screen rect (inside the border) the embed's PseudoTerminal
     // occupies, published by the interactive render branch each frame. Drives
     // mouse-coordinate translation into 1-based pane-local SGR sequences.
@@ -5891,6 +5897,19 @@ impl AppState {
             .filter_map(|s| s.tmux_session_name.as_deref())
             .collect();
 
+        let current_tmux_session = if std::env::var_os("TMUX").is_some() {
+            Command::new("tmux")
+                .args(["display-message", "-p", "#{session_name}"])
+                .output()
+                .await
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|session| session.trim().to_string())
+        } else {
+            None
+        };
+
         let sessions_output = String::from_utf8_lossy(&output.stdout);
         let mut other_sessions = Vec::new();
         let mut ssh_sessions = Vec::new();
@@ -5900,6 +5919,12 @@ impl AppState {
             if parts.len() >= 3 {
                 // Session name may contain colons, so reconstruct from all parts except last two
                 let name = parts[..parts.len() - 2].join(":");
+
+                // A live observer of ainb's own tmux client would consume each
+                // repaint and trigger another repaint forever.
+                if current_tmux_session.as_deref() == Some(name.as_str()) {
+                    continue;
+                }
 
                 // Skip shell sessions (ainb-ws-*, ainb-sh-*, ainb-shell-*)
                 if name.starts_with("ainb-ws-")

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -5,7 +5,9 @@ mod tests {
     use super::*;
     use crate::app::EventHandler;
     use crate::app::events::AppEvent;
-    use crate::app::state::{AppState, NewSessionState, NewSessionStep, SessionAgentOption};
+    use crate::app::state::{
+        AppState, MAX_OBSERVER_FAILURES, NewSessionState, NewSessionStep, SessionAgentOption,
+    };
     use crate::models::{OtherTmuxSession, SessionAgentType, SessionMode};
     use std::path::PathBuf;
 
@@ -100,7 +102,7 @@ mod tests {
     }
 
     #[test]
-    fn successful_observer_clears_prior_failure_count() {
+    fn observer_spawn_keeps_prior_failure_count_until_grace_period() {
         if std::process::Command::new("tmux")
             .arg("-V")
             .output()
@@ -124,12 +126,127 @@ mod tests {
         assert!(!state.sync_terminal_observer(24, 80), "first tick settles");
         std::thread::sleep(std::time::Duration::from_millis(300));
         assert!(state.sync_terminal_observer(24, 80), "observer starts");
+        assert_eq!(
+            state.observer_failed_target.as_ref().map(|(_, _, attempts)| *attempts),
+            Some(2),
+            "a spawned client can still fail asynchronously"
+        );
+
+        state.release_interactive_pane();
+        state.record_observer_failure(session.clone());
+        assert_eq!(
+            state.observer_failed_target.as_ref().map(|(_, _, attempts)| *attempts),
+            Some(3),
+            "a failed spawn must advance the existing retry count"
+        );
+
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={session}")])
+            .status();
+    }
+
+    #[test]
+    fn surviving_observer_clears_prior_failure_count_after_grace_period() {
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+
+        let session = format!("ainb-observer-grace-{}", std::process::id());
+        let created = std::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "sh"])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        assert!(created, "failed to create tmux session");
+
+        let mut state = state_with_other_tmux_sessions(&[session.as_str()]);
+        state.current_screen = "session_list".to_string();
+        state.observer_failed_target = Some((session.clone(), std::time::Instant::now(), 2));
+        assert!(!state.sync_terminal_observer(24, 80));
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(state.sync_terminal_observer(24, 80));
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(!state.poll_embed_exit());
         assert!(state.observer_failed_target.is_none());
 
         state.release_interactive_pane();
         let _ = std::process::Command::new("tmux")
             .args(["kill-session", "-t", &format!("={session}")])
             .status();
+    }
+
+    #[test]
+    fn ended_observed_session_stops_retry_without_failure_warning() {
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+
+        let session = format!("ainb-observer-ended-{}", std::process::id());
+        let created = std::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "sh"])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        assert!(created, "failed to create tmux session");
+
+        let mut state = state_with_other_tmux_sessions(&[session.as_str()]);
+        state.current_screen = "session_list".to_string();
+        assert!(!state.sync_terminal_observer(24, 80));
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(state.sync_terminal_observer(24, 80));
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={session}")])
+            .status();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while !state.poll_embed_exit() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert_eq!(
+            state.observer_failed_target.as_ref().map(|(_, _, attempts)| *attempts),
+            Some(MAX_OBSERVER_FAILURES)
+        );
+        assert!(
+            state
+                .notifications
+                .iter()
+                .any(|notification| notification.message == "Live session ended, released")
+        );
+        assert!(
+            !state
+                .notifications
+                .iter()
+                .any(|notification| { notification.message.contains("Live preview unavailable") })
+        );
+    }
+
+    #[test]
+    fn live_preview_scrollback_notice_is_deduplicated() {
+        let mut state = AppState::new();
+        state.notify_live_preview_no_scrollback();
+        state.notify_live_preview_no_scrollback();
+
+        assert_eq!(
+            state
+                .notifications
+                .iter()
+                .filter(|notification| {
+                    notification.message == "Live preview has no scrollback. Press A to interact."
+                })
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -57,6 +57,10 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        if !crate::tmux::EmbedClient::read_only_observer_supported() {
+            eprintln!("SKIP: tmux lacks ignore-size client support");
+            return;
+        }
         let _registry_guard = lock_registry_for_test();
 
         let missing = format!("ainb-missing-observer-{}", std::process::id());
@@ -113,6 +117,10 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        if !crate::tmux::EmbedClient::read_only_observer_supported() {
+            eprintln!("SKIP: tmux lacks ignore-size client support");
+            return;
+        }
         let _registry_guard = lock_registry_for_test();
 
         let session = format!("ainb-observer-retry-reset-{}", std::process::id());
@@ -158,6 +166,10 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        if !crate::tmux::EmbedClient::read_only_observer_supported() {
+            eprintln!("SKIP: tmux lacks ignore-size client support");
+            return;
+        }
         let _registry_guard = lock_registry_for_test();
 
         let session = format!("ainb-observer-grace-{}", std::process::id());
@@ -192,6 +204,10 @@ mod tests {
             .map_or(true, |output| !output.status.success())
         {
             eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+        if !crate::tmux::EmbedClient::read_only_observer_supported() {
+            eprintln!("SKIP: tmux lacks ignore-size client support");
             return;
         }
         let _registry_guard = lock_registry_for_test();

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -9,6 +9,7 @@ mod tests {
         AppState, MAX_OBSERVER_FAILURES, NewSessionState, NewSessionStep, SessionAgentOption,
     };
     use crate::models::{OtherTmuxSession, SessionAgentType, SessionMode};
+    use crate::tmux::pty_wrapper::lock_registry_for_test;
     use std::path::PathBuf;
 
     // ========================================================================
@@ -56,6 +57,7 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        let _registry_guard = lock_registry_for_test();
 
         let missing = format!("ainb-missing-observer-{}", std::process::id());
         let mut state = state_with_other_tmux_sessions(&[missing.as_str()]);
@@ -111,6 +113,7 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        let _registry_guard = lock_registry_for_test();
 
         let session = format!("ainb-observer-retry-reset-{}", std::process::id());
         let created = std::process::Command::new("tmux")
@@ -155,6 +158,7 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        let _registry_guard = lock_registry_for_test();
 
         let session = format!("ainb-observer-grace-{}", std::process::id());
         let created = std::process::Command::new("tmux")
@@ -181,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn ended_observed_session_stops_retry_without_failure_warning() {
+    fn retry_suppression_releases_the_previous_observer() {
         if std::process::Command::new("tmux")
             .arg("-V")
             .output()
@@ -190,45 +194,32 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        let _registry_guard = lock_registry_for_test();
 
-        let session = format!("ainb-observer-ended-{}", std::process::id());
+        let active = format!("ainb-observer-active-{}", std::process::id());
+        let blocked = format!("ainb-observer-blocked-{}", std::process::id());
         let created = std::process::Command::new("tmux")
-            .args(["new-session", "-d", "-s", &session, "sh"])
+            .args(["new-session", "-d", "-s", &active, "sh"])
             .status()
             .map(|status| status.success())
             .unwrap_or(false);
         assert!(created, "failed to create tmux session");
 
-        let mut state = state_with_other_tmux_sessions(&[session.as_str()]);
+        let mut state = state_with_other_tmux_sessions(&[active.as_str(), blocked.as_str()]);
         state.current_screen = "session_list".to_string();
         assert!(!state.sync_terminal_observer(24, 80));
         std::thread::sleep(std::time::Duration::from_millis(300));
         assert!(state.sync_terminal_observer(24, 80));
+
+        state.selected_other_tmux_index = Some(1);
+        state.observer_failed_target =
+            Some((blocked, std::time::Instant::now(), MAX_OBSERVER_FAILURES));
+        assert!(!state.sync_terminal_observer(24, 80));
+        assert!(state.embed.is_none());
+
         let _ = std::process::Command::new("tmux")
-            .args(["kill-session", "-t", &format!("={session}")])
+            .args(["kill-session", "-t", &format!("={active}")])
             .status();
-
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-        while !state.poll_embed_exit() && std::time::Instant::now() < deadline {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-
-        assert_eq!(
-            state.observer_failed_target.as_ref().map(|(_, _, attempts)| *attempts),
-            Some(MAX_OBSERVER_FAILURES)
-        );
-        assert!(
-            state
-                .notifications
-                .iter()
-                .any(|notification| notification.message == "Live session ended, released")
-        );
-        assert!(
-            !state
-                .notifications
-                .iter()
-                .any(|notification| { notification.message.contains("Live preview unavailable") })
-        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -28,6 +28,62 @@ mod tests {
     }
 
     #[test]
+    fn observer_waits_for_a_stable_selection() {
+        let mut state = AppState::new();
+        let now = std::time::Instant::now();
+
+        assert!(!state.observer_target_settled("stale", now));
+        assert!(
+            !state.observer_target_settled("stale", now + std::time::Duration::from_millis(100))
+        );
+        assert!(
+            state.observer_target_settled("stale", now + std::time::Duration::from_millis(250))
+        );
+        assert!(
+            !state.observer_target_settled("fresh", now + std::time::Duration::from_millis(250))
+        );
+    }
+
+    #[test]
+    fn dead_observer_stays_suppressed_until_selection_changes() {
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+
+        let missing = format!("ainb-missing-observer-{}", std::process::id());
+        let mut state = state_with_other_tmux_sessions(&[missing.as_str()]);
+        state.current_screen = "session_list".to_string();
+
+        assert!(!state.sync_terminal_observer(24, 80), "first tick settles");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(state.sync_terminal_observer(24, 80), "starts observer once");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while !state.poll_embed_exit() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert_eq!(
+            state.observer_failed_target.as_deref(),
+            Some(missing.as_str())
+        );
+        assert!(state.embed.is_none(), "dead observer must release");
+        assert!(
+            !state.sync_terminal_observer(24, 80),
+            "same stale selection must not respawn an observer"
+        );
+
+        state.selected_other_tmux_index = None;
+        assert!(!state.sync_terminal_observer(24, 80));
+        assert!(state.observer_failed_target.is_none());
+    }
+
+    #[test]
     fn test_toggle_select_other_tmux_session_supports_multiple_names() {
         let mut state = state_with_other_tmux_sessions(&["alpha", "beta"]);
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -69,7 +69,7 @@ mod tests {
         }
 
         assert_eq!(
-            state.observer_failed_target.as_deref(),
+            state.observer_failed_target.as_ref().map(|(target, _)| target.as_str()),
             Some(missing.as_str())
         );
         assert!(state.embed.is_none(), "dead observer must release");

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -100,6 +100,39 @@ mod tests {
     }
 
     #[test]
+    fn successful_observer_clears_prior_failure_count() {
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map_or(true, |output| !output.status.success())
+        {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+
+        let session = format!("ainb-observer-retry-reset-{}", std::process::id());
+        let created = std::process::Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "sh"])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        assert!(created, "failed to create tmux session");
+
+        let mut state = state_with_other_tmux_sessions(&[session.as_str()]);
+        state.current_screen = "session_list".to_string();
+        state.observer_failed_target = Some((session.clone(), std::time::Instant::now(), 2));
+        assert!(!state.sync_terminal_observer(24, 80), "first tick settles");
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(state.sync_terminal_observer(24, 80), "observer starts");
+        assert!(state.observer_failed_target.is_none());
+
+        state.release_interactive_pane();
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={session}")])
+            .status();
+    }
+
+    #[test]
     fn test_toggle_select_other_tmux_session_supports_multiple_names() {
         let mut state = state_with_other_tmux_sessions(&["alpha", "beta"]);
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -45,7 +45,7 @@ mod tests {
     }
 
     #[test]
-    fn dead_observer_stays_suppressed_until_selection_changes() {
+    fn dead_observer_stays_suppressed_for_the_retry_window() {
         if std::process::Command::new("tmux")
             .arg("-V")
             .output()
@@ -69,7 +69,7 @@ mod tests {
         }
 
         assert_eq!(
-            state.observer_failed_target.as_ref().map(|(target, _)| target.as_str()),
+            state.observer_failed_target.as_ref().map(|(target, _, _)| target.as_str()),
             Some(missing.as_str())
         );
         assert!(state.embed.is_none(), "dead observer must release");
@@ -81,6 +81,22 @@ mod tests {
         state.selected_other_tmux_index = None;
         assert!(!state.sync_terminal_observer(24, 80));
         assert!(state.observer_failed_target.is_none());
+    }
+
+    #[test]
+    fn observer_failure_stops_after_three_attempts() {
+        let mut state = AppState::new();
+        for _ in 0..3 {
+            state.record_observer_failure("stale".to_string());
+        }
+
+        assert_eq!(
+            state.observer_failed_target.as_ref().map(|(_, _, attempts)| *attempts),
+            Some(3)
+        );
+        assert!(state.notifications.iter().any(|notification| {
+            notification.message.contains("Live preview unavailable for 'stale'")
+        }));
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -161,11 +161,8 @@ impl LayoutComponent {
 
         // Render tmux preview if selected session has tmux, otherwise show live logs
         // This includes both regular Claude sessions AND shell sessions
-        let selected_has_tmux = state
-            .get_selected_session()
-            .and_then(|s| s.tmux_session_name.as_ref())
-            .is_some()
-            || state.selected_shell_session().is_some();
+        let selected_tmux_name = state.selected_tmux_name();
+        let selected_has_tmux = selected_tmux_name.is_some();
 
         if state.is_interactive_pane() {
             // Live interactive embed occupies the right pane. Resize the embed to
@@ -184,8 +181,24 @@ impl LayoutComponent {
             state.embed_pane_area = Some(inner);
             self.tmux_preview.render_interactive(frame, area, state);
         } else if selected_has_tmux {
-            // Render tmux preview pane (read-only capture)
-            self.tmux_preview.render(frame, content_chunks[1], state);
+            let area = content_chunks[1];
+            let observing_selection =
+                state.embed.is_some() && state.embed_session == selected_tmux_name;
+            if observing_selection {
+                let inner = area.inner(Margin {
+                    vertical: 1,
+                    horizontal: 1,
+                });
+                if let Some(observer) = state.embed.as_mut() {
+                    let _ = observer.resize(inner.height, inner.width);
+                }
+                state.embed_pane_area = None;
+                self.tmux_preview.render_observer(frame, area, state);
+            } else {
+                // Initial attach can take one frame. Keep the existing capture
+                // as a transient fallback, never as the steady-state renderer.
+                self.tmux_preview.render(frame, area, state);
+            }
         } else {
             // Render traditional live logs stream
             self.live_logs_stream.render(frame, content_chunks[1], state);

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -35,15 +35,24 @@ use crate::app::{
 /// the session twice back-to-back (attach size → layout size).
 ///
 /// Must mirror `render`'s split: vertical chrome is the status bar (3) +
-/// session info (3) + menu bar (6), and the pane border takes 2 more rows/
-/// cols off the interior. `sidebar_width` is the live
+/// session info (3) + current menu bar height, and the pane border takes 2
+/// more rows/cols off the interior. `sidebar_width` is the live
 /// `sessions_pane_state.effective_width(..)` for the same terminal width.
-pub fn interactive_embed_size(width: u16, height: u16, sidebar_width: u16) -> (u16, u16) {
-    const VERTICAL_CHROME: u16 = 3 + 3 + 6; // status bar + session info + menu bar
+pub fn interactive_embed_size(
+    width: u16,
+    height: u16,
+    sidebar_width: u16,
+    show_menu_bar: bool,
+) -> (u16, u16) {
     const PANE_BORDERS: u16 = 2;
-    let rows = height.saturating_sub(VERTICAL_CHROME + PANE_BORDERS).max(1);
+    let vertical_chrome = 3 + 3 + session_menu_bar_height(show_menu_bar);
+    let rows = height.saturating_sub(vertical_chrome + PANE_BORDERS).max(1);
     let cols = width.saturating_sub(sidebar_width.saturating_add(PANE_BORDERS)).max(1);
     (rows, cols)
+}
+
+fn session_menu_bar_height(show_menu_bar: bool) -> u16 {
+    if show_menu_bar { 6 } else { 1 }
 }
 
 pub struct LayoutComponent {
@@ -119,11 +128,8 @@ impl LayoutComponent {
 
         // The bottom keymap legend can be hidden (⇧M) to give the session list
         // more room; hidden it collapses to a single hint row.
-        let menu_bar_h = if state.app_config.ui_preferences.show_session_menu_bar {
-            6 // full legend: 4 lines + borders
-        } else {
-            1 // collapsed hint row
-        };
+        let menu_bar_h =
+            session_menu_bar_height(state.app_config.ui_preferences.show_session_menu_bar);
         let main_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -159,10 +165,15 @@ impl LayoutComponent {
             self.session_list.render(frame, content_chunks[0], state);
         }
 
-        // Render tmux preview if selected session has tmux, otherwise show live logs
-        // This includes both regular Claude sessions AND shell sessions
-        let selected_tmux_name = state.selected_tmux_name();
-        let selected_has_tmux = selected_tmux_name.is_some();
+        // The legacy capture renderer supports regular sessions and shells.
+        // A live observer can also render SSH and other-tmux sessions, but its
+        // initial and failed states must retain those rows' live-logs fallback.
+        let selected_has_legacy_preview = state
+            .get_selected_session()
+            .and_then(|session| session.tmux_session_name.as_ref())
+            .is_some()
+            || state.selected_shell_session().is_some();
+        let observing_selection = state.is_observing_selected_terminal();
 
         if state.is_interactive_pane() {
             // Live interactive embed occupies the right pane. Resize the embed to
@@ -180,25 +191,21 @@ impl LayoutComponent {
             // 1-based pane-local SGR coordinates (see encode_mouse_event).
             state.embed_pane_area = Some(inner);
             self.tmux_preview.render_interactive(frame, area, state);
-        } else if selected_has_tmux {
+        } else if observing_selection {
             let area = content_chunks[1];
-            let observing_selection =
-                state.embed.is_some() && state.embed_session == selected_tmux_name;
-            if observing_selection {
-                let inner = area.inner(Margin {
-                    vertical: 1,
-                    horizontal: 1,
-                });
-                if let Some(observer) = state.embed.as_mut() {
-                    let _ = observer.resize(inner.height, inner.width);
-                }
-                state.embed_pane_area = None;
-                self.tmux_preview.render_observer(frame, area, state);
-            } else {
-                // Initial attach can take one frame. Keep the existing capture
-                // as a transient fallback, never as the steady-state renderer.
-                self.tmux_preview.render(frame, area, state);
+            let inner = area.inner(Margin {
+                vertical: 1,
+                horizontal: 1,
+            });
+            if let Some(observer) = state.embed.as_mut() {
+                let _ = observer.resize(inner.height, inner.width);
             }
+            state.embed_pane_area = None;
+            self.tmux_preview.render_observer(frame, area, state);
+        } else if selected_has_legacy_preview {
+            // Initial attach can take one frame. Keep the existing capture as
+            // a transient fallback, never as the steady-state renderer.
+            self.tmux_preview.render(frame, content_chunks[1], state);
         } else {
             // Render traditional live logs stream
             self.live_logs_stream.render(frame, content_chunks[1], state);
@@ -1724,14 +1731,15 @@ mod interactive_embed_size_tests {
         // plus the border (2) → 78; pre-collapsed to the 5-col rail → 113.
         // Must equal what the first interactive frame resizes the embed to
         // (the tripwire drives the real render path against this).
-        assert_eq!(interactive_embed_size(120, 30, 40), (16, 78));
-        assert_eq!(interactive_embed_size(120, 30, 5), (16, 113));
-        assert_eq!(interactive_embed_size(80, 24, 5), (10, 73));
+        assert_eq!(interactive_embed_size(120, 30, 40, true), (16, 78));
+        assert_eq!(interactive_embed_size(120, 30, 5, true), (16, 113));
+        assert_eq!(interactive_embed_size(80, 24, 5, true), (10, 73));
+        assert_eq!(interactive_embed_size(120, 30, 40, false), (21, 78));
     }
 
     #[test]
     fn never_returns_zero_cells() {
-        assert_eq!(interactive_embed_size(0, 0, 5), (1, 1));
-        assert_eq!(interactive_embed_size(7, 14, 40), (1, 1));
+        assert_eq!(interactive_embed_size(0, 0, 5, true), (1, 1));
+        assert_eq!(interactive_embed_size(7, 14, 40, true), (1, 1));
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
+++ b/ainb-tui/crates/ainb-core/src/components/tmux_preview.rs
@@ -63,31 +63,39 @@ impl TmuxPreviewPane {
         }
     }
 
-    /// Render the live interactive embed (the pane that IS the tmux session).
-    /// Draws the embedded vt100 screen via tui-term inside a focus-cued block
-    /// (distinct border + `● INTERACTIVE — Ctrl+Q release` badge). Falls back to
-    /// a placeholder if the embed/screen is momentarily unavailable.
+    /// Render the live interactive terminal observer with input focus.
     pub fn render_interactive(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        self.render_terminal(frame, area, state, true);
+    }
+
+    /// Render the same terminal observer without granting it input ownership.
+    pub fn render_observer(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        self.render_terminal(frame, area, state, false);
+    }
+
+    fn render_terminal(&self, frame: &mut Frame, area: Rect, state: &AppState, interactive: bool) {
+        let (badge, badge_color, hint) = if interactive {
+            ("INTERACTIVE", SELECTION_GREEN, "Ctrl+Q release")
+        } else {
+            ("LIVE PREVIEW", GOLD, "A interact")
+        };
         let title = Line::from(vec![
             Span::styled(
                 " ● ",
-                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+                Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
             ),
             Span::styled(
-                "INTERACTIVE ",
-                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+                format!("{badge} "),
+                Style::default().fg(badge_color).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("— ", Style::default().fg(MUTED_GRAY)),
-            Span::styled(
-                "Ctrl+Q",
-                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" release ", Style::default().fg(MUTED_GRAY)),
+            Span::styled("| ", Style::default().fg(MUTED_GRAY)),
+            Span::styled(hint, Style::default().fg(MUTED_GRAY)),
+            Span::raw(" "),
         ]);
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(SELECTION_GREEN))
+            .border_style(Style::default().fg(badge_color))
             .style(Style::default().bg(DARK_BG))
             .title(title);
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -502,8 +502,12 @@ async fn run_tui_loop(
                 height: 24,
             });
             let sidebar = app.state.sessions_pane_state.effective_width(sz.width);
-            let (rows, cols) =
-                crate::components::layout::interactive_embed_size(sz.width, sz.height, sidebar);
+            let (rows, cols) = crate::components::layout::interactive_embed_size(
+                sz.width,
+                sz.height,
+                sidebar,
+                app.state.app_config.ui_preferences.show_session_menu_bar,
+            );
             needs_redraw |= app.state.sync_terminal_observer(rows, cols);
         }
 
@@ -598,17 +602,21 @@ async fn run_tui_loop(
 
                     use crossterm::event::KeyCode;
 
-                    // Interactive embed escape hatch. A read-only preview also
-                    // owns an embed client, so only interactive focus may
-                    // consume Ctrl+Q instead of the host UI.
+                    // Ctrl+Q belongs to the terminal mode. Interactive mode
+                    // releases; read-only preview consumes it without letting
+                    // the host's plain `q` shortcut navigate home.
                     {
                         use crossterm::event::KeyModifiers;
-                        if app.state.is_interactive_pane()
-                            && key_event.code == KeyCode::Char('q')
+                        if key_event.code == KeyCode::Char('q')
                             && key_event.modifiers.contains(KeyModifiers::CONTROL)
                         {
-                            app.state.release_interactive_pane();
-                            continue;
+                            if app.state.is_interactive_pane() {
+                                app.state.release_interactive_pane();
+                                continue;
+                            }
+                            if app.state.is_observing_selected_terminal() {
+                                continue;
+                            }
                         }
                     }
 
@@ -686,9 +694,13 @@ async fn run_tui_loop(
                         continue;
                     }
 
-                    // Intercept keys when tmux preview is in scroll mode
+                    // A read-only terminal uses tmux's own scrollback; host
+                    // preview scroll mode would swallow navigation invisibly.
+                    let observing_terminal = app.state.is_observing_selected_terminal();
                     let preview = layout.tmux_preview_mut();
-                    if preview.is_scroll_mode() {
+                    if observing_terminal {
+                        preview.exit_scroll_mode();
+                    } else if preview.is_scroll_mode() {
                         match key_event.code {
                             KeyCode::Esc => {
                                 preview.exit_scroll_mode();
@@ -741,21 +753,27 @@ async fn run_tui_loop(
                             }
                             // Tmux preview scroll events
                             AppEvent::ScrollPreviewUp => {
-                                let preview = layout.tmux_preview_mut();
-                                if !preview.is_scroll_mode() {
-                                    preview.enter_scroll_mode();
+                                if !app.state.is_observing_selected_terminal() {
+                                    let preview = layout.tmux_preview_mut();
+                                    if !preview.is_scroll_mode() {
+                                        preview.enter_scroll_mode();
+                                    }
+                                    preview.scroll_up();
                                 }
-                                preview.scroll_up();
                             }
                             AppEvent::ScrollPreviewDown => {
-                                let preview = layout.tmux_preview_mut();
-                                if !preview.is_scroll_mode() {
-                                    preview.enter_scroll_mode();
+                                if !app.state.is_observing_selected_terminal() {
+                                    let preview = layout.tmux_preview_mut();
+                                    if !preview.is_scroll_mode() {
+                                        preview.enter_scroll_mode();
+                                    }
+                                    preview.scroll_down();
                                 }
-                                preview.scroll_down();
                             }
                             AppEvent::EnterScrollMode => {
-                                layout.tmux_preview_mut().enter_scroll_mode();
+                                if !app.state.is_observing_selected_terminal() {
+                                    layout.tmux_preview_mut().enter_scroll_mode();
+                                }
                             }
                             AppEvent::ExitScrollMode => {
                                 layout.tmux_preview_mut().exit_scroll_mode();
@@ -775,7 +793,10 @@ async fn run_tui_loop(
                                     app.state.sessions_pane_state.effective_width(sz.width);
                                 let (rows, cols) =
                                     crate::components::layout::interactive_embed_size(
-                                        sz.width, sz.height, sidebar,
+                                        sz.width,
+                                        sz.height,
+                                        sidebar,
+                                        app.state.app_config.ui_preferences.show_session_menu_bar,
                                     );
                                 // Failure (no tmux session on the row / attach
                                 // error) surfaces as a notification from

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -602,9 +602,9 @@ async fn run_tui_loop(
 
                     use crossterm::event::KeyCode;
 
-                    // Ctrl+Q belongs to the terminal mode. Interactive mode
-                    // releases; read-only preview consumes it without letting
-                    // the host's plain `q` shortcut navigate home.
+                    // Ctrl+Q belongs to the terminal screen. Interactive mode
+                    // releases; every other session-list state consumes it so
+                    // the host's plain `q` shortcut is never timing-dependent.
                     {
                         use crossterm::event::KeyModifiers;
                         if key_event.code == KeyCode::Char('q')
@@ -612,9 +612,8 @@ async fn run_tui_loop(
                         {
                             if app.state.is_interactive_pane() {
                                 app.state.release_interactive_pane();
-                                continue;
                             }
-                            if app.state.is_observing_selected_terminal() {
+                            if app.state.current_screen == crate::app::screens::ids::SESSION_LIST {
                                 continue;
                             }
                         }
@@ -754,10 +753,7 @@ async fn run_tui_loop(
                             // Tmux preview scroll events
                             AppEvent::ScrollPreviewUp => {
                                 if app.state.is_observing_selected_terminal() {
-                                    app.state.add_info_notification(
-                                        "Live preview has no scrollback. Press A to interact."
-                                            .to_string(),
-                                    );
+                                    app.state.notify_live_preview_no_scrollback();
                                 } else {
                                     let preview = layout.tmux_preview_mut();
                                     if !preview.is_scroll_mode() {
@@ -768,10 +764,7 @@ async fn run_tui_loop(
                             }
                             AppEvent::ScrollPreviewDown => {
                                 if app.state.is_observing_selected_terminal() {
-                                    app.state.add_info_notification(
-                                        "Live preview has no scrollback. Press A to interact."
-                                            .to_string(),
-                                    );
+                                    app.state.notify_live_preview_no_scrollback();
                                 } else {
                                     let preview = layout.tmux_preview_mut();
                                     if !preview.is_scroll_mode() {
@@ -782,10 +775,7 @@ async fn run_tui_loop(
                             }
                             AppEvent::EnterScrollMode => {
                                 if app.state.is_observing_selected_terminal() {
-                                    app.state.add_info_notification(
-                                        "Live preview has no scrollback. Press A to interact."
-                                            .to_string(),
-                                    );
+                                    app.state.notify_live_preview_no_scrollback();
                                 } else {
                                     layout.tmux_preview_mut().enter_scroll_mode();
                                 }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -753,7 +753,12 @@ async fn run_tui_loop(
                             }
                             // Tmux preview scroll events
                             AppEvent::ScrollPreviewUp => {
-                                if !app.state.is_observing_selected_terminal() {
+                                if app.state.is_observing_selected_terminal() {
+                                    app.state.add_info_notification(
+                                        "Live preview has no scrollback. Press A to interact."
+                                            .to_string(),
+                                    );
+                                } else {
                                     let preview = layout.tmux_preview_mut();
                                     if !preview.is_scroll_mode() {
                                         preview.enter_scroll_mode();
@@ -762,7 +767,12 @@ async fn run_tui_loop(
                                 }
                             }
                             AppEvent::ScrollPreviewDown => {
-                                if !app.state.is_observing_selected_terminal() {
+                                if app.state.is_observing_selected_terminal() {
+                                    app.state.add_info_notification(
+                                        "Live preview has no scrollback. Press A to interact."
+                                            .to_string(),
+                                    );
+                                } else {
                                     let preview = layout.tmux_preview_mut();
                                     if !preview.is_scroll_mode() {
                                         preview.enter_scroll_mode();
@@ -771,7 +781,12 @@ async fn run_tui_loop(
                                 }
                             }
                             AppEvent::EnterScrollMode => {
-                                if !app.state.is_observing_selected_terminal() {
+                                if app.state.is_observing_selected_terminal() {
+                                    app.state.add_info_notification(
+                                        "Live preview has no scrollback. Press A to interact."
+                                            .to_string(),
+                                    );
+                                } else {
                                     layout.tmux_preview_mut().enter_scroll_mode();
                                 }
                             }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -491,6 +491,22 @@ async fn run_tui_loop(
             needs_redraw = true;
         }
 
+        // Read-only preview is a real tmux client feeding the same vt100
+        // parser used after input focus is granted. Keep it aligned with the
+        // current selection and viewport before painting.
+        if app.state.current_screen == crate::app::screens::ids::SESSION_LIST
+            && !app.state.is_interactive_pane()
+        {
+            let sz = terminal.size().unwrap_or(ratatui::layout::Size {
+                width: 80,
+                height: 24,
+            });
+            let sidebar = app.state.sessions_pane_state.effective_width(sz.width);
+            let (rows, cols) =
+                crate::components::layout::interactive_embed_size(sz.width, sz.height, sidebar);
+            needs_redraw |= app.state.sync_terminal_observer(rows, cols);
+        }
+
         // Live embed output is the third repaint source alongside input and
         // plugin frames: the PTY reader thread marks the embed dirty as bytes
         // stream in, with no host input involved. Without this the dirty-gate
@@ -582,14 +598,12 @@ async fn run_tui_loop(
 
                     use crossterm::event::KeyCode;
 
-                    // Interactive embed escape hatch: Ctrl+Q releases focus and
-                    // kills the ephemeral tmux client. Keyed off the RESOURCE
-                    // (embed exists), never the mode flag, so the hatch works
-                    // even from a leaked state where the embed is alive but
-                    // focus drifted off the preview pane.
+                    // Interactive embed escape hatch. A read-only preview also
+                    // owns an embed client, so only interactive focus may
+                    // consume Ctrl+Q instead of the host UI.
                     {
                         use crossterm::event::KeyModifiers;
-                        if app.state.embed.is_some()
+                        if app.state.is_interactive_pane()
                             && key_event.code == KeyCode::Char('q')
                             && key_event.modifiers.contains(KeyModifiers::CONTROL)
                         {
@@ -1086,6 +1100,10 @@ async fn run_tui_loop(
                 match action {
                     AsyncAction::AttachToOtherTmux(session_name) => {
                         use crate::app::AttachHandler;
+
+                        // Fullscreen attach owns terminal size and input. Drop
+                        // preview client first so tmux has only one authority.
+                        app.state.release_interactive_pane();
 
                         info!(
                             "[ACTION] Handling AttachToOtherTmux for session '{}'",
@@ -1784,6 +1802,10 @@ async fn run_tui_loop(
                         };
 
                         if let Some(tmux_session_name) = tmux_session_name {
+                            // Fullscreen attach owns terminal size and input.
+                            // Preview reconnects after detach.
+                            app.state.release_interactive_pane();
+
                             // Mark session as attached
                             for workspace in &mut app.state.workspaces {
                                 for session in &mut workspace.sessions {

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -518,6 +518,10 @@ mod tests {
             eprintln!("SKIP: tmux unavailable");
             return;
         }
+        if !EmbedClient::read_only_observer_supported() {
+            eprintln!("SKIP: tmux lacks ignore-size client support");
+            return;
+        }
         let _g = lock_serial();
         let session = new_session("observe");
         let session_size = window_size(&session);

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -119,6 +119,12 @@ impl EmbedClient {
         Self::attach_target_with_mode(session_name, rows, cols, true)
     }
 
+    /// Read-only observation is safe only when this tmux can keep the preview
+    /// client's size out of the shared window-size calculation.
+    pub fn read_only_observer_supported() -> bool {
+        supports_ignore_size()
+    }
+
     /// Attach to an exact tmux target. Window and pane targets are selected
     /// before starting the embedded client, then the client attaches to the
     /// owning session without losing the exact target.

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -97,13 +97,27 @@ impl EmbedClient {
     /// Attach to `session_name` at the given cell size and start streaming its
     /// output into a vt100 parser on a dedicated reader thread.
     pub fn attach(session_name: &str, rows: u16, cols: u16) -> Result<Self> {
-        Self::attach_target(session_name, rows, cols)
+        Self::attach_target_with_mode(session_name, rows, cols, false)
+    }
+
+    /// Observe `session_name` through tmux's native read-only client mode.
+    pub fn observe(session_name: &str, rows: u16, cols: u16) -> Result<Self> {
+        Self::attach_target_with_mode(session_name, rows, cols, true)
     }
 
     /// Attach to an exact tmux target. Window and pane targets are selected
     /// before starting the embedded client, then the client attaches to the
     /// owning session without losing the exact target.
     pub fn attach_target(target: &str, rows: u16, cols: u16) -> Result<Self> {
+        Self::attach_target_with_mode(target, rows, cols, false)
+    }
+
+    fn attach_target_with_mode(
+        target: &str,
+        rows: u16,
+        cols: u16,
+        read_only: bool,
+    ) -> Result<Self> {
         let session_name = target.split_once(':').map_or(target, |(session, _)| session).trim();
         anyhow::ensure!(!session_name.is_empty(), "tmux target has no session name");
         if target.contains(':') {
@@ -120,6 +134,9 @@ impl EmbedClient {
 
         let mut cmd = CommandBuilder::new("tmux");
         cmd.arg("attach-session");
+        if read_only {
+            cmd.arg("-r");
+        }
         cmd.arg("-t");
         cmd.arg(session_name);
         apply_embed_env(&mut cmd);
@@ -348,6 +365,50 @@ mod tests {
             std::thread::sleep(Duration::from_millis(50));
         }
         false
+    }
+
+    fn assert_same_screen(left: &vt100::Screen, right: &vt100::Screen) {
+        assert_eq!(left.size(), right.size());
+        assert_eq!(left.cursor_position(), right.cursor_position());
+        for row in 0..left.size().0 {
+            for col in 0..left.size().1 {
+                assert_eq!(
+                    left.cell(row, col),
+                    right.cell(row, col),
+                    "cell {row},{col}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn terminal_state_matches_across_fragmented_bytes_and_resize() {
+        let before_resize: &[&[u8]] = &[
+            b"alpha\r",
+            b"\n\x1b[3",
+            b"1mred\x1b[0m ",
+            b"\xf0",
+            b"\x9f\xa6",
+            b"\x80\r\nthird",
+            b"\x1b[1A\x1b[5CX",
+        ];
+        let after_resize: &[&[u8]] = &[b"\x1b[2;", b"3H\x1b[44", b"mZ\x1b[0m\r", b"\nlast"];
+
+        let mut attach = vt100::Parser::new(6, 12, 0);
+        let mut preview = vt100::Parser::new(6, 12, 0);
+        attach.process(&before_resize.concat());
+        for chunk in before_resize {
+            preview.process(chunk);
+        }
+
+        attach.screen_mut().set_size(8, 16);
+        preview.screen_mut().set_size(8, 16);
+        attach.process(&after_resize.concat());
+        for chunk in after_resize {
+            preview.process(chunk);
+        }
+
+        assert_same_screen(attach.screen(), preview.screen());
     }
 
     // ── env enforcement policy (no tmux needed) ─────────────────────────────

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -136,6 +136,9 @@ impl EmbedClient {
         cmd.arg("attach-session");
         if read_only {
             cmd.arg("-r");
+            // Native tmux client flag: render this client, but never let its
+            // small preview PTY decide the shared window size.
+            cmd.args(["-f", "ignore-size"]);
         }
         cmd.arg("-t");
         cmd.arg(session_name);
@@ -367,48 +370,20 @@ mod tests {
         false
     }
 
-    fn assert_same_screen(left: &vt100::Screen, right: &vt100::Screen) {
-        assert_eq!(left.size(), right.size());
-        assert_eq!(left.cursor_position(), right.cursor_position());
-        for row in 0..left.size().0 {
-            for col in 0..left.size().1 {
-                assert_eq!(
-                    left.cell(row, col),
-                    right.cell(row, col),
-                    "cell {row},{col}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn terminal_state_matches_across_fragmented_bytes_and_resize() {
-        let before_resize: &[&[u8]] = &[
-            b"alpha\r",
-            b"\n\x1b[3",
-            b"1mred\x1b[0m ",
-            b"\xf0",
-            b"\x9f\xa6",
-            b"\x80\r\nthird",
-            b"\x1b[1A\x1b[5CX",
-        ];
-        let after_resize: &[&[u8]] = &[b"\x1b[2;", b"3H\x1b[44", b"mZ\x1b[0m\r", b"\nlast"];
-
-        let mut attach = vt100::Parser::new(6, 12, 0);
-        let mut preview = vt100::Parser::new(6, 12, 0);
-        attach.process(&before_resize.concat());
-        for chunk in before_resize {
-            preview.process(chunk);
-        }
-
-        attach.screen_mut().set_size(8, 16);
-        preview.screen_mut().set_size(8, 16);
-        attach.process(&after_resize.concat());
-        for chunk in after_resize {
-            preview.process(chunk);
-        }
-
-        assert_same_screen(attach.screen(), preview.screen());
+    fn window_size(session: &str) -> Option<(u16, u16)> {
+        let output = Command::new("tmux")
+            .args([
+                "display-message",
+                "-p",
+                "-t",
+                &format!("={session}"),
+                "#{window_height}x#{window_width}",
+            ])
+            .output()
+            .ok()?;
+        let size = String::from_utf8(output.stdout).ok()?;
+        let (rows, cols) = size.trim().split_once('x')?;
+        Some((rows.parse().ok()?, cols.parse().ok()?))
     }
 
     // ── env enforcement policy (no tmux needed) ─────────────────────────────
@@ -523,14 +498,15 @@ mod tests {
         }
         let _g = lock_serial();
         let session = new_session("observe");
-        let client = EmbedClient::observe(&session, 24, 80).expect("observe");
+        let session_size = window_size(&session);
+        let mut client = EmbedClient::observe(&session, 12, 34).expect("observe");
         let pane_target = format!("{session}:");
         let sent = Command::new("tmux")
             .args([
                 "send-keys",
                 "-t",
                 &pane_target,
-                "printf 'OBSERVE_READONLY_OK\\n'",
+                "printf '\\033[31mOBSERVE_READONLY_OK\\033[0m\\r\\nfragment-safe UTF-8: 🦊\\n'",
                 "C-m",
             ])
             .status()
@@ -542,6 +518,9 @@ mod tests {
                 "OBSERVE_READONLY_OK",
                 Instant::now() + Duration::from_secs(8),
             );
+        let resized = client.resize(30, 100).is_ok();
+        let parser_size = client.parser().read().map(|parser| parser.screen().size()).ok();
+        let preserved_window_size = window_size(&session);
         let readonly = Command::new("tmux")
             .args(["list-clients", "-t", &session, "-F", "#{client_readonly}"])
             .output()
@@ -554,6 +533,16 @@ mod tests {
         drop(client);
         kill_session(&session);
         assert!(found, "read-only observer never received tmux output");
+        assert!(resized, "observer resize failed");
+        assert_eq!(
+            parser_size,
+            Some((30, 100)),
+            "observer did not resize its VT100 screen"
+        );
+        assert_eq!(
+            preserved_window_size, session_size,
+            "read-only observer must not resize its tmux window"
+        );
         assert!(readonly, "observer client must be read-only");
     }
 

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -516,6 +516,48 @@ mod tests {
     }
 
     #[test]
+    fn observe_reads_output_through_a_read_only_tmux_client() {
+        if !tmux_available() {
+            eprintln!("SKIP: tmux unavailable");
+            return;
+        }
+        let _g = lock_serial();
+        let session = new_session("observe");
+        let client = EmbedClient::observe(&session, 24, 80).expect("observe");
+        let pane_target = format!("{session}:");
+        let sent = Command::new("tmux")
+            .args([
+                "send-keys",
+                "-t",
+                &pane_target,
+                "printf 'OBSERVE_READONLY_OK\\n'",
+                "C-m",
+            ])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        let found = sent
+            && screen_contains(
+                &client,
+                "OBSERVE_READONLY_OK",
+                Instant::now() + Duration::from_secs(8),
+            );
+        let readonly = Command::new("tmux")
+            .args(["list-clients", "-t", &session, "-F", "#{client_readonly}"])
+            .output()
+            .map(|output| {
+                output.status.success()
+                    && String::from_utf8_lossy(&output.stdout).lines().any(|line| line == "1")
+            })
+            .unwrap_or(false);
+
+        drop(client);
+        kill_session(&session);
+        assert!(found, "read-only observer never received tmux output");
+        assert!(readonly, "observer client must be read-only");
+    }
+
+    #[test]
     fn shutdown_does_not_kill_the_session() {
         if !tmux_available() {
             eprintln!("SKIP: tmux unavailable");

--- a/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
+++ b/ainb-tui/crates/ainb-core/src/tmux/embed_client.rs
@@ -8,7 +8,7 @@
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{SyncSender, TrySendError};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use anyhow::{Context, Result};
 use portable_pty::CommandBuilder;
@@ -62,6 +62,20 @@ fn apply_embed_env_from(
     if !term_seen {
         cmd.env("TERM", "xterm-256color");
     }
+}
+
+/// Whether this tmux understands the client flag used to keep a small preview
+/// PTY from resizing the shared window. The usage probe never attaches to or
+/// mutates a user session.
+fn supports_ignore_size() -> bool {
+    static SUPPORTS_IGNORE_SIZE: OnceLock<bool> = OnceLock::new();
+    *SUPPORTS_IGNORE_SIZE.get_or_init(|| {
+        std::process::Command::new("tmux")
+            .args(["attach-session", "-?"])
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stderr).contains("[-f flags]"))
+            .unwrap_or(false)
+    })
 }
 
 /// A live `tmux attach-session` client embedded in the preview pane.
@@ -136,9 +150,11 @@ impl EmbedClient {
         cmd.arg("attach-session");
         if read_only {
             cmd.arg("-r");
-            // Native tmux client flag: render this client, but never let its
-            // small preview PTY decide the shared window size.
-            cmd.args(["-f", "ignore-size"]);
+            if supports_ignore_size() {
+                // Native tmux client flag: render this client, but never let
+                // its small preview PTY decide the shared window size.
+                cmd.args(["-f", "ignore-size"]);
+            }
         }
         cmd.arg("-t");
         cmd.arg(session_name);

--- a/docs/tui/attach.md
+++ b/docs/tui/attach.md
@@ -42,7 +42,7 @@ Use the in-pane attach for quick interventions — answer an agent's prompt, nud
 | | `a` full-screen | `A` in-pane |
 |---|---|---|
 | Surface | whole terminal (TUI suspends) | right pane (ainb chrome stays) |
-| Visual cue | tmux status bar fills the screen | `● INTERACTIVE — Ctrl+Q release` badge on the pane |
+| Visual cue | tmux status bar fills the screen | `● INTERACTIVE \| Ctrl+Q release` badge on the pane |
 | Leave with | `Ctrl+B` `d` (tmux detach) | `Ctrl+Q` |
 | Lands you | back in ainb, session still listed | read-only preview back |
 | tmux session | survives | survives |
@@ -56,12 +56,12 @@ Use the in-pane attach for quick interventions — answer an agent's prompt, nud
 | `Ctrl+B` `d` | Detach from a full-screen attach (standard tmux detach) |
 | `Ctrl+Q` | Release the in-pane embed (only key ainb intercepts while interactive) |
 | `1`–`9` | Quick-attach by the number badge next to each attachable row |
-| `B` | Toggle the sessions sidebar — collapse to the rail before `A` for a near-full-width embed |
+| `B` | Toggle the sessions sidebar, collapse to the rail before `A` for a near-full-width embed |
 | **Mouse** | Forwarded into the embed while interactive; wheel scrolls tmux scrollback/copy-mode |
 
 ## How it works
 
-The embed drives a real `tmux attach-session` inside a PTY sized to the pane interior: output is parsed by a vt100 screen and rendered in place, key events are encoded to the exact terminal byte sequences a terminal would send, and mouse events are translated into pane-local SGR (mode 1006) reports. The embed honors your sidebar layout — it takes whatever the pane gives it (collapse the sidebar with `B` first for near-full width). One sizing note: the embed is a real tmux client, and under tmux's default `window-size latest` the session's window adopts the newest client's size, so the embedded pane's dimensions become the session's dimensions until another client resizes it. The full-screen path is simpler still — the TUI suspends, hands the terminal to `tmux attach-session`, and resumes when the client detaches. In both modes the client is the only thing that dies on exit; the tmux session and whatever is running inside it are untouched.
+The in-pane attach drives a real `tmux attach-session` inside a PTY sized to the pane interior: output is parsed by a vt100 screen and rendered in place, key events are encoded to the exact terminal byte sequences a terminal would send, and mouse events are translated into pane-local SGR (mode 1006) reports. Its `● INTERACTIVE | Ctrl+Q release` badge marks a client that can affect the shared window size. The `● LIVE PREVIEW | A interact` observer is read-only and uses tmux's `ignore-size` flag, so highlighting a row never resizes its session. Preview has no scrollback; press `A` to interact when history navigation matters. The full-screen path is simpler still: the TUI suspends, hands the terminal to `tmux attach-session`, and resumes when the client detaches. In both modes the client is the only thing that dies on exit; the tmux session and whatever is running inside it are untouched.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Render selected tmux previews through a native read-only PTY client and the same VT100 path as in-pane attach.
- Preserve ANSI styling, CRLF, cursor movement, UTF-8, fragmented output, and viewport resize state.
- Keep preview input app-owned until explicit interactive attach.
- Use tmux `ignore-size` observers, retry dead targets with a short cooldown, and never observe ainb own tmux session.

## Validation
- `cargo fmt --check`
- Targeted observer lifecycle, parser resize, and window-size isolation tests
- `cargo test -p ainb --test tripwire_inbox_opens_and_renders --locked --no-fail-fast`
- `cargo check -p ainb --locked` and `cargo build -p ainb --locked`
- Project `tmux-verify` native read-only preview journey against real ANSI, cursor, and UTF-8 tmux fixture
- Independent branch review after reviewer fixes

## Known baseline
- Existing mouse and palette boundary tripwire failure reproduces on clean baseline `d4ce86c9`; not attributed to this patch.
- Unrelated Fleet stale-window library test also fails on clean `origin/main` commit `c63afb69`; no branch changes touch that code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable, read-only live previews for selected terminals without resizing the underlying session.
  - Added clearer labels and keyboard guidance for interactive panes and live previews.
  - Fullscreen attachments now release the interactive preview before taking control.

- **Bug Fixes**
  - Improved preview resizing, selection handling, and recovery when previews become unavailable.
  - Prevented scrolling in read-only previews and clarified their lack of scrollback.

- **Documentation**
  - Updated attach and preview guidance for live-preview behavior and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->