### PR TITLE
feat(sessions): the copilot pane offers to start the hangar daemon it needs

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1386,6 +1386,17 @@ impl EventHandler {
                 return Some(AppEvent::Consumed);
             }
         }
+        // The copilot pane's offer to start the daemon owns Enter while it is
+        // up, and takes it BEFORE the chat reducer. The composer under it has
+        // nothing to send to — that is precisely the condition the offer
+        // appears in — so Enter reaching the reducer there is a key the footer
+        // advertised and nothing performed.
+        //
+        // Gated on the same predicate the pane paints from, so the offer, the
+        // footer's verb and the key cannot disagree.
+        if key_event.code == KeyCode::Enter && state.copilot_daemon_cta_open() {
+            return Some(AppEvent::SessionStartHangarDaemon);
+        }
         // The broadcast composer, which replaces the thread's while rows are
         // checked. Handled BEFORE the chat reducer because there is no chat
         // host behind it — the pane is a composer and a receipt list, not a
@@ -2394,14 +2405,6 @@ impl EventHandler {
                 match crate::components::session_tabs::resolve(state, state.session_tab) {
                     SessionTab::Preview => {}
                     SessionTab::Ask => return Some(AppEvent::SessionAskSend),
-                    // The copilot pane offering to start the daemon is not a
-                    // composer, and Enter on it is the offer's own key. Checked
-                    // against the same predicate the pane paints from, so the
-                    // footer's verb, the line on screen and the key that fires
-                    // are one fact.
-                    SessionTab::Copilot if state.copilot_daemon_cta_open() => {
-                        return Some(AppEvent::SessionStartHangarDaemon);
-                    }
                     SessionTab::Thread | SessionTab::Copilot => {
                         return Some(AppEvent::SessionTabComposerSend);
                     }

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1392,9 +1392,12 @@ impl EventHandler {
         // appears in — so Enter reaching the reducer there is a key the footer
         // advertised and nothing performed.
         //
-        // Gated on the same predicate the pane paints from, so the offer, the
-        // footer's verb and the key cannot disagree.
-        if key_event.code == KeyCode::Enter && state.copilot_daemon_cta_open() {
+        // Gated on ARMED, not merely shown: with focus on the session list,
+        // `Enter` is that list's, and starting a daemon on a keystroke the
+        // operator aimed somewhere else is not a thing to do quietly. The
+        // footer reads the same predicate, so it promises this only when it
+        // will happen.
+        if key_event.code == KeyCode::Enter && state.copilot_daemon_cta_armed() {
             return Some(AppEvent::SessionStartHangarDaemon);
         }
         // The broadcast composer, which replaces the thread's while rows are

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -92,6 +92,9 @@ pub enum AppEvent {
     SessionAskSend,
     /// `Enter` on a composer tab (`thread` / `copilot`): send the message.
     SessionTabComposerSend,
+    /// `Enter` on the `copilot` tab while it is offering to start the hangar
+    /// daemon it needs.
+    SessionStartHangarDaemon,
     /// Toggle the sessions sidebar between full width and the thin rail —
     /// the keyboard twin ('B') of clicking the [-]/[+] glyph on its border.
     ToggleSessionsSidebar,
@@ -2391,6 +2394,14 @@ impl EventHandler {
                 match crate::components::session_tabs::resolve(state, state.session_tab) {
                     SessionTab::Preview => {}
                     SessionTab::Ask => return Some(AppEvent::SessionAskSend),
+                    // The copilot pane offering to start the daemon is not a
+                    // composer, and Enter on it is the offer's own key. Checked
+                    // against the same predicate the pane paints from, so the
+                    // footer's verb, the line on screen and the key that fires
+                    // are one fact.
+                    SessionTab::Copilot if state.copilot_daemon_cta_open() => {
+                        return Some(AppEvent::SessionStartHangarDaemon);
+                    }
                     SessionTab::Thread | SessionTab::Copilot => {
                         return Some(AppEvent::SessionTabComposerSend);
                     }
@@ -4466,6 +4477,14 @@ impl EventHandler {
             // Enter was pressed with no composer open.
             AppEvent::SessionTabComposerSend => {
                 state.add_info_notification("open a conversation first".to_string());
+            }
+            // Answered in the pane, not by sending the operator to another
+            // screen: the offer exists because the way out of a copilot that
+            // cannot open was to already know it was the hangar daemon, and to
+            // go and find the row that starts it.
+            AppEvent::SessionStartHangarDaemon => {
+                state.daemon_start_cta.start();
+                state.ui_needs_refresh = true;
             }
             AppEvent::SwitchPaneFocus => {
                 use crate::app::state::FocusedPane;

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11951,12 +11951,7 @@ impl AppState {
             return false;
         }
         match self.session_tab {
-            // A copilot pane showing the start-the-daemon offer is NOT a
-            // composer: there is no conversation behind it, so a key routed
-            // into the chat reducer there would land in a composer nothing
-            // paints. It keeps the ordinary sessions-screen bindings instead,
-            // which is what its footer advertises.
-            SessionTab::Copilot => self.copilot_chat.is_some() && !self.copilot_daemon_cta_open(),
+            SessionTab::Copilot => self.copilot_chat.is_some(),
             // A broadcast owns the keyboard whether or not a thread host has
             // been opened: the composer is there the moment rows are checked.
             SessionTab::Thread => {
@@ -11980,12 +11975,6 @@ impl AppState {
         use crate::components::session_tabs::SessionTab;
         if self.session_tab == SessionTab::Thread && !self.broadcast_targets().is_empty() {
             return self.broadcast.capturing();
-        }
-        // Same rule as [`Self::session_tab_owns_keys`]: the offer is not a
-        // composer, so it must not suppress the screen's own shortcuts on
-        // behalf of one that is not on screen.
-        if self.copilot_daemon_cta_open() {
-            return false;
         }
         let host = match self.session_tab {
             SessionTab::Copilot => self.copilot_chat.as_ref(),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11896,8 +11896,7 @@ impl AppState {
         )
     }
 
-    /// Whether the copilot pane is showing its start-the-daemon offer instead
-    /// of a conversation.
+    /// Whether the copilot pane is showing its start-the-daemon offer.
     ///
     /// The single predicate the renderer, the footer and the key path all ask,
     /// so the pane cannot paint an offer the footer does not advertise or the
@@ -12021,6 +12020,28 @@ impl AppState {
                 }
                 self.session_chat.as_ref().map(|(_, host)| host)
             }
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
+        }
+    }
+
+    /// The chat host a tab is showing, WITHOUT opening or ticking it.
+    ///
+    /// The one resolver from tab to host. [`Self::chat_host_for`] ends by
+    /// calling it, so a caller that ticks through that and paints through this
+    /// cannot tick one conversation and paint another — the alternative was
+    /// reaching for `copilot_chat` at the render site and assuming the two
+    /// agree, which is a fact written twice.
+    ///
+    /// Wildcard-free: a sixth tab has to say here which conversation it shows.
+    #[must_use]
+    pub fn chat_host(
+        &self,
+        tab: crate::components::session_tabs::SessionTab,
+    ) -> Option<&crate::fleet::chat_host::ChatHost> {
+        use crate::components::session_tabs::SessionTab;
+        match tab {
+            SessionTab::Copilot => self.copilot_chat.as_ref(),
+            SessionTab::Thread => self.session_chat.as_ref().map(|(_, host)| host),
             SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
         }
     }
@@ -12183,6 +12204,14 @@ impl AppState {
         // separate self borrows, taken in turn.
         let mut changed = false;
         let reachable = daemon.reachable;
+        // The copilot pane's start offer is one per process, so a report from a
+        // previous outage has to be retired when that outage ends. Done HERE,
+        // on the refresh that reads the poller's cell every tick, rather than
+        // on the pane: a daemon that came up and went down again while the
+        // operator was on another tab is still a change this sees.
+        if self.daemon_start_cta.observe_daemon((!reachable) && daemon.not_running) {
+            changed = true;
+        }
         let live: HashSet<Uuid> = marks.iter().map(|(id, ..)| *id).collect();
         // A session that recovered (or vanished) must lose its ERR clock, or a
         // later failure would render with the age of the previous one.

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -12025,7 +12025,7 @@ impl AppState {
                 if host.tick(now_ms) {
                     self.ui_needs_refresh = true;
                 }
-                self.copilot_chat.as_ref()
+                self.chat_host(tab)
             }
             SessionTab::Thread => {
                 let key = self.selected_session_chat_key()?;
@@ -12041,7 +12041,7 @@ impl AppState {
                         self.ui_needs_refresh = true;
                     }
                 }
-                self.session_chat.as_ref().map(|(_, host)| host)
+                self.chat_host(tab)
             }
             SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
         }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3685,6 +3685,13 @@ pub struct AppState {
     /// open. It costs one `fleet/adapter_list` per session.
     pub copilot_dial: crate::fleet::copilot_dial::CopilotDial,
 
+    /// The copilot pane's offer to start the hangar daemon it needs.
+    ///
+    /// One per process, not one per pane: the offer starts the daemon the whole
+    /// TUI talks to, and a second copy would let two panes each shell a start
+    /// into the same home.
+    pub daemon_start_cta: crate::fleet::daemon_cta::DaemonStartCta,
+
     /// The broadcast composer, shown on `thread` while rows are checked.
     ///
     /// Survives a change of checkbox set on purpose: an operator who ticks a
@@ -4221,6 +4228,7 @@ impl Default for AppState {
             session_tab: crate::components::session_tabs::SessionTab::default(),
             ask_state: crate::fleet::answer::AskState::default(),
             copilot_dial: crate::fleet::copilot_dial::CopilotDial::new(),
+            daemon_start_cta: crate::fleet::daemon_cta::DaemonStartCta::default(),
             broadcast: crate::fleet::broadcast::Broadcast::default(),
             copilot_chat: None,
             session_chat: None,
@@ -11867,6 +11875,66 @@ impl AppState {
             && matches!(self.session_tab, SessionTab::Thread | SessionTab::Copilot)
     }
 
+    /// Whether the hangar daemon is DOWN, as opposed to merely not answering.
+    ///
+    /// The one condition the copilot pane's start offer may rest on. Read from
+    /// the attention poller's cell, which dials the same socket every five
+    /// seconds on its own thread and classifies the typed failure — so this is
+    /// a lock and two bools on the render path, never a dial.
+    ///
+    /// `reachable` alone is NOT enough and that is the whole point: a daemon
+    /// that is up but wedged is equally unreachable, and offering to start it
+    /// would put a fresh lie on the surface the offer exists to fix.
+    #[must_use]
+    pub fn hangar_daemon_not_running(&self) -> bool {
+        self.daemon_attention.lock().map_or_else(
+            |poisoned| {
+                let daemon = poisoned.into_inner();
+                (!daemon.reachable) && daemon.not_running
+            },
+            |daemon| (!daemon.reachable) && daemon.not_running,
+        )
+    }
+
+    /// Whether the copilot pane is showing its start-the-daemon offer instead
+    /// of a conversation.
+    ///
+    /// The single predicate the renderer, the footer and the key path all ask,
+    /// so the pane cannot paint an offer the footer does not advertise or the
+    /// key does not fire.
+    #[must_use]
+    pub fn copilot_daemon_cta_open(&self) -> bool {
+        self.session_tab == crate::components::session_tabs::SessionTab::Copilot
+            && self.hangar_daemon_not_running()
+    }
+
+    /// Why a conversation tab cannot send right now, in the pane's own words.
+    ///
+    /// Asked of the LIVE chat surface rather than inferred from the tab, so the
+    /// footer's promise and the composer's `⊘` are one fact. A footer that
+    /// advertised `Enter send message` over a pane reading "nothing to send to"
+    /// is the same class of lie as a chip offering an answer no transport can
+    /// deliver.
+    #[must_use]
+    pub fn session_tab_send_block(
+        &self,
+        tab: crate::components::session_tabs::SessionTab,
+    ) -> Option<String> {
+        use crate::components::session_tabs::SessionTab;
+        // A broadcast replaces the thread's composer with one that is not a
+        // conversation at all, so the thread host has nothing to say about it.
+        if tab == SessionTab::Thread && !self.broadcast_targets().is_empty() {
+            return None;
+        }
+        match tab {
+            SessionTab::Copilot => self.copilot_chat.as_ref(),
+            SessionTab::Thread => self.session_chat.as_ref().map(|(_, host)| host),
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
+        }?
+        .state()
+        .send_block()
+    }
+
     /// Whether a conversation pane currently owns the keyboard.
     ///
     /// Broader than [`Self::session_composer_captures_text`] on purpose. That
@@ -11883,7 +11951,12 @@ impl AppState {
             return false;
         }
         match self.session_tab {
-            SessionTab::Copilot => self.copilot_chat.is_some(),
+            // A copilot pane showing the start-the-daemon offer is NOT a
+            // composer: there is no conversation behind it, so a key routed
+            // into the chat reducer there would land in a composer nothing
+            // paints. It keeps the ordinary sessions-screen bindings instead,
+            // which is what its footer advertises.
+            SessionTab::Copilot => self.copilot_chat.is_some() && !self.copilot_daemon_cta_open(),
             // A broadcast owns the keyboard whether or not a thread host has
             // been opened: the composer is there the moment rows are checked.
             SessionTab::Thread => {
@@ -11907,6 +11980,12 @@ impl AppState {
         use crate::components::session_tabs::SessionTab;
         if self.session_tab == SessionTab::Thread && !self.broadcast_targets().is_empty() {
             return self.broadcast.capturing();
+        }
+        // Same rule as [`Self::session_tab_owns_keys`]: the offer is not a
+        // composer, so it must not suppress the screen's own shortcuts on
+        // behalf of one that is not on screen.
+        if self.copilot_daemon_cta_open() {
+            return false;
         }
         let host = match self.session_tab {
             SessionTab::Copilot => self.copilot_chat.as_ref(),

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11896,15 +11896,38 @@ impl AppState {
         )
     }
 
-    /// Whether the copilot pane is showing its start-the-daemon offer.
+    /// Whether the copilot pane is SHOWING its start-the-daemon offer.
     ///
-    /// The single predicate the renderer, the footer and the key path all ask,
-    /// so the pane cannot paint an offer the footer does not advertise or the
-    /// key does not fire.
+    /// About the pane, not about the keyboard: the offer stays on screen while
+    /// the operator works the session list beside it. The renderer asks this
+    /// one.
     #[must_use]
     pub fn copilot_daemon_cta_open(&self) -> bool {
         self.session_tab == crate::components::session_tabs::SessionTab::Copilot
             && self.hangar_daemon_not_running()
+    }
+
+    /// Whether pressing `Enter` right now would fire that offer.
+    ///
+    /// A SECOND predicate deliberately, because the two answer different
+    /// questions and only this one may be advertised. Starting a daemon is not
+    /// something to do on a mis-routed keystroke: with focus on the session
+    /// list, `Enter` belongs to the list, so the offer neither claims the key
+    /// nor lets the footer promise it.
+    ///
+    /// A start already in flight disarms it too, so the footer stops
+    /// advertising a second press that [`DaemonStartCta::start`] declines.
+    ///
+    /// The footer's verb and the key handler both read THIS, so what is
+    /// promised and what happens are one fact.
+    #[must_use]
+    pub fn copilot_daemon_cta_armed(&self) -> bool {
+        self.copilot_daemon_cta_open()
+            // The right pane. `SessionTabNext` puts focus here whenever it
+            // lands on a tab that takes input, and takes it away again when it
+            // lands on one that does not.
+            && self.focused_pane == FocusedPane::LiveLogs
+            && *self.daemon_start_cta.status() != crate::fleet::daemon_cta::CtaStatus::Starting
     }
 
     /// Why a conversation tab cannot send right now, in the pane's own words.

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2409,6 +2409,7 @@ mod tests {
             by_cwd,
             reachable: false,
             error: Some("attention/list via /x/hangar.sock: refused".into()),
+            not_running: true,
         };
 
         state.refresh_attention_markers(2_000);

--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -269,13 +269,13 @@ impl ActionMenu {
 /// What a finished lifecycle action reported.
 #[derive(Debug, Clone)]
 pub struct ActionOutcome {
-    action: Action,
-    ok: bool,
+    pub(crate) action: Action,
+    pub(crate) ok: bool,
     /// One line for the row itself.
-    summary: String,
+    pub(crate) summary: String,
     /// Everything the command said: the argv, its exit status, and its output.
     /// This is what the error view shows, verbatim.
-    detail: String,
+    pub(crate) detail: String,
 }
 
 impl DaemonsState {
@@ -627,7 +627,7 @@ fn run_hook_action(intent: BinaryIntent) -> String {
 /// Runs on a throwaway thread. The captured argv, exit status, and output are
 /// what the row's error view shows verbatim — the operator sees the actual
 /// failure, not our summary of it.
-fn run_daemon_action(kind_id: &str, verb: &str, action: Action) -> ActionOutcome {
+pub(crate) fn run_daemon_action(kind_id: &str, verb: &str, action: Action) -> ActionOutcome {
     let argv = format!("ainb daemon {kind_id} {verb}");
     // Never self-exec a test harness: under `cargo test` current_exe() is the
     // test binary, and libtest treats the trailing argv as name filters, so

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -171,6 +171,21 @@ impl LayoutComponent {
                 if state.copilot_dial.tick() {
                     state.ui_needs_refresh = true;
                 }
+                // The offer's own tick, for the same reason: the start runs on
+                // a detached worker, and its result has to reach the pane
+                // without the operator pressing anything else.
+                if state.daemon_start_cta.tick() {
+                    state.ui_needs_refresh = true;
+                }
+                // With no daemon there is no channel, no session and no
+                // timeline, so the pane offers the one thing that fixes it
+                // rather than painting a composer with nothing behind it. The
+                // dial header goes with it: its three settings are the DAEMON's
+                // registry, and none of them can be turned from here either.
+                if state.copilot_daemon_cta_open() {
+                    session_tabs::render_copilot_daemon_cta(frame, inner, &state.daemon_start_cta);
+                    return;
+                }
                 // Cloned rather than borrowed: `chat_host_for` needs `&mut
                 // state` to tick the conversation, and the header is three
                 // strings and a status.

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -181,9 +181,13 @@ impl LayoutComponent {
                 // state` to tick the conversation, and the header is three
                 // strings and a status.
                 let header = session_tabs::copilot_header(&state.copilot_dial);
-                // Ticked for its effect, then re-read: `chat_host_for` borrows
-                // the whole state mutably, and the offer beside it is another
-                // field of the same state.
+                // Ticked for its effect, then re-read through `chat_host`:
+                // `chat_host_for` borrows the whole state mutably and the offer
+                // beside it is another field of the same state, so the two
+                // borrows cannot be held at once. `chat_host_for` ENDS by
+                // calling `chat_host`, so what is painted below is what was
+                // ticked here rather than a second guess at which host this tab
+                // shows.
                 let _ = state.chat_host_for(active);
                 // Inserted between the header and the conversation rather than
                 // replacing either. Both still have something true to say with
@@ -191,13 +195,7 @@ impl LayoutComponent {
                 // with, and the call the chat could not make — and the offer is
                 // the one thing neither of them could say.
                 let offer = state.copilot_daemon_cta_open().then_some(&state.daemon_start_cta);
-                session_tabs::render_copilot(
-                    frame,
-                    inner,
-                    header,
-                    offer,
-                    state.copilot_chat.as_ref(),
-                );
+                session_tabs::render_copilot(frame, inner, header, offer, state.chat_host(active));
             }
             SessionTab::Thread => {
                 // Checked rows win over the cursor, the same rule `Enter` and

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -177,21 +177,27 @@ impl LayoutComponent {
                 if state.daemon_start_cta.tick() {
                     state.ui_needs_refresh = true;
                 }
-                // With no daemon there is no channel, no session and no
-                // timeline, so the pane offers the one thing that fixes it
-                // rather than painting a composer with nothing behind it. The
-                // dial header goes with it: its three settings are the DAEMON's
-                // registry, and none of them can be turned from here either.
-                if state.copilot_daemon_cta_open() {
-                    session_tabs::render_copilot_daemon_cta(frame, inner, &state.daemon_start_cta);
-                    return;
-                }
                 // Cloned rather than borrowed: `chat_host_for` needs `&mut
                 // state` to tick the conversation, and the header is three
                 // strings and a status.
                 let header = session_tabs::copilot_header(&state.copilot_dial);
-                let host = state.chat_host_for(active);
-                session_tabs::render_copilot(frame, inner, header, host);
+                // Ticked for its effect, then re-read: `chat_host_for` borrows
+                // the whole state mutably, and the offer beside it is another
+                // field of the same state.
+                let _ = state.chat_host_for(active);
+                // Inserted between the header and the conversation rather than
+                // replacing either. Both still have something true to say with
+                // the daemon down — the dials an operator recovers an adapter
+                // with, and the call the chat could not make — and the offer is
+                // the one thing neither of them could say.
+                let offer = state.copilot_daemon_cta_open().then_some(&state.daemon_start_cta);
+                session_tabs::render_copilot(
+                    frame,
+                    inner,
+                    header,
+                    offer,
+                    state.copilot_chat.as_ref(),
+                );
             }
             SessionTab::Thread => {
                 // Checked rows win over the cursor, the same rule `Enter` and

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -684,6 +684,7 @@ pub fn render_copilot(
     frame: &mut Frame,
     area: Rect,
     header: Vec<Line<'static>>,
+    offer: Option<&crate::fleet::daemon_cta::DaemonStartCta>,
     host: Option<&crate::fleet::chat_host::ChatHost>,
 ) {
     let height = u16::try_from(header.len()).unwrap_or(u16::MAX).min(area.height);
@@ -693,6 +694,40 @@ pub fn render_copilot(
     ])
     .areas(area);
     frame.render_widget(ratatui::widgets::Paragraph::new(header), head);
+    if rest.height == 0 {
+        return;
+    }
+    // The offer is INSERTED, never a replacement. The dials above it are how an
+    // operator recovers from an adapter that will not spawn, and the
+    // conversation below still has its own failure to report — a pane that
+    // swapped both for one sentence would take away two working surfaces to
+    // add one.
+    let rest = match offer {
+        Some(offer) => {
+            let lines = daemon_offer_lines(offer);
+            let wanted = u16::try_from(lines.len()).unwrap_or(u16::MAX);
+            // Never at the cost of the conversation: below four rows the chat
+            // renderer draws nothing at all, and an offer that blanked it would
+            // hide the daemon's own words to make room for a key.
+            let height = wanted.min(rest.height.saturating_sub(MIN_CHAT_ROWS));
+            if height == 0 {
+                rest
+            } else {
+                let [block, below] = Layout::vertical([
+                    ratatui::layout::Constraint::Length(height),
+                    ratatui::layout::Constraint::Min(0),
+                ])
+                .areas(rest);
+                frame.render_widget(
+                    ratatui::widgets::Paragraph::new(lines)
+                        .wrap(ratatui::widgets::Wrap { trim: false }),
+                    block,
+                );
+                below
+            }
+        }
+        None => rest,
+    };
     if rest.height == 0 {
         return;
     }
@@ -706,24 +741,16 @@ pub fn render_copilot(
     }
 }
 
-/// Render the copilot pane's offer to start the hangar daemon.
+/// The copilot pane's offer to start the hangar daemon, as lines.
 ///
-/// Replaces the conversation rather than annotating it, and that is the point:
-/// with no daemon there is no channel, no session and no timeline, so a
-/// composer under this would be a control that cannot act. The offer is
-/// answered HERE, with one key, instead of sending the operator to the Daemons
-/// screen to work out for themselves which row the copilot needs.
+/// Built rather than painted, so the caller can size it against what is left of
+/// the pane and refuse to take the conversation's last rows for it.
 ///
 /// Every state says what it is. A start that failed keeps the key, because the
-/// remedy for "the port was busy" is to try again; a start that is out shows no
-/// key at all, so the offer cannot be fired twice into one home.
-pub fn render_copilot_daemon_cta(
-    frame: &mut Frame,
-    area: Rect,
-    cta: &crate::fleet::daemon_cta::DaemonStartCta,
-) {
+/// remedy for a port that was busy is to try again; a start that is out shows
+/// no key at all, so the offer cannot be fired twice into one home.
+fn daemon_offer_lines(cta: &crate::fleet::daemon_cta::DaemonStartCta) -> Vec<Line<'static>> {
     use crate::fleet::daemon_cta::CtaStatus;
-    use ratatui::widgets::{Paragraph, Wrap};
 
     let mut lines = vec![
         Line::raw(""),
@@ -731,7 +758,6 @@ pub fn render_copilot_daemon_cta(
             " copilot needs the hangar daemon, which is not running.",
             Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
         ),
-        Line::raw(""),
     ];
     match cta.status() {
         CtaStatus::Offered => lines.push(offer_line()),
@@ -741,13 +767,12 @@ pub fn render_copilot_daemon_cta(
         )),
         // The command's own closing line, never a paraphrase: `start` reports
         // "already running" as a SUCCESS, and an operator still staring at this
-        // pane afterwards needs to read that rather than a tick.
+        // offer afterwards needs to read that rather than a tick.
         CtaStatus::Reported { ok, detail } => {
             lines.push(Line::styled(
                 format!("   {} {detail}", if *ok { "\u{2713}" } else { "\u{2717}" }),
                 Style::default().fg(if *ok { SELECTION_GREEN } else { ALERT_RED }),
             ));
-            lines.push(Line::raw(""));
             // The offer stands on BOTH outcomes. A start that exited zero and
             // left this pane still asking for a daemon has not produced one,
             // and withdrawing the key there would leave the operator with a
@@ -755,7 +780,8 @@ pub fn render_copilot_daemon_cta(
             lines.push(offer_line());
         }
     }
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+    lines.push(Line::raw(""));
+    lines
 }
 
 /// The key line, worded once so the two states that offer it cannot differ.
@@ -986,12 +1012,19 @@ pub fn render_broadcast(
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
 }
 
+/// The fewest rows the chat renderer will paint a conversation into.
+///
+/// Named because the daemon offer above it has to respect the same floor: an
+/// offer that ate the conversation's last rows would hide the daemon's own
+/// words to make room for a key that explains them.
+pub const MIN_CHAT_ROWS: u16 = 4;
+
 /// Render one chat conversation into the right pane.
 pub fn render_chat(frame: &mut Frame, area: Rect, host: &crate::fleet::chat_host::ChatHost) {
     // Below this the chat renderer draws nothing at all rather than something
     // illegible, so say so instead of leaving a blank pane — a blank box with
     // no explanation is the symptom this screen exists to remove.
-    if area.width < 24 || area.height < 4 {
+    if area.width < 24 || area.height < MIN_CHAT_ROWS {
         frame.render_widget(
             ratatui::widgets::Paragraph::new("widen the pane to show this conversation")
                 .style(Style::default().fg(MUTED_GRAY)),
@@ -1194,10 +1227,6 @@ mod tests {
             !footer.contains("send message"),
             "and must not still promise a send: {footer}"
         );
-        // A pane with no conversation behind it is not a composer, or a key
-        // typed at it lands in one nothing paints.
-        assert!(!state.session_tab_owns_keys());
-        assert!(!state.session_composer_captures_text());
     }
 
     /// The offer appears ONLY for a daemon that is not there. A daemon that

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -704,12 +704,20 @@ pub fn render_copilot(
     // add one.
     let rest = match offer {
         Some(offer) => {
-            let lines = daemon_offer_lines(offer);
-            let wanted = u16::try_from(lines.len()).unwrap_or(u16::MAX);
-            // Never at the cost of the conversation: below four rows the chat
-            // renderer draws nothing at all, and an offer that blanked it would
-            // hide the daemon's own words to make room for a key.
-            let height = wanted.min(rest.height.saturating_sub(MIN_CHAT_ROWS));
+            // Yield to the conversation where there is room, because below its
+            // floor the chat renderer draws nothing at all and an offer that
+            // blanked it would hide the daemon's own words. But never to
+            // NOTHING: one row is always taken while any row exists, and the
+            // clamp below guarantees that row is the key. A pane too short even
+            // for that already says "widen the pane" for the chat.
+            let budget = rest.height.saturating_sub(MIN_CHAT_ROWS).max(1).min(rest.height);
+            // Clamped by what is PASSED, not only by the rect. A `Paragraph`
+            // handed more rows than it has drops the ones at the BOTTOM in
+            // silence, and the bottom of this block is the action line — so the
+            // pane would keep the diagnosis and lose the remedy while the
+            // footer went on advertising it.
+            let lines = daemon_offer_lines(offer, rest.width, budget);
+            let height = offer_block_height(&lines, rest.width).min(budget);
             if height == 0 {
                 rest
             } else {
@@ -741,47 +749,126 @@ pub fn render_copilot(
     }
 }
 
-/// The copilot pane's offer to start the hangar daemon, as lines.
+/// How many ROWS `lines` occupy at `width` once wrapped.
 ///
-/// Built rather than painted, so the caller can size it against what is left of
-/// the pane and refuse to take the conversation's last rows for it.
+/// The block is sized by what will be painted, not by how many `Line`s were
+/// built: a headline that wraps to two rows pushes the key off a block measured
+/// in lines, which is the silent cut this exists to stop.
+fn offer_block_height(lines: &[Line<'static>], width: u16) -> u16 {
+    lines.iter().map(|line| wrapped_rows(line, width)).sum::<u16>()
+}
+
+/// The rows one line occupies at `width`, greedily word-wrapped like the
+/// `Paragraph` that paints it. Always at least one, so a blank still costs its
+/// row.
+fn wrapped_rows(line: &Line<'static>, width: u16) -> u16 {
+    let width = usize::from(width.max(1));
+    let text: String = line.spans.iter().map(|span| span.content.as_ref()).collect();
+    let mut rows: u16 = 1;
+    let mut used = 0usize;
+    for word in text.split_inclusive(' ') {
+        let len = word.chars().count();
+        if used > 0 && used + len > width {
+            rows = rows.saturating_add(1);
+            used = len;
+        } else {
+            used += len;
+        }
+        // A single word longer than the pane wraps on its own.
+        while used > width {
+            rows = rows.saturating_add(1);
+            used -= width;
+        }
+    }
+    rows
+}
+
+/// The copilot pane's offer to start the hangar daemon, as the lines that will
+/// FIT in `max_rows` at `width`.
+///
+/// Built rather than painted so the caller can size the block against what is
+/// left of the pane, and CLAMPED here rather than left to the paragraph: a
+/// paragraph given more rows than it has drops the ones at the bottom without
+/// saying so, and the bottom of this block is the key.
+///
+/// Dropped in priority order, from the least load-bearing end. The action line
+/// is priority zero and is never a casualty — a pane that kept the diagnosis
+/// and lost the remedy is the dead end this whole surface removes. Next most
+/// load-bearing is the last start's own words, then the headline, then the
+/// padding.
 ///
 /// Every state says what it is. A start that failed keeps the key, because the
 /// remedy for a port that was busy is to try again; a start that is out shows
 /// no key at all, so the offer cannot be fired twice into one home.
-fn daemon_offer_lines(cta: &crate::fleet::daemon_cta::DaemonStartCta) -> Vec<Line<'static>> {
+fn daemon_offer_lines(
+    cta: &crate::fleet::daemon_cta::DaemonStartCta,
+    width: u16,
+    max_rows: u16,
+) -> Vec<Line<'static>> {
     use crate::fleet::daemon_cta::CtaStatus;
 
-    let mut lines = vec![
-        Line::raw(""),
-        Line::styled(
-            " copilot needs the hangar daemon, which is not running.",
-            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+    // (priority, line) in SCREEN order. 0 is never dropped.
+    let mut rows: Vec<(u8, Line<'static>)> = vec![
+        (3, Line::raw("")),
+        (
+            2,
+            Line::styled(
+                " copilot needs the hangar daemon, which is not running.",
+                Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+            ),
         ),
     ];
     match cta.status() {
-        CtaStatus::Offered => lines.push(offer_line()),
-        CtaStatus::Starting => lines.push(Line::styled(
-            "   \u{25cf} starting the hangar daemon\u{2026}",
-            Style::default().fg(ALERT_AMBER),
+        CtaStatus::Offered => rows.push((0, offer_line())),
+        // The spinner IS the action line's stand-in while a start is out: it is
+        // what tells the operator their key press went somewhere.
+        CtaStatus::Starting => rows.push((
+            0,
+            Line::styled(
+                "   \u{25cf} starting the hangar daemon\u{2026}",
+                Style::default().fg(ALERT_AMBER),
+            ),
         )),
         // The command's own closing line, never a paraphrase: `start` reports
         // "already running" as a SUCCESS, and an operator still staring at this
         // offer afterwards needs to read that rather than a tick.
         CtaStatus::Reported { ok, detail } => {
-            lines.push(Line::styled(
-                format!("   {} {detail}", if *ok { "\u{2713}" } else { "\u{2717}" }),
-                Style::default().fg(if *ok { SELECTION_GREEN } else { ALERT_RED }),
+            rows.push((
+                1,
+                Line::styled(
+                    format!("   {} {detail}", if *ok { "\u{2713}" } else { "\u{2717}" }),
+                    Style::default().fg(if *ok { SELECTION_GREEN } else { ALERT_RED }),
+                ),
             ));
             // The offer stands on BOTH outcomes. A start that exited zero and
             // left this pane still asking for a daemon has not produced one,
             // and withdrawing the key there would leave the operator with a
             // green tick and nothing to press.
-            lines.push(offer_line());
+            rows.push((0, offer_line()));
         }
     }
-    lines.push(Line::raw(""));
-    lines
+    rows.push((3, Line::raw("")));
+
+    // Drop the lowest priority first, and the LAST of that priority, so the
+    // padding above the headline outlives the padding below the key only if it
+    // has to.
+    while offer_block_height(
+        &rows.iter().map(|(_, line)| line.clone()).collect::<Vec<_>>(),
+        width,
+    ) > max_rows
+    {
+        let Some(index) = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, (priority, _))| *priority > 0)
+            .max_by_key(|(index, (priority, _))| (*priority, *index))
+            .map(|(index, _)| index)
+        else {
+            break;
+        };
+        rows.remove(index);
+    }
+    rows.into_iter().map(|(_, line)| line).collect()
 }
 
 /// The key line, worded once so the two states that offer it cannot differ.
@@ -1196,6 +1283,36 @@ mod tests {
             .collect()
     }
 
+    /// Render the copilot pane into a rect of exactly `w`x`h` and return its
+    /// rows, so a test can ask what a SHORT pane actually painted.
+    fn copilot_rows(
+        offer: Option<&crate::fleet::daemon_cta::DaemonStartCta>,
+        w: u16,
+        h: u16,
+    ) -> Vec<String> {
+        let backend = ratatui::backend::TestBackend::new(w, h);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                render_copilot(
+                    frame,
+                    frame.area(),
+                    vec![Line::raw(" engine   claude-agent-acp  \u{25c0} \u{2325}e")],
+                    offer,
+                    None,
+                );
+            })
+            .expect("draw the copilot pane");
+        let buffer = terminal.backend().buffer().clone();
+        (0..h)
+            .map(|y| {
+                (0..w)
+                    .map(|x| buffer.cell((x, y)).map_or(" ", ratatui::buffer::Cell::symbol))
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
     /// Put the attention poller's cell in the state it reaches when the socket
     /// is dialled and nothing accepts.
     fn with_daemon(state: &mut AppState, reachable: bool, not_running: bool) {
@@ -1273,6 +1390,55 @@ mod tests {
         );
     }
 
+    /// A pane too short for the whole offer keeps the KEY, not the top of the
+    /// block.
+    ///
+    /// A `Paragraph` drops the rows it has no room for from the BOTTOM, and the
+    /// bottom of this block is the remedy — so a short pane silently kept the
+    /// diagnosis and lost the way out, while the footer went on advertising it.
+    /// Driven through a real render into a deliberately short rect, because
+    /// only the painted buffer settles what survived.
+    #[test]
+    fn a_short_pane_keeps_the_offers_key_and_drops_its_padding() {
+        let cta = crate::fleet::daemon_cta::DaemonStartCta::default();
+        // 6 rows: 1 header + 5 left, of which the chat floor claims 4. One row
+        // for the offer, and it has to be the one that says what to press.
+        for height in [6, 7, 8, 12] {
+            let rows = copilot_rows(Some(&cta), 90, height);
+            let painted = rows.join("\n");
+            assert!(
+                painted.contains(START_DAEMON_VERB) && painted.contains('\u{23ce}'),
+                "a {height}-row pane lost the offer's key:\n{painted}"
+            );
+        }
+
+        // And at a WIDTH that wraps the headline onto a second row, so the
+        // block is sized by rows painted rather than by lines built.
+        let narrow = copilot_rows(Some(&cta), 30, 8).join("\n");
+        assert!(
+            narrow.contains("start the hangar") && narrow.contains('\u{23ce}'),
+            "a wrapped headline pushed the key off the block:\n{narrow}"
+        );
+    }
+
+    /// The offer never takes the conversation's floor while there is room to
+    /// leave it: the daemon's own words below are what an operator reads when
+    /// the start does not help.
+    #[test]
+    fn a_tall_pane_gives_the_offer_its_padding_and_the_chat_its_floor() {
+        let cta = crate::fleet::daemon_cta::DaemonStartCta::default();
+        let rows = copilot_rows(Some(&cta), 90, 20);
+        let painted = rows.join("\n");
+        assert!(painted.contains(START_DAEMON_VERB));
+        assert!(
+            painted.contains("copilot needs the hangar daemon"),
+            "a pane with room must still lead with the reason:\n{painted}"
+        );
+        assert!(
+            painted.contains("opening the copilot channel"),
+            "the conversation below must keep its rows:\n{painted}"
+        );
+    }
     #[test]
     fn preview_and_copilot_are_never_disabled() {
         let state = state_with(Vec::new(), false);

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -98,19 +98,12 @@ impl SessionTab {
     /// than a dialog is to dismiss.
     #[must_use]
     pub fn enter_verb_in(self, state: &AppState) -> std::borrow::Cow<'static, str> {
-        // The daemon offer OWNS Enter while it is up: the composer beneath it
-        // has nothing to send to, so this is the only verb the key has. While a
-        // start is already out the key is a no-op, and the footer says nothing
-        // rather than advertising a second press that the offer declines.
-        if self == Self::Copilot && state.copilot_daemon_cta_open() {
-            return std::borrow::Cow::Borrowed(
-                if *state.daemon_start_cta.status() == crate::fleet::daemon_cta::CtaStatus::Starting
-                {
-                    ""
-                } else {
-                    START_DAEMON_VERB
-                },
-            );
+        // The daemon offer OWNS Enter while it is ARMED: the composer beneath it
+        // has nothing to send to, so this is the only verb the key has. Armed,
+        // not merely shown — focus elsewhere, or a start already out, and the
+        // key does nothing here, so neither may this say otherwise.
+        if self == Self::Copilot && state.copilot_daemon_cta_armed() {
+            return std::borrow::Cow::Borrowed(START_DAEMON_VERB);
         }
         let targets = state.broadcast_targets().len();
         if self == Self::Thread && targets > 0 {
@@ -1331,9 +1324,11 @@ mod tests {
     fn a_pane_offering_a_daemon_advertises_that_and_not_a_send() {
         let mut state = state_with(Vec::new(), true);
         state.session_tab = SessionTab::Copilot;
+        state.focused_pane = crate::app::state::FocusedPane::LiveLogs;
         with_daemon(&mut state, false, true);
 
         assert!(state.copilot_daemon_cta_open());
+        assert!(state.copilot_daemon_cta_armed());
         assert_eq!(SessionTab::Copilot.enter_verb_in(&state), START_DAEMON_VERB);
         let footer = footer_text(&state, SessionTab::Copilot, false);
         assert!(
@@ -1354,6 +1349,7 @@ mod tests {
     fn an_unreachable_daemon_that_is_still_running_is_not_offered_a_start() {
         let mut state = state_with(Vec::new(), true);
         state.session_tab = SessionTab::Copilot;
+        state.focused_pane = crate::app::state::FocusedPane::LiveLogs;
         with_daemon(&mut state, false, false);
 
         assert!(!state.hangar_daemon_not_running());
@@ -1373,6 +1369,7 @@ mod tests {
     fn a_pane_that_cannot_send_advertises_no_verb_at_all() {
         let mut state = state_with(Vec::new(), true);
         state.session_tab = SessionTab::Copilot;
+        state.focused_pane = crate::app::state::FocusedPane::LiveLogs;
         // Daemon UP: this is not the offer's case, it is the one where the
         // conversation opened and its scope never resolved.
         with_daemon(&mut state, true, false);
@@ -1439,6 +1436,68 @@ mod tests {
             "the conversation below must keep its rows:\n{painted}"
         );
     }
+
+    /// With focus on the session list, `Enter` is the LIST's. The offer stays
+    /// on screen, and the footer stops promising a key it will not get.
+    #[test]
+    fn the_offer_neither_claims_enter_nor_advertises_it_from_the_session_list() {
+        let mut state = state_with(Vec::new(), true);
+        state.session_tab = SessionTab::Copilot;
+        state.focused_pane = crate::app::state::FocusedPane::Sessions;
+        with_daemon(&mut state, false, true);
+
+        assert!(
+            state.copilot_daemon_cta_open(),
+            "the offer is still on screen beside the list"
+        );
+        assert!(
+            !state.copilot_daemon_cta_armed(),
+            "but Enter belongs to the list, so starting a daemon is not on it"
+        );
+        let footer = footer_text(&state, SessionTab::Copilot, false);
+        assert!(
+            !footer.contains(START_DAEMON_VERB),
+            "and the footer must not promise a key that goes elsewhere: {footer}"
+        );
+    }
+
+    /// A start already out disarms the key, so the footer stops advertising a
+    /// second press that the offer declines.
+    #[test]
+    fn a_start_in_flight_disarms_the_key_and_the_verb() {
+        let mut state = state_with(Vec::new(), true);
+        state.session_tab = SessionTab::Copilot;
+        state.focused_pane = crate::app::state::FocusedPane::LiveLogs;
+        with_daemon(&mut state, false, true);
+        assert!(state.copilot_daemon_cta_armed());
+
+        state.daemon_start_cta.start();
+        assert!(!state.copilot_daemon_cta_armed());
+        assert!(!footer_text(&state, SessionTab::Copilot, true).contains(START_DAEMON_VERB));
+    }
+
+    /// The tab the pane TICKS and the tab it PAINTS resolve to the same host.
+    ///
+    /// The render path ticks through `chat_host_for` (which needs `&mut`) and
+    /// then paints through `chat_host`, because the two borrows cannot be held
+    /// at once. That is only safe while the two resolve identically, so it is
+    /// pinned rather than assumed — reaching for `copilot_chat` at the render
+    /// site was the same fact written twice.
+    #[test]
+    fn ticking_a_tabs_host_and_painting_it_resolve_to_the_same_conversation() {
+        let mut state = state_with(Vec::new(), true);
+        state.workspaces[0].sessions[0].provider_session_id = Some("hook-sess-1".to_string());
+
+        for tab in ALL_TABS {
+            let ticked = state.chat_host_for(tab).map(std::ptr::from_ref);
+            let painted = state.chat_host(tab).map(std::ptr::from_ref);
+            assert_eq!(
+                ticked, painted,
+                "{tab:?} ticks one conversation and paints another"
+            );
+        }
+    }
+
     #[test]
     fn preview_and_copilot_are_never_disabled() {
         let state = state_with(Vec::new(), false);

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -105,27 +105,53 @@ impl SessionTab {
         if self == Self::Copilot && state.copilot_daemon_cta_armed() {
             return std::borrow::Cow::Borrowed(START_DAEMON_VERB);
         }
-        // A refused ask has NO verb. The footer is the last thing an operator
-        // reads before pressing the key, so "send answer" over a row that
-        // cannot send is the advertisement that makes the whole pane a lie —
-        // the same defect as a green tick over a failed send.
-        if self == Self::Ask
-            && selected_blocking(state).is_some_and(|chip| chip.answerable.refusal().is_some())
-        {
+        // A pane that cannot act advertises NO verb. The footer is the last
+        // thing an operator reads before pressing the key, so a verb over a
+        // pane that will decline it is the advertisement that makes the whole
+        // surface a lie — the same defect as a green tick over a failed send.
+        if self.enter_refusal(state).is_some() {
             return std::borrow::Cow::Borrowed("");
         }
         let targets = state.broadcast_targets().len();
         if self == Self::Thread && targets > 0 {
             return std::borrow::Cow::Owned(format!("broadcast to {targets}"));
         }
-        // A pane that cannot send advertises NO verb. `send message` printed
-        // over a composer reading "nothing to send to" is a footer promising a
-        // key that does nothing, which is the same dead end as a greyed chip
-        // with no reason — and it was on screen at the same time as the reason.
-        if state.session_tab_send_block(self).is_some() {
-            return std::borrow::Cow::Borrowed("");
-        }
         std::borrow::Cow::Borrowed(self.enter_verb())
+    }
+
+    /// Why `Enter` on this tab cannot do its ordinary job right now, in the
+    /// refusing surface's OWN words, or `None` when it can.
+    ///
+    /// ONE place, exhaustive over the tabs, rather than a branch per surface
+    /// that discovered the problem for itself. `ask` learned it from a native
+    /// picker it cannot answer and `thread`/`copilot` from a chat host with
+    /// nothing to send to, and those are the same rule wearing two faces: a
+    /// footer must never advertise a verb the pane will decline. Two adjacent
+    /// special cases invite a third, and the third is the one that gets
+    /// forgotten.
+    ///
+    /// Wildcard-free, so a sixth tab has to answer here rather than inherit
+    /// whichever arm happens to be last.
+    ///
+    /// The REASON, not a bool: both sources already have a sentence, and it is
+    /// the sentence the pane itself prints — dropping it at this boundary would
+    /// leave the footer and the pane deriving the same fact twice.
+    #[must_use]
+    pub fn enter_refusal(self, state: &AppState) -> Option<String> {
+        match self {
+            // Attaching asks nothing of the pane, and a history pane has no
+            // verb to refuse in the first place.
+            Self::Preview | Self::Log => None,
+            // The chip's own refusal. A native picker is answered in the
+            // agent's terminal, and nothing typed here ever reaches it.
+            Self::Ask => selected_blocking(state)
+                .and_then(|chip| chip.answerable.refusal())
+                .map(ToString::to_string),
+            // The LIVE conversation's answer, not an inference from the tab.
+            // `send_block` already yields to a broadcast, whose composer is not
+            // the chat host's and is never blocked by it.
+            Self::Thread | Self::Copilot => state.session_tab_send_block(self),
+        }
     }
 
     /// What `Enter` does on this tab. One sentence, shown in the footer, so the
@@ -1518,6 +1544,46 @@ mod tests {
                 ticked, painted,
                 "{tab:?} ticks one conversation and paints another"
             );
+        }
+    }
+
+    /// Both refusals go through the ONE predicate, in the refusing surface's
+    /// own words.
+    ///
+    /// They arrived as two adjacent special cases — an `ask` whose picker is
+    /// native, and a chat host with nothing to send to — and a third tab
+    /// needing this must extend the match rather than add a fourth branch to
+    /// the footer. Asserted on the REASON, so a predicate that answered `true`
+    /// for the wrong surface would not pass.
+    #[test]
+    fn one_predicate_carries_every_reason_a_tab_refuses_enter() {
+        use crate::fleet::attention::{Answerable, Unanswerable};
+
+        // The `ask` case, which landed on main: a native picker is answered in
+        // the agent's own terminal.
+        let mut refused = SessionAttention::local(AttentionKind::Ask, 0);
+        refused.answerable = Answerable::No(Unanswerable::NativePicker);
+        let mut state = state_with(vec![refused], true);
+        assert_eq!(
+            SessionTab::Ask.enter_refusal(&state).as_deref(),
+            Some(Unanswerable::NativePicker.reason()),
+            "the ask tab must carry the chip's own refusal, not a paraphrase"
+        );
+        assert_eq!(SessionTab::Ask.enter_verb_in(&state), "");
+
+        // The chat case: a copilot whose scope the daemon never minted.
+        state.session_tab = SessionTab::Copilot;
+        state.copilot_chat = Some(crate::fleet::chat_host::ChatHost::copilot());
+        with_daemon(&mut state, true, false);
+        assert!(
+            SessionTab::Copilot.enter_refusal(&state).is_some(),
+            "a copilot with no scope has nothing to send to"
+        );
+        assert_eq!(SessionTab::Copilot.enter_verb_in(&state), "");
+
+        // And the tabs with nothing to refuse say so rather than defaulting.
+        for tab in [SessionTab::Preview, SessionTab::Log] {
+            assert_eq!(tab.enter_refusal(&state), None, "{tab:?}");
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -48,6 +48,12 @@ pub const ALL_TABS: [SessionTab; 5] = [
     SessionTab::Log,
 ];
 
+/// What `Enter` does while the copilot pane is offering to start the daemon.
+///
+/// One constant, read by the footer, the offer's own key line and the key
+/// handler's test, so the three cannot advertise different things.
+pub const START_DAEMON_VERB: &str = "start the hangar daemon";
+
 impl SessionTab {
     /// The strip label as it renders RIGHT NOW.
     ///
@@ -92,12 +98,32 @@ impl SessionTab {
     /// than a dialog is to dismiss.
     #[must_use]
     pub fn enter_verb_in(self, state: &AppState) -> std::borrow::Cow<'static, str> {
+        // The daemon offer OWNS Enter while it is up: the composer beneath it
+        // has nothing to send to, so this is the only verb the key has. While a
+        // start is already out the key is a no-op, and the footer says nothing
+        // rather than advertising a second press that the offer declines.
+        if self == Self::Copilot && state.copilot_daemon_cta_open() {
+            return std::borrow::Cow::Borrowed(
+                if *state.daemon_start_cta.status() == crate::fleet::daemon_cta::CtaStatus::Starting
+                {
+                    ""
+                } else {
+                    START_DAEMON_VERB
+                },
+            );
+        }
         let targets = state.broadcast_targets().len();
         if self == Self::Thread && targets > 0 {
-            std::borrow::Cow::Owned(format!("broadcast to {targets}"))
-        } else {
-            std::borrow::Cow::Borrowed(self.enter_verb())
+            return std::borrow::Cow::Owned(format!("broadcast to {targets}"));
         }
+        // A pane that cannot send advertises NO verb. `send message` printed
+        // over a composer reading "nothing to send to" is a footer promising a
+        // key that does nothing, which is the same dead end as a greyed chip
+        // with no reason — and it was on screen at the same time as the reason.
+        if state.session_tab_send_block(self).is_some() {
+            return std::borrow::Cow::Borrowed("");
+        }
+        std::borrow::Cow::Borrowed(self.enter_verb())
     }
 
     /// What `Enter` does on this tab. One sentence, shown in the footer, so the
@@ -680,6 +706,72 @@ pub fn render_copilot(
     }
 }
 
+/// Render the copilot pane's offer to start the hangar daemon.
+///
+/// Replaces the conversation rather than annotating it, and that is the point:
+/// with no daemon there is no channel, no session and no timeline, so a
+/// composer under this would be a control that cannot act. The offer is
+/// answered HERE, with one key, instead of sending the operator to the Daemons
+/// screen to work out for themselves which row the copilot needs.
+///
+/// Every state says what it is. A start that failed keeps the key, because the
+/// remedy for "the port was busy" is to try again; a start that is out shows no
+/// key at all, so the offer cannot be fired twice into one home.
+pub fn render_copilot_daemon_cta(
+    frame: &mut Frame,
+    area: Rect,
+    cta: &crate::fleet::daemon_cta::DaemonStartCta,
+) {
+    use crate::fleet::daemon_cta::CtaStatus;
+    use ratatui::widgets::{Paragraph, Wrap};
+
+    let mut lines = vec![
+        Line::raw(""),
+        Line::styled(
+            " copilot needs the hangar daemon, which is not running.",
+            Style::default().fg(SOFT_WHITE).add_modifier(Modifier::BOLD),
+        ),
+        Line::raw(""),
+    ];
+    match cta.status() {
+        CtaStatus::Offered => lines.push(offer_line()),
+        CtaStatus::Starting => lines.push(Line::styled(
+            "   \u{25cf} starting the hangar daemon\u{2026}",
+            Style::default().fg(ALERT_AMBER),
+        )),
+        // The command's own closing line, never a paraphrase: `start` reports
+        // "already running" as a SUCCESS, and an operator still staring at this
+        // pane afterwards needs to read that rather than a tick.
+        CtaStatus::Reported { ok, detail } => {
+            lines.push(Line::styled(
+                format!("   {} {detail}", if *ok { "\u{2713}" } else { "\u{2717}" }),
+                Style::default().fg(if *ok { SELECTION_GREEN } else { ALERT_RED }),
+            ));
+            lines.push(Line::raw(""));
+            // The offer stands on BOTH outcomes. A start that exited zero and
+            // left this pane still asking for a daemon has not produced one,
+            // and withdrawing the key there would leave the operator with a
+            // green tick and nothing to press.
+            lines.push(offer_line());
+        }
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+}
+
+/// The key line, worded once so the two states that offer it cannot differ.
+fn offer_line() -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            "   \u{23ce}  ",
+            Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{START_DAEMON_VERB} now"),
+            Style::default().fg(SOFT_WHITE),
+        ),
+    ])
+}
+
 /// One setting row: label, value, and the key that cycles it.
 fn dial_row(label: &str, value: String, key: char, dim: bool) -> Line<'static> {
     Line::from(vec![
@@ -1060,6 +1152,96 @@ mod tests {
         state.selected_workspace_index = Some(0);
         state.selected_session_index = select.then_some(0);
         state
+    }
+
+    /// Everything the footer actually paints, as one line of text.
+    fn footer_text(state: &AppState, tab: SessionTab, capturing: bool) -> String {
+        footer(state, tab, capturing)
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    /// Put the attention poller's cell in the state it reaches when the socket
+    /// is dialled and nothing accepts.
+    fn with_daemon(state: &mut AppState, reachable: bool, not_running: bool) {
+        *state.daemon_attention.lock().unwrap() = crate::fleet::attention::DaemonAttention {
+            by_cwd: std::collections::HashMap::new(),
+            reachable,
+            error: (!reachable).then(|| "connect /x/hangar.sock: refused".to_string()),
+            not_running,
+        };
+    }
+
+    /// The footer's verb is the one the key fires. With no daemon that is the
+    /// offer, and `send message` — advertised over a pane that says "nothing to
+    /// send to" in the same breath — must be gone.
+    #[test]
+    fn a_pane_offering_a_daemon_advertises_that_and_not_a_send() {
+        let mut state = state_with(Vec::new(), true);
+        state.session_tab = SessionTab::Copilot;
+        with_daemon(&mut state, false, true);
+
+        assert!(state.copilot_daemon_cta_open());
+        assert_eq!(SessionTab::Copilot.enter_verb_in(&state), START_DAEMON_VERB);
+        let footer = footer_text(&state, SessionTab::Copilot, false);
+        assert!(
+            footer.contains(START_DAEMON_VERB),
+            "the footer must name the verb Enter fires: {footer}"
+        );
+        assert!(
+            !footer.contains("send message"),
+            "and must not still promise a send: {footer}"
+        );
+        // A pane with no conversation behind it is not a composer, or a key
+        // typed at it lands in one nothing paints.
+        assert!(!state.session_tab_owns_keys());
+        assert!(!state.session_composer_captures_text());
+    }
+
+    /// The offer appears ONLY for a daemon that is not there. A daemon that
+    /// answered the dial and then wedged is equally unreachable and must not be
+    /// offered a start: that would be a fresh lie on the surface the offer was
+    /// added to fix.
+    #[test]
+    fn an_unreachable_daemon_that_is_still_running_is_not_offered_a_start() {
+        let mut state = state_with(Vec::new(), true);
+        state.session_tab = SessionTab::Copilot;
+        with_daemon(&mut state, false, false);
+
+        assert!(!state.hangar_daemon_not_running());
+        assert!(!state.copilot_daemon_cta_open());
+        assert_ne!(SessionTab::Copilot.enter_verb_in(&state), START_DAEMON_VERB);
+
+        // And with the daemon up, nothing about this offer is on screen.
+        with_daemon(&mut state, true, false);
+        assert!(!state.copilot_daemon_cta_open());
+    }
+
+    /// The footer asks the LIVE pane whether it can send. A copilot that opened
+    /// against a daemon which never minted its channel says it cannot, and the
+    /// footer must not promise otherwise — that is the exact pairing an
+    /// operator saw: `⊘ nothing to send to` under `Enter send message`.
+    #[test]
+    fn a_pane_that_cannot_send_advertises_no_verb_at_all() {
+        let mut state = state_with(Vec::new(), true);
+        state.session_tab = SessionTab::Copilot;
+        // Daemon UP: this is not the offer's case, it is the one where the
+        // conversation opened and its scope never resolved.
+        with_daemon(&mut state, true, false);
+        state.copilot_chat = Some(crate::fleet::chat_host::ChatHost::copilot());
+
+        assert!(
+            state.session_tab_send_block(SessionTab::Copilot).is_some(),
+            "a copilot with no minted scope has nothing to send to"
+        );
+        assert_eq!(SessionTab::Copilot.enter_verb_in(&state), "");
+        let footer = footer_text(&state, SessionTab::Copilot, true);
+        assert!(
+            !footer.contains("Enter"),
+            "a footer with no verb must not print a bare Enter either: {footer}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/attention.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/attention.rs
@@ -385,6 +385,18 @@ pub struct DaemonAttention {
     pub reachable: bool,
     /// Why the last poll failed, for the one banner line the header shows.
     pub error: Option<String>,
+    /// `true` when that failure means NOTHING IS SERVING the socket, so
+    /// starting a daemon is the remedy a surface may offer.
+    ///
+    /// Carried separately from [`Self::reachable`] because the two answer
+    /// different questions and only one of them licenses an offer. A daemon
+    /// that is up but wedged is equally unreachable, and a surface that read
+    /// only the flag above would offer to start a process that is already
+    /// running. Classified from the typed [`DaemonError`] at the poll, never
+    /// from its wording.
+    ///
+    /// [`DaemonError`]: crate::fleet::bridge::daemon::DaemonError
+    pub not_running: bool,
 }
 
 impl DaemonAttention {
@@ -395,6 +407,7 @@ impl DaemonAttention {
             by_cwd,
             reachable: true,
             error: None,
+            not_running: false,
         }
     }
 
@@ -412,15 +425,23 @@ impl DaemonAttention {
     /// successful poll drops it. That is the safe direction: it is unanswerable
     /// from here for as long as it lingers, and the alternative is a live
     /// request disappearing because one socket read timed out.
+    ///
+    /// `not_running` is the caller's classification of the TYPED failure
+    /// (`DaemonError::means_not_running`), passed explicitly rather than
+    /// defaulted: it is the only thing licensing a "start the daemon" offer,
+    /// and a call site that forgot it would be offering to start a daemon that
+    /// is answering.
     #[must_use]
     pub fn down(
         previous: std::collections::HashMap<String, Vec<SessionAttention>>,
         error: String,
+        not_running: bool,
     ) -> Self {
         Self {
             by_cwd: previous,
             reachable: false,
             error: Some(error),
+            not_running,
         }
     }
 
@@ -613,7 +634,7 @@ mod tests {
         // then the daemon is gone. With nothing to carry forward the merge sees
         // only the local row and the surface keeps working — which is the whole
         // point of reading notifyd off disk.
-        let down = DaemonAttention::down(std::collections::HashMap::new(), "refused".into());
+        let down = DaemonAttention::down(std::collections::HashMap::new(), "refused".into(), true);
         assert!(down.rows_for("/work/proj").is_empty());
         let mut chips = vec![SessionAttention::local(AttentionKind::Ask, 1_000)];
         chips.extend(down.rows_for("/work/proj").iter().cloned());
@@ -636,7 +657,7 @@ mod tests {
                 "att-1".into(),
             )],
         );
-        let down = DaemonAttention::down(by_cwd, "refused".into());
+        let down = DaemonAttention::down(by_cwd, "refused".into(), true);
         let chips = normalise(down.rows_for("/work/proj").to_vec());
         assert_eq!(chips.len(), 1);
         assert!(

--- a/ainb-tui/crates/ainb-core/src/fleet/attention_poll.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/attention_poll.rs
@@ -92,17 +92,32 @@ async fn poll_once(last_good: &HashMap<String, Vec<SessionAttention>>) -> Daemon
         Ok(client) => client,
         // Not an error worth a banner: no hangar home configured is the normal
         // state of a host that never ran the daemon.
-        Err(error) => return DaemonAttention::down(last_good.clone(), error.to_string()),
+        //
+        // The classification travels WITH the reason, from the typed error
+        // rather than its wording: this cell is the host's only off-thread
+        // answer to "is there a daemon at all", and the copilot pane's offer to
+        // start one is only honest if that answer is.
+        Err(error) => {
+            return DaemonAttention::down(
+                last_good.clone(),
+                error.to_string(),
+                error.means_not_running(),
+            );
+        }
     };
     let socket = client.socket().display().to_string();
     match client.attention_list_fleet().await {
         Ok(rows) => DaemonAttention::up(group_by_cwd(&rows)),
         // Name the socket. "attention/list failed" without it leaves the
         // operator guessing which daemon, which home, which socket.
-        Err(error) => DaemonAttention::down(
-            last_good.clone(),
-            format!("attention/list via {socket}: {error}"),
-        ),
+        Err(error) => {
+            let not_running = error.means_not_running();
+            DaemonAttention::down(
+                last_good.clone(),
+                format!("attention/list via {socket}: {error}"),
+                not_running,
+            )
+        }
     }
 }
 
@@ -329,6 +344,7 @@ mod tests {
         let down = DaemonAttention::down(
             previous,
             "attention/list via /x/hangar.sock: refused".into(),
+            true,
         );
         assert!(!down.reachable);
         assert_eq!(
@@ -344,7 +360,7 @@ mod tests {
 
     #[test]
     fn a_daemon_that_never_answered_has_nothing_to_carry_forward() {
-        let down = DaemonAttention::down(HashMap::new(), "no hangar home".into());
+        let down = DaemonAttention::down(HashMap::new(), "no hangar home".into(), false);
         assert!(down.rows_for("/work/proj").is_empty());
     }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/daemon_cta.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemon_cta.rs
@@ -1,0 +1,196 @@
+// ABOUTME: The copilot pane's offer to start the hangar daemon it needs, and
+// what that start actually reported.
+//
+// The pane it sits on can only fail one way that an operator can fix from the
+// keyboard: the daemon behind every one of its four calls is not running. Every
+// other failure is the daemon's own words, and this offers nothing for those —
+// a key that starts a second daemon while the first is merely slow is a worse
+// surface than the error it replaced.
+//
+// It owns no lifecycle of its own. The start is the SAME `ainb daemon
+// hangar-daemon start` the Daemons screen shells, through the same function, so
+// the two cannot drift in what they run or in what they report having run.
+
+use std::sync::{Arc, Mutex};
+
+use crate::cli::daemon::Action;
+use crate::components::daemons::{ActionOutcome, run_daemon_action};
+
+/// The stable id of the daemon this offer starts, as `ainb daemon <id>` spells
+/// it.
+///
+/// Read off [`crate::fleet::daemons::probe::DaemonKind`] rather than written
+/// out, so a rename of the CLI verb cannot leave this offer shelling a name
+/// that no longer resolves.
+fn hangar_daemon_id() -> &'static str {
+    crate::fleet::daemons::probe::DaemonKind::HangarDaemon.id()
+}
+
+/// What the offer is doing.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CtaStatus {
+    /// Nothing attempted yet: the pane advertises the key.
+    #[default]
+    Offered,
+    /// A start is out. The pane advertises nothing while it is.
+    Starting,
+    /// The start returned. `ok` is the exit status, `detail` is what it said.
+    ///
+    /// Kept even when `ok` is true, because a successful `start` on a home that
+    /// already has an owner reports "already running" — which is the sentence
+    /// an operator needs when the pane is still asking for a daemon afterwards.
+    Reported {
+        /// Whether the command exited zero.
+        ok: bool,
+        /// The command's own closing line, never a paraphrase.
+        detail: String,
+    },
+}
+
+/// The offer's state and its in-flight start.
+#[derive(Debug, Default)]
+pub struct DaemonStartCta {
+    status: CtaStatus,
+    inbox: Arc<Mutex<Option<ActionOutcome>>>,
+}
+
+impl DaemonStartCta {
+    /// What the offer is doing right now.
+    #[must_use]
+    pub const fn status(&self) -> &CtaStatus {
+        &self.status
+    }
+
+    /// Fold a finished start in.
+    ///
+    /// Returns `true` when anything changed, so the caller marks the frame
+    /// dirty without diffing the pane.
+    pub fn tick(&mut self) -> bool {
+        let landed = self.inbox.lock().map_or_else(
+            |poisoned| poisoned.into_inner().take(),
+            |mut inbox| inbox.take(),
+        );
+        let Some(outcome) = landed else {
+            return false;
+        };
+        // The LAST non-empty line of everything the command said, which is the
+        // same line the Daemons screen badges a row with. The full transcript
+        // is in that screen's error view; repeating it inside a chat pane would
+        // bury the conversation under a daemon log.
+        let detail = if outcome.ok {
+            outcome.summary
+        } else {
+            outcome
+                .detail
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or("(the command said nothing)")
+                .trim()
+                .to_string()
+        };
+        self.status = CtaStatus::Reported {
+            ok: outcome.ok,
+            detail,
+        };
+        true
+    }
+
+    /// Start the hangar daemon on a detached worker.
+    ///
+    /// A no-op while one is already out, so key-repeat cannot spawn a second
+    /// start into a home the first one is mid-way through taking.
+    ///
+    /// Every exit path publishes SOMETHING, including a worker that could not
+    /// be spawned: an offer that swallowed its own failure would leave the pane
+    /// on `starting…` forever, which is the never-resolving spinner this whole
+    /// surface exists to remove.
+    pub fn start(&mut self) {
+        if self.status == CtaStatus::Starting {
+            return;
+        }
+        self.status = CtaStatus::Starting;
+        let inbox = Arc::clone(&self.inbox);
+        let publish_inbox = Arc::clone(&inbox);
+        let spawned = std::thread::Builder::new().name("ainb-daemon-cta".into()).spawn(move || {
+            let outcome = run_daemon_action(hangar_daemon_id(), Action::Start.id(), Action::Start);
+            if let Ok(mut cell) = publish_inbox.lock() {
+                *cell = Some(outcome);
+            }
+        });
+        if let Err(error) = spawned {
+            self.status = CtaStatus::Reported {
+                ok: false,
+                detail: format!("the start worker did not start: {error}"),
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(ok: bool, summary: &str, detail: &str) -> ActionOutcome {
+        ActionOutcome {
+            action: Action::Start,
+            ok,
+            summary: summary.to_string(),
+            detail: detail.to_string(),
+        }
+    }
+
+    /// An offer with nothing landed advertises the key and says nothing else.
+    #[test]
+    fn a_fresh_offer_is_offered_and_a_tick_over_an_empty_inbox_changes_nothing() {
+        let mut cta = DaemonStartCta::default();
+        assert_eq!(cta.status(), &CtaStatus::Offered);
+        assert!(!cta.tick(), "an empty inbox must not dirty the frame");
+        assert_eq!(cta.status(), &CtaStatus::Offered);
+    }
+
+    /// A start that failed reports the command's OWN closing line. A start that
+    /// "worked" still reports what it said, because `already running` is a
+    /// success the operator has to read.
+    #[test]
+    fn a_landed_start_reports_what_the_command_said() {
+        let mut cta = DaemonStartCta::default();
+        *cta.inbox.lock().unwrap() = Some(outcome(
+            false,
+            "start failed",
+            "cmd: ainb daemon hangar-daemon start\nexit: exit status: 1\n\nstderr:\nrefusing to \
+             self-exec a cargo test binary",
+        ));
+        assert!(cta.tick());
+        assert_eq!(
+            cta.status(),
+            &CtaStatus::Reported {
+                ok: false,
+                detail: "refusing to self-exec a cargo test binary".to_string(),
+            },
+            "a failed start must carry the command's last word, not a paraphrase"
+        );
+
+        let mut cta = DaemonStartCta::default();
+        *cta.inbox.lock().unwrap() = Some(outcome(true, "already running (pid 4242)", "cmd: …"));
+        assert!(cta.tick());
+        assert_eq!(
+            cta.status(),
+            &CtaStatus::Reported {
+                ok: true,
+                detail: "already running (pid 4242)".to_string(),
+            }
+        );
+    }
+
+    /// The id this shells is the DaemonKind's, so the offer and the Daemons
+    /// screen address one daemon.
+    #[test]
+    fn the_offer_addresses_the_daemon_the_daemons_screen_does() {
+        assert_eq!(hangar_daemon_id(), "hangar-daemon");
+        assert!(
+            crate::cli::daemon::kind_from_id(hangar_daemon_id()).is_some(),
+            "the offer must shell a daemon id `ainb daemon` can resolve"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/daemon_cta.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/daemon_cta.rs
@@ -51,6 +51,13 @@ pub enum CtaStatus {
 #[derive(Debug, Default)]
 pub struct DaemonStartCta {
     status: CtaStatus,
+    /// Whether the daemon was down the last time anything looked.
+    ///
+    /// `None` until the first look. Kept so a REPORT can be retired when the
+    /// outage it belongs to ends: this offer is one per process, so without it
+    /// the pane reopens on the next outage still showing the tick from the
+    /// last one.
+    last_seen_down: Option<bool>,
     inbox: Arc<Mutex<Option<ActionOutcome>>>,
 }
 
@@ -94,6 +101,38 @@ impl DaemonStartCta {
             detail,
         };
         true
+    }
+
+    /// Fold in what the daemon's liveness now looks like.
+    ///
+    /// A [`CtaStatus::Reported`] describes ONE start, against the outage that
+    /// prompted it. Any change in whether the daemon is there ends that outage,
+    /// so the report stops being current and the offer goes back to plain
+    /// [`CtaStatus::Offered`]. Without this the pane reopens on the NEXT outage
+    /// still claiming `✓ already running (pid 4242)` about a daemon that is
+    /// down right now — a stale success is worse than no report at all,
+    /// because an operator reads it as this outage's.
+    ///
+    /// Called from the attention refresh rather than from the pane, so a cycle
+    /// that happened while the operator was on another tab is still observed:
+    /// the refresh reads the poller's cell every tick, far faster than the
+    /// poller can change it.
+    ///
+    /// A start still IN FLIGHT is left alone. Its own landing is what retires
+    /// it, and clearing it here would lose the report the operator pressed for.
+    ///
+    /// Returns `true` when the offer changed, so the caller marks the frame
+    /// dirty.
+    pub fn observe_daemon(&mut self, down: bool) -> bool {
+        if self.last_seen_down == Some(down) {
+            return false;
+        }
+        self.last_seen_down = Some(down);
+        if matches!(self.status, CtaStatus::Reported { .. }) {
+            self.status = CtaStatus::Offered;
+            return true;
+        }
+        false
     }
 
     /// Start the hangar daemon on a detached worker.
@@ -181,6 +220,48 @@ mod tests {
                 detail: "already running (pid 4242)".to_string(),
             }
         );
+    }
+
+    /// A report belongs to ONE outage. The next one must not open still
+    /// showing the last one's tick.
+    ///
+    /// This offer is one per process, so without retiring the report the pane
+    /// reopens on a daemon that is down RIGHT NOW while claiming a success from
+    /// a cycle the operator may not even remember.
+    #[test]
+    fn a_report_does_not_survive_into_the_next_outage() {
+        let mut cta = DaemonStartCta::default();
+        // The outage that prompted the start, then the start landing.
+        assert!(
+            !cta.observe_daemon(true),
+            "the first look reports no change"
+        );
+        *cta.inbox.lock().unwrap() = Some(outcome(true, "already running (pid 4242)", "cmd: …"));
+        cta.tick();
+        assert!(matches!(cta.status(), CtaStatus::Reported { ok: true, .. }));
+
+        // The daemon comes up, then goes down again: the pane reopens on a
+        // clean offer, not on the last outage's tick.
+        let cleared = cta.observe_daemon(false);
+        cta.observe_daemon(true);
+        assert_eq!(
+            cta.status(),
+            &CtaStatus::Offered,
+            "the offer reopened carrying the previous outage's result"
+        );
+        assert!(cleared, "and retiring it must dirty the frame");
+    }
+
+    /// A start still in flight is not retired by a liveness reading. Its own
+    /// landing is what resolves it, and clearing it here would lose the report
+    /// the operator pressed for.
+    #[test]
+    fn a_start_in_flight_survives_a_liveness_change() {
+        let mut cta = DaemonStartCta::default();
+        cta.observe_daemon(true);
+        cta.status = CtaStatus::Starting;
+        assert!(!cta.observe_daemon(false));
+        assert_eq!(cta.status(), &CtaStatus::Starting);
     }
 
     /// The id this shells is the DaemonKind's, so the offer and the Daemons

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -27,6 +27,7 @@ pub mod broadcast;
 pub mod chat_host;
 pub mod control;
 pub mod copilot_dial;
+pub mod daemon_cta;
 pub mod daemons;
 pub mod plumbing;
 pub mod read;

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_copilot_daemon_cta.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_copilot_daemon_cta.rs
@@ -1,0 +1,396 @@
+//! Tripwire: the copilot pane names the daemon it needs, offers to start it,
+//! and stops advertising a send it cannot perform.
+//!
+//! Three claims, and only a real screen with a real STOPPED daemon settles any
+//! of them:
+//!
+//! 1. **The cause is the headline, not a suffix.** The reason the copilot did
+//!    not open used to arrive tacked onto an unrelated sentence ("no copilot
+//!    session yet, nothing to send to · daemon timed out after 5s"), leaving an
+//!    operator to already know that "daemon" meant the hangar daemon, that it
+//!    can be started, and where.
+//! 2. **The remedy is on the pane.** One key, answered in place. Sending the
+//!    operator to another screen to find the row that starts it is the dead end
+//!    this replaces.
+//! 3. **The footer stops lying.** `Enter send message` was advertised on a pane
+//!    that said "nothing to send to" in the same breath. A surface must never
+//!    offer an action it cannot perform.
+//!
+//! Deliberately UNSEEDED beyond an isolated `$HOME`: no hangar home is
+//! requested, so the TUI's own autostart declines the ephemeral home and no
+//! daemon exists anywhere. That is exactly the state an operator hits on a
+//! fresh install, and it is the only state in which this offer may appear.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// The pane's headline, as `session_tabs::render_copilot_daemon_cta` writes it.
+const CTA_HEADLINE: &str = "copilot needs the hangar daemon, which is not running.";
+/// The verb the footer and the pane's key line must agree on
+/// (`session_tabs::START_DAEMON_VERB`).
+const START_VERB: &str = "start the hangar daemon";
+/// The footer's old promise, which must be gone from this pane.
+const LYING_FOOTER: &str = "Enter send message";
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A tmux session killed by EXACT name on drop.
+struct ExactTmuxSession {
+    name: String,
+}
+
+impl ExactTmuxSession {
+    fn create(name: String, command: &[&str]) -> Self {
+        let mut args: Vec<String> =
+            ["new-session", "-d", "-s"].iter().map(|a| (*a).to_string()).collect();
+        args.push(name.clone());
+        args.extend(["-x", "200", "-y", "50"].iter().map(|a| (*a).to_string()));
+        args.extend(command.iter().map(|part| (*part).to_string()));
+        let status = Command::new("tmux").args(&args).status().expect("tmux new-session");
+        assert!(status.success(), "tmux new-session {name} failed");
+        Self { name }
+    }
+}
+
+impl Drop for ExactTmuxSession {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={}", self.name)])
+            .status();
+    }
+}
+
+/// Stops whatever daemon this test's own Enter press started, in the home it
+/// started it in.
+///
+/// The offer under test really starts a daemon, so the test really has to take
+/// it back down. By `ainb hangar daemon stop` under this `$HOME`, never by
+/// killing a pid read from anywhere else: the home is temporary and the stop
+/// verb is home-scoped, so nothing outside it can be reached.
+struct StopDaemonOnDrop {
+    home: PathBuf,
+}
+
+impl Drop for StopDaemonOnDrop {
+    fn drop(&mut self) {
+        let out = Command::new(ainb_bin())
+            .args(["hangar", "daemon", "stop"])
+            .env("HOME", &self.home)
+            .env("AINB_DISABLE_PLUGINS", "1")
+            .output();
+        if let Ok(out) = out {
+            eprintln!(
+                "cleanup: hangar daemon stop -> {} {}",
+                out.status,
+                String::from_utf8_lossy(&out.stdout).trim()
+            );
+        }
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn send_key(session: &str, key: &str) {
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+    assert!(status.success(), "tmux send-keys {key:?} failed");
+}
+
+fn poll<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Press `key` until `arrived`, then stop pressing and keep polling for `ok`.
+fn poll_until<F, G>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut arrived: G,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+    G: FnMut(&str) -> bool,
+{
+    let mut on_screen = false;
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        on_screen = on_screen || arrived(&cap);
+        if !on_screen {
+            send_key(session, key);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Press `key` up to `attempts` times, stopping as soon as `ok` holds.
+///
+/// Re-checks between presses: the attention poller decides whether this pane
+/// shows the offer at all, and it answers a socket rather than a memo, so the
+/// pane takes more than one repaint to settle.
+fn press_until<F>(
+    session: &str,
+    key: &str,
+    attempts: usize,
+    mut ok: F,
+) -> Result<String, Vec<String>>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut seen = Vec::new();
+    for _ in 0..attempts {
+        for _ in 0..6 {
+            let cap = capture_pane(session);
+            if ok(&cap) {
+                return Ok(cap);
+            }
+            if seen.last() != Some(&cap) {
+                seen.push(cap);
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        send_key(session, key);
+    }
+    Err(seen)
+}
+
+fn init_git_repo(dir: &Path) {
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "tripwire")
+            .env("GIT_AUTHOR_EMAIL", "tripwire@example.invalid")
+            .env("GIT_COMMITTER_NAME", "tripwire")
+            .env("GIT_COMMITTER_EMAIL", "tripwire@example.invalid")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init", "--initial-branch=main"]);
+    fs::write(dir.join("README.md"), "daemon cta fixture\n").expect("seed a file");
+    git(&["add", "README.md"]);
+    git(&["-c", "commit.gpgsign=false", "commit", "-m", "seed"]);
+}
+
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            "completed = true\n\
+             completed_at = \"2026-09-04T00:00:00+00:00\"\n\
+             version = \"{ver}\"\n\
+             skipped_dependencies = []\n\
+             git_directories = []\n",
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+    fs::write(
+        base.join("install.json"),
+        r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
+    )
+    .expect("seed install.json");
+}
+
+fn seed_session_registry(home: &Path, tmux_name: &str, worktree: &Path) {
+    let entry = serde_json::json!({
+        "sessions": {
+            tmux_name: {
+                "session_id": "6f1f5f7e-0000-4000-8000-0000000000d1",
+                "tmux_session_name": tmux_name,
+                "worktree_path": worktree,
+                "workspace_name": "daemoncta",
+                "created_at": "2026-09-04T00:00:00Z",
+                "agent_type": "Claude",
+                "skip_permissions": true,
+            }
+        }
+    });
+    fs::write(
+        home.join(".agents-in-a-box").join("sessions.json"),
+        serde_json::to_vec_pretty(&entry).expect("encode sessions.json"),
+    )
+    .expect("seed sessions.json");
+}
+
+#[test]
+fn the_copilot_pane_offers_to_start_the_daemon_it_needs_and_starts_it() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-dcta-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    let home = home_tmp.path();
+    seed_isolated_home(home);
+    // Armed BEFORE the TUI launches, so a daemon started by the key press below
+    // is taken back down even if an assertion after it fails.
+    let _stop_daemon = StopDaemonOnDrop {
+        home: home.to_path_buf(),
+    };
+
+    let pid = std::process::id();
+    let worktree = home.join("daemoncta");
+    fs::create_dir_all(&worktree).expect("create worktree dir");
+    init_git_repo(&worktree);
+    let agent_tmux = format!("tmux_dcta_{pid}");
+    seed_session_registry(home, &agent_tmux, &worktree);
+    let _pane = ExactTmuxSession::create(agent_tmux, &["sh", "-c", "sleep 900"]);
+
+    let tui_tmux = format!("tripwire-dcta-{pid}");
+    let tui = ExactTmuxSession::create(tui_tmux.clone(), &[]);
+    // NO `AINB_HANGAR_HOME`. The home then derives under this temporary `$HOME`
+    // and was never asked for, so `ensure_hangar_daemon` declines it and the
+    // TUI comes up with no daemon at all — the state under test.
+    let launch = format!(
+        "HOME={home} AINB_DISABLE_PLUGINS=1 exec {bin} tui",
+        home = home.display(),
+        bin = ainb_bin().display()
+    );
+    assert!(
+        Command::new("tmux")
+            .args(["send-keys", "-t", &tui_tmux, &launch, "Enter"])
+            .status()
+            .expect("launch ainb tui")
+            .success(),
+        "tmux refused the launch command"
+    );
+
+    assert!(
+        poll(&tui_tmux, Instant::now() + Duration::from_secs(90), |c| {
+            c.contains("Sessions") && c.contains("[s]")
+        })
+        .is_some(),
+        "HomeScreen never rendered:\n{}",
+        capture_pane(&tui_tmux)
+    );
+    assert!(
+        poll_until(
+            &tui_tmux,
+            "s",
+            Instant::now() + Duration::from_secs(90),
+            |c| c.contains("Workspaces ("),
+            // The STRIP, not the bare word: the home screen's Recent line
+            // carries the workspace name, so a loose match can fire before `s`
+            // is ever pressed.
+            |c| c.contains("preview") && c.contains("copilot"),
+        )
+        .is_some(),
+        "the sessions screen never rendered:\n{}",
+        capture_pane(&tui_tmux)
+    );
+
+    // Walk to the copilot tab. Matched on the offer's own headline, because
+    // that is the whole claim: this pane must name the hangar daemon, on its
+    // own line, rather than trailing it off the end of a sentence about having
+    // nothing to send to.
+    let offered = press_until(&tui_tmux, "Tab", 8, |c| c.contains(CTA_HEADLINE)).unwrap_or_else(
+        |seen| {
+            panic!(
+                "Tab never reached a copilot pane naming the daemon. Panes visited:\n  {}\n---\n{}\n---",
+                seen.iter()
+                    .filter_map(|cap| cap.lines().nth(4))
+                    .map(str::trim)
+                    .collect::<Vec<_>>()
+                    .join("\n  "),
+                capture_pane(&tui_tmux)
+            )
+        },
+    );
+
+    // The remedy is ON the pane, with the key next to it.
+    assert!(
+        offered.contains(START_VERB) && offered.contains('\u{23ce}'),
+        "the pane must offer the start with the key that fires it, not merely \
+         diagnose:\n{offered}"
+    );
+
+    // Claim 3: the footer stops promising a send. Both halves are asserted —
+    // the lie is gone AND the verb that replaced it is the one on the pane, so
+    // a footer that simply dropped every verb would not pass either.
+    assert!(
+        !offered.contains(LYING_FOOTER),
+        "the footer still advertises `{LYING_FOOTER}` on a pane with nothing to \
+         send to:\n{offered}"
+    );
+    assert!(
+        offered.contains("Enter") && offered.contains(START_VERB),
+        "the footer must name the verb Enter actually fires here:\n{offered}"
+    );
+
+    // THE remedy: one key, answered in place. The proof is the offer going
+    // away — the pane only shows it while the poller reports a socket with
+    // nothing behind it, so a copilot header appearing here means a daemon
+    // really came up and really answered.
+    send_key(&tui_tmux, "Enter");
+    let settled = poll(&tui_tmux, Instant::now() + Duration::from_secs(90), |c| {
+        !c.contains(CTA_HEADLINE) || c.contains('\u{2717}')
+    })
+    .unwrap_or_else(|| capture_pane(&tui_tmux));
+    assert!(
+        !settled.contains('\u{2717}'),
+        "the start did not land, and the pane says so — which is the honest \
+         reporting half working, but the start itself failed:\n{settled}"
+    );
+    assert!(
+        !settled.contains(CTA_HEADLINE),
+        "Enter must actually start the daemon, not merely report that it \
+         tried:\n{settled}"
+    );
+    // And what replaces it is the copilot pane proper, dials and all, rather
+    // than a blank box.
+    let opened = poll(&tui_tmux, Instant::now() + Duration::from_secs(60), |c| {
+        c.contains("\u{25c0} \u{2325}e") && c.contains("\u{25c0} \u{2325}g")
+    });
+    assert!(
+        opened.is_some(),
+        "the started daemon must hand the operator the real copilot pane:\n{}",
+        capture_pane(&tui_tmux)
+    );
+
+    drop(tui);
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_copilot_daemon_cta.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_copilot_daemon_cta.rs
@@ -11,7 +11,8 @@
 //!    can be started, and where.
 //! 2. **The remedy is on the pane.** One key, answered in place. Sending the
 //!    operator to another screen to find the row that starts it is the dead end
-//!    this replaces.
+//!    this replaces. INSERTED beside the dial header, never in place of it:
+//!    those dials are the other recovery this pane already offered.
 //! 3. **The footer stops lying.** `Enter send message` was advertised on a pane
 //!    that said "nothing to send to" in the same breath. A surface must never
 //!    offer an action it cannot perform.
@@ -27,7 +28,7 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
-/// The pane's headline, as `session_tabs::render_copilot_daemon_cta` writes it.
+/// The pane's headline, as `session_tabs::daemon_offer_lines` writes it.
 const CTA_HEADLINE: &str = "copilot needs the hangar daemon, which is not running.";
 /// The verb the footer and the pane's key line must agree on
 /// (`session_tabs::START_DAEMON_VERB`).
@@ -341,6 +342,18 @@ fn the_copilot_pane_offers_to_start_the_daemon_it_needs_and_starts_it() {
             )
         },
     );
+
+    // ADDITIVE, and this is the half CI caught when it was not: the offer is
+    // INSERTED. The dial header a daemon-down copilot pane already had is still
+    // there, with the keys that turn it — those dials are how an operator
+    // recovers from an adapter that will not spawn, and replacing them with one
+    // sentence takes a working surface away to add another.
+    for key in ["\u{2325}e", "\u{2325}o", "\u{2325}g"] {
+        assert!(
+            offered.contains(key),
+            "the offer replaced the dial header instead of joining it: `{key}` gone:\n{offered}"
+        );
+    }
 
     // The remedy is ON the pane, with the key next to it.
     assert!(

--- a/ainb-tui/crates/ainb-hangar-client/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-client/src/lib.rs
@@ -84,6 +84,41 @@ pub enum DaemonError {
     Decode(String),
 }
 
+impl DaemonError {
+    /// Whether this failure means NOTHING IS SERVING, so starting a daemon is
+    /// the fix.
+    ///
+    /// The distinction a caller offering a "start the daemon" action needs, and
+    /// the reason it is decided here rather than by reading the `Display` text:
+    /// a surface that offers to start a daemon which is already running, and
+    /// merely slow or wedged, is a lie of exactly the kind the offer exists to
+    /// remove.
+    ///
+    /// Wildcard-free, so a new variant has to declare which side it falls on
+    /// instead of inheriting "not running" from whichever arm is last.
+    ///
+    /// * [`Self::Connect`] is the unambiguous case: the socket was dialled and
+    ///   nothing accepted.
+    /// * [`Self::Token`] fails BEFORE any dial. The token file is written by
+    ///   the daemon's own start path, so an unreadable one is the never-started
+    ///   host. A token that a start genuinely cannot fix (one owned by another
+    ///   user) is indistinguishable from here, and the start reports its own
+    ///   refusal verbatim rather than this guessing on its behalf.
+    /// * [`Self::NoHome`] is NOT it: there is no hangar home to serve, and no
+    ///   daemon start creates one.
+    /// * Everything else means something ANSWERED — slowly, wrongly, or with a
+    ///   frame this build could not decode. A second daemon is not the remedy.
+    #[must_use]
+    pub const fn means_not_running(&self) -> bool {
+        match self {
+            Self::Token(_) | Self::Connect { .. } => true,
+            Self::NoHome | Self::Io(_) | Self::Timeout(_) | Self::Rpc { .. } | Self::Decode(_) => {
+                false
+            }
+        }
+    }
+}
+
 /// The daemon unix socket path (`{hangar_home}/hangar.sock`).
 #[must_use]
 pub fn socket_path() -> Option<PathBuf> {
@@ -810,6 +845,40 @@ mod tests {
     use super::*;
     use ainb_hangar_proto::fleet::{FleetEvent, FleetProvenance};
     use tokio::net::UnixListener;
+
+    /// The one classification a "start the daemon" offer is allowed to rest on.
+    ///
+    /// A timeout is the case this exists to exclude: the daemon answered the
+    /// dial and then took too long, so it IS running and offering to start it
+    /// would put a second lie on the surface the offer was added to fix.
+    #[test]
+    fn only_a_dead_socket_and_a_missing_token_read_as_not_running() {
+        assert!(
+            DaemonError::Connect {
+                path: "/tmp/hangar.sock".to_string(),
+                source: std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+            }
+            .means_not_running()
+        );
+        assert!(DaemonError::Token("No such file or directory".to_string()).means_not_running());
+
+        for answered in [
+            DaemonError::Timeout(Duration::from_secs(5)),
+            DaemonError::Io("broken pipe".to_string()),
+            DaemonError::Rpc {
+                code: -32601,
+                message: "method not found".to_string(),
+            },
+            DaemonError::Decode("unknown field".to_string()),
+            // No home to serve: no start creates one.
+            DaemonError::NoHome,
+        ] {
+            assert!(
+                !answered.means_not_running(),
+                "{answered} must not be read as a stopped daemon"
+            );
+        }
+    }
 
     async fn write_test_frame(writer: &mut OwnedWriteHalf, value: &Value) {
         let body = serde_json::to_vec(value).expect("test frame serializes");


### PR DESCRIPTION
## The problem

The copilot tab failed with the cause buried and a footer that lied about it:

```
Fleet chat · #copilot · channel:01M1PM15FGSWD4JMCVVJYX8SQ2
LIVE · 0 messages · copilot not started: daemon timed out after 5s

⊘ tessdf
no copilot session yet, nothing to send to
⇥ tab | Enter send message | ⇧⇥ focus | Esc leave
```

Two defects. The reason is tacked onto an unrelated sentence, so an operator has to
already know that "daemon" means the hangar daemon, that it can be started, and where.
And the footer advertises `Enter send message` on a pane that says "nothing to send to"
in the same breath.

## What this does

When the hangar daemon is **not running**, the copilot pane says so and offers the fix,
answered in place. The offer is INSERTED between the dial header and the conversation,
never in place of either — both still have something true to say with the daemon down:

```
 copilot needs the hangar daemon, which is not running.

   ⏎  start the hangar daemon now
```

Enter really starts it, through the same `ainb daemon hangar-daemon start` runner the
Daemons screen shells (`components::daemons::run_daemon_action`), on a detached worker,
and reports the command's own closing line verbatim on failure. The offer clears when a
daemon comes up and answers, and the real copilot pane takes its place.

Separately, the footer now asks the live pane whether it can send, so `Enter send message`
disappears from any conversation tab that is blocked — including the screenshot's case,
where the daemon was up and the ACP session mint had timed out.

## How "daemon down" is distinguished

Not from the error wording. `DaemonError::means_not_running` is a wildcard-free match on
the typed error, classified at the attention poller (which already dials the socket every
five seconds off the UI thread):

- `Connect { .. }` — the socket was dialled and nothing accepted → offer the start
- `Token(_)` — fails before any dial; the token is written by the daemon's own start path
- `Timeout`, `Io`, `Rpc`, `Decode` — something ANSWERED → **no offer**
- `NoHome` — there is no hangar home to serve, and no start creates one → **no offer**

So the screenshot's own failure (`daemon timed out after 5s`, on a daemon that was up and
had already answered `channel_list` and `message_list`) gets the honest footer fix and
**not** the start offer. Offering to start a daemon that is running would be a new lie on
the surface this exists to remove.

## Verification

- `tripwire_sessions_copilot_daemon_cta` drives a real TUI in tmux with no daemon
  anywhere, walks to the copilot tab, asserts the headline and the key, asserts the footer
  no longer says `Enter send message`, presses Enter, and waits for the offer to go away —
  which only happens once a daemon has come up and answered the poller. The daemon it
  starts is stopped again in its own temporary home.
- Falsified: reverting the render turns the tripwire red at "Tab never reached a copilot
  pane naming the daemon"; reverting the footer guard turns it red at "the footer still
  advertises `Enter send message`" with the real pane in the message; flipping `Timeout`
  into the not-running arm turns the client unit test red.
- `tripwire_sessions_copilot_engine_swap` (both tests) green, including
  `with_no_daemon_the_copilot_header_names_the_failed_call`. The first push DID break that
  one — the offer replaced the whole pane — and CI caught it on `ainb-hooks (ubuntu-latest)`.
  Fixed by inserting the offer instead, and this branch's own tripwire now asserts the dial
  keys survive so the additive rule is pinned here too.
- `cargo nextest run -p ainb -p ainb-hangar-client --lib --tests -E 'not binary(/^tripwire_/)'`:
  **4944 run, 4944 passed**, 17 skipped.
- `cargo fmt --check` clean.

### Review round 2 — four defects found and fixed

1. **The offer's own action line could be cut while the footer advertised it.** The block
   was clamped by rect but still handed every line, and a `Paragraph` drops the bottom rows
   silently — so a short pane kept the diagnosis and lost `⏎ start the hangar daemon now`.
   Now clamped by what is PASSED: sized by rows painted (wrap included), cut in priority
   order, action line priority zero and never dropped. Falsified with a real render into a
   6-row rect — red showed a pane with the offer entirely absent.
2. **Stale success text on the next outage.** `CtaStatus` never left `Reported`, so the pane
   reopened showing `✓ already running (pid 4242)` about a daemon that was down. Retired on
   the attention refresh when the outage ends; a start in flight is left alone. Red:
   `left: Reported { ok: true, detail: "already running (pid 4242)" } right: Offered`.
3. **Enter fired the start from the wrong focus.** Gated only on the offer being shown, so
   `Enter` aimed at the session list started a daemon. Split into a second predicate,
   `copilot_daemon_cta_armed` (shown + right pane focused + no start in flight), read by
   both the key handler and the footer verb. Red: `but Enter belongs to the list, so
   starting a daemon is not on it`.
4. **The pane could tick one conversation and paint another.** The render site reached for
   `copilot_chat` directly after ticking through `chat_host_for`. There is now one resolver,
   `chat_host`, and `chat_host_for` ends by calling it. Red: `Copilot ticks one conversation
   and paints another / left: Some(0x16f210768) right: Some(0x16f210528)`.

### Sync with main (#871)

`origin/main` moved 20 commits under this branch, and #871 changed the same function.
Merged in; one conflict, in `enter_verb_in`, where #871 added an empty verb for an `ask`
whose picker is native. Both branches kept — and then unified: `SessionTab::enter_refusal`
is now one exhaustive predicate over the tabs carrying the refusing surface's own sentence,
so a sixth tab extends the match rather than adding a fourth footer branch. Pure refactor,
no behaviour moves. Falsified by dropping the `Ask` arm:
`left: None  right: Some("this renders in the agent's own picker — attach with `a` to
answer it there")`.

Re-verified on the resolved head: `cargo fmt --check` clean, **5026 run, 5026 passed**, 17
skipped, and both copilot tripwires (3 tests) green.

TUI-additive: nothing that worked before changes while a daemon is up.