### PR TITLE
fix(recovery): keep a session's label after it stops, and let the recovery panel be searched

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -564,18 +564,23 @@ pub enum AppEvent {
     SkillsSearchBackspace,  // Remove last char from search query
     SkillsSearchClose,      // Exit search mode (Esc)
     // Session recovery events
-    SessionRecoveryBack,           // Return to home screen (Esc)
-    SessionRecoveryNext,           // Navigate to next session (Down/j)
-    SessionRecoveryPrev,           // Navigate to previous session (Up/k)
-    SessionRecoveryResume,         // Resume selected session (r)
-    SessionRecoveryArchive,        // Archive/delete selected item (d)
-    SessionRecoveryRefresh,        // Refresh session list (R)
-    SessionRecoveryToggleView,     // Toggle view mode: Sessions/Worktrees/All (Tab)
-    SessionRecoveryRecoverAll,     // Recover all orphaned worktrees (Shift+A)
-    SessionRecoveryToggleSelect,   // Toggle multi-select on current item (Space)
-    SessionRecoveryDeleteSelected, // Delete all multi-selected items (Shift+D)
-    ToggleSelectSession,           // Toggle multi-select on current session (Space)
-    DeleteSelectedSessions,        // Bulk delete all multi-selected sessions (Shift+D)
+    SessionRecoveryBack,             // Return to home screen (Esc)
+    SessionRecoveryNext,             // Navigate to next session (Down/j)
+    SessionRecoveryPrev,             // Navigate to previous session (Up/k)
+    SessionRecoveryResume,           // Resume selected session (r)
+    SessionRecoveryArchive,          // Archive/delete selected item (d)
+    SessionRecoveryRefresh,          // Refresh session list (R)
+    SessionRecoveryToggleView,       // Toggle view mode: Sessions/Worktrees/All (Tab)
+    SessionRecoveryRecoverAll,       // Recover all orphaned worktrees (Shift+A)
+    SessionRecoveryToggleSelect,     // Toggle multi-select on current item (Space)
+    SessionRecoveryDeleteSelected,   // Delete all multi-selected items (Shift+D)
+    SessionRecoverySearchStart,      // Open the inline filter (/)
+    SessionRecoverySearchChar(char), // Append char to the filter query
+    SessionRecoverySearchBackspace,  // Remove last char from the filter query
+    SessionRecoverySearchClose,      // Close the bar, KEEP the filter applied (Enter)
+    SessionRecoverySearchCancel,     // Close the bar and drop the filter (Esc)
+    ToggleSelectSession,             // Toggle multi-select on current session (Space)
+    DeleteSelectedSessions,          // Bulk delete all multi-selected sessions (Shift+D)
     // Phase 5 (new-session redesign) Configure-screen events. Emitted by the
     // `configure::handle_key` outcome plumbing in `handle_new_session_keys`.
     /// Enter on Configure → record launch + start session. Carries the
@@ -1553,6 +1558,8 @@ impl EventHandler {
             && state.session_composer_captures_text();
         let skills_text_active =
             state.current_screen == screen_ids::SKILLS && state.skills_state.search_active;
+        let recovery_text_active = state.current_screen == screen_ids::SESSION_RECOVERY
+            && state.session_recovery_state.search_active;
         // SkillManager add-source / search prompt — when its input
         // overlay is open the user is typing a URI or filter, which
         // routinely contains `:` (e.g. `gh:owner/repo`,
@@ -1618,6 +1625,7 @@ impl EventHandler {
             || config_text_active
             || state.auth_provider_popup_state.show_popup
             || skills_text_active
+            || recovery_text_active
             || skill_manager_input_active
             || git_view_text_active
             || session_composer_active
@@ -1880,6 +1888,8 @@ impl EventHandler {
             let analytics_text_active = false;
             let skills_text_active =
                 state.current_screen == screen_ids::SKILLS && state.skills_state.search_active;
+            let recovery_text_active = state.current_screen == screen_ids::SESSION_RECOVERY
+                && state.session_recovery_state.search_active;
             let git_view_text_active = state.current_screen == screen_ids::GIT_VIEW
                 && state.git_view_state.as_ref().map(|gv| gv.is_in_commit_mode()).unwrap_or(false);
             let suppress_global_w = matches!(
@@ -1893,6 +1903,7 @@ impl EventHandler {
             ) || state.auth_provider_popup_state.show_popup
                 || analytics_text_active
                 || skills_text_active
+                || recovery_text_active
                 || git_view_text_active;
             if !suppress_global_w
                 && matches!(key_event.code, KeyCode::Char('W'))
@@ -3242,7 +3253,29 @@ impl EventHandler {
             };
         }
 
+        // Filter mode eats every printable key: without this, typing "d" into
+        // the query would archive a session instead of narrowing the list.
+        if state.session_recovery_state.search_active {
+            return match key_event.code {
+                KeyCode::Esc => Some(AppEvent::SessionRecoverySearchCancel),
+                KeyCode::Enter => Some(AppEvent::SessionRecoverySearchClose),
+                KeyCode::Backspace => Some(AppEvent::SessionRecoverySearchBackspace),
+                // Arrows still navigate while typing; j/k cannot, they are query text.
+                KeyCode::Up => Some(AppEvent::SessionRecoveryPrev),
+                KeyCode::Down => Some(AppEvent::SessionRecoveryNext),
+                KeyCode::Char(c) => Some(AppEvent::SessionRecoverySearchChar(c)),
+                _ => None,
+            };
+        }
+
         match key_event.code {
+            // Enter closes the bar but keeps the filter applied, and the empty
+            // state then tells the operator "Esc clears the filter". Esc has to
+            // actually do that before it leaves the screen, or the filter
+            // survives into the next visit with no way to drop it.
+            KeyCode::Esc if !state.session_recovery_state.search_query.is_empty() => {
+                Some(AppEvent::SessionRecoverySearchCancel)
+            }
             KeyCode::Esc => Some(AppEvent::SessionRecoveryBack),
             KeyCode::Up | KeyCode::Char('k') => Some(AppEvent::SessionRecoveryPrev),
             KeyCode::Down | KeyCode::Char('j') => Some(AppEvent::SessionRecoveryNext),
@@ -3253,6 +3286,7 @@ impl EventHandler {
             KeyCode::Char('A') => Some(AppEvent::SessionRecoveryRecoverAll),
             KeyCode::Char(' ') => Some(AppEvent::SessionRecoveryToggleSelect),
             KeyCode::Char('D') => Some(AppEvent::SessionRecoveryDeleteSelected),
+            KeyCode::Char('/') => Some(AppEvent::SessionRecoverySearchStart),
             _ => None,
         }
     }
@@ -7270,6 +7304,25 @@ impl EventHandler {
                 // Query is preserved so the filter stays applied after exit.
             }
             // Session recovery events
+            AppEvent::SessionRecoverySearchStart => {
+                // Reuse cancel to drop any prior query and re-anchor the
+                // selection, then take focus.
+                state.session_recovery_state.search_cancel();
+                state.session_recovery_state.search_active = true;
+            }
+            AppEvent::SessionRecoverySearchChar(c) => {
+                state.session_recovery_state.search_push(c);
+            }
+            AppEvent::SessionRecoverySearchBackspace => {
+                state.session_recovery_state.search_pop();
+            }
+            AppEvent::SessionRecoverySearchClose => {
+                // Query is preserved so the narrowed list stays actionable.
+                state.session_recovery_state.search_active = false;
+            }
+            AppEvent::SessionRecoverySearchCancel => {
+                state.session_recovery_state.search_cancel();
+            }
             AppEvent::SessionRecoveryBack => {
                 // If overlay is showing, dismiss it first
                 if state.session_recovery_state.recovery_overlay.is_some() {
@@ -8401,6 +8454,92 @@ fn is_known_screen_id(id: &str) -> bool {
 }
 
 #[cfg(test)]
+mod session_recovery_key_tests {
+    use super::*;
+    use crate::app::screens::ids;
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    fn recovery_state() -> AppState {
+        let mut state = AppState::default();
+        state.current_screen = ids::SESSION_RECOVERY.to_string();
+        state.session_recovery_state.recovery_overlay = None;
+        state
+    }
+
+    fn key(state: &mut AppState, c: char) -> Option<AppEvent> {
+        EventHandler::handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE), state)
+    }
+
+    #[test]
+    fn slash_opens_the_recovery_filter() {
+        let mut state = recovery_state();
+        assert!(matches!(
+            key(&mut state, '/'),
+            Some(AppEvent::SessionRecoverySearchStart)
+        ));
+    }
+
+    /// While typing, the panel's single-key actions must not fire: `d`
+    /// archives, `D` deletes worktrees, `A` recovers everything.
+    #[test]
+    fn typing_a_query_does_not_trigger_panel_actions() {
+        let mut state = recovery_state();
+        state.session_recovery_state.search_active = true;
+        for c in ['d', 'D', 'A', 'r', 'R', ' ', 'j', 'k'] {
+            assert!(
+                matches!(key(&mut state, c), Some(AppEvent::SessionRecoverySearchChar(got)) if got == c),
+                "`{c}` leaked past the filter bar"
+            );
+        }
+    }
+
+    /// After Enter the bar is closed but the filter is still applied, and the
+    /// panel prints "Esc clears the filter." Esc must honour that instead of
+    /// walking off the screen with the query still set.
+    #[test]
+    fn escape_clears_an_applied_filter_before_leaving_the_screen() {
+        let mut state = recovery_state();
+        state.session_recovery_state.search_query = "zzzz".to_string();
+        state.session_recovery_state.search_active = false;
+
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(matches!(
+            EventHandler::handle_key_event(esc, &mut state),
+            Some(AppEvent::SessionRecoverySearchCancel)
+        ));
+
+        // Second Esc, with no filter left to drop, leaves as it always did.
+        state.session_recovery_state.search_query.clear();
+        assert!(matches!(
+            EventHandler::handle_key_event(esc, &mut state),
+            Some(AppEvent::SessionRecoveryBack)
+        ));
+    }
+
+    /// Esc cancels the filter rather than leaving the screen; Enter closes the
+    /// bar and keeps the narrowed list actionable.
+    #[test]
+    fn escape_cancels_and_enter_keeps_the_filter() {
+        let mut state = recovery_state();
+        state.session_recovery_state.search_active = true;
+        assert!(matches!(
+            EventHandler::handle_key_event(
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                &mut state
+            ),
+            Some(AppEvent::SessionRecoverySearchCancel)
+        ));
+        assert!(matches!(
+            EventHandler::handle_key_event(
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+                &mut state
+            ),
+            Some(AppEvent::SessionRecoverySearchClose)
+        ));
+    }
+}
+
+#[cfg(test)]
 mod session_list_key_tests {
     use super::*;
     use crate::app::screens::ids;
@@ -9247,6 +9386,7 @@ mod text_input_guard_tests {
             state.config_screen_state = Default::default();
             state.config_popup_state = Default::default();
             state.skills_state.search_active = false;
+            state.session_recovery_state.search_active = false;
             state.git_view_state = None;
         }
 
@@ -9370,6 +9510,15 @@ mod text_input_guard_tests {
         assert!(
             EventHandler::is_text_input_context(&state),
             "Skills search_active must be treated as text input"
+        );
+
+        // Session recovery filter bar.
+        reset_text_context_state(&mut state);
+        state.current_screen = screen_ids::SESSION_RECOVERY.to_string();
+        state.session_recovery_state.search_active = true;
+        assert!(
+            EventHandler::is_text_input_context(&state),
+            "Session recovery search_active must be treated as text input"
         );
 
         // GitView commit-message mode.

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -5947,7 +5947,7 @@ impl AppState {
                 continue;
             };
 
-            let stopped = Self::stopped_session_from_metadata(metadata);
+            let stopped = Self::stopped_session_from_metadata(metadata, &self.session_label_store);
             // Group by the actual source repository (matches Phase 1's
             // grouping above). The previous `worktree_path.parent()` key was
             // always the shared `~/.agents-in-a-box/worktrees/` dir, which
@@ -5978,8 +5978,12 @@ impl AppState {
 
     /// Build a `Session` model in `Stopped` state from persisted metadata.
     /// Used to render sessions whose tmux is dead but whose worktree is alive.
+    /// `labels` is threaded in rather than loaded here because this runs once
+    /// per stopped session inside a refresh loop, and a per-row file read is a
+    /// syscall per session for a store that only changes on rename.
     pub(crate) fn stopped_session_from_metadata(
         metadata: &crate::interactive::SessionMetadata,
+        labels: &crate::config::SessionLabelStore,
     ) -> crate::models::Session {
         use crate::models::{Session, SessionMode, SessionStatus};
 
@@ -6002,6 +6006,10 @@ impl AppState {
             session.branch_name = branch_name;
         }
         session.tmux_session_name = Some(metadata.tmux_session_name.clone());
+        // The durable label is keyed by tmux name and outlives the tmux
+        // session, so a stopped row keeps the same "<label> · <branch>" the
+        // running row had instead of dropping back to a bare branch.
+        session.display_name = labels.get(&metadata.tmux_session_name).cloned();
         session.status = SessionStatus::Stopped;
         session.created_at = metadata.created_at;
         session

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -599,7 +599,10 @@ mod tests {
             codex_thread_id: None,
         };
 
-        let session = AppState::stopped_session_from_metadata(&metadata);
+        let session = AppState::stopped_session_from_metadata(
+            &metadata,
+            &crate::config::SessionLabelStore::default(),
+        );
         assert_eq!(session.id, metadata.session_id);
         assert!(matches!(session.status, SessionStatus::Stopped));
         assert_eq!(
@@ -639,7 +642,10 @@ mod tests {
             codex_thread_id: None,
         };
 
-        let session = AppState::stopped_session_from_metadata(&metadata);
+        let session = AppState::stopped_session_from_metadata(
+            &metadata,
+            &crate::config::SessionLabelStore::default(),
+        );
         assert!(
             !session.skip_permissions,
             "Some(false) must be preserved, not defaulted to yolo"
@@ -675,7 +681,10 @@ mod tests {
             codex_thread_id: None,
         };
 
-        let session = AppState::stopped_session_from_metadata(&metadata);
+        let session = AppState::stopped_session_from_metadata(
+            &metadata,
+            &crate::config::SessionLabelStore::default(),
+        );
 
         assert_eq!(session.branch_name, "feature");
         assert_ne!(session.branch_name, "ainb/fpl");

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -1559,6 +1559,66 @@ mod tests {
         );
     }
 
+    /// A stopped session must still PAINT its durable label. Asserted against
+    /// a rendered buffer, not `display_name`, because the loss was in the row
+    /// the operator actually reads after stopping a session.
+    #[test]
+    fn stopped_session_row_paints_its_durable_label() {
+        use crate::config::SessionLabelStore;
+        use crate::interactive::SessionMetadata;
+        use crate::models::SessionAgentType;
+        use ratatui::{Terminal, backend::TestBackend};
+        use std::path::PathBuf;
+
+        let mut labels = SessionLabelStore::default();
+        labels.set(
+            "tmux_stopped_row".to_string(),
+            Some("RPC flake".to_string()),
+        );
+
+        let metadata = SessionMetadata {
+            session_id: uuid::Uuid::new_v4(),
+            tmux_session_name: "tmux_stopped_row".to_string(),
+            worktree_path: PathBuf::from("/tmp/ainb-stopped-label"),
+            workspace_name: "ws".to_string(),
+            created_at: chrono::Utc::now(),
+            agent_type: SessionAgentType::Claude,
+            headroom_enabled: false,
+            rtk_enabled: false,
+            skip_permissions: None,
+            model: None,
+            model_source: Default::default(),
+            codex_model: None,
+            codex_thread_id: None,
+        };
+
+        let mut session = AppState::stopped_session_from_metadata(&metadata, &labels);
+        session.branch_name = "fix/rpc-acp-flake".to_string();
+        assert!(matches!(session.status, SessionStatus::Stopped));
+
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        state.expand_all_workspaces = true;
+        state.session_filter = SessionFilter::All;
+        let mut workspace = Workspace::new("ws".to_string(), "/tmp/ainb-stopped-label".into());
+        workspace.add_session(session);
+        state.workspaces.push(workspace);
+        state.selected_workspace_index = Some(0);
+
+        let mut list = SessionListComponent::new();
+        let mut terminal = Terminal::new(TestBackend::new(120, 20)).expect("terminal");
+        terminal
+            .draw(|frame| list.render(frame, frame.area(), &mut state))
+            .expect("draw");
+        let painted: String =
+            terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+
+        assert!(
+            painted.contains("RPC flake · fix/rpc-acp-flake"),
+            "stopped row lost its label, painted: {painted}"
+        );
+    }
+
     #[test]
     fn durable_label_keeps_live_branch_visible() {
         let mut session = Session::new("workspace".to_string(), "/tmp/workspace".to_string());

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use uuid::Uuid;
 
+use crate::config::screen_model::fuzzy_matches;
 use crate::interactive::session_manager::{SessionMetadata, SessionStore};
 use crate::models::SessionAgentType;
 
@@ -42,6 +43,9 @@ pub struct OrphanedSession {
     pub worktree_branch: Option<String>,
     pub can_resume: bool,
     pub time_ago: String,
+    /// Durable session label from session-labels.json, keyed by tmux name.
+    #[serde(default)]
+    pub label: Option<String>,
 }
 
 /// Type of orphaned worktree
@@ -98,6 +102,37 @@ pub struct OrphanedWorktree {
     pub time_ago: String,
     /// Agent type from sessions.json (if known)
     pub agent_type: Option<SessionAgentType>,
+    /// Durable session label, joined via sessions.json (worktrees carry no
+    /// tmux name of their own, so the label has to come through the store).
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+/// Does an orphaned session pass the filter? Matches the fields an operator
+/// would actually type: tmux name, durable label, branch and task text.
+fn session_matches(session: &OrphanedSession, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let f = fuzzy_matches;
+    f(&session.session, query)
+        || session.label.as_deref().is_some_and(|l| f(l, query))
+        || session.worktree_branch.as_deref().is_some_and(|b| f(b, query))
+        || f(&session.task, query)
+}
+
+/// Worktree equivalent. Paths are deliberately left out: every row shares the
+/// ~/.agents-in-a-box/worktrees prefix, so matching them makes short queries
+/// hit everything.
+fn worktree_matches(worktree: &OrphanedWorktree, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let f = fuzzy_matches;
+    f(&worktree.name, query)
+        || worktree.label.as_deref().is_some_and(|l| f(l, query))
+        || worktree.branch.as_deref().is_some_and(|b| f(b, query))
+        || worktree.source_repo.as_deref().is_some_and(|r| f(r, query))
 }
 
 /// Result of a bulk recovery operation
@@ -118,6 +153,7 @@ impl Default for OrphanedWorktree {
             orphan_type: OrphanType::NoMetadata,
             time_ago: String::new(),
             agent_type: None,
+            label: None,
         }
     }
 }
@@ -152,6 +188,14 @@ impl RecoveryViewMode {
     }
 }
 
+/// A row of the visible (filtered) list, resolved back to its real index in
+/// the underlying unfiltered vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryRow {
+    Session(usize),
+    Worktree(usize),
+}
+
 /// State for the session recovery component
 #[derive(Debug, Clone)]
 pub struct SessionRecoveryState {
@@ -175,6 +219,12 @@ pub struct SessionRecoveryState {
     pub action_result: Option<String>,
     /// Bulk recovery result overlay (shown after multi-resume)
     pub recovery_overlay: Option<RecoveryOverlay>,
+    /// Fuzzy filter query. ONE query shared by all three tabs, applied within
+    /// whichever tab is showing: switching tabs re-filters the new tab's rows
+    /// rather than each tab remembering a filter the operator cannot see.
+    pub search_query: String,
+    /// Whether the inline search bar has keyboard focus.
+    pub search_active: bool,
 }
 
 /// Overlay showing results of a bulk recovery operation
@@ -217,27 +267,79 @@ impl SessionRecoveryState {
             last_error: None,
             action_result: None,
             recovery_overlay: None,
+            search_query: String::new(),
+            search_active: false,
         }
     }
 
-    /// Get the total count of items in current view (includes separator in All view)
+    /// Real indices into `orphaned_sessions` that pass the current filter.
+    /// Recomputed on demand rather than cached: these lists are tens of rows,
+    /// and a cache is one more thing to invalidate on every keystroke.
+    pub fn visible_sessions(&self) -> Vec<usize> {
+        self.orphaned_sessions
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| session_matches(s, &self.search_query))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Real indices into `orphaned_worktrees` that pass the current filter.
+    pub fn visible_worktrees(&self) -> Vec<usize> {
+        self.orphaned_worktrees
+            .iter()
+            .enumerate()
+            .filter(|(_, w)| worktree_matches(w, &self.search_query))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Resolve a view position (what `selected_index` and `selected_items`
+    /// both store) back to a real index. THE choke point: every action goes
+    /// through here, so a filtered list can never resume or delete the row
+    /// underneath the one the operator is looking at.
+    pub fn row_at(&self, view_index: usize) -> Option<RecoveryRow> {
+        match self.view_mode {
+            RecoveryViewMode::Sessions => {
+                self.visible_sessions().get(view_index).copied().map(RecoveryRow::Session)
+            }
+            RecoveryViewMode::Worktrees => {
+                self.visible_worktrees().get(view_index).copied().map(RecoveryRow::Worktree)
+            }
+            RecoveryViewMode::All => {
+                let sessions = self.visible_sessions();
+                if view_index < sessions.len() {
+                    return Some(RecoveryRow::Session(sessions[view_index]));
+                }
+                let worktrees = self.visible_worktrees();
+                let offset = usize::from(!sessions.is_empty() && !worktrees.is_empty());
+                // checked_sub, not a bare `-`: with the filter hiding every
+                // session there is no separator either, so the subtraction
+                // would underflow instead of landing on worktree 0.
+                let wt_pos = view_index.checked_sub(sessions.len() + offset)?;
+                worktrees.get(wt_pos).copied().map(RecoveryRow::Worktree)
+            }
+        }
+    }
+
+    /// Get the total count of visible items in current view (includes separator in All view)
     pub fn current_view_count(&self) -> usize {
         match self.view_mode {
-            RecoveryViewMode::Sessions => self.orphaned_sessions.len(),
-            RecoveryViewMode::Worktrees => self.orphaned_worktrees.len(),
+            RecoveryViewMode::Sessions => self.visible_sessions().len(),
+            RecoveryViewMode::Worktrees => self.visible_worktrees().len(),
             RecoveryViewMode::All => {
-                self.orphaned_sessions.len()
-                    + self.orphaned_worktrees.len()
+                self.visible_sessions().len()
+                    + self.visible_worktrees().len()
                     + self.separator_offset()
             }
         }
     }
 
-    /// Returns 1 if a separator exists in All view (both sessions and worktrees present), 0 otherwise
+    /// Returns 1 if a separator exists in All view (both sessions and worktrees visible), 0 otherwise
     fn separator_offset(&self) -> usize {
         if self.view_mode == RecoveryViewMode::All
-            && !self.orphaned_sessions.is_empty()
-            && !self.orphaned_worktrees.is_empty()
+            && !self.visible_sessions().is_empty()
+            && !self.visible_worktrees().is_empty()
         {
             1
         } else {
@@ -247,7 +349,7 @@ impl SessionRecoveryState {
 
     /// The list index where the separator lives (only valid when separator_offset() == 1)
     fn separator_index(&self) -> usize {
-        self.orphaned_sessions.len()
+        self.visible_sessions().len()
     }
 
     /// Check if current selection is on the separator row
@@ -261,23 +363,53 @@ impl SessionRecoveryState {
             RecoveryViewMode::Sessions => false,
             RecoveryViewMode::Worktrees => true,
             RecoveryViewMode::All => {
-                self.selected_index > self.orphaned_sessions.len() + self.separator_offset() - 1
+                matches!(
+                    self.row_at(self.selected_index),
+                    Some(RecoveryRow::Worktree(_))
+                )
             }
         }
     }
 
-    /// Get the worktree index relative to orphaned_worktrees list
+    /// Get the index of the selected worktree within `orphaned_worktrees`
+    /// (a REAL index, already mapped back through the filter).
     pub fn worktree_index(&self) -> Option<usize> {
-        if !self.is_worktree_selected() {
-            return None;
+        match self.row_at(self.selected_index)? {
+            RecoveryRow::Worktree(idx) => Some(idx),
+            RecoveryRow::Session(_) => None,
         }
-        match self.view_mode {
-            RecoveryViewMode::Worktrees => Some(self.selected_index),
-            RecoveryViewMode::All => {
-                Some(self.selected_index - self.orphaned_sessions.len() - self.separator_offset())
-            }
-            RecoveryViewMode::Sessions => None,
-        }
+    }
+
+    /// Push a char into the filter. View positions mean something different
+    /// after every keystroke, so the selection and the marks are re-anchored.
+    pub fn search_push(&mut self, c: char) {
+        self.search_query.push(c);
+        self.after_query_change();
+    }
+
+    pub fn search_pop(&mut self) {
+        self.search_query.pop();
+        self.after_query_change();
+    }
+
+    /// Esc: drop the filter entirely and close the bar. Enter, by contrast,
+    /// only clears `search_active` so the narrowed list stays actionable.
+    pub fn search_cancel(&mut self) {
+        self.search_query.clear();
+        self.search_active = false;
+        self.after_query_change();
+    }
+
+    fn after_query_change(&mut self) {
+        self.selected_index = 0;
+        // Marks are view positions, not identities: a query change silently
+        // re-points them at other rows, and `D` deletes worktrees. Drop them.
+        self.selected_items.clear();
+        let count = self.current_view_count();
+        self.list_state.select(if count == 0 { None } else { Some(0) });
+        // list_state owns the scroll offset and it survives a shrink, so a
+        // narrowed list would otherwise render scrolled past its own end.
+        *self.list_state.offset_mut() = 0;
     }
 
     /// Toggle to next view mode
@@ -347,6 +479,9 @@ impl SessionRecoveryState {
         }
 
         let mut orphaned = Vec::new();
+        // Loaded once for the whole scan: the store is a single JSON file and
+        // this loop runs per orphan file.
+        let labels = crate::config::SessionLabelStore::load();
 
         for entry in std::fs::read_dir(&agents_dir).map_err(|e| e.to_string())? {
             let entry = entry.map_err(|e| e.to_string())?;
@@ -403,6 +538,9 @@ impl SessionRecoveryState {
                             .or_else(|| Self::detect_branch_from_directory(&directory));
 
                         orphaned.push(OrphanedSession {
+                            // `session` IS the tmux session name, which is the
+                            // key the label store is written under.
+                            label: labels.get(&session).cloned(),
                             session,
                             task: meta["task"].as_str().unwrap_or("Unknown task").to_string(),
                             directory,
@@ -531,17 +669,12 @@ impl SessionRecoveryState {
             }
         }
 
-        // Enrich orphaned worktrees with agent_type from sessions.json
-        let store = SessionStore::load();
-        for worktree in &mut orphaned {
-            // Try to find matching session by worktree path
-            for (_, metadata) in store.sessions() {
-                if metadata.worktree_path == worktree.path {
-                    worktree.agent_type = Some(metadata.agent_type);
-                    break;
-                }
-            }
-        }
+        // Enrich orphaned worktrees with agent_type and label from sessions.json
+        Self::enrich_worktrees(
+            &mut orphaned,
+            &SessionStore::load(),
+            &crate::config::SessionLabelStore::load(),
+        );
 
         // Sort by time_ago (most recent first based on directory mtime)
         orphaned.sort_by(|a, b| {
@@ -551,6 +684,28 @@ impl SessionRecoveryState {
         });
 
         Ok(orphaned)
+    }
+
+    /// Join each orphaned worktree back to its sessions.json entry. The path is
+    /// the only bridge a worktree has: it carries no tmux name of its own, and
+    /// the tmux name is the key the label store is written under.
+    ///
+    /// Split out of the scan so the join itself is testable without a home
+    /// directory full of real worktrees.
+    fn enrich_worktrees(
+        worktrees: &mut [OrphanedWorktree],
+        store: &SessionStore,
+        labels: &crate::config::SessionLabelStore,
+    ) {
+        for worktree in worktrees {
+            for metadata in store.sessions().values() {
+                if metadata.worktree_path == worktree.path {
+                    worktree.agent_type = Some(metadata.agent_type);
+                    worktree.label = labels.get(&metadata.tmux_session_name).cloned();
+                    break;
+                }
+            }
+        }
     }
 
     /// Extract information from a worktree directory
@@ -628,6 +783,7 @@ impl SessionRecoveryState {
             orphan_type,
             time_ago,
             agent_type: None, // Enriched later from sessions.json
+            label: None,      // Enriched later from sessions.json
         })
     }
 
@@ -723,7 +879,10 @@ impl SessionRecoveryState {
         if self.is_worktree_selected() {
             return None;
         }
-        self.orphaned_sessions.get(self.selected_index)
+        match self.row_at(self.selected_index)? {
+            RecoveryRow::Session(idx) => self.orphaned_sessions.get(idx),
+            RecoveryRow::Worktree(_) => None,
+        }
     }
 
     /// Get the selected worktree
@@ -934,7 +1093,13 @@ impl SessionRecoveryState {
             succeeded: vec![],
             failed: vec![],
         };
-        let worktrees: Vec<_> = self.orphaned_worktrees.clone();
+        // Acts on the VISIBLE rows: under a filter, "recover all" quietly
+        // recovering rows the operator cannot see is worse than the filter.
+        let worktrees: Vec<_> = self
+            .visible_worktrees()
+            .into_iter()
+            .map(|i| self.orphaned_worktrees[i].clone())
+            .collect();
         for worktree in &worktrees {
             if worktree.orphan_type == OrphanType::BrokenSymlink {
                 continue;
@@ -1113,104 +1278,41 @@ impl SessionRecoveryState {
         let mut results = Vec::new();
 
         for idx in indices {
-            match self.view_mode {
-                RecoveryViewMode::Sessions => {
-                    if let Some(session) = self.orphaned_sessions.get(idx) {
-                        let session = session.clone();
-                        let name = session.session.clone();
-                        match Self::resume_single_session(&session) {
-                            Ok(tmux_name) => {
-                                resumed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: true,
-                                    detail: format!("→ {}", tmux_name),
-                                });
-                            }
-                            Err(e) => {
-                                failed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: false,
-                                    detail: e,
-                                });
-                            }
-                        }
-                    }
+            // Marks are view positions; row_at maps each back to the row the
+            // operator actually marked, filter or no filter.
+            let (name, outcome) = match self.row_at(idx) {
+                Some(RecoveryRow::Session(i)) => {
+                    let session = self.orphaned_sessions[i].clone();
+                    (
+                        session.session.clone(),
+                        Self::resume_single_session(&session),
+                    )
                 }
-                RecoveryViewMode::Worktrees => {
-                    if let Some(worktree) = self.orphaned_worktrees.get(idx) {
-                        let worktree = worktree.clone();
-                        let name = worktree.name.clone();
-                        match Self::resume_single_worktree(&worktree) {
-                            Ok(tmux_name) => {
-                                resumed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: true,
-                                    detail: format!("→ {}", tmux_name),
-                                });
-                            }
-                            Err(e) => {
-                                failed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: false,
-                                    detail: e,
-                                });
-                            }
-                        }
-                    }
+                Some(RecoveryRow::Worktree(i)) => {
+                    let worktree = self.orphaned_worktrees[i].clone();
+                    (
+                        worktree.name.clone(),
+                        Self::resume_single_worktree(&worktree),
+                    )
                 }
-                RecoveryViewMode::All => {
-                    let session_count = self.orphaned_sessions.len();
-                    let sep = self.separator_offset();
-                    if idx < session_count {
-                        let session = self.orphaned_sessions[idx].clone();
-                        let name = session.session.clone();
-                        match Self::resume_single_session(&session) {
-                            Ok(tmux_name) => {
-                                resumed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: true,
-                                    detail: format!("→ {}", tmux_name),
-                                });
-                            }
-                            Err(e) => {
-                                failed += 1;
-                                results.push(RecoveryResultLine {
-                                    name,
-                                    success: false,
-                                    detail: e,
-                                });
-                            }
-                        }
-                    } else if idx >= session_count + sep {
-                        let worktree_idx = idx - session_count - sep;
-                        if let Some(worktree) = self.orphaned_worktrees.get(worktree_idx) {
-                            let worktree = worktree.clone();
-                            let name = worktree.name.clone();
-                            match Self::resume_single_worktree(&worktree) {
-                                Ok(tmux_name) => {
-                                    resumed += 1;
-                                    results.push(RecoveryResultLine {
-                                        name,
-                                        success: true,
-                                        detail: format!("→ {}", tmux_name),
-                                    });
-                                }
-                                Err(e) => {
-                                    failed += 1;
-                                    results.push(RecoveryResultLine {
-                                        name,
-                                        success: false,
-                                        detail: e,
-                                    });
-                                }
-                            }
-                        }
-                    }
+                None => continue,
+            };
+            match outcome {
+                Ok(tmux_name) => {
+                    resumed += 1;
+                    results.push(RecoveryResultLine {
+                        name,
+                        success: true,
+                        detail: format!("→ {}", tmux_name),
+                    });
+                }
+                Err(e) => {
+                    failed += 1;
+                    results.push(RecoveryResultLine {
+                        name,
+                        success: false,
+                        detail: e,
+                    });
                 }
             }
         }
@@ -1242,53 +1344,23 @@ impl SessionRecoveryState {
         let mut failed = 0;
 
         for idx in indices {
-            match self.view_mode {
-                RecoveryViewMode::Sessions => {
-                    if idx < self.orphaned_sessions.len() {
-                        // Archive the session
-                        let session = self.orphaned_sessions[idx].clone();
-                        if Self::archive_session_by_name(&session.session).is_ok() {
-                            deleted += 1;
-                        } else {
-                            failed += 1;
-                        }
-                    }
+            // Same mapping as resume: this arm deletes worktree directories,
+            // so acting on a raw view index under a filter is destructive.
+            let ok = match self.row_at(idx) {
+                Some(RecoveryRow::Session(i)) => {
+                    let session = self.orphaned_sessions[i].clone();
+                    Self::archive_session_by_name(&session.session).is_ok()
                 }
-                RecoveryViewMode::Worktrees => {
-                    if idx < self.orphaned_worktrees.len() {
-                        let worktree = self.orphaned_worktrees[idx].clone();
-                        if Self::cleanup_single_worktree(&worktree).is_ok() {
-                            deleted += 1;
-                        } else {
-                            failed += 1;
-                        }
-                    }
+                Some(RecoveryRow::Worktree(i)) => {
+                    let worktree = self.orphaned_worktrees[i].clone();
+                    Self::cleanup_single_worktree(&worktree).is_ok()
                 }
-                RecoveryViewMode::All => {
-                    let session_count = self.orphaned_sessions.len();
-                    let sep = self.separator_offset();
-                    if idx < session_count {
-                        // Session item
-                        let session = self.orphaned_sessions[idx].clone();
-                        if Self::archive_session_by_name(&session.session).is_ok() {
-                            deleted += 1;
-                        } else {
-                            failed += 1;
-                        }
-                    } else if idx >= session_count + sep {
-                        // Worktree item (skip separator)
-                        let worktree_idx = idx - session_count - sep;
-                        if worktree_idx < self.orphaned_worktrees.len() {
-                            let worktree = self.orphaned_worktrees[worktree_idx].clone();
-                            if Self::cleanup_single_worktree(&worktree).is_ok() {
-                                deleted += 1;
-                            } else {
-                                failed += 1;
-                            }
-                        }
-                    }
-                    // idx == separator_index is skipped (can't be selected)
-                }
+                None => continue,
+            };
+            if ok {
+                deleted += 1;
+            } else {
+                failed += 1;
             }
         }
 
@@ -1391,8 +1463,10 @@ impl SessionRecovery {
     }
 
     fn render_session_list(frame: &mut Frame, area: Rect, state: &mut SessionRecoveryState) {
-        let session_count = state.orphaned_sessions.len();
-        let worktree_count = state.orphaned_worktrees.len();
+        // Visible counts, not raw ones: a header saying (5) over a filtered
+        // list of 1 reads as a broken filter.
+        let session_count = state.visible_sessions().len();
+        let worktree_count = state.visible_worktrees().len();
         let total_count = state.current_view_count();
 
         // Build title based on view mode
@@ -1439,8 +1513,14 @@ impl SessionRecovery {
                 ),
             ]))
             .title_bottom(Line::from(vec![
+                // Filter leads the footer. Appended last it fell off the right
+                // edge at 100 and 140 cols, hiding the only on-screen
+                // affordance for the feature.
+                Span::styled("/", Style::default().fg(GOLD).add_modifier(Modifier::BOLD)),
+                Span::styled(" filter ", Style::default().fg(MUTED_GRAY)),
+                Span::styled("|", Style::default().fg(SUBDUED_BORDER)),
                 Span::styled(
-                    "Tab",
+                    " Tab",
                     Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(" view ", Style::default().fg(MUTED_GRAY)),
@@ -1470,23 +1550,62 @@ impl SessionRecovery {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        // Layout: tabs at top, then list
+        // Layout: tabs at top, optional search row, then list. The search row
+        // is zero-height while no filter is in play, so an empty query renders
+        // exactly the panel it rendered before search existed.
+        let show_search = state.search_active || !state.search_query.is_empty();
         let layout = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(2), Constraint::Min(0)])
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Length(u16::from(show_search)),
+                Constraint::Min(0),
+            ])
             .split(inner);
 
         // Render tabs
         Self::render_view_tabs(frame, layout[0], state);
 
+        if show_search {
+            let mut spans = vec![
+                Span::styled("/", Style::default().fg(GOLD)),
+                Span::styled(
+                    state.search_query.clone(),
+                    Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+                ),
+            ];
+            if state.search_active {
+                spans.push(Span::styled("▏", Style::default().fg(SELECTION_GREEN)));
+            }
+            frame.render_widget(Paragraph::new(Line::from(spans)), layout[1]);
+        }
+
         // Loading state
         if state.loading {
             let loading = Paragraph::new("Loading...").style(Style::default().fg(MUTED_GRAY));
-            frame.render_widget(loading, layout[1]);
+            frame.render_widget(loading, layout[2]);
             return;
         }
 
-        // Empty state
+        // Empty state. A filter that hides everything is not the same news as
+        // having nothing to recover, so it gets its own line.
+        if total_count == 0 && !state.search_query.is_empty() {
+            let no_matches = Paragraph::new(vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    format!("No matches for \"{}\"", state.search_query),
+                    Style::default().fg(WARNING_ORANGE),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Esc clears the filter.",
+                    Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+                )),
+            ]);
+            frame.render_widget(no_matches, layout[2]);
+            return;
+        }
+
         if total_count == 0 {
             let empty_msg = match state.view_mode {
                 RecoveryViewMode::Sessions => "No orphaned sessions found",
@@ -1505,15 +1624,15 @@ impl SessionRecovery {
                     Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
                 )),
             ]);
-            frame.render_widget(empty_state, layout[1]);
+            frame.render_widget(empty_state, layout[2]);
             return;
         }
 
         // Build list items based on view mode
-        let items = Self::build_list_items(state);
+        let items = Self::build_list_items(state, layout[2].width);
         let list = List::new(items);
 
-        frame.render_stateful_widget(list, layout[1], &mut state.list_state);
+        frame.render_stateful_widget(list, layout[2], &mut state.list_state);
 
         // Render recovery overlay on top if present
         if let Some(ref overlay) = state.recovery_overlay {
@@ -1614,8 +1733,8 @@ impl SessionRecovery {
 
     /// Render the view mode tabs
     fn render_view_tabs(frame: &mut Frame, area: Rect, state: &SessionRecoveryState) {
-        let session_count = state.orphaned_sessions.len();
-        let worktree_count = state.orphaned_worktrees.len();
+        let session_count = state.visible_sessions().len();
+        let worktree_count = state.visible_worktrees().len();
 
         let tab_titles = vec![
             format!("Sessions ({})", session_count),
@@ -1644,19 +1763,24 @@ impl SessionRecovery {
     }
 
     /// Build list items based on current view mode
-    fn build_list_items(state: &SessionRecoveryState) -> Vec<ListItem<'static>> {
+    fn build_list_items(state: &SessionRecoveryState, pane_width: u16) -> Vec<ListItem<'static>> {
+        let budget = Self::row_name_budget(pane_width);
         let mut items = Vec::new();
         let mut current_idx = 0;
+        // Iterate the SAME filtered sets row_at resolves against, so a list
+        // position and a selected_index always mean the same row.
+        let sessions = state.visible_sessions();
+        let worktrees = state.visible_worktrees();
 
         // Add sessions if in Sessions or All view
         if matches!(
             state.view_mode,
             RecoveryViewMode::Sessions | RecoveryViewMode::All
         ) {
-            for session in &state.orphaned_sessions {
+            for session in sessions.iter().map(|i| &state.orphaned_sessions[*i]) {
                 let is_selected = current_idx == state.selected_index;
                 let is_marked = state.selected_items.contains(&current_idx);
-                items.push(Self::render_session_item(session, is_selected, is_marked));
+                items.push(Self::render_session_item(session, is_selected, is_marked, budget));
                 current_idx += 1;
             }
         }
@@ -1668,8 +1792,8 @@ impl SessionRecovery {
         ) {
             // Add separator in All view
             if state.view_mode == RecoveryViewMode::All
-                && !state.orphaned_sessions.is_empty()
-                && !state.orphaned_worktrees.is_empty()
+                && !sessions.is_empty()
+                && !worktrees.is_empty()
             {
                 items.push(ListItem::new(Line::from(vec![
                     Span::styled("── ", Style::default().fg(SUBDUED_BORDER)),
@@ -1682,10 +1806,10 @@ impl SessionRecovery {
                 current_idx += 1; // Separator occupies a list position
             }
 
-            for worktree in &state.orphaned_worktrees {
+            for worktree in worktrees.iter().map(|i| &state.orphaned_worktrees[*i]) {
                 let is_selected = current_idx == state.selected_index;
                 let is_marked = state.selected_items.contains(&current_idx);
-                items.push(Self::render_worktree_item(worktree, is_selected, is_marked));
+                items.push(Self::render_worktree_item(worktree, is_selected, is_marked, budget));
                 current_idx += 1;
             }
         }
@@ -1693,11 +1817,45 @@ impl SessionRecovery {
         items
     }
 
+    /// Columns a list row may spend on "<label> · <name>", derived from the
+    /// pane it is painted into. A row spends 8 columns on cursor, checkbox and
+    /// status glyph and 10 on the trailing " (2h ago)", so the string gets
+    /// whatever is left. Floor of 12 keeps a pathologically narrow pane from
+    /// collapsing the name to nothing.
+    ///
+    /// Fixed at 25 before this was width-aware, which was right at 100 columns
+    /// and wasted half a wide terminal's pane on every labelled row. The 10
+    /// reproduces that 25 exactly at 100 columns; a four-digit age
+    /// (" (1440m ago)") is one column over and clips as it did before.
+    fn row_name_budget(pane_width: u16) -> usize {
+        (pane_width as usize).saturating_sub(8 + 10).max(12)
+    }
+
+    /// Name with its durable session label in front, matching the session
+    /// list's "<label> · <name>" shape. An unlabeled row returns the bare name,
+    /// so it keeps exactly the columns it has today with no stray separator.
+    fn with_label(label: Option<&String>, name: &str, budget: usize) -> String {
+        let Some(label) = label else {
+            return name.chars().take(budget).collect();
+        };
+        // The two halves share ONE budget. Giving each of them the full budget
+        // pushed " (2h ago)" off the row, and age is the signal an operator
+        // sorts a recovery list by. Label is capped at half so the name it
+        // prefixes never collapses to a couple of characters.
+        let label: String = label.chars().take(budget / 2).collect();
+        let name_budget = budget.saturating_sub(label.chars().count() + 3);
+        format!(
+            "{label} · {}",
+            name.chars().take(name_budget).collect::<String>()
+        )
+    }
+
     /// Render a single session list item
     fn render_session_item(
         session: &OrphanedSession,
         is_selected: bool,
         is_marked: bool,
+        budget: usize,
     ) -> ListItem<'static> {
         let resume_indicator = if session.can_resume { "📄" } else { "⚠" };
         let time_indicator = if session.time_ago.is_empty() {
@@ -1737,7 +1895,7 @@ impl SessionRecovery {
         spans.push(Span::raw(" "));
 
         spans.push(Span::styled(
-            session.session.clone(),
+            Self::with_label(session.label.as_ref(), &session.session, budget),
             if is_selected {
                 Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
             } else {
@@ -1774,6 +1932,7 @@ impl SessionRecovery {
         worktree: &OrphanedWorktree,
         is_selected: bool,
         is_marked: bool,
+        budget: usize,
     ) -> ListItem<'static> {
         // Determine if worktree is resumable (not a broken symlink)
         let can_resume = worktree.orphan_type != OrphanType::BrokenSymlink;
@@ -1812,10 +1971,9 @@ impl SessionRecovery {
         ));
         spans.push(Span::raw(" "));
 
-        // Truncate name if too long
-        let display_name: String = worktree.name.chars().take(25).collect();
+        // with_label owns the width budget for both halves of the string.
         spans.push(Span::styled(
-            display_name,
+            Self::with_label(worktree.label.as_ref(), &worktree.name, budget),
             if is_selected {
                 Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD)
             } else {
@@ -1929,12 +2087,29 @@ impl SessionRecovery {
         }
     }
 
+    /// Detail-pane row for a durable session label, or a blank line when the
+    /// item has none, so an unlabeled item's layout does not shift.
+    fn label_line(label: Option<&String>) -> Line<'static> {
+        match label {
+            Some(label) => Line::from(vec![
+                Span::styled("Label:    ", Style::default().fg(MUTED_GRAY)),
+                Span::styled(label.clone(), Style::default().fg(GOLD)),
+            ]),
+            None => Line::from(""),
+        }
+    }
+
     fn render_session_info(frame: &mut Frame, area: Rect, session: &OrphanedSession) {
         let lines = vec![
             Line::from(vec![
                 Span::styled("Session:  ", Style::default().fg(MUTED_GRAY)),
                 Span::styled(&session.session, Style::default().fg(SOFT_WHITE)),
             ]),
+            // The label is what the operator named this run; the tmux name
+            // above is machinery. A row that carries one in the list has to
+            // carry it here too, or the two halves of the panel disagree
+            // about which session is selected.
+            Self::label_line(session.label.as_ref()),
             Line::from(""),
             Line::from(vec![
                 Span::styled("Status:   ", Style::default().fg(MUTED_GRAY)),
@@ -2009,6 +2184,7 @@ impl SessionRecovery {
                 Span::styled("Name:     ", Style::default().fg(MUTED_GRAY)),
                 Span::styled(&worktree.name, Style::default().fg(SOFT_WHITE)),
             ]),
+            Self::label_line(worktree.label.as_ref()),
             Line::from(""),
             Line::from(vec![
                 Span::styled("Type:     ", Style::default().fg(MUTED_GRAY)),
@@ -2099,7 +2275,491 @@ impl SessionRecovery {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionRecoveryState;
+    use super::{
+        OrphanType, OrphanedSession, OrphanedWorktree, RecoveryRow, RecoveryViewMode,
+        SessionMetadata, SessionRecovery, SessionRecoveryState, SessionStore,
+    };
+    use crate::config::SessionLabelStore;
+    use crate::models::SessionAgentType;
+    use ratatui::{Terminal, backend::TestBackend};
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn orphan_session(name: &str, label: Option<&str>) -> OrphanedSession {
+        OrphanedSession {
+            session: name.to_string(),
+            task: "some task".to_string(),
+            directory: "/tmp/ainb-recovery".to_string(),
+            created: String::new(),
+            status: "running".to_string(),
+            transcript_path: None,
+            worktree_branch: None,
+            can_resume: false,
+            time_ago: String::new(),
+            label: label.map(str::to_string),
+        }
+    }
+
+    /// Render the panel and return the buffer as lines, so a row assertion can
+    /// name the row rather than only ask whether text exists somewhere.
+    fn render_to_lines(state: &mut SessionRecoveryState, w: u16, h: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).expect("terminal");
+        terminal
+            .draw(|frame| SessionRecovery::render(frame, frame.area(), state))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        (0..h)
+            .map(|y| {
+                (0..w)
+                    .map(|x| buf.cell((x, y)).map_or(" ", |c| c.symbol()).to_string())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    /// A recoverable session row carries the same durable label the session
+    /// list shows, in the same "<label> · <name>" shape, and the age column it
+    /// had before labels existed still fits beside it.
+    ///
+    /// Sized like a real row on purpose: a 30-char tmux name, a 23-char label
+    /// and a narrow 100-col terminal. A short name in a wide terminal cannot
+    /// catch the label overflowing the pane.
+    #[test]
+    fn recovery_session_row_paints_its_label() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        let mut session = orphan_session(
+            "ainb-save-prefix-abeb7e09-a02f",
+            Some("RPC flake investigation"),
+        );
+        session.time_ago = "2h ago".to_string();
+        state.orphaned_sessions = vec![session];
+
+        let lines = render_to_lines(&mut state, 100, 20);
+        let row = lines
+            .iter()
+            .find(|line| line.contains("[ ] ") && line.contains("RPC flake in"))
+            .unwrap_or_else(|| panic!("recovery row lost its label: {lines:#?}"));
+        assert!(
+            row.contains(" · ainb-save"),
+            "label ate the whole name: {row}"
+        );
+        assert!(
+            row.contains("(2h ago)"),
+            "label pushed the age off the row: {row}"
+        );
+    }
+
+    /// An unlabeled row must render exactly as it did before labels existed:
+    /// bare name, no dangling separator.
+    #[test]
+    fn recovery_row_without_a_label_is_unchanged() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![orphan_session("tmux_plain", None)];
+
+        let lines = render_to_lines(&mut state, 120, 20);
+        // Anchor on the checkbox: the details pane on the right prints the bare
+        // session name too, and matching that line instead means this guard
+        // never looks at the list row it is guarding.
+        let row = lines
+            .iter()
+            .find(|line| line.contains("[ ] ") && line.contains("tmux_plain"))
+            .expect("row rendered");
+        assert!(!row.contains('·'), "unlabeled row grew a separator: {row}");
+    }
+
+    /// Worktree rows join their label through sessions.json, so they get the
+    /// same prefix treatment as session rows, under the same width budget.
+    /// Real worktree names run past 30 chars, which is exactly where an
+    /// unbudgeted label prefix starts eating the age column.
+    #[test]
+    fn recovery_worktree_row_paints_its_label() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Worktrees;
+        state.orphaned_worktrees = vec![OrphanedWorktree {
+            name: "agents-in-a-box--save-prefix-abeb".to_string(),
+            orphan_type: OrphanType::NoTmux,
+            label: Some("prove-hangar-acp-leg-b-p3".to_string()),
+            time_ago: "2h ago".to_string(),
+            ..Default::default()
+        }];
+
+        let lines = render_to_lines(&mut state, 100, 20);
+        let row = lines
+            .iter()
+            .find(|line| line.contains("[ ] ") && line.contains("prove-hangar"))
+            .unwrap_or_else(|| panic!("recovery worktree row lost its label: {lines:#?}"));
+        assert!(
+            row.contains(" · agents-in"),
+            "label ate the whole name: {row}"
+        );
+        assert!(
+            row.contains("(2h ago)"),
+            "label pushed the age off the row: {row}"
+        );
+    }
+
+    /// A wide terminal gives the list pane far more than the 25 columns the
+    /// budget was once hard-coded to, and a labelled row is exactly the row
+    /// that pays for the shortfall. At 200 cols both halves must survive whole.
+    #[test]
+    fn a_wide_terminal_stops_truncating_a_labelled_row() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Worktrees;
+        state.orphaned_worktrees = vec![OrphanedWorktree {
+            name: "agents-in-a-box--save-prefix-abeb".to_string(),
+            orphan_type: OrphanType::NoTmux,
+            label: Some("prove-hangar-acp-leg-b-p3".to_string()),
+            time_ago: "2h ago".to_string(),
+            ..Default::default()
+        }];
+
+        let lines = render_to_lines(&mut state, 200, 20);
+        let row = lines
+            .iter()
+            .find(|line| line.contains("[ ] ") && line.contains("prove-hangar"))
+            .unwrap_or_else(|| panic!("wide row lost its label: {lines:#?}"));
+        assert!(
+            row.contains("prove-hangar-acp-leg-b-p3 · agents-in-a-box--save-prefix-abeb"),
+            "a 200-col pane still truncated a row that fits: {row}"
+        );
+        assert!(row.contains("(2h ago)"), "wide row lost its age: {row}");
+    }
+
+    /// The details pane is the other half of the recovery panel. A row that
+    /// carries a label in the list has to carry it here too, or the operator
+    /// reads a bare tmux name and cannot tell which run is selected.
+    #[test]
+    fn the_details_pane_names_the_selected_row_by_its_label() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Worktrees;
+        state.orphaned_worktrees = vec![OrphanedWorktree {
+            name: "agents-in-a-box--save-prefix-abeb".to_string(),
+            orphan_type: OrphanType::NoTmux,
+            label: Some("prove-hangar-acp-leg-b-p3".to_string()),
+            time_ago: "2h ago".to_string(),
+            ..Default::default()
+        }];
+        state.selected_index = 0;
+
+        let lines = render_to_lines(&mut state, 200, 20);
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Label:") && line.contains("prove-hangar-acp-leg-b-p3")),
+            "details pane shows no label for the selected row: {lines:#?}"
+        );
+    }
+
+    /// The footer is the only place that tells an operator `/` filters. It has
+    /// more hints than fit, so the one the bug report asked for has to survive
+    /// a narrow terminal.
+    #[test]
+    fn the_filter_hint_survives_a_narrow_terminal() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![orphan_session("alpha_one", None)];
+
+        let lines = render_to_lines(&mut state, 100, 20);
+        assert!(
+            lines.iter().any(|line| line.contains("/ filter")),
+            "the filter hint is off-screen at 100 cols: {lines:#?}"
+        );
+    }
+
+    /// The production join for a worktree label: path -> sessions.json entry ->
+    /// tmux name -> label store. Every other label test hands the row a `label`
+    /// it built itself, which proves the renderer and nothing about the join.
+    #[test]
+    fn a_worktree_joins_its_label_through_sessions_json() {
+        let worktree_path = PathBuf::from("/tmp/ainb-recovery/by-name/save-prefix");
+        let mut store = SessionStore::default();
+        store.upsert(SessionMetadata {
+            session_id: Uuid::nil(),
+            tmux_session_name: "ainb-save-prefix".to_string(),
+            worktree_path: worktree_path.clone(),
+            workspace_name: "save-prefix".to_string(),
+            created_at: chrono::Utc::now(),
+            agent_type: SessionAgentType::default(),
+            headroom_enabled: false,
+            rtk_enabled: false,
+            skip_permissions: None,
+            model: None,
+            model_source: Default::default(),
+            codex_model: None,
+            codex_thread_id: None,
+        });
+        let mut labels = SessionLabelStore::default();
+        labels.set(
+            "ainb-save-prefix".to_string(),
+            Some("RPC flake".to_string()),
+        );
+
+        let mut rows = vec![
+            OrphanedWorktree {
+                path: worktree_path,
+                ..orphan_worktree("save-prefix", None)
+            },
+            // No sessions.json entry: nothing bridges this row to a label.
+            orphan_worktree("stranger", None),
+        ];
+        SessionRecoveryState::enrich_worktrees(&mut rows, &store, &labels);
+
+        assert_eq!(rows[0].label.as_deref(), Some("RPC flake"));
+        assert_eq!(
+            rows[1].label, None,
+            "a row with no metadata invented a label"
+        );
+    }
+
+    fn orphan_worktree(name: &str, branch: Option<&str>) -> OrphanedWorktree {
+        OrphanedWorktree {
+            name: name.to_string(),
+            branch: branch.map(str::to_string),
+            orphan_type: OrphanType::NoTmux,
+            ..Default::default()
+        }
+    }
+
+    /// Three sessions, a query that only the third can match. The list must
+    /// show that row and nothing else.
+    #[test]
+    fn filter_narrows_the_visible_rows() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![
+            orphan_session("alpha_one", None),
+            orphan_session("beta_two", None),
+            orphan_session("gamma_three", None),
+        ];
+        for c in "gamma".chars() {
+            state.search_push(c);
+        }
+
+        let lines = render_to_lines(&mut state, 120, 20);
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("gamma_three"),
+            "filtered row missing: {lines:#?}"
+        );
+        assert!(
+            !joined.contains("alpha_one"),
+            "filtered-out row still painted: {lines:#?}"
+        );
+        assert!(
+            !joined.contains("beta_two"),
+            "filtered-out row still painted: {lines:#?}"
+        );
+    }
+
+    /// THE trap: under a filter, view row 0 is NOT raw row 0. Resume and
+    /// archive both read `selected()`, so this is what stops the panel acting
+    /// on a session the operator never looked at.
+    #[test]
+    fn filtered_selection_resolves_to_the_underlying_row() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![
+            orphan_session("alpha_one", None),
+            orphan_session("beta_two", None),
+            orphan_session("gamma_three", None),
+        ];
+        for c in "gamma".chars() {
+            state.search_push(c);
+        }
+
+        assert_eq!(state.selected_index, 0, "filter must re-anchor the cursor");
+        assert_eq!(
+            state.selected().map(|s| s.session.as_str()),
+            Some("gamma_three"),
+            "view row 0 resolved to the wrong session"
+        );
+        // Multi-select marks are view positions too, so they map the same way.
+        assert_eq!(state.row_at(0), Some(RecoveryRow::Session(2)));
+        // And the highlighted row in the painted buffer is that same row.
+        let lines = render_to_lines(&mut state, 120, 20);
+        let cursor_row = lines.iter().find(|l| l.contains('▶')).expect("a row is selected");
+        assert!(
+            cursor_row.contains("gamma_three"),
+            "cursor is on the wrong row: {cursor_row}"
+        );
+    }
+
+    /// A label from bug 1 is a filter field: the operator types the prefix
+    /// they see, not the tmux name they do not.
+    #[test]
+    fn filter_matches_the_durable_label() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![
+            orphan_session("tmux_aaa", Some("RPC flake")),
+            orphan_session("tmux_bbb", None),
+        ];
+        for c in "rpc".chars() {
+            state.search_push(c);
+        }
+
+        assert_eq!(state.current_view_count(), 1);
+        assert_eq!(
+            state.selected().map(|s| s.session.as_str()),
+            Some("tmux_aaa")
+        );
+    }
+
+    /// All view with every session filtered out. The old index math computed
+    /// `0 + 0 - 1` here; this must resolve to the first worktree instead of
+    /// panicking or silently selecting nothing.
+    #[test]
+    fn all_view_survives_filtering_every_session_away() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::All;
+        state.orphaned_sessions = vec![orphan_session("alpha_one", None)];
+        state.orphaned_worktrees = vec![
+            orphan_worktree("wt-keep", Some("feat/keep")),
+            orphan_worktree("wt-drop", None),
+        ];
+        for c in "keep".chars() {
+            state.search_push(c);
+        }
+
+        assert_eq!(
+            state.current_view_count(),
+            1,
+            "only the matching worktree is visible"
+        );
+        assert!(state.is_worktree_selected());
+        assert_eq!(state.worktree_index(), Some(0));
+        assert_eq!(
+            state.selected_worktree().map(|w| w.name.as_str()),
+            Some("wt-keep")
+        );
+        let lines = render_to_lines(&mut state, 120, 20);
+        assert!(lines.join("\n").contains("wt-keep"));
+    }
+
+    /// A filtered All view still maps worktree rows past the separator back to
+    /// the right worktree, not the one at the same raw offset.
+    #[test]
+    fn all_view_maps_worktree_rows_past_the_separator() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::All;
+        state.orphaned_sessions = vec![
+            orphan_session("drop_me", None),
+            orphan_session("keep_session", None),
+        ];
+        state.orphaned_worktrees = vec![
+            orphan_worktree("drop-wt", None),
+            orphan_worktree("keep-wt", None),
+        ];
+        for c in "keep".chars() {
+            state.search_push(c);
+        }
+
+        // View is [keep_session][separator][keep-wt].
+        assert_eq!(state.row_at(0), Some(RecoveryRow::Session(1)));
+        assert_eq!(state.row_at(1), None, "the separator is not an item");
+        assert_eq!(state.row_at(2), Some(RecoveryRow::Worktree(1)));
+    }
+
+    /// A query change re-points every view position, so stale marks would
+    /// delete the wrong worktree. They get dropped instead.
+    #[test]
+    fn a_query_change_drops_multi_select_marks() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![
+            orphan_session("alpha_one", None),
+            orphan_session("beta_two", None),
+        ];
+        state.toggle_select();
+        assert!(state.has_multi_selection());
+
+        state.search_push('b');
+        assert!(
+            !state.has_multi_selection(),
+            "marks survived a query change"
+        );
+    }
+
+    /// Esc drops the filter and puts every row back, byte for byte.
+    #[test]
+    fn escape_restores_the_unfiltered_list() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![
+            orphan_session("alpha_one", None),
+            orphan_session("beta_two", None),
+            orphan_session("gamma_three", None),
+        ];
+        let baseline = render_to_lines(&mut state, 120, 20);
+
+        state.search_active = true;
+        for c in "gamma".chars() {
+            state.search_push(c);
+        }
+        // Not assert_ne! against the baseline: the search bar row alone makes
+        // the buffers differ, so that check passes even with the filter
+        // disconnected. Name the rows that must and must not survive.
+        let filtered = render_to_lines(&mut state, 120, 20).join("\n");
+        assert!(
+            filtered.contains("gamma_three"),
+            "filter hid the match: {filtered}"
+        );
+        assert!(
+            !filtered.contains("alpha_one"),
+            "filter kept a non-match: {filtered}"
+        );
+
+        state.search_cancel();
+        assert!(!state.search_active);
+        assert_eq!(
+            render_to_lines(&mut state, 120, 20),
+            baseline,
+            "an empty query must render exactly the unfiltered panel"
+        );
+    }
+
+    /// A filter that matches nothing says so. A blank panel reads as a crash.
+    #[test]
+    fn no_matches_renders_a_legible_empty_state() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![orphan_session("alpha_one", None)];
+        for c in "zzzz".chars() {
+            state.search_push(c);
+        }
+
+        let lines = render_to_lines(&mut state, 120, 20);
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("No matches for"),
+            "no empty-state line: {lines:#?}"
+        );
+        assert!(
+            joined.contains("zzzz"),
+            "empty state does not echo the query: {lines:#?}"
+        );
+    }
+
+    /// The query is visible while it is being typed, or the operator cannot
+    /// tell a filtered list from an empty one.
+    #[test]
+    fn the_search_bar_paints_the_query() {
+        let mut state = SessionRecoveryState::default();
+        state.view_mode = RecoveryViewMode::Sessions;
+        state.orphaned_sessions = vec![orphan_session("alpha_one", None)];
+        state.search_active = true;
+        for c in "alp".chars() {
+            state.search_push(c);
+        }
+
+        let lines = render_to_lines(&mut state, 120, 20);
+        assert!(
+            lines.iter().any(|l| l.contains("/alp")),
+            "search bar missing: {lines:#?}"
+        );
+    }
 
     #[test]
     fn default_defers_recovery_scan_until_the_screen_is_opened() {

--- a/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_recovery.rs
@@ -1780,7 +1780,12 @@ impl SessionRecovery {
             for session in sessions.iter().map(|i| &state.orphaned_sessions[*i]) {
                 let is_selected = current_idx == state.selected_index;
                 let is_marked = state.selected_items.contains(&current_idx);
-                items.push(Self::render_session_item(session, is_selected, is_marked, budget));
+                items.push(Self::render_session_item(
+                    session,
+                    is_selected,
+                    is_marked,
+                    budget,
+                ));
                 current_idx += 1;
             }
         }
@@ -1809,7 +1814,12 @@ impl SessionRecovery {
             for worktree in worktrees.iter().map(|i| &state.orphaned_worktrees[*i]) {
                 let is_selected = current_idx == state.selected_index;
                 let is_marked = state.selected_items.contains(&current_idx);
-                items.push(Self::render_worktree_item(worktree, is_selected, is_marked, budget));
+                items.push(Self::render_worktree_item(
+                    worktree,
+                    is_selected,
+                    is_marked,
+                    budget,
+                ));
                 current_idx += 1;
             }
         }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_recovery_search_filters.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_recovery_search_filters.rs
@@ -1,0 +1,272 @@
+// ABOUTME: Tripwire for the recovery panel's `/` fuzzy filter.
+//
+// The recovery panel had no search, so finding one worktree in a long orphan
+// list meant scrolling. `/` now filters it. This drives the REAL `ainb tui`
+// binary in a detached tmux session, presses the REAL keys, and asserts on the
+// REAL painted pane: the unit tests render the component in-process and never
+// prove the key ever reaches it.
+//
+// Isolated HOME: the orphan scan reads `~/.agents-in-a-box/worktrees`, so
+// pointing HOME at a tempdir is what stops the developer's own orphans (and
+// there are always some) from deciding whether the assertions pass.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// The two orphan worktrees. The query below matches ALPHA as a subsequence
+/// and cannot match BETA, so "filtered" and "not filtered" are distinguishable
+/// without relying on row order.
+const ALPHA: &str = "alpharepo--feature-aaa11111--aaa11111";
+const BETA: &str = "betarepo--feature-bbb22222--bbb22222";
+const QUERY: &str = "alpha";
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux").arg("-V").output().is_ok_and(|o| o.status.success())
+}
+
+fn git_available() -> bool {
+    Command::new("git").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn git_ok(cwd: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=ainb-test",
+            "-c",
+            "user.email=ainb@test.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Skips the first-run wizard. `env!` not a shell grep of Cargo.toml: workspace
+/// crates literally carry `version.workspace = true` there.
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    std::fs::create_dir_all(&cfg).expect("create isolated config dir");
+    let onboarding = format!(
+        r#"completed = true
+completed_at = "2026-05-11T00:00:00+00:00"
+version = "{ver}"
+skipped_dependencies = []
+git_directories = []
+"#,
+        ver = env!("CARGO_PKG_VERSION"),
+    );
+    std::fs::write(cfg.join("onboarding.toml"), onboarding).expect("seed onboarding.toml");
+
+    // The notifyd install modal opens over the home screen and EATS the first
+    // keypress, which reads exactly like "r does not open recovery". Its paths
+    // resolve AINB_HANGAR_HOME before AINB_HOME, so seed both bases, and seed
+    // the FULL record: a minimal {"prompt_dismissed": true} fails to parse and
+    // falls back to the default, so the modal fires anyway.
+    let install = concat!(
+        r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"#,
+        r#""codex_hooks_json":null,"copilot_hooks_json":null,"#,
+        r#""antigravity_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
+    );
+    // `notifyd::Paths::under` puts install.json at the BASE, and the base is
+    // `$AINB_HANGAR_HOME`, else `$AINB_HOME`, else `~/.agents-in-a-box`. The
+    // launch below sets AINB_HOME to the tempdir itself, so seed both the
+    // tempdir root and the home-relative fallback.
+    for base in [home.to_path_buf(), home.join(".agents-in-a-box")] {
+        std::fs::create_dir_all(&base).expect("create notifyd base");
+        std::fs::write(base.join("install.json"), install).expect("seed install.json");
+    }
+}
+
+/// Two REAL linked worktrees with no tmux session and no sessions.json entry,
+/// which is exactly what the scan classifies as orphaned.
+fn seed_orphan_worktrees(home: &Path) {
+    let repo = home.join("src").join("originrepo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+    assert!(git_ok(&repo, &["init"]), "git init");
+    std::fs::write(repo.join("README.md"), "hi").expect("seed README");
+    assert!(git_ok(&repo, &["add", "README.md"]), "git add");
+    assert!(git_ok(&repo, &["commit", "-m", "init"]), "git commit");
+
+    let by_name = home.join(".agents-in-a-box").join("worktrees").join("by-name");
+    std::fs::create_dir_all(&by_name).expect("create by-name dir");
+
+    for (dir, branch) in [(ALPHA, "feature/aaa11111"), (BETA, "feature/bbb22222")] {
+        let path = by_name.join(dir);
+        assert!(
+            git_ok(
+                &repo,
+                &["worktree", "add", path.to_str().unwrap(), "-b", branch]
+            ),
+            "git worktree add {dir}"
+        );
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+    None
+}
+
+/// Single keystroke, never with `Enter` appended.
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+/// Literal text, so `/` and friends are not read as tmux key names.
+fn send_text(session: &str, text: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, "-l", text])
+        .status()
+        .expect("tmux send-keys -l");
+}
+
+/// Kills by EXACT session name only. Never kill-server, never a wildcard:
+/// other agents' sessions live in this tmux server.
+struct TmuxGuard(String);
+
+impl Drop for TmuxGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux").args(["kill-session", "-t", &self.0]).output();
+    }
+}
+
+fn deadline(secs: u64) -> Instant {
+    Instant::now() + Duration::from_secs(secs)
+}
+
+#[test]
+fn slash_filters_the_recovery_panel_and_esc_restores_it() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux unavailable");
+        return;
+    }
+    if !git_available() {
+        eprintln!("SKIP: git unavailable");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir");
+    let home_path = home.path().canonicalize().expect("canonicalize home");
+    seed_isolated_home(&home_path);
+    seed_orphan_worktrees(&home_path);
+
+    let session = format!("tripwire-recovery-search-{}", std::process::id());
+    let _ = Command::new("tmux").args(["kill-session", "-t", &session]).output();
+    assert!(
+        Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "-x", "180", "-y", "50"])
+            .status()
+            .is_ok_and(|s| s.success()),
+        "failed to create tmux session {session}"
+    );
+    let _guard = TmuxGuard(session.clone());
+
+    let cmd = format!(
+        "HOME={} AINB_HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home_path.display(),
+        home_path.display(),
+        ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("launch ainb tui");
+
+    let home_screen = poll_capture(&session, deadline(60), |c| c.contains("Workspaces"))
+        .unwrap_or_else(|| panic!("HomeScreen never rendered:\n{}", capture_pane(&session)));
+    // Pre-press negative: we are not already looking at the recovery panel, so
+    // the assertions after `r` cannot be satisfied by the screen we started on.
+    assert!(
+        !home_screen.contains("All Orphans"),
+        "already on the recovery panel before pressing r:\n{home_screen}"
+    );
+
+    // `r` opens Session Recovery from the home screen. It lands on the Sessions
+    // tab, which is empty here: the orphans seeded above are worktrees, so Tab
+    // once to the Worktrees tab before anything can be asserted about rows.
+    send_key(&session, "r");
+    poll_capture(&session, deadline(45), |c| c.contains("Worktrees (2)"))
+        .unwrap_or_else(|| panic!("recovery panel never opened:\n{}", capture_pane(&session)));
+    send_key(&session, "Tab");
+    let opened = poll_capture(&session, deadline(30), |c| {
+        c.contains(ALPHA) && c.contains(BETA)
+    })
+    .unwrap_or_else(|| {
+        panic!(
+            "recovery panel never listed both orphans:\n{}",
+            capture_pane(&session)
+        )
+    });
+    assert!(
+        opened.contains("/ filter"),
+        "the filter affordance is not on screen, so nobody can find the feature:\n{opened}"
+    );
+
+    // `/` opens the search bar, then the query narrows the list. Sent as
+    // literal text so `/` is not interpreted as a tmux key name.
+    send_text(&session, "/");
+    send_text(&session, QUERY);
+    let filtered = poll_capture(&session, deadline(30), |c| {
+        c.contains(ALPHA) && !c.contains(BETA)
+    })
+    .unwrap_or_else(|| {
+        panic!(
+            "typing {QUERY:?} did not narrow the list:\n{}",
+            capture_pane(&session)
+        )
+    });
+    assert!(
+        filtered.contains(QUERY),
+        "the search bar does not echo what was typed:\n{filtered}"
+    );
+
+    // Esc clears the filter. A forward-only test passes while the way out is
+    // broken, which is how a swallowed Esc shipped here before.
+    send_key(&session, "Escape");
+    let restored = poll_capture(&session, deadline(30), |c| {
+        c.contains(ALPHA) && c.contains(BETA)
+    })
+    .unwrap_or_else(|| {
+        panic!(
+            "Esc did not restore the unfiltered list:\n{}",
+            capture_pane(&session)
+        )
+    });
+    assert!(
+        restored.contains("All Orphans") || restored.contains("Worktrees"),
+        "Esc left the recovery panel entirely instead of clearing the filter:\n{restored}"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_stopped_session_keeps_its_label.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_stopped_session_keeps_its_label.rs
@@ -1,0 +1,196 @@
+// ABOUTME: Tripwire for "stopping a session loses its label".
+//
+// A session the operator named shows `<label> · <branch>` in the list while it
+// runs. Stop it and the row fell back to a bare branch name, which is the one
+// moment the label matters: two stopped worktrees off the same repo are
+// otherwise told apart only by an 8-hex branch suffix.
+//
+// The unit test for this calls `stopped_session_from_metadata` with a store it
+// built itself. That proves the renderer and nothing about the wiring. This
+// drives the REAL loader (`AppState::load_real_workspaces`) against a REAL git
+// worktree, a REAL sessions.json and a REAL session-labels.json, then renders
+// the REAL session-list component and asserts on the painted buffer.
+//
+// Own test binary on purpose: `AINB_HOME` is process-global, and isolating it
+// keeps the developer's live sessions and labels out of the assertions.
+
+use std::path::Path;
+use std::process::Command;
+
+use ainb::app::state::{AppState, SessionFilter};
+use ainb::components::SessionListComponent;
+use ainb::config::SessionLabelStore;
+use ainb::interactive::session_manager::{ModelSource, SessionMetadata, SessionStore};
+use ainb::models::session::SessionAgentType;
+use chrono::Utc;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use uuid::Uuid;
+
+/// The label under test. Distinctive enough that finding it in the buffer
+/// cannot be an accident of chrome, a repo name or a branch suffix.
+const LABEL: &str = "prove-hangar-acp-leg";
+
+fn tool_available(bin: &str, arg: &str) -> bool {
+    Command::new(bin).arg(arg).output().is_ok_and(|o| o.status.success())
+}
+
+/// Real git state only. Hand-faked `.git` fixtures are how the sibling
+/// workspace-name bug survived four releases.
+fn git_ok(cwd: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args([
+            "-c",
+            "user.name=ainb-test",
+            "-c",
+            "user.email=ainb@test.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn painted(state: &mut AppState) -> String {
+    // What the operator does to look at stopped sessions: `F` cycles the filter
+    // onto stopped-only (the default is active-only, which hides them), and the
+    // workspace has to be expanded for its rows to paint at all. Without both,
+    // the list renders an empty tree and every label assertion below passes or
+    // fails for the wrong reason.
+    state.session_filter = SessionFilter::StoppedOnly;
+    state.expand_all_workspaces = true;
+
+    let mut list = SessionListComponent::new();
+    let mut term = Terminal::new(TestBackend::new(140, 40)).expect("test terminal");
+    term.draw(|f| list.render(f, f.area(), state)).expect("draw");
+    term.backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(ratatui::buffer::Cell::symbol)
+        .collect()
+}
+
+#[tokio::test]
+async fn a_stopped_session_still_paints_the_label_it_ran_under() {
+    if !tool_available("git", "--version") {
+        eprintln!("SKIP: git unavailable");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("tempdir");
+    let home_path = home.path().canonicalize().expect("canonicalize home");
+    // Isolates SessionStore, SessionLabelStore AND WorktreeManager together, so
+    // neither a real session nor a real label can leak into the assertion.
+    std::env::set_var("AINB_HOME", &home_path);
+    std::fs::create_dir_all(home_path.join(".agents-in-a-box")).unwrap();
+
+    // Real repo plus a real linked worktree off it. The branch carries the
+    // 8-hex shape a launched session actually gets, so the assertion below
+    // cannot pass by matching some friendlier name.
+    let repo = home_path.join("src/myrepo");
+    std::fs::create_dir_all(&repo).unwrap();
+    assert!(git_ok(&repo, &["init"]), "git init");
+    std::fs::write(repo.join("README.md"), "hi").unwrap();
+    assert!(git_ok(&repo, &["add", "README.md"]), "git add");
+    assert!(git_ok(&repo, &["commit", "-m", "init"]), "git commit");
+
+    let worktree = home_path.join("src/myrepo--agents-abeb7e09");
+    assert!(
+        git_ok(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                worktree.to_str().unwrap(),
+                "-b",
+                "agents/abeb7e09"
+            ],
+        ),
+        "git worktree add"
+    );
+
+    // No tmux session is created for this name, so the loader can only reach
+    // this row through the STOPPED path. That is the path under test.
+    let tmux_name = format!("tmux_ainblabel-stopped-{}", std::process::id());
+
+    let mut store = SessionStore::default();
+    let session_id = Uuid::new_v4();
+    store.upsert(SessionMetadata {
+        session_id,
+        tmux_session_name: tmux_name.clone(),
+        worktree_path: worktree.clone(),
+        workspace_name: "myrepo".to_string(),
+        created_at: Utc::now(),
+        agent_type: SessionAgentType::default(),
+        headroom_enabled: false,
+        rtk_enabled: false,
+        skip_permissions: None,
+        model: None,
+        model_source: ModelSource::default(),
+        codex_model: None,
+        codex_thread_id: None,
+    });
+    store.save().expect("save sessions.json");
+
+    let mut labels = SessionLabelStore::default();
+    labels.set(tmux_name.clone(), Some(LABEL.to_string()));
+    labels.save().expect("save session-labels.json");
+
+    // ── Drive the real loader ────────────────────────────────────────────
+    let mut state = AppState::new();
+    state.load_real_workspaces().await;
+
+    let session = state
+        .workspaces
+        .iter()
+        .flat_map(|w| w.sessions.iter())
+        .find(|s| s.id == session_id)
+        .expect("the stopped session must be visible in the tree at all");
+    assert_eq!(
+        session.status,
+        ainb::models::SessionStatus::Stopped,
+        "fixture must exercise the STOPPED path, got {:?}",
+        session.status
+    );
+
+    // ── User-visible proof ───────────────────────────────────────────────
+    let buffer = painted(&mut state);
+    assert!(
+        buffer.contains(LABEL),
+        "a stopped session lost the label it ran under:\n{buffer}"
+    );
+    // The label must PREFIX the branch, not replace it. An operator needs both:
+    // the label to recognise the run, the branch to know what to do with it.
+    assert!(
+        buffer.contains("agents/abeb7e09"),
+        "the label displaced the branch on the stopped row:\n{buffer}"
+    );
+
+    // Negative control. With the label removed from the store and nothing else
+    // changed, the same render must lose it. Without this the assertion above
+    // would also pass on a build that painted the label from anywhere else.
+    let mut cleared = SessionLabelStore::default();
+    cleared.set(tmux_name.clone(), None);
+    cleared.save().expect("clear session-labels.json");
+
+    let mut unlabelled = AppState::new();
+    unlabelled.load_real_workspaces().await;
+    let without = painted(&mut unlabelled);
+    assert!(
+        !without.contains(LABEL),
+        "the label survived its own removal, so this test proves nothing:\n{without}"
+    );
+    assert!(
+        without.contains("agents/abeb7e09"),
+        "clearing the label should leave the branch, not the row:\n{without}"
+    );
+
+    std::env::remove_var("AINB_HOME");
+}


### PR DESCRIPTION
Two operator-reported bugs on the session surfaces.

## 1. A stopped session lost its label

`stopped_session_from_metadata` is the single place a Stopped row is built, and it was the only session path that never consulted `SessionLabelStore`. A session that showed `<label> · <branch>` while running dropped back to a bare branch name the moment it stopped, which is exactly when the operator needs to tell two stopped worktrees apart.

The store is now threaded in at that one choke point (the caller already holds a loaded one, so no extra file read). Recovery rows join their label too: sessions directly by tmux name, worktrees through the existing sessions.json enrichment pass. The Details pane names the selected row by its label instead of its bare tmux name.

## 2. The recovery panel could not be searched

`/` opens a fuzzy filter over name, label, branch and repo, reusing `screen_model::fuzzy_matches` and the search pattern the Skills panel already established. Esc clears, Enter closes the bar and keeps the filter so the normal keys act on the narrowed list.

The real hazard here is the selection index: once a list is filtered, a view position no longer equals a row position, and resume/delete act on the position. `row_at()` now owns that mapping and every action site goes through it, which also deleted three separate copies of the raw-index arithmetic and a latent `len + offset - 1` underflow.

## Also

- The row name budget followed a hard-coded 25 columns; it now follows the pane width. Identical at 100 cols, full name at 200.
- Label and name share one budget so a labelled row cannot push the age column off the end.

## Verification

- 30 tests green across `components::session_recovery` and `components::session_list`.
- Every label and filter assertion reads a painted `TestBackend` buffer, not a struct field.
- Each new test was run against the change backed out and confirmed to fail.
- The worktree label join (path -> sessions.json -> tmux name -> label) is unit-tested directly, including the negative case.

## Known gaps

- Boss/Docker rows and other-tmux rows still show no label: neither carries a tmux name, so there is no key to join on.
- `refresh()` does not clear the query on panel re-entry. Esc clears it and the search row stays visible whenever the query is non-empty, so the state is visible rather than silent.
- BrokenSymlink worktrees miss the label for the same path-equality reason they already miss `agent_type`.
- All render proofs are in-process; no live tmux drive of the real binary yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an inline fuzzy search bar to Session Recovery, available with `/` across sessions and worktrees.
  - Filtering now safely preserves the correct targets for resume, delete, and bulk actions.
  - Added durable session labels to recovery entries, stopped sessions, worktrees, and the details view.
  - Added clearer empty states, result counts, and filter guidance.

- **Bug Fixes**
  - Stopped sessions now retain their labels and branch display after recovery or reload.

- **Tests**
  - Added coverage for recovery filtering, keyboard behavior, label rendering, and stopped-session persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->