### PR TITLE
fix(ask): show an AskUserQuestion's own options instead of approve/deny

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11802,6 +11802,31 @@ impl AppState {
             // pane leads with what the agent actually said rather than "the
             // request carried no question text" on a row where the producer
             // plainly had one.
+            // An `AskUserQuestion` states its own question and its own
+            // answers, so it must not wear the permission vocabulary.
+            //
+            // It arrives as a `PermissionRequest`, which classifies APPROVE and
+            // would then have approve/deny synthesised onto it — the wrong two
+            // words on the majority of permission chips, since 540 of 718 such
+            // records are this tool. Carrying the real options also stops the
+            // pane offering a free-text box as the only way to answer a prompt
+            // that already has four named answers.
+            if let Some((question, options)) =
+                payload.as_ref().and_then(ainb_plugin_notifyd::ask_user_question)
+            {
+                return Some(
+                    SessionAttention::local(AttentionKind::Ask, rec.ts)
+                        .with_detail(question)
+                        .with_options(
+                            options
+                                .into_iter()
+                                .map(|(label, description)| {
+                                    crate::fleet::attention::AttentionOption { label, description }
+                                })
+                                .collect(),
+                        ),
+                );
+            }
             return Some(
                 SessionAttention::local(Self::chip_for_alert(kind), rec.ts).with_detail(
                     payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3741,7 +3741,7 @@ pub struct AppState {
     ///
     /// Same shape as [`Self::attention_error_since`]: stamped once, reused
     /// while the chip stays that kind, dropped when it does not.
-    pub attention_local_since: HashMap<(Uuid, AttentionKind), i64>,
+    pub attention_local_since: HashMap<(Uuid, AttentionKind, Option<String>), i64>,
 }
 
 /// Result of background workspace loading
@@ -11808,23 +11808,27 @@ impl AppState {
             // It arrives as a `PermissionRequest`, which classifies APPROVE and
             // would then have approve/deny synthesised onto it — the wrong two
             // words on the majority of permission chips, since 540 of 718 such
-            // records are this tool. Carrying the real options also stops the
-            // pane offering a free-text box as the only way to answer a prompt
-            // that already has four named answers.
-            if let Some((question, options)) =
-                payload.as_ref().and_then(ainb_plugin_notifyd::ask_user_question)
-            {
+            // records are this tool. Worse, `cli/fleet/atc.rs` excludes this
+            // tool from the blocking approve round-trip, so no waiter is ever
+            // parked and every approve/deny send failed at an empty broker.
+            //
+            // Marked NativePicker HERE rather than inferred later from a
+            // non-empty option list: a payload that carried no options is still
+            // the agent's own picker, and inferring from the list let exactly
+            // those rows fall back to a composer that types at it.
+            if let Some(ask) = payload.as_ref().and_then(ainb_plugin_notifyd::ask_user_question) {
                 return Some(
                     SessionAttention::local(AttentionKind::Ask, rec.ts)
-                        .with_detail(question)
+                        .with_detail(ask.question.unwrap_or_default())
                         .with_options(
-                            options
+                            ask.options
                                 .into_iter()
                                 .map(|(label, description)| {
                                     crate::fleet::attention::AttentionOption { label, description }
                                 })
                                 .collect(),
-                        ),
+                        )
+                        .unanswerable(crate::fleet::attention::Unanswerable::NativePicker),
                 );
             }
             return Some(
@@ -12062,8 +12066,15 @@ impl AppState {
             if matches!(chip.answerable, Answerable::Daemon { .. }) {
                 continue;
             }
-            let first_seen =
-                *self.attention_local_since.entry((id, chip.kind)).or_insert(chip.since_ms);
+            // Keyed by the DETAIL as well as the kind. Two different
+            // questions of the same kind are two different waits: an
+            // `AskUserQuestion` firing while an idle prompt is still open used
+            // to inherit that prompt's first-seen instant, so a question
+            // seconds old rendered as "40m" and its `request_id`
+            // (`ASK:<since_ms>`) collided with the older one — which is how a
+            // previous question's draft could land under a new one.
+            let key = (id, chip.kind, chip.detail.clone());
+            let first_seen = *self.attention_local_since.entry(key).or_insert(chip.since_ms);
             chip.since_ms = first_seen;
         }
     }
@@ -12144,17 +12155,17 @@ impl AppState {
         // A session that recovered (or vanished) must lose its ERR clock, or a
         // later failure would render with the age of the previous one.
         self.attention_error_since.retain(|id, _| live.contains(id));
-        self.attention_local_since.retain(|(id, _), _| live.contains(id));
+        self.attention_local_since.retain(|(id, ..), _| live.contains(id));
         // Every (session, kind) a LOCAL chip still claims this pass. Anything
         // else loses its clock below, so a question that closed and a later one
         // of the same kind do not share an instant.
-        let still_open: HashSet<(Uuid, AttentionKind)> = marks
+        let still_open: HashSet<(Uuid, AttentionKind, Option<String>)> = marks
             .iter()
             .flat_map(|(id, chips, ..)| {
                 chips
                     .iter()
                     .filter(|chip| !matches!(chip.answerable, Answerable::Daemon { .. }))
-                    .map(move |chip| (*id, chip.kind))
+                    .map(move |chip| (*id, chip.kind, chip.detail.clone()))
             })
             .collect();
         self.attention_local_since.retain(|key, _| still_open.contains(key));

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2090,6 +2090,62 @@ mod tests {
         );
     }
 
+    /// An `AskUserQuestion` shows ITS OWN options, not approve/deny.
+    ///
+    /// It arrives as a `PermissionRequest`, which classifies APPROVE, and the
+    /// approve/deny pair would then be synthesised onto it. That is the wrong
+    /// vocabulary on the majority of permission chips: 540 of 718 such records
+    /// in one local log are this tool, each carrying its real question and a
+    /// full option list that was being thrown away.
+    #[test]
+    fn an_ask_user_question_carries_its_own_question_and_options() {
+        use crate::fleet::attention::AttentionKind;
+        let mut record = rec("claude", CWD, "PermissionRequest", NOW - 1000);
+        record.payload_json = r#"{
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": [{
+                "header": "Environment",
+                "question": "Which environment ship to?",
+                "options": [
+                    {"label": "staging", "description": "Safe test env before prod."},
+                    {"label": "prod", "description": "Live user-facing env."},
+                    {"label": "canary", "description": "Small subset traffic first."}
+                ]
+            }]}
+        }"#
+        .to_string();
+        let chip = AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[record])
+            .expect("the question marks the row");
+        assert_eq!(
+            chip.kind,
+            AttentionKind::Ask,
+            "a question is not an approval, whatever hook carried it"
+        );
+        assert_eq!(chip.detail.as_deref(), Some("Which environment ship to?"));
+        assert_eq!(
+            chip.options.iter().map(|o| o.label.as_str()).collect::<Vec<_>>(),
+            vec!["staging", "prod", "canary"],
+            "the operator picks the agent's own answers, in the agent's own order"
+        );
+        assert_eq!(
+            chip.options[0].description, "Safe test env before prod.",
+            "each option keeps the explanation that makes it choosable"
+        );
+    }
+
+    /// An ordinary permission request is untouched: it is still an approval.
+    #[test]
+    fn a_plain_tool_permission_request_stays_an_approval() {
+        use crate::fleet::attention::AttentionKind;
+        let mut record = rec("claude", CWD, "PermissionRequest", NOW - 1000);
+        record.payload_json =
+            r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf build"}}"#.to_string();
+        assert_eq!(
+            kind_of(CWD, Some("claude"), false, 0, NOW, &[record]),
+            Some(AttentionKind::Approve),
+        );
+    }
+
     /// An idle prompt stays ASK. Same bare event, different subtype.
     #[test]
     fn a_claude_idle_prompt_stays_ask() {

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2133,6 +2133,103 @@ mod tests {
         );
     }
 
+    /// An AskUserQuestion with NO options is STILL the agent's picker.
+    ///
+    /// Detection keys on `tool_name`, never on the option list being non-empty.
+    /// Inferring it from the list let exactly these records fall back to a
+    /// composer that types literal text at a pane sitting on a native picker.
+    #[test]
+    fn an_ask_user_question_without_options_is_still_a_native_picker() {
+        use crate::fleet::attention::{Answerable, AttentionKind, Unanswerable};
+        let mut record = rec("claude", CWD, "PermissionRequest", NOW - 1000);
+        record.payload_json =
+            r#"{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Now what?"}]}}"#
+                .to_string();
+        let chip = AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[record])
+            .expect("the question marks the row");
+        assert_eq!(chip.kind, AttentionKind::Ask);
+        assert!(chip.options.is_empty());
+        assert_eq!(
+            chip.answerable,
+            Answerable::No(Unanswerable::NativePicker),
+            "no options does not make it typeable"
+        );
+    }
+
+    /// A blank question does not drop it back onto the approve/deny path.
+    ///
+    /// `cli/fleet/atc.rs` excludes AskUserQuestion from the blocking approve
+    /// round-trip, so no waiter is ever parked for it: falling back to APPROVE
+    /// gave the operator two words that could never be delivered.
+    #[test]
+    fn an_ask_user_question_without_a_question_is_not_an_approval() {
+        use crate::fleet::attention::{Answerable, AttentionKind, Unanswerable};
+        let mut record = rec("claude", CWD, "PermissionRequest", NOW - 1000);
+        record.payload_json = r#"{"tool_name":"AskUserQuestion","tool_input":{}}"#.to_string();
+        let chip = AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[record])
+            .expect("the row is still marked");
+        assert_eq!(chip.kind, AttentionKind::Ask);
+        assert_eq!(chip.answerable, Answerable::No(Unanswerable::NativePicker));
+    }
+
+    /// The jq-less hook shape carries the picker too.
+    ///
+    /// Without `jq` the hook cannot build nested JSON and stashes the whole
+    /// input as a JSON string under `_raw`. Reading only the top level left
+    /// every jq-less machine on the old approve/deny rendering.
+    #[test]
+    fn an_ask_user_question_is_found_in_the_jq_less_raw_payload() {
+        use crate::fleet::attention::AttentionKind;
+        let inner = r#"{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Ship where?","options":[{"label":"prod","description":"live"}]}]}}"#;
+        let mut record = rec("claude", CWD, "PermissionRequest", NOW - 1000);
+        record.payload_json = serde_json::json!({ "_raw": inner }).to_string();
+        let chip = AppState::attention_for_session(CWD, Some("claude"), false, 0, NOW, &[record])
+            .expect("the nested payload still marks the row");
+        assert_eq!(chip.kind, AttentionKind::Ask);
+        assert_eq!(chip.detail.as_deref(), Some("Ship where?"));
+        assert_eq!(
+            chip.options.iter().map(|o| o.label.as_str()).collect::<Vec<_>>(),
+            vec!["prod"]
+        );
+    }
+
+    /// A NEW question must not inherit an older question's age.
+    ///
+    /// `attention_local_since` is keyed by the chip's DETAIL as well as its
+    /// kind. Keying on kind alone meant an `AskUserQuestion` firing while an
+    /// idle prompt was still open took that prompt's first-seen instant: a
+    /// question seconds old rendered as the older one's age, and `request_id`
+    /// (`ASK:<since_ms>`) collided, which is how one question's draft could
+    /// surface under another. Before these chips shared a kind, they could not
+    /// collide at all.
+    #[test]
+    fn a_new_question_does_not_inherit_an_older_questions_clock() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let mut state = state_with_session_at("/work/two-questions", Some("tmux_proj"));
+        let id = state.workspaces[0].sessions[0].id;
+        let mut chips = vec![
+            SessionAttention::local(AttentionKind::Ask, 1_000).with_detail("Which sqlite path?"),
+        ];
+        state.stamp_local_since(id, &mut chips);
+        assert_eq!(chips[0].since_ms, 1_000, "first sighting stamps the clock");
+
+        // The same question again, re-reported later: it keeps its first age.
+        let mut repeat = vec![
+            SessionAttention::local(AttentionKind::Ask, 9_000).with_detail("Which sqlite path?"),
+        ];
+        state.stamp_local_since(id, &mut repeat);
+        assert_eq!(repeat[0].since_ms, 1_000, "a repeat must not reset the age");
+
+        // A DIFFERENT question, same kind, same session: its own clock.
+        let mut fresh =
+            vec![SessionAttention::local(AttentionKind::Ask, 9_000).with_detail("Ship where?")];
+        state.stamp_local_since(id, &mut fresh);
+        assert_eq!(
+            fresh[0].since_ms, 9_000,
+            "a different question is a different wait and starts its own clock"
+        );
+    }
+
     /// An ordinary permission request is untouched: it is still an approval.
     #[test]
     fn a_plain_tool_permission_request_stays_an_approval() {

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -92,6 +92,15 @@ impl SessionTab {
     /// than a dialog is to dismiss.
     #[must_use]
     pub fn enter_verb_in(self, state: &AppState) -> std::borrow::Cow<'static, str> {
+        // A refused ask has NO verb. The footer is the last thing an operator
+        // reads before pressing the key, so "send answer" over a row that
+        // cannot send is the advertisement that makes the whole pane a lie —
+        // the same defect as a green tick over a failed send.
+        if self == Self::Ask
+            && selected_blocking(state).is_some_and(|chip| chip.answerable.refusal().is_some())
+        {
+            return std::borrow::Cow::Borrowed("");
+        }
         let targets = state.broadcast_targets().len();
         if self == Self::Thread && targets > 0 {
             std::borrow::Cow::Owned(format!("broadcast to {targets}"))
@@ -386,9 +395,19 @@ pub fn render_ask(frame: &mut Frame, area: Rect, state: &AppState) {
     }
     lines.push(Line::raw(""));
 
-    let on_free_text = ask.focus() == AskFocus::FreeText;
+    // A refused chip renders as a READING surface, not an answering one.
+    //
+    // The options and the question are still worth showing — a native picker's
+    // choices tell the operator what is being asked even when the answer is
+    // typed elsewhere. What must go is every affordance that promises a send:
+    // the selection caret, the free-text row, the composer and its caret. A
+    // pane that paints a cursor under "nothing to send to" is the same lying
+    // surface as a green tick over a failed send.
+    let refusal = chip.answerable.refusal();
+    let can_answer = refusal.is_none();
+    let on_free_text = can_answer && ask.focus() == AskFocus::FreeText;
     for (index, option) in chip.options.iter().enumerate() {
-        let selected = !on_free_text && ask.cursor() == index;
+        let selected = can_answer && !on_free_text && ask.cursor() == index;
         lines.push(Line::from(vec![
             Span::styled(
                 if selected { "\u{25b8}" } else { " " },
@@ -415,39 +434,43 @@ pub fn render_ask(frame: &mut Frame, area: Rect, state: &AppState) {
         }
     }
 
-    // The free-text row is always present, even on a structured request: an
-    // agent's question is not always answerable with one of its own options,
-    // and a surface that only offers them forces the operator back to the pane.
-    lines.push(Line::from(vec![
-        Span::styled(
-            if on_free_text { "\u{25b8}" } else { " " },
-            Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!("{} ", circled(chip.options.len())),
-            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            if chip.options.is_empty() {
-                "answer".to_string()
-            } else {
-                "other (type it)".to_string()
-            },
-            Style::default().fg(if on_free_text {
-                SELECTION_GREEN
-            } else {
-                MUTED_GRAY
-            }),
-        ),
-    ]));
-    if on_free_text {
+    // back to the pane. On a REFUSED chip it is omitted entirely: a composer
+    // row on a row that cannot send is an affordance that does nothing.
+    if can_answer {
+        // The free-text row is present on every ANSWERABLE request, even a
+        // structured one: an agent's question is not always answerable with one of
+        // its own options, and a surface that only offers them forces the operator
         lines.push(Line::from(vec![
-            Span::raw("    "),
-            Span::styled(ask.free_text().to_string(), Style::default().fg(SOFT_WHITE)),
-            // A visible caret, so an empty composer reads as "type here" rather
-            // than as a pane that is doing nothing.
-            Span::styled("\u{2588}", Style::default().fg(SELECTION_GREEN)),
+            Span::styled(
+                if on_free_text { "\u{25b8}" } else { " " },
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("{} ", circled(chip.options.len())),
+                Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                if chip.options.is_empty() {
+                    "answer".to_string()
+                } else {
+                    "other (type it)".to_string()
+                },
+                Style::default().fg(if on_free_text {
+                    SELECTION_GREEN
+                } else {
+                    MUTED_GRAY
+                }),
+            ),
         ]));
+        if on_free_text {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(ask.free_text().to_string(), Style::default().fg(SOFT_WHITE)),
+                // A visible caret, so an empty composer reads as "type here" rather
+                // than as a pane that is doing nothing.
+                Span::styled("\u{2588}", Style::default().fg(SELECTION_GREEN)),
+            ]));
+        }
     }
 
     // What the last send did. Every one of the three states is VISIBLE: an

--- a/ainb-tui/crates/ainb-core/src/fleet/attention.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/attention.rs
@@ -91,6 +91,16 @@ pub enum Unanswerable {
     /// The state is informational. `DONE` and `ERR` are not questions; there is
     /// nothing to answer.
     NotAQuestion,
+    /// The agent is rendering its OWN picker for this question, and only that
+    /// picker can accept the answer.
+    ///
+    /// The question and its options are still shown — they arrived in the hook
+    /// payload and are worth reading — but a pick cannot be delivered from
+    /// here. Typing an option's label into a pane that is waiting on arrow
+    /// keys is not an answer, and a composer that looks like it sends one is
+    /// the lying surface this screen exists to remove. So the pane shows what
+    /// is being asked and says where to answer it.
+    NativePicker,
 }
 
 impl Unanswerable {
@@ -103,6 +113,9 @@ impl Unanswerable {
             }
             Self::NoTransport => "this session has no live pane and no daemon route to answer over",
             Self::NotAQuestion => "nothing is waiting on an answer here",
+            Self::NativePicker => {
+                "this renders in the agent's own picker — attach with `a` to answer it there"
+            }
         }
     }
 }
@@ -477,6 +490,24 @@ pub fn route_answer(
             Answerable::No(Unanswerable::DaemonGone)
         };
     }
+    // A locally-lifted question that carries its OWN options is the agent's
+    // native picker, and only that picker can take the pick.
+    //
+    // The options came out of an `AskUserQuestion` hook payload, so ainb knows
+    // exactly what is being asked and can show it — but the pane is waiting on
+    // the picker's own keys, and `resolve_and_send_typed` delivers literal
+    // text. Typing "staging" at a picker is not choosing `staging`. Offering a
+    // composer here would look like an answer and deliver nothing, which is
+    // strictly worse than saying where the answer goes.
+    //
+    // A DAEMON row is exempt and handled above: it carries an attention id and
+    // `attention/answer` really does deliver a structured pick.
+    if chip.kind == AttentionKind::Ask
+        && chip.source == AttentionSource::Local
+        && !chip.options.is_empty()
+    {
+        return Answerable::No(Unanswerable::NativePicker);
+    }
     // A local permission request goes to the broker, never to the pane: the
     // hook is blocked in `client_await` and reads nothing typed at the
     // terminal. The broker is notifyd's and local, so this is the route that
@@ -498,6 +529,64 @@ pub fn route_answer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A question with its OWN options is the agent's picker, not ours.
+    ///
+    /// ainb can read an `AskUserQuestion` payload and show exactly what is
+    /// being asked, but the pane is waiting on the picker's keys and the send
+    /// path delivers literal text. Typing "staging" at a picker does not
+    /// choose `staging`, so a composer here would look like an answer and
+    /// deliver nothing.
+    #[test]
+    fn a_local_question_carrying_its_own_options_refuses_to_pretend() {
+        let chip =
+            SessionAttention::local(AttentionKind::Ask, 0).with_options(vec![AttentionOption {
+                label: "staging".into(),
+                description: String::new(),
+            }]);
+        let route = route_answer(&chip, Some("some-pane"), Some("s-1"), true);
+        assert_eq!(
+            route,
+            Answerable::No(Unanswerable::NativePicker),
+            "a live pane must not make a native picker look answerable"
+        );
+        let reason = Unanswerable::NativePicker.reason();
+        assert!(reason.contains("own picker"), "{reason}");
+        assert!(
+            reason.contains('a'),
+            "it must say how to get there: {reason}"
+        );
+    }
+
+    /// A local question with NO options is an ordinary prompt: still typed.
+    #[test]
+    fn a_local_question_without_options_still_routes_to_the_pane() {
+        let chip = SessionAttention::local(AttentionKind::Ask, 0);
+        assert_eq!(
+            route_answer(&chip, Some("some-pane"), Some("s-1"), true),
+            Answerable::Tmux,
+            "free text at a plain prompt is exactly what the pane route is for"
+        );
+    }
+
+    /// A DAEMON row keeps its structured route even carrying options: its
+    /// `attention/answer` really does deliver a pick.
+    #[test]
+    fn a_daemon_question_with_options_still_answers_through_the_daemon() {
+        let chip =
+            SessionAttention::daemon(AttentionKind::Ask, 0, "att-1".into()).with_options(vec![
+                AttentionOption {
+                    label: "yes".into(),
+                    description: String::new(),
+                },
+            ]);
+        assert_eq!(
+            route_answer(&chip, Some("some-pane"), Some("s-1"), true),
+            Answerable::Daemon {
+                attention_id: "att-1".into()
+            },
+        );
+    }
 
     #[test]
     fn only_ask_and_approve_block() {

--- a/ainb-tui/crates/ainb-core/src/fleet/attention.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/attention.rs
@@ -490,23 +490,24 @@ pub fn route_answer(
             Answerable::No(Unanswerable::DaemonGone)
         };
     }
-    // A locally-lifted question that carries its OWN options is the agent's
-    // native picker, and only that picker can take the pick.
+    // The agent is rendering its OWN picker, and only that picker takes the
+    // pick. Carried on the chip by its producer, not inferred from a non-empty
+    // option list: a payload that sent no options is still a native picker, and
+    // inferring from the list let exactly those rows fall through to a composer
+    // that types literal text at it.
     //
-    // The options came out of an `AskUserQuestion` hook payload, so ainb knows
-    // exactly what is being asked and can show it — but the pane is waiting on
-    // the picker's own keys, and `resolve_and_send_typed` delivers literal
-    // text. Typing "staging" at a picker is not choosing `staging`. Offering a
-    // composer here would look like an answer and deliver nothing, which is
-    // strictly worse than saying where the answer goes.
+    // `resolve_and_send_typed` delivers text; typing "staging" at a picker is
+    // not choosing `staging`. Offering a composer here would look like an
+    // answer and deliver nothing.
     //
-    // A DAEMON row is exempt and handled above: it carries an attention id and
-    // `attention/answer` really does deliver a structured pick.
-    if chip.kind == AttentionKind::Ask
-        && chip.source == AttentionSource::Local
-        && !chip.options.is_empty()
-    {
-        return Answerable::No(Unanswerable::NativePicker);
+    // Still requires a PANE, because the refusal names one: telling an operator
+    // to attach to a session whose pane is gone is its own wrong answer, and
+    // `NoTransport` is what that actually is. A DAEMON row is exempt and
+    // handled above — `attention/answer` really does deliver a structured pick.
+    if matches!(chip.answerable, Answerable::No(Unanswerable::NativePicker)) {
+        return tmux_session.map_or(Answerable::No(Unanswerable::NoTransport), |_| {
+            Answerable::No(Unanswerable::NativePicker)
+        });
     }
     // A local permission request goes to the broker, never to the pane: the
     // hook is blocked in `client_await` and reads nothing typed at the
@@ -539,11 +540,12 @@ mod tests {
     /// deliver nothing.
     #[test]
     fn a_local_question_carrying_its_own_options_refuses_to_pretend() {
-        let chip =
-            SessionAttention::local(AttentionKind::Ask, 0).with_options(vec![AttentionOption {
+        let chip = SessionAttention::local(AttentionKind::Ask, 0)
+            .with_options(vec![AttentionOption {
                 label: "staging".into(),
                 description: String::new(),
-            }]);
+            }])
+            .unanswerable(Unanswerable::NativePicker);
         let route = route_answer(&chip, Some("some-pane"), Some("s-1"), true);
         assert_eq!(
             route,
@@ -552,9 +554,32 @@ mod tests {
         );
         let reason = Unanswerable::NativePicker.reason();
         assert!(reason.contains("own picker"), "{reason}");
+        // `contains('a')` would pass on any English sentence and guard
+        // nothing; the point is that the refusal names the KEY.
         assert!(
-            reason.contains('a'),
-            "it must say how to get there: {reason}"
+            reason.contains("`a`"),
+            "it must name the key that gets there: {reason}"
+        );
+    }
+
+    /// With NO pane, the refusal must not tell anyone to attach to one.
+    ///
+    /// A session whose pane was killed still carries its last question. Saying
+    /// "attach with `a`" points at nothing, and `NoTransport` is what that
+    /// actually is.
+    #[test]
+    fn a_native_picker_with_no_pane_reports_no_transport_instead() {
+        let chip =
+            SessionAttention::local(AttentionKind::Ask, 0).unanswerable(Unanswerable::NativePicker);
+        assert_eq!(
+            route_answer(&chip, None, Some("s-1"), true),
+            Answerable::No(Unanswerable::NoTransport),
+            "there is nothing to attach to, so do not say attach"
+        );
+        assert_eq!(
+            route_answer(&chip, Some("pane"), Some("s-1"), true),
+            Answerable::No(Unanswerable::NativePicker),
+            "with a pane, naming the picker is the right refusal"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -50,7 +50,7 @@ pub use install::{
     install_under_home, prompt_state, repair_hooks, repair_or_install_hooks, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
-pub use osnotify::{AlertKind, classify_attention, notification_subtype};
+pub use osnotify::{AlertKind, ask_user_question, classify_attention, notification_subtype};
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use procs::{ClassifiedDaemon, DaemonClass, NotifydProc, scan as scan_daemons};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/lib.rs
@@ -50,7 +50,9 @@ pub use install::{
     install_under_home, prompt_state, repair_hooks, repair_or_install_hooks, status, uninstall,
 };
 pub use listener::{RunConfig, run_daemon};
-pub use osnotify::{AlertKind, ask_user_question, classify_attention, notification_subtype};
+pub use osnotify::{
+    AlertKind, AskUserQuestion, ask_user_question, classify_attention, notification_subtype,
+};
 pub use paths::Paths;
 pub use pid::PidFile;
 pub use procs::{ClassifiedDaemon, DaemonClass, NotifydProc, scan as scan_daemons};

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -98,6 +98,52 @@ fn non_blank(subtype: Option<&str>) -> Option<&str> {
     subtype.map(str::trim).filter(|subtype| !subtype.is_empty())
 }
 
+/// The question and options a hook payload carries for an `AskUserQuestion`.
+///
+/// Returns `(question, options)` where each option is `(label, description)`.
+///
+/// The picker's whole structure is already in the payload: 540 of 718
+/// `PermissionRequest` records in one local log are `AskUserQuestion`, and
+/// every one carries `tool_input.questions`. They are stored too, because a
+/// permission request is user-facing — unlike `PreToolUse`, which the listener
+/// drops as telemetry. So the options reach the chip with no new ingestion.
+///
+/// Without this the row shows the permission vocabulary — approve / deny — for
+/// a prompt whose real answers are its own options, which is the wrong two
+/// words on the majority of permission chips.
+///
+/// Only the FIRST question is lifted. A multi-question call is answered one
+/// question at a time in the native picker, and showing the second one's
+/// options against the first one's prompt would be worse than showing none.
+#[must_use]
+pub fn ask_user_question(payload: &serde_json::Value) -> Option<(String, Vec<(String, String)>)> {
+    if payload.get("tool_name")?.as_str()? != "AskUserQuestion" {
+        return None;
+    }
+    let first = payload.get("tool_input")?.get("questions")?.as_array()?.first()?;
+    let question = non_blank(first.get("question").and_then(|q| q.as_str()))?.to_string();
+    let options = first
+        .get("options")
+        .and_then(|o| o.as_array())
+        .map(|options| {
+            options
+                .iter()
+                .filter_map(|option| {
+                    let label = non_blank(option.get("label").and_then(|l| l.as_str()))?;
+                    let description = option
+                        .get("description")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                    Some((label.to_string(), description))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Some((question, options))
+}
+
 /// The `notification_type` a hook payload carries, if any.
 ///
 /// One accessor so the OS-notification path and the TUI chip path cannot

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -100,31 +100,65 @@ fn non_blank(subtype: Option<&str>) -> Option<&str> {
 
 /// The question and options a hook payload carries for an `AskUserQuestion`.
 ///
-/// Returns `(question, options)` where each option is `(label, description)`.
+/// `Some` for EVERY `AskUserQuestion`, keyed on `tool_name` alone. The question
+/// text and the option list are both optional, because neither absence changes
+/// what the row IS: the agent is rendering its own picker either way, and the
+/// caller must be able to say so. Keying on the presence of a question, or of a
+/// non-empty option list, silently dropped those records back onto the
+/// permission path — where `cli/fleet/atc.rs` explicitly excludes this tool from
+/// the blocking approve round-trip, so no waiter is ever parked and every send
+/// fails at an empty broker.
 ///
-/// The picker's whole structure is already in the payload: 540 of 718
-/// `PermissionRequest` records in one local log are `AskUserQuestion`, and
-/// every one carries `tool_input.questions`. They are stored too, because a
-/// permission request is user-facing — unlike `PreToolUse`, which the listener
-/// drops as telemetry. So the options reach the chip with no new ingestion.
+/// The whole picker is already in the payload: 540 of 718 `PermissionRequest`
+/// records in one local log are `AskUserQuestion`, and every one carries
+/// `tool_input.questions`. They are stored too, because a permission request is
+/// user-facing — unlike `PreToolUse`, which the listener drops as telemetry. So
+/// this costs no new ingestion.
 ///
-/// Without this the row shows the permission vocabulary — approve / deny — for
-/// a prompt whose real answers are its own options, which is the wrong two
-/// words on the majority of permission chips.
+/// Reads BOTH payload shapes, like [`notification_subtype`]: without `jq` the
+/// hook cannot build nested JSON and stashes the whole input as a JSON *string*
+/// under `_raw`. Missing that left every jq-less machine on the old approve/deny
+/// rendering.
 ///
 /// Only the FIRST question is lifted. A multi-question call is answered one
-/// question at a time in the native picker, and showing the second one's
-/// options against the first one's prompt would be worse than showing none.
+/// question at a time in the native picker, and showing the second question's
+/// options under the first question's prompt would be worse than showing none.
 #[must_use]
-pub fn ask_user_question(payload: &serde_json::Value) -> Option<(String, Vec<(String, String)>)> {
+pub fn ask_user_question(payload: &serde_json::Value) -> Option<AskUserQuestion> {
+    read_ask_user_question(payload).or_else(|| {
+        let raw = payload.get("_raw")?.as_str()?;
+        let nested = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+        read_ask_user_question(&nested)
+    })
+}
+
+/// One `AskUserQuestion` as the row needs it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AskUserQuestion {
+    /// The question as the agent worded it, when it sent one.
+    pub question: Option<String>,
+    /// Each option's `(label, description)`, in the agent's own order. Empty
+    /// when the payload carried none — still an `AskUserQuestion`.
+    pub options: Vec<(String, String)>,
+}
+
+/// [`ask_user_question`] against one already-unwrapped payload.
+fn read_ask_user_question(payload: &serde_json::Value) -> Option<AskUserQuestion> {
     if payload.get("tool_name")?.as_str()? != "AskUserQuestion" {
         return None;
     }
-    let first = payload.get("tool_input")?.get("questions")?.as_array()?.first()?;
-    let question = non_blank(first.get("question").and_then(|q| q.as_str()))?.to_string();
+    let first = payload
+        .get("tool_input")
+        .and_then(|input| input.get("questions"))
+        .and_then(|questions| questions.as_array())
+        .and_then(|questions| questions.first());
+    let Some(first) = first else {
+        return Some(AskUserQuestion::default());
+    };
+    let question = non_blank(first.get("question").and_then(|q| q.as_str())).map(str::to_string);
     let options = first
         .get("options")
-        .and_then(|o| o.as_array())
+        .and_then(|options| options.as_array())
         .map(|options| {
             options
                 .iter()
@@ -141,7 +175,7 @@ pub fn ask_user_question(payload: &serde_json::Value) -> Option<(String, Vec<(St
                 .collect()
         })
         .unwrap_or_default();
-    Some((question, options))
+    Some(AskUserQuestion { question, options })
 }
 
 /// The `notification_type` a hook payload carries, if any.


### PR DESCRIPTION
## What was wrong

An `AskUserQuestion` reaches the hooks as a `PermissionRequest`. That classifies `NeedsPermission` → `AttentionKind::Approve`, and approve/deny was then synthesised onto it. So a prompt whose real answers are its own named options wore the permission vocabulary, and the ask pane offered a free-text box as the only way to answer it.

Measured on one local event log: **540 of 718 `PermissionRequest` records are `AskUserQuestion`**, so this was the majority of permission chips.

## The picker was already in the payload

Every one of those 540 carries `tool_input.questions` with the question text and each option's `label` and `description`. They are already stored, because a permission request is user-facing — `PreToolUse` carries the same structure but the listener drops it as telemetry. So this needs no new ingestion and no schema change.

## What changes

| | before | after |
|---|---|---|
| chip kind | APPROVE | ASK |
| question | hook `message` | the agent's real question |
| options | synthesised approve / deny | the agent's own options, in order, with descriptions |
| plain `Bash` approval | APPROVE | unchanged |

## The send is deliberately NOT faked

The pane is waiting on the native picker's own keys, and `resolve_and_send_typed` delivers literal text — typing `staging` at a picker does not choose `staging`. With a live pane the row would otherwise route to tmux and offer a composer that looks like it answers and delivers nothing. That is the same defect as a green tick over a still-blocked prompt.

So a LOCAL question carrying its own options refuses, and the refusal names where the answer goes:

```
this renders in the agent's own picker — attach with `a` to answer it there
```

The question and every option stay on screen. Showing what is being asked is worth it even when the answer is typed elsewhere.

A DAEMON row carrying options is unaffected and keeps its structured route: `attention/answer` really does deliver a pick.

## Delivering a pick for real

Out of scope here, and it needs two things this PR does not assume:

1. The one verified send path taught to carry keys rather than text — INV-2 forbids a private `send-keys`.
2. The picker's keybindings proved against a live pane, not guessed.

## Tests

Five, each falsified by removing its own guard and watching it go red:

- `an_ask_user_question_carries_its_own_question_and_options`
- `a_plain_tool_permission_request_stays_an_approval`
- `a_local_question_carrying_its_own_options_refuses_to_pretend`
- `a_local_question_without_options_still_routes_to_the_pane`
- `a_daemon_question_with_options_still_answers_through_the_daemon`

`cargo nextest run -p ainb-plugin-notifyd -p ainb`: 5133 passed, 0 failed. rustfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive question prompts display their question text and agent-provided answer choices.
  - Answer choices retain their labels, descriptions, and original order.
  - Notifications recognize and support question prompts, including prompts with no listed choices.
  - Different questions are tracked independently, preventing stale prompt status from carrying over.

- **Bug Fixes**
  - Regular permission requests continue to use approve/deny actions.
  - Native-picker prompts no longer offer unsupported text-entry responses.
  - Unavailable prompts are presented as read-only instead of offering unusable actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->