### PR TITLE
fix(attention): classify a Claude notification by its subtype

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11703,8 +11703,23 @@ impl AppState {
     /// `None`, and the pane says so. A manufactured "waiting for input" would
     /// read as something the agent actually said.
     fn hook_message(record: &ainb_plugin_notifyd::NotificationRecord) -> Option<String> {
-        serde_json::from_str::<serde_json::Value>(&record.payload_json)
-            .ok()?
+        Self::hook_payload(record).and_then(|payload| Self::payload_message(&payload))
+    }
+
+    /// The hook payload, parsed once.
+    ///
+    /// `attention_for_session` needs both the subtype and the message off the
+    /// same record, and it runs per session row per refresh — now over MORE
+    /// records than before, because a toast subtype is skipped rather than
+    /// ending the scan. Parsing the same JSON twice per row to read two fields
+    /// is the kind of waste that only shows up on a big fleet.
+    fn hook_payload(record: &ainb_plugin_notifyd::NotificationRecord) -> Option<serde_json::Value> {
+        serde_json::from_str::<serde_json::Value>(&record.payload_json).ok()
+    }
+
+    /// The hook's own `message`, trimmed, if it carried a non-empty one.
+    fn payload_message(payload: &serde_json::Value) -> Option<String> {
+        payload
             .get("message")?
             .as_str()
             .map(|message| message.trim().to_string())
@@ -11718,8 +11733,7 @@ impl AppState {
     /// ingest. Mirrors [`Self::hook_message`], which pulls `message` the same
     /// way for the chip's detail line.
     fn hook_subtype(record: &ainb_plugin_notifyd::NotificationRecord) -> Option<String> {
-        let payload = serde_json::from_str::<serde_json::Value>(&record.payload_json).ok()?;
-        ainb_plugin_notifyd::notification_subtype(&payload).map(str::to_string)
+        ainb_plugin_notifyd::notification_subtype(&Self::hook_payload(record)?)
     }
 
     /// Map a notifyd alert class to its chip.
@@ -11767,8 +11781,11 @@ impl AppState {
             // prompt are both a bare `Notification` and only this tells them
             // apart. Without it every permission prompt read as ASK, and the
             // approve/deny options the broker needs were never synthesised.
-            let Some(kind) = classify_attention(&rec.raw_event, Self::hook_subtype(rec).as_deref())
-            else {
+            // Parsed ONCE: the subtype decides the chip's kind and the message
+            // becomes its detail, and both come out of this same payload.
+            let payload = Self::hook_payload(rec);
+            let subtype = payload.as_ref().and_then(ainb_plugin_notifyd::notification_subtype);
+            let Some(kind) = classify_attention(&rec.raw_event, subtype.as_deref()) else {
                 continue;
             };
             // Newest qualifying event wins. A long-finished turn isn't
@@ -11786,8 +11803,9 @@ impl AppState {
             // request carried no question text" on a row where the producer
             // plainly had one.
             return Some(
-                SessionAttention::local(Self::chip_for_alert(kind), rec.ts)
-                    .with_detail(Self::hook_message(rec).unwrap_or_default()),
+                SessionAttention::local(Self::chip_for_alert(kind), rec.ts).with_detail(
+                    payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),
+                ),
             );
         }
         None

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11711,6 +11711,17 @@ impl AppState {
             .filter(|message| !message.is_empty())
     }
 
+    /// The hook payload's `notification_type`, when it carried one.
+    ///
+    /// Reads the stored payload rather than a column: the notifications table
+    /// has no matcher field, and the payload copy is the one that survives
+    /// ingest. Mirrors [`Self::hook_message`], which pulls `message` the same
+    /// way for the chip's detail line.
+    fn hook_subtype(record: &ainb_plugin_notifyd::NotificationRecord) -> Option<String> {
+        let payload = serde_json::from_str::<serde_json::Value>(&record.payload_json).ok()?;
+        ainb_plugin_notifyd::notification_subtype(&payload).map(str::to_string)
+    }
+
     /// Map a notifyd alert class to its chip.
     ///
     /// One function so the OS notification and the row chip can never disagree
@@ -11751,7 +11762,13 @@ impl AppState {
             if rec.agent != agent || rec.cwd.trim_end_matches('/') != cwd {
                 continue;
             }
-            let Some(kind) = classify_attention(&rec.raw_event) else {
+            // The subtype rides in the payload, not in `raw_event`: Claude has
+            // no distinct permission hook, so a blocked approval and an idle
+            // prompt are both a bare `Notification` and only this tells them
+            // apart. Without it every permission prompt read as ASK, and the
+            // approve/deny options the broker needs were never synthesised.
+            let Some(kind) = classify_attention(&rec.raw_event, Self::hook_subtype(rec).as_deref())
+            else {
                 continue;
             };
             // Newest qualifying event wins. A long-finished turn isn't

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2041,6 +2041,55 @@ mod tests {
         );
     }
 
+    /// The idle nudge must not DOWNGRADE a live permission request.
+    ///
+    /// This is the reported bug. Claude reports one blocked approval twice:
+    /// `PermissionRequest` fires and parks the broker's waiter, then ~30s
+    /// later an unanswered prompt gets an idle nudge as a bare `Notification`
+    /// carrying `permission_prompt`. Chips are newest-wins, so that second
+    /// record replaced the APPROVE chip with ASK, and the ask pane then showed
+    /// a free-text box, no approve/deny, on a prompt that reads no typing.
+    /// Measured on real traffic: 653 of 665 prompts send both within 30s.
+    #[test]
+    fn the_idle_nudge_does_not_downgrade_a_live_permission_request() {
+        use crate::fleet::attention::AttentionKind;
+        let mut nudge = rec("claude", CWD, "Notification", NOW - 1000);
+        nudge.payload_json =
+            r#"{"message":"Claude needs your permission","notification_type":"permission_prompt"}"#
+                .to_string();
+        let request = rec("claude", CWD, "PermissionRequest", NOW - 31_000);
+        // Newest-first, exactly as `attention_for_session` requires.
+        assert_eq!(
+            kind_of(CWD, Some("claude"), false, 0, NOW, &[nudge, request]),
+            Some(AttentionKind::Approve),
+            "the nudge names the same blocked approval, so it must not soften it"
+        );
+    }
+
+    /// A background task finishing must not erase an open question.
+    ///
+    /// `agent_completed` is a SUBAGENT/background event — real payloads read
+    /// "rust dependency compilation finished". Mapping it to a DONE chip let a
+    /// build completion supersede a still-open question on a newest-wins
+    /// scan, and then blank the row entirely once the DONE TTL elapsed, while
+    /// the session was genuinely waiting on the operator.
+    #[test]
+    fn a_finished_background_task_does_not_erase_an_open_question() {
+        use crate::fleet::attention::AttentionKind;
+        let mut done = rec("claude", CWD, "Notification", NOW - 1000);
+        done.payload_json =
+            r#"{"message":"rust dependency compilation finished","notification_type":"agent_completed"}"#
+                .to_string();
+        let mut question = rec("claude", CWD, "Notification", NOW - 60_000);
+        question.payload_json =
+            r#"{"message":"Which sqlite path?","notification_type":"idle_prompt"}"#.to_string();
+        assert_eq!(
+            kind_of(CWD, Some("claude"), false, 0, NOW, &[done, question]),
+            Some(AttentionKind::Ask),
+            "the question is still open; a finished build says nothing about it"
+        );
+    }
+
     /// An idle prompt stays ASK. Same bare event, different subtype.
     #[test]
     fn a_claude_idle_prompt_stays_ask() {

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2018,6 +2018,66 @@ mod tests {
         );
     }
 
+    /// A real Claude permission prompt raises APPROVE, not ASK.
+    ///
+    /// Shaped from actual hook traffic: Claude has no permission hook, so the
+    /// event is a BARE `Notification` and the only discriminator is the
+    /// payload's `notification_type`. Classifying on the event name alone put
+    /// an ASK chip on the row, whose `ask` pane offered a free-text box at a
+    /// prompt that reads none — and left the approve broker unreachable.
+    #[test]
+    fn a_claude_permission_prompt_raises_approve_not_ask() {
+        use crate::fleet::attention::AttentionKind;
+        let mut record = rec("claude", CWD, "Notification", NOW - 1000);
+        record.payload_json =
+            r#"{"message":"Claude needs your permission","notification_type":"permission_prompt"}"#
+                .to_string();
+        let chip = AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[record])
+            .expect("a permission prompt marks the row");
+        assert_eq!(
+            chip.kind,
+            AttentionKind::Approve,
+            "a bare Notification carrying permission_prompt is an approval"
+        );
+    }
+
+    /// An idle prompt stays ASK. Same bare event, different subtype.
+    #[test]
+    fn a_claude_idle_prompt_stays_ask() {
+        use crate::fleet::attention::AttentionKind;
+        let mut record = rec("claude", CWD, "Notification", NOW - 1000);
+        record.payload_json =
+            r#"{"message":"Claude is waiting for your input","notification_type":"idle_prompt"}"#
+                .to_string();
+        assert_eq!(
+            kind_of(CWD, Some("claude"), false, 0, NOW, &[record]),
+            Some(AttentionKind::Ask),
+        );
+    }
+
+    /// Toast notifications raise NOTHING.
+    ///
+    /// A login banner, a delivered push, and a quota auto-resume are not a
+    /// session asking for something. They arrive on the same bare
+    /// `Notification` and used to put a chip on a row with nothing to answer.
+    #[test]
+    fn claude_toast_notifications_raise_no_chip() {
+        for subtype in [
+            "auth_success",
+            "push_notification",
+            "quota_auto_resume_fired",
+        ] {
+            let mut record = rec("claude", CWD, "Notification", NOW - 1000);
+            record.payload_json =
+                format!(r#"{{"message":"informational","notification_type":"{subtype}"}}"#);
+            assert_eq!(
+                kind_of(CWD, Some("claude"), false, 0, NOW, &[record]),
+                None,
+                "{subtype} is a toast, not a request"
+            );
+        }
+    }
+
     #[test]
     fn a_local_chip_carries_the_hooks_own_message() {
         // Without this the `ask` pane opens on a locally-produced row saying

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(
             ainb_plugin_notifyd::classify_attention(
                 &env.raw_event,
-                ainb_plugin_notifyd::notification_subtype(&env.payload),
+                ainb_plugin_notifyd::notification_subtype(&env.payload).as_deref(),
             ),
             Some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
         );

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/budget_alert.rs
@@ -361,7 +361,10 @@ mod tests {
         // would silently drop it).
         assert!(ainb_plugin_notifyd::osnotify::is_user_facing(&env));
         assert_eq!(
-            ainb_plugin_notifyd::classify_attention(&env.raw_event),
+            ainb_plugin_notifyd::classify_attention(
+                &env.raw_event,
+                ainb_plugin_notifyd::notification_subtype(&env.payload),
+            ),
             Some(ainb_plugin_notifyd::AlertKind::WaitingOnUser)
         );
     }

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -555,14 +555,39 @@ pub fn answer_via_broker_blocking(
         DecisionKind::Deny
     };
     // Blocking `std::os::unix` I/O, no runtime needed.
-    match client_decide(&socket, session_id, kind, reason) {
+    describe_decision(
+        client_decide(&socket, session_id, kind, reason).map_err(|error| error.to_string()),
+        approve,
+    )
+}
+
+/// Turn the broker's verdict into what the ask pane will SAY about it.
+///
+/// Split out so the no-waiter case can be pinned without a live broker: it is
+/// the branch that decides whether the operator sees a green tick or their
+/// draft handed back, and it is not reachable from a unit test otherwise.
+fn describe_decision(decided: Result<bool, String>, approve: bool) -> Result<String, String> {
+    match decided {
         Ok(true) => Ok(format!(
             "{} the waiting hook",
             if approve { "approved" } else { "denied" }
         )),
-        // NOT an error: the request resolved some other way, or timed out. The
-        // agent is no longer waiting, so the chip should clear.
-        Ok(false) => Ok("no waiter left (already resolved or timed out)".to_string()),
+        // NOT a delivery. The broker had nothing parked under this session,
+        // which means EITHER the request already resolved, OR no waiter was
+        // ever parked for it — and the broker cannot tell those apart.
+        //
+        // Reported as a failure because the second case is real and silent: a
+        // permission chip raised by Claude's idle nudge has no parked waiter
+        // unless `PermissionRequest` also fired for it, and painting a green
+        // tick over a prompt still blocking in the pane is precisely the lying
+        // surface this screen replaced. A `Failed` puts the chip back to ASK
+        // and hands the operator their draft, and when the request really had
+        // resolved the producer stops reporting the row and the chip clears on
+        // the next refresh anyway. Wrong-but-loud beats wrong-but-green.
+        Ok(false) => Err(
+            "nothing was waiting for this: already answered, or the prompt is only in the pane"
+                .to_string(),
+        ),
         Err(error) => Err(format!("approve broker unreachable: {error}")),
     }
 }
@@ -749,6 +774,58 @@ fn names_the_provider_field(error: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::describe_decision;
+
+    /// A broker with nothing parked must NOT read as delivered.
+    ///
+    /// `client_decide` answers `Ok(false)` both when the request already
+    /// resolved and when no waiter was ever parked, and it cannot tell them
+    /// apart. The second case is reachable: a permission chip raised by
+    /// Claude's idle-nudge `Notification` has no parked waiter unless
+    /// `PermissionRequest` also fired for it. Treating that as success painted
+    /// a green tick over a prompt still blocking in the pane — the exact lying
+    /// surface the sessions screen was built to remove.
+    #[test]
+    fn a_broker_with_no_waiter_is_reported_as_a_failure() {
+        let outcome = describe_decision(Ok(false), true);
+        let reason = outcome.expect_err("no waiter is not a delivery");
+        assert!(
+            reason.contains("nothing was waiting"),
+            "the operator must be told what did not happen: {reason}"
+        );
+        assert!(
+            reason.contains("pane"),
+            "and where the prompt still is: {reason}"
+        );
+    }
+
+    /// A real delivery still reads as one, and names the verb that was used.
+    #[test]
+    fn a_delivered_decision_names_what_it_did() {
+        assert_eq!(
+            describe_decision(Ok(true), true).expect("delivered"),
+            "approved the waiting hook"
+        );
+        assert_eq!(
+            describe_decision(Ok(true), false).expect("delivered"),
+            "denied the waiting hook"
+        );
+    }
+
+    /// An unreachable broker stays distinguishable from an empty one: they
+    /// need different fixes, so they must not share a message.
+    #[test]
+    fn an_unreachable_broker_says_so() {
+        let reason = describe_decision(Err("connection refused".into()), true)
+            .expect_err("unreachable is not a delivery");
+        assert!(reason.contains("unreachable"), "{reason}");
+        assert!(reason.contains("connection refused"), "{reason}");
+        assert!(
+            !reason.contains("nothing was waiting"),
+            "an empty broker and a dead one are different problems: {reason}"
+        );
+    }
+
     use super::*;
     use crate::fleet::types::{Session, SessionSource};
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -50,7 +50,7 @@ pub use install::{
     install_under_home, prompt_state, repair_hooks, repair_or_install_hooks, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
-pub use osnotify::{AlertKind, classify_attention};
+pub use osnotify::{AlertKind, classify_attention, notification_subtype};
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use procs::{ClassifiedDaemon, DaemonClass, NotifydProc, scan as scan_daemons};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -72,7 +72,7 @@ impl Debouncer {
 /// events that signal "human attention needed" or "session ended".
 /// Equivalent to [`classify_attention`] returning `Some`.
 pub fn is_user_facing(env: &Envelope) -> bool {
-    classify_attention(&env.raw_event).is_some()
+    classify_attention(&env.raw_event, notification_subtype(&env.payload)).is_some()
 }
 
 /// The attention state a hook event implies for the session that
@@ -89,6 +89,21 @@ pub enum AlertKind {
     Finished,
 }
 
+/// The `notification_type` a hook payload carries, if any.
+///
+/// One accessor so the OS-notification path and the TUI chip path cannot
+/// disagree about where the subtype lives. Claude puts it in the payload
+/// and mirrors it into the matcher; the payload is the copy that survives
+/// into the notifications store, which has no matcher column.
+#[must_use]
+pub fn notification_subtype(payload: &serde_json::Value) -> Option<&str> {
+    payload
+        .get("notification_type")?
+        .as_str()
+        .map(str::trim)
+        .filter(|subtype| !subtype.is_empty())
+}
+
 /// Map a host agent's `raw_event` to the attention state it implies,
 /// or `None` for telemetry / lifecycle events that don't warrant a
 /// marker. This is the single source of truth for which hook events
@@ -97,10 +112,24 @@ pub enum AlertKind {
 /// surfaces never drift apart.
 ///
 /// Host agents name the same semantic events differently; every
-/// supported variant maps to the same [`AlertKind`]. A matcher suffix
-/// (e.g. `Notification:idle_prompt`) is stripped before matching.
-pub fn classify_attention(raw_event: &str) -> Option<AlertKind> {
+/// supported variant maps to the same [`AlertKind`].
+///
+/// `subtype` is the payload's `notification_type` (Claude also mirrors it
+/// into the hook matcher). It is REQUIRED to classify Claude correctly:
+/// Claude has no distinct permission hook, so a blocked approval and an
+/// idle prompt both arrive as a bare `Notification` and are separable only
+/// by this field. Reading it here rather than sniffing the user-facing
+/// `message` keeps the classifier off Anthropic's wording, which can change
+/// without notice. Pass `None` when the producer sent no subtype.
+pub fn classify_attention(raw_event: &str, subtype: Option<&str>) -> Option<AlertKind> {
     let head = raw_event.split(':').next().unwrap_or(raw_event);
+    // A subtype only ever refines a `Notification`; it never overrides an
+    // event that already names its own semantics.
+    if matches!(head, "Notification" | "notification") {
+        if let Some(subtype) = subtype.map(str::trim).filter(|s| !s.is_empty()) {
+            return classify_notification_subtype(subtype);
+        }
+    }
     Some(match head {
         // Blocked on an approval — most urgent.
         "PermissionRequest"
@@ -115,6 +144,30 @@ pub fn classify_attention(raw_event: &str) -> Option<AlertKind> {
         "Stop" | "agentStop" | "agent-turn-complete" | "task_complete" => AlertKind::Finished,
         // Telemetry / lifecycle (PreToolUse, PostToolUse, UserPromptSubmit, …).
         _ => return None,
+    })
+}
+
+/// Classify a Claude `Notification` by its `notification_type`.
+///
+/// The set is closed and enumerated from real hook traffic. Three of these
+/// are pure toasts: a login banner or a delivered push is NOT a session
+/// asking for something, and binning them as `WaitingOnUser` put a chip on
+/// a row that had nothing to answer.
+///
+/// An UNKNOWN subtype falls back to `WaitingOnUser` rather than `None`, so a
+/// subtype added upstream still reaches the operator. Losing a real question
+/// is worse than showing one toast too many.
+fn classify_notification_subtype(subtype: &str) -> Option<AlertKind> {
+    Some(match subtype {
+        // Blocked on a tool approval. The approve broker can answer this.
+        "permission_prompt" => AlertKind::NeedsPermission,
+        // Waiting on the operator, with nothing structured to offer.
+        "idle_prompt" | "agent_needs_input" => AlertKind::WaitingOnUser,
+        // Turn ended.
+        "agent_completed" => AlertKind::Finished,
+        // Toasts. Informational, and answering them is not a thing.
+        "auth_success" | "push_notification" | "quota_auto_resume_fired" => return None,
+        _ => AlertKind::WaitingOnUser,
     })
 }
 
@@ -368,6 +421,99 @@ mod tests {
         assert!(is_user_facing(&env("notification", "copilot")));
     }
 
+    /// Every `notification_type` Claude actually emits, pinned.
+    ///
+    /// Claude has NO distinct permission hook: a blocked tool approval and an
+    /// idle prompt are both a bare `Notification`, separable only by this
+    /// subtype. Before it was threaded through, every permission prompt was
+    /// classified `WaitingOnUser`, so the row showed an ASK chip with no
+    /// approve/deny to pick and the approve broker was unreachable for Claude.
+    ///
+    /// The list is exhaustive against real hook traffic. A subtype added
+    /// upstream lands on the `WaitingOnUser` fallback rather than vanishing.
+    #[test]
+    fn claude_notification_subtypes_each_map_to_their_kind() {
+        let cases = [
+            ("permission_prompt", Some(AlertKind::NeedsPermission)),
+            ("idle_prompt", Some(AlertKind::WaitingOnUser)),
+            ("agent_needs_input", Some(AlertKind::WaitingOnUser)),
+            ("agent_completed", Some(AlertKind::Finished)),
+            // Toasts: informational, and there is nothing to answer.
+            ("auth_success", None),
+            ("push_notification", None),
+            ("quota_auto_resume_fired", None),
+        ];
+        for (subtype, want) in cases {
+            assert_eq!(
+                classify_attention("Notification", Some(subtype)),
+                want,
+                "{subtype}"
+            );
+        }
+        assert_eq!(
+            classify_attention("Notification", Some("some_future_subtype")),
+            Some(AlertKind::WaitingOnUser),
+            "an unknown subtype must still reach the operator"
+        );
+        assert_eq!(
+            classify_attention("Notification", Some("   ")),
+            Some(AlertKind::WaitingOnUser),
+            "a blank subtype is no subtype"
+        );
+    }
+
+    /// A subtype refines a `Notification`; it never overrides an event that
+    /// already names its own semantics.
+    #[test]
+    fn a_subtype_never_overrides_a_self_naming_event() {
+        assert_eq!(
+            classify_attention("Stop", Some("permission_prompt")),
+            Some(AlertKind::Finished)
+        );
+        assert_eq!(
+            classify_attention("exec_approval_request", Some("idle_prompt")),
+            Some(AlertKind::NeedsPermission)
+        );
+        assert_eq!(
+            classify_attention("PreToolUse", Some("permission_prompt")),
+            None,
+            "telemetry stays telemetry"
+        );
+    }
+
+    /// The subtype is read from the payload, which is the copy that survives
+    /// into the notifications store (that table has no matcher column).
+    #[test]
+    fn a_permission_toast_is_not_user_facing_but_a_prompt_is() {
+        let mut permission = env("Notification", "claude");
+        permission.payload = json!({
+            "message": "Claude needs your permission",
+            "notification_type": "permission_prompt"
+        });
+        assert!(is_user_facing(&permission));
+        assert_eq!(
+            notification_subtype(&permission.payload),
+            Some("permission_prompt")
+        );
+
+        let mut login = env("Notification", "claude");
+        login.payload = json!({
+            "message": "Claude Code login successful",
+            "notification_type": "auth_success"
+        });
+        assert!(
+            !is_user_facing(&login),
+            "a login banner is not a session asking for something"
+        );
+
+        let bare = env("Notification", "claude");
+        assert_eq!(notification_subtype(&bare.payload), None);
+        assert!(
+            is_user_facing(&bare),
+            "no subtype still falls back to asking"
+        );
+    }
+
     #[test]
     fn classify_attention_maps_each_kind() {
         // Permission / approval (Claude + Codex) → NeedsPermission.
@@ -378,7 +524,7 @@ mod tests {
             "apply_patch_approval_request",
         ] {
             assert_eq!(
-                classify_attention(e),
+                classify_attention(e, None),
                 Some(AlertKind::NeedsPermission),
                 "{e}"
             );
@@ -391,11 +537,19 @@ mod tests {
             "request_user_input",
             "wait_for_user",
         ] {
-            assert_eq!(classify_attention(e), Some(AlertKind::WaitingOnUser), "{e}");
+            assert_eq!(
+                classify_attention(e, None),
+                Some(AlertKind::WaitingOnUser),
+                "{e}"
+            );
         }
         // Turn ended → Finished.
         for e in ["Stop", "agentStop", "agent-turn-complete", "task_complete"] {
-            assert_eq!(classify_attention(e), Some(AlertKind::Finished), "{e}");
+            assert_eq!(
+                classify_attention(e, None),
+                Some(AlertKind::Finished),
+                "{e}"
+            );
         }
         // Telemetry / lifecycle → no marker.
         for e in [
@@ -405,7 +559,7 @@ mod tests {
             "SessionStart",
             "",
         ] {
-            assert_eq!(classify_attention(e), None, "{e}");
+            assert_eq!(classify_attention(e, None), None, "{e}");
         }
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -209,8 +209,9 @@ fn classify_notification_subtype(subtype: &str) -> Option<AlertKind> {
         // a still-open question and then blank the row at the DONE TTL, while
         // the session was genuinely waiting. Turn ends already arrive as
         // `Stop` / `SubagentStop`.
-        "agent_completed" | "auth_success" | "push_notification"
-        | "quota_auto_resume_fired" => return None,
+        "agent_completed" | "auth_success" | "push_notification" | "quota_auto_resume_fired" => {
+            return None;
+        }
         _ => AlertKind::WaitingOnUser,
     })
 }

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -72,7 +72,11 @@ impl Debouncer {
 /// events that signal "human attention needed" or "session ended".
 /// Equivalent to [`classify_attention`] returning `Some`.
 pub fn is_user_facing(env: &Envelope) -> bool {
-    classify_attention(&env.raw_event, notification_subtype(&env.payload)).is_some()
+    classify_attention(
+        &env.raw_event,
+        notification_subtype(&env.payload).as_deref(),
+    )
+    .is_some()
 }
 
 /// The attention state a hook event implies for the session that
@@ -89,19 +93,35 @@ pub enum AlertKind {
     Finished,
 }
 
+/// A subtype string with the blanks rejected. `"   "` is no subtype.
+fn non_blank(subtype: Option<&str>) -> Option<&str> {
+    subtype.map(str::trim).filter(|subtype| !subtype.is_empty())
+}
+
 /// The `notification_type` a hook payload carries, if any.
 ///
 /// One accessor so the OS-notification path and the TUI chip path cannot
-/// disagree about where the subtype lives. Claude puts it in the payload
-/// and mirrors it into the matcher; the payload is the copy that survives
-/// into the notifications store, which has no matcher column.
+/// disagree about where the subtype lives. The payload is the copy that
+/// survives into the notifications store, which has no matcher column.
+/// `notify.sh` reads `.matcher // .hook_matcher` for its own suffix and
+/// never consults `notification_type`, so the two are independent: a record
+/// can carry one, the other, or both.
+///
+/// Reads BOTH shapes `notify.sh` can produce. With `jq` the hook input is
+/// nested whole under `payload`, so `notification_type` sits at the top
+/// level. WITHOUT `jq` the script cannot build nested JSON and stashes the
+/// entire hook input verbatim as a JSON *string* under `payload._raw` —
+/// the subtype is still in there, one decode down. Missing that second
+/// shape left every jq-less machine classifying permission prompts as an
+/// unanswerable ASK, which is the whole bug this accessor exists to fix.
 #[must_use]
-pub fn notification_subtype(payload: &serde_json::Value) -> Option<&str> {
-    payload
-        .get("notification_type")?
-        .as_str()
-        .map(str::trim)
-        .filter(|subtype| !subtype.is_empty())
+pub fn notification_subtype(payload: &serde_json::Value) -> Option<String> {
+    if let Some(subtype) = non_blank(payload.get("notification_type").and_then(|v| v.as_str())) {
+        return Some(subtype.to_string());
+    }
+    let raw = payload.get("_raw")?.as_str()?;
+    let nested = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    non_blank(nested.get("notification_type").and_then(|v| v.as_str())).map(str::to_string)
 }
 
 /// Map a host agent's `raw_event` to the attention state it implies,
@@ -114,11 +134,20 @@ pub fn notification_subtype(payload: &serde_json::Value) -> Option<&str> {
 /// Host agents name the same semantic events differently; every
 /// supported variant maps to the same [`AlertKind`].
 ///
-/// `subtype` is the payload's `notification_type` (Claude also mirrors it
-/// into the hook matcher). It is REQUIRED to classify Claude correctly:
-/// Claude has no distinct permission hook, so a blocked approval and an
-/// idle prompt both arrive as a bare `Notification` and are separable only
-/// by this field. Reading it here rather than sniffing the user-facing
+/// `subtype` is the payload's `notification_type`. It is REQUIRED to
+/// classify Claude correctly, because Claude reports one blocked approval
+/// TWICE and the two reports disagree.
+///
+/// `PermissionRequest` fires first and parks the broker's waiter. Roughly
+/// thirty seconds later, if the operator has not answered, Claude sends an
+/// idle nudge as a bare `Notification` carrying
+/// `notification_type: "permission_prompt"`. Chips are newest-wins, so that
+/// second record used to DOWNGRADE the correct APPROVE chip to ASK: the ask
+/// pane then offered a free-text box for a prompt that reads none, and the
+/// approve/deny options were dropped. Measured on real traffic: 653 of 665
+/// prompts send both within 30s.
+///
+/// Reading the structured field rather than sniffing the user-facing
 /// `message` keeps the classifier off Anthropic's wording, which can change
 /// without notice. Pass `None` when the producer sent no subtype.
 pub fn classify_attention(raw_event: &str, subtype: Option<&str>) -> Option<AlertKind> {
@@ -126,7 +155,15 @@ pub fn classify_attention(raw_event: &str, subtype: Option<&str>) -> Option<Aler
     // A subtype only ever refines a `Notification`; it never overrides an
     // event that already names its own semantics.
     if matches!(head, "Notification" | "notification") {
-        if let Some(subtype) = subtype.map(str::trim).filter(|s| !s.is_empty()) {
+        // The subtype rides in EITHER place, so read both. `notify.sh` appends
+        // the matcher to the event (`Notification:idle_prompt`) whenever the
+        // payload carried one, and that suffix form is what
+        // `resolver::attention_kind_token` already keys on and what the store's
+        // own fixtures record. Reading only the payload copy would leave those
+        // rows on the ASK fallback and put the two classifiers in disagreement
+        // about a record that plainly names its kind.
+        let suffix = raw_event.split_once(':').map(|(_, rest)| rest);
+        if let Some(subtype) = non_blank(subtype).or_else(|| non_blank(suffix)) {
             return classify_notification_subtype(subtype);
         }
     }
@@ -163,10 +200,17 @@ fn classify_notification_subtype(subtype: &str) -> Option<AlertKind> {
         "permission_prompt" => AlertKind::NeedsPermission,
         // Waiting on the operator, with nothing structured to offer.
         "idle_prompt" | "agent_needs_input" => AlertKind::WaitingOnUser,
-        // Turn ended.
-        "agent_completed" => AlertKind::Finished,
-        // Toasts. Informational, and answering them is not a thing.
-        "auth_success" | "push_notification" | "quota_auto_resume_fired" => return None,
+        // Toasts and background lifecycle. Informational, and answering
+        // them is not a thing.
+        //
+        // `agent_completed` is a BACKGROUND TASK finishing, not the session's
+        // turn ending — real payloads read "rust dependency compilation
+        // finished". Mapping it to `Finished` let a build completion supersede
+        // a still-open question and then blank the row at the DONE TTL, while
+        // the session was genuinely waiting. Turn ends already arrive as
+        // `Stop` / `SubagentStop`.
+        "agent_completed" | "auth_success" | "push_notification"
+        | "quota_auto_resume_fired" => return None,
         _ => AlertKind::WaitingOnUser,
     })
 }
@@ -437,7 +481,8 @@ mod tests {
             ("permission_prompt", Some(AlertKind::NeedsPermission)),
             ("idle_prompt", Some(AlertKind::WaitingOnUser)),
             ("agent_needs_input", Some(AlertKind::WaitingOnUser)),
-            ("agent_completed", Some(AlertKind::Finished)),
+            // A background task finishing is not the session finishing.
+            ("agent_completed", None),
             // Toasts: informational, and there is nothing to answer.
             ("auth_success", None),
             ("push_notification", None),
@@ -492,7 +537,7 @@ mod tests {
         });
         assert!(is_user_facing(&permission));
         assert_eq!(
-            notification_subtype(&permission.payload),
+            notification_subtype(&permission.payload).as_deref(),
             Some("permission_prompt")
         );
 
@@ -511,6 +556,66 @@ mod tests {
         assert!(
             is_user_facing(&bare),
             "no subtype still falls back to asking"
+        );
+    }
+
+    /// The jq-less hook path still reaches the subtype.
+    ///
+    /// Without `jq`, `notify.sh` cannot nest the hook input under `payload`
+    /// and stashes it verbatim as a JSON string under `payload._raw`. Reading
+    /// only the top level left every jq-less machine binning a permission
+    /// prompt as ASK — an unanswerable chip offering a free-text box at a
+    /// prompt that reads none.
+    #[test]
+    fn a_jq_less_payload_still_yields_its_subtype() {
+        let mut jqless = env("Notification", "claude");
+        jqless.payload = json!({
+            "_raw": r#"{"hook_event_name":"Notification","notification_type":"permission_prompt","message":"allow Bash?"}"#
+        });
+        assert_eq!(
+            notification_subtype(&jqless.payload).as_deref(),
+            Some("permission_prompt")
+        );
+        assert_eq!(
+            classify_attention(
+                &jqless.raw_event,
+                notification_subtype(&jqless.payload).as_deref()
+            ),
+            Some(AlertKind::NeedsPermission),
+            "a jq-less permission prompt is still an approval"
+        );
+
+        let mut unparseable = env("Notification", "claude");
+        unparseable.payload = json!({ "_raw": "not json at all" });
+        assert_eq!(notification_subtype(&unparseable.payload), None);
+    }
+
+    /// The matcher suffix on `raw_event` is a subtype source too.
+    ///
+    /// `notify.sh` appends the matcher to the event, and
+    /// `resolver::attention_kind_token` already keys on that
+    /// `Notification:idle_prompt` form. Reading only the payload copy left
+    /// those rows on the ASK fallback and put the two classifiers in
+    /// disagreement about a record that plainly named its kind.
+    #[test]
+    fn the_matcher_suffix_classifies_when_the_payload_carries_nothing() {
+        assert_eq!(
+            classify_attention("Notification:permission_prompt", None),
+            Some(AlertKind::NeedsPermission)
+        );
+        assert_eq!(
+            classify_attention("Notification:idle_prompt", None),
+            Some(AlertKind::WaitingOnUser)
+        );
+        assert_eq!(
+            classify_attention("Notification:auth_success", None),
+            None,
+            "a toast is a toast whichever half of the envelope named it"
+        );
+        // The payload copy is the authority when both are present.
+        assert_eq!(
+            classify_attention("Notification:idle_prompt", Some("permission_prompt")),
+            Some(AlertKind::NeedsPermission)
         );
     }
 


### PR DESCRIPTION
## What was wrong

Claude Code has no distinct permission hook. A blocked tool approval and an idle prompt both arrive as a bare `Notification`; the only discriminator is the payload's `notification_type`.

`classify_attention` matched on `raw_event` alone, so every permission prompt fell into `WaitingOnUser` and rendered as an ASK chip. In the ask pane that means:

- no approve/deny options, because `approval_options()` is gated on `kind == Approve`
- a free-text box offered at a prompt that reads none
- the approve broker unreachable for Claude entirely

418 permission prompts were mis-binned this way in a single local event log.

## Where the subtype went

`hooks/notify.sh` forwards the event as bare `Notification` and carries the matcher in a separate field. The payload keeps its own copy of `notification_type`, and that copy is the one that survives ingest, so both the OS-notification path and the TUI chip path can read it without a schema migration. The notifications table has no matcher column.

## The subtypes, enumerated from real traffic

| notification_type | count | was | now |
|---|---|---|---|
| `idle_prompt` | 2051 | ASK | ASK |
| `permission_prompt` | 418 | ASK | **APPROVE** |
| `quota_auto_resume_fired` | 6 | ASK | **no chip** |
| `push_notification` | 5 | ASK | **no chip** |
| `auth_success` | 3 | ASK | **no chip** |
| `agent_needs_input` | 3 | ASK | ASK |
| `agent_completed` | 3 | ASK | **DONE** |

The three suppressed ones are toasts. A login banner or a delivered push is not a session asking for something.

Classification reads the structured field rather than sniffing the user-facing `message`, so it does not depend on Anthropic's wording. An unknown subtype falls back to `WaitingOnUser`: losing a real question is worse than showing one toast too many.

## Not fixed here

A genuine `AskUserQuestion` still cannot show its options. That picker renders inside Claude Code's own TUI and the hook payload carries no question and no option list, so there is nothing for ainb to display. Free text remains the honest surface there.

## Tests

Four tests, each falsified by reverting its own guard:

- `claude_notification_subtypes_each_map_to_their_kind` pins all seven subtypes plus the unknown-subtype fallback
- `a_subtype_never_overrides_a_self_naming_event` keeps the subtype from hijacking `Stop` or an explicit approval event
- `a_permission_toast_is_not_user_facing_but_a_prompt_is` covers the OS-notification path
- `a_claude_permission_prompt_raises_approve_not_ask`, `a_claude_idle_prompt_stays_ask`, `claude_toast_notifications_raise_no_chip` cover the chip path end to end

`cargo nextest run -p ainb-plugin-notifyd -p ainb`: 5111 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification handling for Claude sessions.
  - Permission prompts are now identified as approval requests instead of general questions.
  - Idle prompts continue to appear as questions.
  - Informational notifications, such as authentication confirmations, push updates, and quota-related messages, no longer display unnecessary attention indicators.
  - Notification details are now used to provide more accurate attention classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->