### PR TITLE
fix(sessions): unstick the log tab, and make ERR readable and expiring

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -1487,7 +1487,7 @@ impl EventHandler {
         let host = match state.session_tab {
             SessionTab::Copilot => state.copilot_chat.as_mut(),
             SessionTab::Thread => state.session_chat.as_mut().map(|(_, host)| host),
-            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Err | SessionTab::Log => None,
         }?;
         let outcome = reduce_chat_key(host.state_mut(), chat_key);
         state.ui_needs_refresh = true;
@@ -2397,7 +2397,7 @@ impl EventHandler {
                     // Deliberately nothing: a history pane has no verb, and
                     // silently attaching from it is the surprise this scoping
                     // exists to stop.
-                    SessionTab::Log => return None,
+                    SessionTab::Err | SessionTab::Log => return None,
                 }
                 // Enter on a Stopped interactive session = resume it.
                 // Enter on a Running session = attach (mirrors 'a').
@@ -4429,7 +4429,9 @@ impl EventHandler {
                     SessionTab::Ask | SessionTab::Thread | SessionTab::Copilot => {
                         FocusedPane::LiveLogs
                     }
-                    SessionTab::Preview | SessionTab::Log => FocusedPane::Sessions,
+                    SessionTab::Preview | SessionTab::Err | SessionTab::Log => {
+                        FocusedPane::Sessions
+                    }
                 };
                 state.ui_needs_refresh = true;
             }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -12075,9 +12075,18 @@ impl AppState {
         // Every cwd a row on screen consumed, so the rows that matched nothing
         // can be counted rather than dropped.
         let mut claimed: HashSet<String> = HashSet::new();
+        // How long a failure keeps lighting a chip. Read once per refresh
+        // rather than per session: it is a lock-free `Arc` clone, but the whole
+        // pass has to agree on one window or two rows of the same age would
+        // disagree about whether they have retired.
+        let err_window_ms =
+            i64::from(crate::config::tunables::snapshot().ui.attention_err_window_hours)
+                * 60
+                * 60
+                * 1000;
 
         // Phase 1 — read-only compute (no mutable borrow of self).
-        let mut marks: Vec<(Uuid, Vec<SessionAttention>, bool, bool)> = Vec::new();
+        let mut marks: Vec<(Uuid, Vec<SessionAttention>, bool, Option<String>)> = Vec::new();
         for ws in &self.workspaces {
             for s in &ws.sessions {
                 if s.is_attached {
@@ -12086,7 +12095,7 @@ impl AppState {
                     // row for the session under the cursor would be reported as
                     // waiting somewhere else.
                     claimed.insert(s.workspace_path.trim_end_matches('/').to_string());
-                    marks.push((s.id, Vec::new(), true, false));
+                    marks.push((s.id, Vec::new(), true, None));
                     continue;
                 }
                 let generating = matches!(s.status, crate::models::SessionStatus::Running);
@@ -12118,8 +12127,15 @@ impl AppState {
                     claimed.insert(cwd.clone());
                     chips.extend(daemon_rows.iter().cloned());
                 }
-                let failed = matches!(s.status, crate::models::SessionStatus::Error(_));
-                marks.push((s.id, chips, false, failed));
+                // The REASON, not a boolean. `SessionStatus::Error` has always
+                // carried the sentence explaining what broke, and the ERR chip
+                // has always thrown it away — which is why the only surface an
+                // operator could read it on was the bottom logs strip.
+                let failure = match &s.status {
+                    crate::models::SessionStatus::Error(reason) => Some(reason.clone()),
+                    _ => None,
+                };
+                marks.push((s.id, chips, false, failure));
             }
         }
 
@@ -12146,12 +12162,12 @@ impl AppState {
             })
             .collect();
         self.attention_local_since.retain(|key, _| still_open.contains(key));
-        for (id, mut chips, attached, failed) in marks {
+        for (id, mut chips, attached, failure) in marks {
             if attached {
                 self.attention_baseline.insert(id, now_ms);
             }
             self.stamp_local_since(id, &mut chips);
-            if failed {
+            if let Some(reason) = failure {
                 // ERR is a SECOND, independent chip, not a competitor: a
                 // session that failed and then asked a question is both, and
                 // hiding the ASK behind the ERR is what left the operator with
@@ -12160,11 +12176,27 @@ impl AppState {
                 // every later one reuses it — the age must not restart at 0s
                 // five times a minute.
                 let since = *self.attention_error_since.entry(id).or_insert(now_ms);
-                chips.push(SessionAttention::local(AttentionKind::Err, since));
+                chips.push(SessionAttention::local(AttentionKind::Err, since).with_detail(reason));
             } else {
                 self.attention_error_since.remove(&id);
             }
             let mut chips = crate::fleet::attention::normalise(chips);
+            // Split the errors off BEFORE the window is applied, and from the
+            // normalised list so both producers are covered by one rule.
+            //
+            // Two different questions are being answered here. The ROW asks
+            // "does something need me now", and a failure from this morning
+            // does not — an ERR that never retires eventually paints the whole
+            // screen red and stops meaning anything. The `err` PANE asks "what
+            // went wrong", which has no expiry, so it reads this unwindowed
+            // list. Retiring the chip therefore hides the alarm and never the
+            // reason.
+            let errors: Vec<SessionAttention> =
+                chips.iter().filter(|chip| chip.kind == AttentionKind::Err).cloned().collect();
+            chips.retain(|chip| {
+                chip.kind != AttentionKind::Err
+                    || now_ms.saturating_sub(chip.since_ms) <= err_window_ms
+            });
             // Route each surviving chip against the session it landed on. Done
             // here, after the merge, because only the session row knows whether
             // there is a pane to type into — and only now is it settled which
@@ -12210,6 +12242,10 @@ impl AppState {
             if let Some(s) = self.find_session_mut(id) {
                 if s.live_attention != chips {
                     s.live_attention = chips;
+                    changed = true;
+                }
+                if s.errors != errors {
+                    s.errors = errors;
                     changed = true;
                 }
             }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -11902,7 +11902,7 @@ impl AppState {
             SessionTab::Thread => {
                 self.session_chat.is_some() || !self.broadcast_targets().is_empty()
             }
-            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => false,
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Err | SessionTab::Log => false,
         }
     }
 
@@ -11924,7 +11924,7 @@ impl AppState {
         let host = match self.session_tab {
             SessionTab::Copilot => self.copilot_chat.as_ref(),
             SessionTab::Thread => self.session_chat.as_ref().map(|(_, host)| host),
-            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Err | SessionTab::Log => None,
         };
         host.is_some_and(|host| host.state().is_capturing_text())
     }
@@ -11966,7 +11966,7 @@ impl AppState {
                 }
                 self.session_chat.as_ref().map(|(_, host)| host)
             }
-            SessionTab::Preview | SessionTab::Ask | SessionTab::Log => None,
+            SessionTab::Preview | SessionTab::Ask | SessionTab::Err | SessionTab::Log => None,
         }
     }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3715,6 +3715,17 @@ pub struct AppState {
     /// start one without having to remember whether it already did.
     pub attention_poll_running: Arc<std::sync::atomic::AtomicBool>,
 
+    /// The `log` tab's history, filled by [`crate::fleet::session_log`] on its
+    /// own thread.
+    ///
+    /// Read on the render path, never QUERIED there: the store read used to
+    /// live inside `terminal.draw` and cost a real store up to 948 ms a frame.
+    pub session_log: Arc<crate::fleet::session_log::Shared>,
+
+    /// Whether the session-log worker is alive. Same idempotence flag, and the
+    /// same reason, as [`Self::attention_poll_running`].
+    pub session_log_running: Arc<std::sync::atomic::AtomicBool>,
+
     /// Daemon attention rows whose cwd matched no row on this screen, counted
     /// for the header so the ONE attention surface never silently swallows a
     /// request it could not place.
@@ -4217,6 +4228,8 @@ impl Default for AppState {
                 crate::fleet::attention::DaemonAttention::default(),
             )),
             attention_poll_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            session_log: Arc::new(crate::fleet::session_log::Shared::default()),
+            session_log_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             attention_elsewhere: 0,
             session_tab: crate::components::session_tabs::SessionTab::default(),
             ask_state: crate::fleet::answer::AskState::default(),

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2425,6 +2425,134 @@ mod tests {
         );
     }
 
+    /// The line the ERR chip used to throw away.
+    ///
+    /// `SessionStatus::Error` has always carried the sentence explaining what
+    /// broke; `SessionAttention::local` sets `detail: None`, so the only place
+    /// an operator could read it was the bottom logs strip — which is not
+    /// per-session and scrolls away. The `err` pane reads this field.
+    #[test]
+    fn an_err_chip_carries_the_failure_reason() {
+        use crate::fleet::attention::AttentionKind;
+        use crate::models::SessionStatus;
+        let mut state = state_with_session_at("/work/broken", Some("tmux_proj"));
+        state.workspaces[0].sessions[0].status =
+            SessionStatus::Error("adapter exited 1: no such model".to_string());
+
+        state.refresh_attention_markers(2_000);
+
+        let chip = state.workspaces[0].sessions[0]
+            .live_attention
+            .iter()
+            .find(|chip| chip.kind == AttentionKind::Err)
+            .expect("a failed session raises an ERR chip");
+        assert_eq!(
+            chip.detail.as_deref(),
+            Some("adapter exited 1: no such model"),
+            "the reason must ride the chip, not die in the status enum"
+        );
+    }
+
+    /// A failure past the window leaves the ROW and stays in the PANE.
+    ///
+    /// `SessionStatus::Error` never clears by itself, so before this one
+    /// failure lit a chip for as long as the session existed and a whole screen
+    /// eventually read as broken. Retiring it would be a regression on its own
+    /// — the operator could no longer see what failed — which is why `errors`
+    /// keeps it.
+    #[test]
+    fn an_err_past_the_window_leaves_the_row_but_not_the_pane() {
+        use crate::fleet::attention::AttentionKind;
+        use crate::models::SessionStatus;
+        let _lock = crate::config::tunables::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Pin the window rather than inheriting whatever this machine's
+        // config.toml says, or the test asserts against the developer's
+        // settings instead of the shipped default.
+        let mut config = crate::config::AppConfig::default();
+        config.ui.attention_err_window_hours = 2;
+        crate::config::tunables::install_snapshot(config);
+
+        let mut state = state_with_session_at("/work/broken", Some("tmux_proj"));
+        state.workspaces[0].sessions[0].status =
+            SessionStatus::Error("worktree vanished".to_string());
+
+        // First observation stamps the clock.
+        let raised_at = 1_000_000_000_000;
+        state.refresh_attention_markers(raised_at);
+        assert!(
+            state.workspaces[0].sessions[0]
+                .live_attention
+                .iter()
+                .any(|chip| chip.kind == AttentionKind::Err),
+            "a fresh failure must light the row"
+        );
+
+        // Three hours later, still failed, still the same failure.
+        state.refresh_attention_markers(raised_at + 3 * 60 * 60 * 1000);
+
+        let session = &state.workspaces[0].sessions[0];
+        assert!(
+            !session.live_attention.iter().any(|chip| chip.kind == AttentionKind::Err),
+            "an error older than the window must stop lighting the row"
+        );
+        let kept = session
+            .errors
+            .iter()
+            .find(|chip| chip.kind == AttentionKind::Err)
+            .expect("the err pane keeps what the row dropped");
+        assert_eq!(kept.detail.as_deref(), Some("worktree vanished"));
+        assert_eq!(
+            kept.since_ms, raised_at,
+            "and it keeps the TRUE first-observed instant, not the retirement"
+        );
+
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+
+    /// The window is one rule, applied once, so both producers obey it.
+    #[test]
+    fn the_window_retires_a_daemon_error_too() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let _lock = crate::config::tunables::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut config = crate::config::AppConfig::default();
+        config.ui.attention_err_window_hours = 2;
+        crate::config::tunables::install_snapshot(config);
+
+        let cwd = "/work/escalated";
+        let mut state = state_with_session_at(cwd, Some("tmux_proj"));
+        let raised_at = 1_000_000_000_000;
+        install_daemon_row(
+            &state,
+            cwd,
+            SessionAttention::daemon(AttentionKind::Err, raised_at, "att-err".into())
+                .with_detail("the agent escalated: cannot reach the API"),
+        );
+
+        state.refresh_attention_markers(raised_at + 5 * 60 * 60 * 1000);
+
+        let session = &state.workspaces[0].sessions[0];
+        assert!(
+            !session.live_attention.iter().any(|chip| chip.kind == AttentionKind::Err),
+            "a five-hour-old escalation must not still be lighting the row"
+        );
+        assert_eq!(
+            session.errors.len(),
+            1,
+            "but the pane still has it: {:?}",
+            session.errors
+        );
+        assert_eq!(
+            session.errors[0].detail.as_deref(),
+            Some("the agent escalated: cannot reach the API")
+        );
+
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+
     #[test]
     fn a_daemon_row_for_a_cwd_on_no_row_is_counted_elsewhere() {
         use crate::fleet::attention::{AttentionKind, SessionAttention};

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -69,7 +69,10 @@ impl HelpComponent {
             // nothing is worse than an undocumented one, because the operator
             // presses it, nothing happens, and they stop trusting the page.
             // What replaced both is the sessions screen's own right pane.
-            row("Tab", "Sessions: preview / ask / thread / copilot / log"),
+            row(
+                "Tab",
+                "Sessions: preview / ask / err / thread / copilot / log",
+            ),
             row("d", "Daemons: health, hooks, and repair (Esc closes)"),
             row("i", "Stats / usage analytics (Esc closes)"),
             row("w", "Witr process browser (quit witr to return)"),

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -150,6 +150,7 @@ impl LayoutComponent {
                 }
                 session_tabs::render_ask(frame, inner, state);
             }
+            SessionTab::Err => session_tabs::render_err(frame, inner, state),
             SessionTab::Log => {
                 // Started here rather than at construction, for the same reason
                 // the attention poller is: an `ainb` invocation that never opens

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -151,14 +151,24 @@ impl LayoutComponent {
                 session_tabs::render_ask(frame, inner, state);
             }
             SessionTab::Log => {
-                let rows = state.get_selected_session().map_or_else(Vec::new, |session| {
-                    session_tabs::read_log(
-                        &session.workspace_path,
-                        AppState::agent_hook_name(session.agent_type),
-                        200,
-                    )
-                });
-                session_tabs::render_log(frame, inner, &rows);
+                // Started here rather than at construction, for the same reason
+                // the attention poller is: an `ainb` invocation that never opens
+                // this pane never opens the notifications store. `spawn` is
+                // idempotent.
+                crate::fleet::session_log::spawn(&state.session_log, &state.session_log_running);
+                // The read itself belongs to that worker. Asking for it here —
+                // inside `terminal.draw` — is what made this pane cost up to
+                // 948 ms a frame on a real store.
+                let log = state.get_selected_session().map_or(
+                    crate::fleet::session_log::Log::Rows(Vec::new()),
+                    |session| {
+                        state.session_log.read(&crate::fleet::session_log::LogKey::new(
+                            &session.workspace_path,
+                            AppState::agent_hook_name(session.agent_type),
+                        ))
+                    },
+                );
+                session_tabs::render_log(frame, inner, &log);
             }
             // The copilot carries a HEADER the thread does not: its engine,
             // model and guardrail dial. The conversation under it is the same

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -515,8 +515,36 @@ fn circled(index: usize) -> String {
 /// Per-session, not fleet-wide. The cross-session view the host Inbox used to
 /// provide lives on in the hangar plugin's `I` tab; recreating it here would
 /// rebuild the duplication this screen exists to delete.
-pub fn render_log(frame: &mut Frame, area: Rect, rows: &[LogRow]) {
-    use ratatui::widgets::{List, ListItem};
+///
+/// The read happens on [`crate::fleet::session_log`]'s worker, so this takes
+/// what the worker last published — including the two states that are NOT
+/// "there is no history": the first frame after the cursor moved, and a store
+/// that could not be read at all.
+pub fn render_log(frame: &mut Frame, area: Rect, log: &crate::fleet::session_log::Log) {
+    use crate::fleet::session_log::Log;
+    use ratatui::widgets::{List, ListItem, Paragraph};
+
+    let rows = match log {
+        Log::Rows(rows) => rows.as_slice(),
+        Log::Reading => {
+            frame.render_widget(
+                Paragraph::new("reading this session's history\u{2026}")
+                    .style(Style::default().fg(MUTED_GRAY)),
+                area,
+            );
+            return;
+        }
+        // Named, not swallowed. A store that cannot be opened rendered as the
+        // empty state is how an operator concludes their notifications are
+        // gone rather than that a path is wrong.
+        Log::Failed(reason) => {
+            frame.render_widget(
+                Paragraph::new(format!("\u{26a0} {reason}")).style(Style::default().fg(ALERT_RED)),
+                area,
+            );
+            return;
+        }
+    };
 
     if rows.is_empty() {
         frame.render_widget(
@@ -564,38 +592,30 @@ pub struct LogRow {
     pub detail: String,
 }
 
-/// Read one session's notification history out of the notifyd store.
+/// Keep one session's rows out of a batch the store already returned.
 ///
-/// Opens the store per call rather than holding a handle, matching how the chip
-/// producer reads it: the query is microseconds, it only runs while the `log`
-/// tab is actually open, and it keeps the daemon as the database's sole
-/// long-lived owner.
+/// PURE, and deliberately not a store read: the read runs on
+/// [`crate::fleet::session_log`]'s worker thread, because doing it here — which
+/// is inside `terminal.draw` — is what made the `log` tab cost a second a
+/// frame. This is the half that has to happen for whatever the worker fetched.
 #[must_use]
-pub fn read_log(cwd: &str, agent: Option<&str>, limit: u32) -> Vec<LogRow> {
-    let Ok(paths) = ainb_plugin_notifyd::Paths::from_home() else {
-        return Vec::new();
-    };
-    if !paths.db.exists() {
-        return Vec::new();
-    }
-    let Ok(store) = ainb_plugin_notifyd::Store::open(&paths.db) else {
-        return Vec::new();
-    };
+pub fn log_rows(
+    records: &[ainb_plugin_notifyd::NotificationRecord],
+    cwd: &str,
+    agent: Option<&str>,
+    limit: usize,
+) -> Vec<LogRow> {
     let cwd = cwd.trim_end_matches('/');
-    // Window and limit deliberately generous: this is a history pane an
-    // operator opens on purpose, not a per-frame read.
-    let Ok(rows) = store.recent_since(0, limit.saturating_mul(20)) else {
-        return Vec::new();
-    };
-    rows.into_iter()
+    records
+        .iter()
         .filter(|row| {
             row.cwd.trim_end_matches('/') == cwd && agent.is_none_or(|agent| row.agent == agent)
         })
-        .take(limit as usize)
+        .take(limit)
         .map(|row| LogRow {
             ts: row.ts,
             event: row.raw_event.clone(),
-            detail: log_detail(&row),
+            detail: log_detail(row),
         })
         .collect()
 }

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -1,12 +1,13 @@
 // ABOUTME: The sessions screen's right-pane tab strip — the switchboard that
 // turns one preview pane into the whole attention surface.
 //
-// Five tabs over one rect: `preview` (the tmux mirror that was always there),
-// `ask` (answer what is blocking), `thread` (this session's chat), `copilot`
-// (the ainb assistant) and `log` (this session's notification history).
+// Six tabs over one rect: `preview` (the tmux mirror that was always there),
+// `ask` (answer what is blocking), `err` (what failed, and why), `thread` (this
+// session's chat), `copilot` (the ainb assistant) and `log` (this session's
+// notification history).
 //
 // The strip is the reason `Enter` stops being ambiguous. `Enter` used to mean
-// "attach" everywhere, which is the wrong verb on four of these five panes, so
+// "attach" everywhere, which is the wrong verb on five of these six panes, so
 // it becomes scoped to the ACTIVE TAB and each tab declares its own verb here.
 // Attach digits are deliberately NOT scoped: `1`-`9` attach from every tab,
 // because "jump to that session" is the one action that means the same thing
@@ -31,6 +32,13 @@ pub enum SessionTab {
     Preview,
     /// Answer the selected row's ASK or APPROVE.
     Ask,
+    /// What failed on the selected row, and the reason the producer gave.
+    ///
+    /// Sits beside `ask` rather than at the end of the strip because it answers
+    /// the same question — something on this row wants a human — and the chip
+    /// that sends an operator looking is one tab away from the pane that
+    /// explains it.
+    Err,
     /// This session's own chat thread, scope `session:<key>`.
     Thread,
     /// The general ainb assistant, plus its channels.
@@ -40,9 +48,10 @@ pub enum SessionTab {
 }
 
 /// Every tab, in strip order.
-pub const ALL_TABS: [SessionTab; 5] = [
+pub const ALL_TABS: [SessionTab; 6] = [
     SessionTab::Preview,
     SessionTab::Ask,
+    SessionTab::Err,
     SessionTab::Thread,
     SessionTab::Copilot,
     SessionTab::Log,
@@ -77,6 +86,7 @@ impl SessionTab {
         match self {
             Self::Preview => "preview",
             Self::Ask => "ask",
+            Self::Err => "err",
             Self::Thread => "thread",
             Self::Copilot => "copilot",
             Self::Log => "log",
@@ -108,7 +118,10 @@ impl SessionTab {
             Self::Preview => "attach",
             Self::Ask => "send answer",
             Self::Thread | Self::Copilot => "send message",
-            Self::Log => "",
+            // Neither pane takes an answer: one is a history, the other a
+            // post-mortem. An advertised verb that did nothing is the surprise
+            // the scoping exists to remove.
+            Self::Err | Self::Log => "",
         }
     }
 
@@ -134,6 +147,15 @@ impl SessionTab {
                 }
             }
             Self::Log => (!has_session).then_some("select a session first"),
+            Self::Err => {
+                if !has_session {
+                    Some("select a session first")
+                } else if selected_errors(state).is_empty() {
+                    Some("nothing has failed on this session")
+                } else {
+                    None
+                }
+            }
             Self::Thread => {
                 // Checked rows win over the cursor, the same rule `Enter` and
                 // `r` follow on this screen. A broadcast is about the checked
@@ -174,6 +196,35 @@ pub fn selected_blocking(state: &AppState) -> Option<&crate::fleet::attention::S
         .live_attention
         .iter()
         .find(|chip| chip.kind.blocks())
+}
+
+/// Every error the selected session has, newest first — INCLUDING the ones too
+/// old to still light a chip on the row.
+///
+/// Reads `errors`, not `live_attention`. The row's chip list is windowed
+/// (`[ui] attention_err_window_hours`) because "something needs me now" expires;
+/// "what went wrong" does not, and a pane that expired with the chip would put
+/// the operator back where they started — an ERR they can see and cannot read.
+#[must_use]
+pub fn selected_errors(state: &AppState) -> &[crate::fleet::attention::SessionAttention] {
+    state.get_selected_session().map_or(&[], |session| session.errors.as_slice())
+}
+
+/// Whether the selected row is still LIGHTING an ERR chip.
+///
+/// Asked of the row itself rather than by re-deriving the window here: the two
+/// would then be two separate pieces of arithmetic that can disagree, and the
+/// pane would tell an operator a chip is showing when it is not. The pane says
+/// WHY a failure it lists is no longer on the row, which is what stops retiring
+/// the chip from trading one silent surface for another.
+#[must_use]
+pub fn selected_err_is_on_the_row(state: &AppState) -> bool {
+    state.get_selected_session().is_some_and(|session| {
+        session
+            .live_attention
+            .iter()
+            .any(|chip| chip.kind == crate::fleet::attention::AttentionKind::Err)
+    })
 }
 
 /// Move `from` to the next available tab, forward or backward, skipping the
@@ -493,6 +544,92 @@ pub fn render_ask(frame: &mut Frame, area: Rect, state: &AppState) {
         lines.push(Line::styled(
             format!("\u{26a0} {refusal}"),
             Style::default().fg(ALERT_RED),
+        ));
+    }
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+}
+
+/// Render the `err` pane: what failed on this session, and the reason whoever
+/// raised it gave.
+///
+/// The reason is the whole point. `SessionStatus::Error` has always carried a
+/// sentence and the chip has always dropped it, so the only place an operator
+/// could read WHY a row said ERR was the bottom logs strip — which scrolls, and
+/// is not per-session. Both producers land here: a local failure's status text
+/// and a daemon `error`/`escalation` row's payload.
+pub fn render_err(frame: &mut Frame, area: Rect, state: &AppState) {
+    use crate::fleet::attention::AttentionSource;
+    use ratatui::widgets::{Paragraph, Wrap};
+
+    let errors = selected_errors(state);
+    if errors.is_empty() {
+        // Unreachable through the strip (the tab is dimmed), reachable through
+        // a race: the session recovers between the frame that enabled the tab
+        // and this one.
+        frame.render_widget(
+            Paragraph::new("nothing has failed on this session")
+                .style(Style::default().fg(MUTED_GRAY)),
+            area,
+        );
+        return;
+    }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let on_the_row = selected_err_is_on_the_row(state);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (index, chip) in errors.iter().enumerate() {
+        if index > 0 {
+            lines.push(Line::raw(""));
+        }
+        lines.push(Line::from(vec![
+            Span::styled(
+                chip.kind.label(),
+                Style::default().fg(chip_color(chip.kind)).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                crate::fleet::attention::format_age(now_ms, chip.since_ms),
+                Style::default().fg(MUTED_GRAY),
+            ),
+            Span::raw("  "),
+            // Which producer said so. A local failure is ainb's own view of the
+            // process; a daemon row is something the agent itself raised, and
+            // an operator chasing a failure needs to know which of the two they
+            // are reading.
+            Span::styled(
+                match chip.source {
+                    AttentionSource::Local => "local",
+                    AttentionSource::Daemon => "daemon",
+                },
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ]));
+        lines.push(Line::raw(""));
+        match chip.detail.as_deref() {
+            Some(reason) => lines.push(Line::styled(
+                reason.to_string(),
+                Style::default().fg(SOFT_WHITE),
+            )),
+            // Honest, not manufactured. A producer that raised an error with no
+            // text said nothing, and inventing "the session failed" here would
+            // read as something ainb had actually observed.
+            None => lines.push(Line::styled(
+                "the failure carried no reason text",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            )),
+        }
+    }
+
+    // Why the row is quiet about a failure this pane is still showing. Without
+    // it, retiring the chip just moves the mystery: the operator now has an
+    // error on screen and no idea why nothing is flagged.
+    if !on_the_row {
+        lines.push(Line::raw(""));
+        lines.push(Line::styled(
+            "older than the ERR window, so it no longer lights the row \u{b7} \
+             change it at [ui] attention_err_window_hours",
+            Style::default().fg(MUTED_GRAY),
         ));
     }
 
@@ -1069,17 +1206,142 @@ mod tests {
     use crate::models::{Session, SessionStatus, Workspace};
 
     fn state_with(chips: Vec<SessionAttention>, select: bool) -> AppState {
+        state_with_errors(chips, Vec::new(), select)
+    }
+
+    /// `chips` is what the ROW lights; `errors` is what the `err` pane keeps,
+    /// which is deliberately a superset — a failure past the window leaves the
+    /// first and stays in the second.
+    fn state_with_errors(
+        chips: Vec<SessionAttention>,
+        errors: Vec<SessionAttention>,
+        select: bool,
+    ) -> AppState {
         let mut state = AppState::new();
         state.workspaces.clear();
         let mut workspace = Workspace::new("proj".to_string(), "/work/proj".into());
         let mut session = Session::new("proj".to_string(), "/work/proj".to_string());
         session.status = SessionStatus::Idle;
         session.live_attention = chips;
+        session.errors = errors;
         workspace.add_session(session);
         state.workspaces.push(workspace);
         state.selected_workspace_index = Some(0);
         state.selected_session_index = select.then_some(0);
         state
+    }
+
+    /// The rendered text of a pane, so a test asserts what an operator reads.
+    fn rendered<F: FnOnce(&mut Frame, Rect)>(width: u16, height: u16, draw: F) -> String {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                draw(frame, area);
+            })
+            .expect("draw");
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer.cell((x, y)).map_or(" ", |c| c.symbol()).to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn err_chip(since_ms: i64, detail: Option<&str>) -> SessionAttention {
+        let chip = SessionAttention::local(AttentionKind::Err, since_ms);
+        match detail {
+            Some(detail) => chip.with_detail(detail),
+            None => chip,
+        }
+    }
+
+    #[test]
+    fn err_needs_something_to_have_failed() {
+        let none = state_with(Vec::new(), false);
+        assert_eq!(
+            SessionTab::Err.disabled_reason(&none),
+            Some("select a session first")
+        );
+        let quiet = state_with(Vec::new(), true);
+        assert_eq!(
+            SessionTab::Err.disabled_reason(&quiet),
+            Some("nothing has failed on this session")
+        );
+        // A RETIRED error still opens the pane. That is the whole point: the
+        // chip is gone from the row and the reason must not go with it.
+        let retired = state_with_errors(Vec::new(), vec![err_chip(0, Some("boom"))], true);
+        assert!(SessionTab::Err.enabled(&retired));
+    }
+
+    /// The reason the pane exists. `SessionStatus::Error` has always carried a
+    /// sentence; before this it reached no per-session surface at all.
+    #[test]
+    fn the_err_pane_shows_the_reason_the_producer_gave() {
+        let state = state_with_errors(
+            vec![err_chip(0, Some("adapter exited 1: no such model"))],
+            vec![err_chip(0, Some("adapter exited 1: no such model"))],
+            true,
+        );
+        let text = rendered(70, 8, |frame, area| render_err(frame, area, &state));
+        assert!(
+            text.contains("adapter exited 1"),
+            "the err pane must show the reason:\n{text}"
+        );
+        assert!(text.contains("ERR"), "and name the state:\n{text}");
+    }
+
+    /// A producer that raised an error with no text said nothing, and the pane
+    /// says so rather than inventing a sentence that reads like the agent's.
+    #[test]
+    fn an_err_with_no_text_says_so_rather_than_inventing_one() {
+        let state = state_with_errors(vec![err_chip(0, None)], vec![err_chip(0, None)], true);
+        let text = rendered(70, 8, |frame, area| render_err(frame, area, &state));
+        assert!(text.contains("carried no reason text"), "{text}");
+    }
+
+    /// Retiring the chip must not just move the mystery: the pane says WHY the
+    /// row is quiet about a failure it is still showing, and where to change it.
+    #[test]
+    fn a_retired_err_says_why_the_row_no_longer_lights() {
+        let live = state_with_errors(
+            vec![err_chip(0, Some("boom"))],
+            vec![err_chip(0, Some("boom"))],
+            true,
+        );
+        let live_text = rendered(70, 10, |frame, area| render_err(frame, area, &live));
+        assert!(
+            !live_text.contains("no longer lights"),
+            "a chip that IS on the row must not claim it has retired:\n{live_text}"
+        );
+
+        let retired = state_with_errors(Vec::new(), vec![err_chip(0, Some("boom"))], true);
+        let retired_text = rendered(70, 10, |frame, area| render_err(frame, area, &retired));
+        assert!(
+            retired_text.contains("no longer lights"),
+            "a retired failure must say why nothing is flagged:\n{retired_text}"
+        );
+        assert!(
+            retired_text.contains("attention_err_window_hours"),
+            "and name the knob that decides it:\n{retired_text}"
+        );
+    }
+
+    /// `Tab` skips a dimmed pane rather than stopping on it, and the new one is
+    /// no exception.
+    #[test]
+    fn tab_skips_the_err_pane_when_nothing_has_failed() {
+        let state = state_with(Vec::new(), true);
+        assert!(!SessionTab::Err.enabled(&state));
+        assert_ne!(
+            cycle(&state, SessionTab::Ask, true),
+            SessionTab::Err,
+            "Tab must not land on a pane that cannot say anything"
+        );
     }
 
     #[test]
@@ -1159,7 +1421,13 @@ mod tests {
 
     #[test]
     fn cycling_visits_every_tab_when_everything_is_available() {
-        let mut state = state_with(vec![SessionAttention::local(AttentionKind::Ask, 0)], true);
+        let mut state = state_with_errors(
+            vec![SessionAttention::local(AttentionKind::Ask, 0)],
+            // `err` needs a failure to show before it is reachable, the same
+            // way `ask` needs a question.
+            vec![SessionAttention::local(AttentionKind::Err, 0).with_detail("boom")],
+            true,
+        );
         // The thread needs a scope before it is reachable.
         state.workspaces[0].sessions[0].provider_session_id = Some("hook-sess-1".to_string());
         let state = state;
@@ -1185,7 +1453,13 @@ mod tests {
     }
 
     #[test]
-    fn the_strip_always_renders_all_five_labels() {
+    fn the_strip_always_renders_every_label_in_strip_order() {
+        // Declaration order IS strip order and `Tab` order, so pinning it here
+        // is what stops the rendered strip and the key that walks it drifting.
+        assert_eq!(
+            ALL_TABS.iter().map(|tab| tab.label()).collect::<Vec<_>>(),
+            vec!["preview", "ask", "err", "thread", "copilot", "log"],
+        );
         // Dimmed, never hidden — otherwise the strip reflows under the cursor
         // every time a session answers a question.
         for select in [true, false] {
@@ -1211,7 +1485,7 @@ mod tests {
             let verb = tab.enter_verb();
             assert_eq!(
                 verb.is_empty(),
-                tab == SessionTab::Log,
+                matches!(tab, SessionTab::Err | SessionTab::Log),
                 "{tab:?} must declare a verb unless Enter is a no-op there"
             );
         }

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -654,6 +654,13 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         kind: RowKind::Number { min: 1, max: 8760 },
     }),
     Entry::Row(ConfigRow {
+        key: "ui.attention_err_window_hours",
+        category: C::Appearance,
+        label: "Error Chip Window",
+        help: "Hours a failure keeps lighting an ERR chip; the err tab still shows it after",
+        kind: RowKind::Number { min: 1, max: 8760 },
+    }),
+    Entry::Row(ConfigRow {
         key: "ui.inbox_list_limit",
         category: C::Appearance,
         label: "Inbox Row Limit",
@@ -1943,6 +1950,7 @@ mod tests {
                 app_tick_ms: 500,
                 session_query_limit: 250,
                 session_lookback_hours: 12,
+                attention_err_window_hours: 4,
                 inbox_list_limit: 100,
                 double_click_ms: 400,
             },

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -380,6 +380,17 @@ pub struct UiConfig {
     #[serde(default = "default_session_lookback_hours")]
     pub session_lookback_hours: u32,
 
+    /// Rolling window (hours) a failure keeps lighting an `ERR` chip on a
+    /// session row.
+    ///
+    /// `ERR` had no clock at all: `SessionStatus::Error` never clears by
+    /// itself, so one failure lit a chip for as long as the session existed and
+    /// a whole screen of rows eventually read as broken. Past this window the
+    /// chip retires; the `err` tab still shows the failure, so retiring it
+    /// hides the alarm, never the reason.
+    #[serde(default = "default_attention_err_window_hours")]
+    pub attention_err_window_hours: u32,
+
     /// Rows the Inbox screen lists. Kept small because the query runs every
     /// render.
     #[serde(default = "default_inbox_list_limit")]
@@ -403,6 +414,9 @@ fn default_session_query_limit() -> u32 {
 fn default_session_lookback_hours() -> u32 {
     6
 }
+fn default_attention_err_window_hours() -> u32 {
+    2
+}
 fn default_inbox_list_limit() -> u32 {
     200
 }
@@ -417,6 +431,7 @@ impl Default for UiConfig {
             app_tick_ms: default_app_tick_ms(),
             session_query_limit: default_session_query_limit(),
             session_lookback_hours: default_session_lookback_hours(),
+            attention_err_window_hours: default_attention_err_window_hours(),
             inbox_list_limit: default_inbox_list_limit(),
             double_click_ms: default_double_click_ms(),
         }

--- a/ainb-tui/crates/ainb-core/src/fleet/mod.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/mod.rs
@@ -30,6 +30,7 @@ pub mod copilot_dial;
 pub mod daemons;
 pub mod plumbing;
 pub mod read;
+pub mod session_log;
 pub mod unit_program;
 
 pub use ainb_fleet_core::fleet::{discover, enrich_cache, send, types};

--- a/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
@@ -79,6 +79,14 @@ struct Published {
     /// Why the last read failed, for the one line the pane shows instead of
     /// pretending the session has no history.
     error: Option<String>,
+    /// Whether the render path has asked for rows since the last read.
+    ///
+    /// This is what stops the worker outliving the pane. Set by every frame
+    /// that wants the log, cleared by every read the worker completes: once the
+    /// operator leaves the tab nothing sets it again, the worker parks on the
+    /// condvar, and a session nobody is looking at stops costing a query every
+    /// 750 ms for the rest of the process's life.
+    asked: bool,
 }
 
 /// The cell the render loop reads and the worker writes.
@@ -117,8 +125,14 @@ impl Shared {
         let mut published = self.guard();
         if published.want.as_ref() != Some(key) {
             published.want = Some(key.clone());
+        }
+        if !published.asked {
+            published.asked = true;
             // Woken while this lock is still held; the worker simply blocks on
-            // the mutex until the guard drops at the end of the function.
+            // the mutex until the guard drops at the end of the function. Only
+            // on the FALSE->TRUE edge, because that is the only transition a
+            // parked worker is waiting for — notifying on every frame would be
+            // eighty wakeups a second telling it something it already knows.
             self.wake.notify_one();
         }
         if published.have.as_ref() == Some(key) {
@@ -174,15 +188,19 @@ fn worker(shared: &Shared) {
     // schema or checkpoint its WAL.
     let mut store: Option<ainb_plugin_notifyd::Store> = None;
     loop {
-        let want = shared.guard().want.clone();
+        let (want, asked) = {
+            let published = shared.guard();
+            (published.want.clone(), published.asked)
+        };
         let mut backoff = REFRESH;
-        if let Some(key) = want {
+        if let (true, Some(key)) = (asked, want) {
             match read_once(&mut store, &key) {
                 Ok(rows) => {
                     let mut published = shared.guard();
                     published.have = Some(key);
                     published.rows = rows;
                     published.error = None;
+                    published.asked = false;
                 }
                 Err(reason) => {
                     // Drop the handle: the usual causes (the file was replaced,
@@ -190,6 +208,7 @@ fn worker(shared: &Shared) {
                     store = None;
                     let mut published = shared.guard();
                     published.error = Some(reason);
+                    published.asked = false;
                     backoff = RETRY;
                 }
             }
@@ -198,10 +217,23 @@ fn worker(shared: &Shared) {
         // A request that arrived while the read was in flight is served now
         // rather than after a full interval — without this, the pane would show
         // the previous session for up to `REFRESH` after the cursor moved.
-        if published.want != published.have && published.error.is_none() {
+        if published.asked && published.want != published.have && published.error.is_none() {
             continue;
         }
-        let _unused = shared.wake.wait_timeout(published, backoff);
+        if published.asked {
+            // The pane is open and satisfied: sleep the refresh interval, then
+            // read again.
+            let _unused = shared.wake.wait_timeout(published, backoff);
+        } else {
+            // Nobody has asked since the last read, so there is nothing to
+            // refresh FOR. Park until a frame asks again.
+            //
+            // Checked while holding the guard, and `wait` releases it
+            // atomically, so a `read` that lands between the check and the wait
+            // cannot have its notify lost — it would still be blocked on this
+            // mutex.
+            let _unused = shared.wake.wait(published);
+        }
     }
 }
 
@@ -292,6 +324,41 @@ mod tests {
         let key = LogKey::new("/tmp/a", Some("claude"));
         let _unused = shared.read(&key);
         assert_eq!(shared.guard().want, Some(key));
+    }
+
+    /// The worker must not outlive the pane. Every frame that wants rows raises
+    /// `asked`; the worker lowers it after each read and parks when it is down,
+    /// so leaving the tab stops the query rather than leaving it running for
+    /// the rest of the process's life.
+    #[test]
+    fn a_pane_nobody_is_looking_at_stops_asking() {
+        let shared = Shared::default();
+        let key = LogKey::new("/tmp/a", None);
+        let _unused = shared.read(&key);
+        assert!(
+            shared.guard().asked,
+            "a frame that wants rows asks for them"
+        );
+
+        // The worker completing a read.
+        {
+            let mut published = shared.guard();
+            published.have = Some(key.clone());
+            published.rows = vec![row(1)];
+            published.asked = false;
+        }
+        // No further frames: nothing raises it again, so the worker parks.
+        assert!(
+            !shared.guard().asked,
+            "a closed pane must leave nothing for the worker to refresh"
+        );
+
+        // Re-opening the pane raises it again.
+        assert_eq!(shared.read(&key), Log::Rows(vec![row(1)]));
+        assert!(
+            shared.guard().asked,
+            "and a frame that comes back asks again"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
@@ -1,0 +1,309 @@
+// ABOUTME: The `log` tab's notification history, read off the render thread on
+// one long-lived read-only handle.
+//
+// It used to be read INSIDE `terminal.draw`: every repaint of the `log` tab
+// called `Store::open` (read-write, `PRAGMA journal_mode=WAL`, the full
+// `CREATE ... IF NOT EXISTS` batch), pulled up to 4000 rows, and closed the
+// connection again. Three separate costs, all on the UI thread:
+//
+// 1. the open itself, which on a store the daemon has been writing to for
+//    months is not free;
+// 2. the schema migration, which is the TUI applying DDL to a database the
+//    daemon owns;
+// 3. the CLOSE, which on the last connection CHECKPOINTS the WAL. Measured
+//    against a byte-copy of a real store (546 MB file, 9 927 rows, 73.5 MB
+//    WAL): 948 ms for the frame that inherited the fat WAL, 37-631 ms per
+//    frame after that.
+//
+// The render loop repaints on every keystroke and every 250 ms app tick, so
+// that is a pane which answers a `Tab` press a second later. This module is
+// where that read went: one worker thread, one read-only connection held open,
+// a refresh cadence instead of a frame cadence, and a render path that only
+// ever reads a `Vec` someone else filled in.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use crate::components::session_tabs::LogRow;
+
+/// How often the worker re-reads while the pane stays on one session.
+///
+/// A notification history is not a live stream — a row that appears half a
+/// second late is indistinguishable from instant. A CHANGE of session does not
+/// wait for this: the render path signals the condvar, so switching rows
+/// repaints as fast as the query returns.
+const REFRESH: Duration = Duration::from_millis(750);
+
+/// How long the worker sleeps before retrying after a failed read.
+///
+/// Longer than [`REFRESH`] on purpose: the usual failure is "the store does not
+/// exist on this machine", which will still be true 750 ms from now, and
+/// retrying it at the refresh cadence is a syscall per second forever.
+const RETRY: Duration = Duration::from_secs(5);
+
+/// Which session's history is wanted.
+///
+/// The worktree path and the agent's hook name, which is the same identity the
+/// attention producer files notifyd rows under — a session is not identified in
+/// that store by ainb's own UUID, which the hook never sees.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogKey {
+    /// The session's worktree path, trailing slash trimmed.
+    pub cwd: String,
+    /// The agent's hook name, or `None` to accept every agent in that cwd.
+    pub agent: Option<String>,
+}
+
+impl LogKey {
+    /// The key for a session at `cwd` running `agent`.
+    #[must_use]
+    pub fn new(cwd: &str, agent: Option<&str>) -> Self {
+        Self {
+            cwd: cwd.trim_end_matches('/').to_string(),
+            agent: agent.map(ToString::to_string),
+        }
+    }
+}
+
+/// What the worker has published, and what it should read next.
+#[derive(Debug, Default)]
+struct Published {
+    /// The key the render path last asked for.
+    want: Option<LogKey>,
+    /// The key `rows` actually belongs to, so a stale answer is never rendered
+    /// under a session it is not about.
+    have: Option<LogKey>,
+    /// The rows for `have`.
+    rows: Vec<LogRow>,
+    /// Why the last read failed, for the one line the pane shows instead of
+    /// pretending the session has no history.
+    error: Option<String>,
+}
+
+/// The cell the render loop reads and the worker writes.
+#[derive(Debug, Default)]
+pub struct Shared {
+    published: Mutex<Published>,
+    /// Signalled when `want` changes, so a session switch does not wait out
+    /// [`REFRESH`].
+    wake: Condvar,
+}
+
+/// What the `log` pane has to paint right now.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Log {
+    /// The history for the requested session.
+    Rows(Vec<LogRow>),
+    /// The worker has not answered for THIS session yet.
+    Reading,
+    /// The read failed, with the reason.
+    Failed(String),
+}
+
+impl Shared {
+    fn guard(&self) -> std::sync::MutexGuard<'_, Published> {
+        self.published.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Ask for `key`, and return whatever is available for it right now.
+    ///
+    /// One call, not a request and a separate read: the render path wants the
+    /// rows for the session under the cursor, and splitting that into two
+    /// locked operations is how a caller ends up rendering the previous
+    /// session's history under the current session's name.
+    #[must_use]
+    pub fn read(&self, key: &LogKey) -> Log {
+        let mut published = self.guard();
+        if published.want.as_ref() != Some(key) {
+            published.want = Some(key.clone());
+            // Woken while this lock is still held; the worker simply blocks on
+            // the mutex until the guard drops at the end of the function.
+            self.wake.notify_one();
+        }
+        if published.have.as_ref() == Some(key) {
+            return Log::Rows(published.rows.clone());
+        }
+        match &published.error {
+            Some(reason) => Log::Failed(reason.clone()),
+            None => Log::Reading,
+        }
+    }
+}
+
+/// Start the worker, or return immediately when one is already running.
+///
+/// Idempotent by an atomic flag, and released on every exit path including an
+/// unwind, so a worker that dies is replaced on the next frame rather than
+/// leaving the pane permanently stuck on "reading". Same shape, and for the
+/// same reason, as [`crate::fleet::attention_poll::spawn`].
+pub fn spawn(shared: &Arc<Shared>, running: &Arc<AtomicBool>) {
+    if running.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    let shared = Arc::clone(shared);
+    let worker_flag = Arc::clone(running);
+    let spawn_err_flag = Arc::clone(running);
+    let spawned = std::thread::Builder::new().name("ainb-session-log".into()).spawn(move || {
+        struct Guard(Arc<AtomicBool>);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Release);
+            }
+        }
+        let _guard = Guard(worker_flag);
+        worker(&shared);
+    });
+    if let Err(error) = spawned {
+        tracing::warn!(%error, "session log worker thread spawn failed");
+        spawn_err_flag.store(false, Ordering::Release);
+    }
+}
+
+/// How many rows the pane shows.
+///
+/// A history an operator scrolls, not a stream: 200 lines is more than anyone
+/// reads in one sitting and bounds what the query has to carry.
+const LIMIT: u32 = 200;
+
+/// The worker loop: read what is wanted, publish it, wait for a change or the
+/// refresh cadence.
+fn worker(shared: &Shared) {
+    // Opened once and held. The per-call open is the cost this module exists to
+    // remove, and a read-only handle additionally cannot migrate the daemon's
+    // schema or checkpoint its WAL.
+    let mut store: Option<ainb_plugin_notifyd::Store> = None;
+    loop {
+        let want = shared.guard().want.clone();
+        let mut backoff = REFRESH;
+        if let Some(key) = want {
+            match read_once(&mut store, &key) {
+                Ok(rows) => {
+                    let mut published = shared.guard();
+                    published.have = Some(key);
+                    published.rows = rows;
+                    published.error = None;
+                }
+                Err(reason) => {
+                    // Drop the handle: the usual causes (the file was replaced,
+                    // the daemon rebuilt it) are not fixed by reusing it.
+                    store = None;
+                    let mut published = shared.guard();
+                    published.error = Some(reason);
+                    backoff = RETRY;
+                }
+            }
+        }
+        let published = shared.guard();
+        // A request that arrived while the read was in flight is served now
+        // rather than after a full interval — without this, the pane would show
+        // the previous session for up to `REFRESH` after the cursor moved.
+        if published.want != published.have && published.error.is_none() {
+            continue;
+        }
+        let _unused = shared.wake.wait_timeout(published, backoff);
+    }
+}
+
+/// One read, against a handle opened on demand.
+fn read_once(
+    store: &mut Option<ainb_plugin_notifyd::Store>,
+    key: &LogKey,
+) -> Result<Vec<LogRow>, String> {
+    if store.is_none() {
+        let paths = ainb_plugin_notifyd::Paths::from_home().map_err(|error| error.to_string())?;
+        if !paths.db.exists() {
+            return Err(format!(
+                "no notification store at {} yet",
+                paths.db.display()
+            ));
+        }
+        // READ-ONLY. The TUI is a reader of a database the daemon owns: it must
+        // not create it, must not apply DDL to it, and must not checkpoint its
+        // WAL — the last of which is what made a single frame cost 948 ms.
+        *store = Some(
+            ainb_plugin_notifyd::Store::open_readonly(&paths.db)
+                .map_err(|error| error.to_string())?,
+        );
+    }
+    let store = store.as_ref().expect("opened above");
+    // Filtered in SQL, not here. Reading the newest 4000 rows fleet-wide and
+    // keeping the handful for one cwd is what made this expensive enough to
+    // matter — see `Store::recent_for_cwd`.
+    let records = store
+        .recent_for_cwd(&key.cwd, key.agent.as_deref(), 0, LIMIT)
+        .map_err(|error| error.to_string())?;
+    Ok(crate::components::session_tabs::log_rows(
+        &records,
+        &key.cwd,
+        key.agent.as_deref(),
+        LIMIT as usize,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(ts: i64) -> LogRow {
+        LogRow {
+            ts,
+            event: "Notification".to_string(),
+            detail: "hello".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_key_normalises_its_trailing_slash() {
+        assert_eq!(
+            LogKey::new("/tmp/work/", Some("claude")),
+            LogKey::new("/tmp/work", Some("claude"))
+        );
+    }
+
+    #[test]
+    fn an_unanswered_key_reads_as_reading_not_as_empty() {
+        let shared = Shared::default();
+        // The distinction the pane needs: "no rows yet" is not "this session
+        // has no history", and rendering the empty state for the first is how
+        // an operator concludes their log is gone.
+        assert_eq!(shared.read(&LogKey::new("/tmp/a", None)), Log::Reading);
+    }
+
+    #[test]
+    fn rows_are_only_returned_for_the_key_they_were_read_for() {
+        let shared = Shared::default();
+        let a = LogKey::new("/tmp/a", None);
+        let b = LogKey::new("/tmp/b", None);
+        {
+            let mut published = shared.guard();
+            published.have = Some(a.clone());
+            published.rows = vec![row(1)];
+        }
+        assert_eq!(shared.read(&a), Log::Rows(vec![row(1)]));
+        // `b` must NOT inherit `a`'s history just because it is what the worker
+        // last published.
+        assert_eq!(shared.read(&b), Log::Reading);
+    }
+
+    #[test]
+    fn reading_records_what_the_worker_should_fetch_next() {
+        let shared = Shared::default();
+        let key = LogKey::new("/tmp/a", Some("claude"));
+        let _unused = shared.read(&key);
+        assert_eq!(shared.guard().want, Some(key));
+    }
+
+    #[test]
+    fn a_failed_read_is_reported_rather_than_rendered_as_no_history() {
+        let shared = Shared::default();
+        {
+            let mut published = shared.guard();
+            published.error = Some("no notification store yet".to_string());
+        }
+        assert_eq!(
+            shared.read(&LogKey::new("/tmp/a", None)),
+            Log::Failed("no notification store yet".to_string())
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/session_log.rs
@@ -23,7 +23,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::components::session_tabs::LogRow;
 
@@ -31,15 +31,21 @@ use crate::components::session_tabs::LogRow;
 ///
 /// A notification history is not a live stream — a row that appears half a
 /// second late is indistinguishable from instant. A CHANGE of session does not
-/// wait for this: the render path signals the condvar, so switching rows
-/// repaints as fast as the query returns.
+/// wait for this: an unanswered key outranks the interval in [`next_action`],
+/// and [`Shared::read`] signals the condvar so a worker already asleep on it
+/// wakes rather than serving the switch up to `REFRESH` late.
 const REFRESH: Duration = Duration::from_millis(750);
 
-/// How long the worker sleeps before retrying after a failed read.
+/// How long the worker waits before retrying after a failed read.
 ///
 /// Longer than [`REFRESH`] on purpose: the usual failure is "the store does not
 /// exist on this machine", which will still be true 750 ms from now, and
 /// retrying it at the refresh cadence is a syscall per second forever.
+///
+/// Enforced by `next_attempt`, NOT by how long the worker happens to sleep. It
+/// used to be a `wait_timeout` argument, which the render path could defeat
+/// without meaning to: every frame raises `asked` and signals, so a failing
+/// store was re-opened on every keystroke and the backoff never happened.
 const RETRY: Duration = Duration::from_secs(5);
 
 /// Which session's history is wanted.
@@ -76,26 +82,44 @@ struct Published {
     have: Option<LogKey>,
     /// The rows for `have`.
     rows: Vec<LogRow>,
-    /// Why the last read failed, for the one line the pane shows instead of
-    /// pretending the session has no history.
-    error: Option<String>,
-    /// Whether the render path has asked for rows since the last read.
+    /// The key a read FAILED for, and why.
+    ///
+    /// Keyed for the same reason `rows` is. An un-keyed reason is a failure
+    /// about one session rendered under whichever session the cursor is on
+    /// next: move off a row whose store read failed and the healthy row beside
+    /// it paints the red "could not be read" line, on evidence that was never
+    /// about it.
+    error: Option<(LogKey, String)>,
+    /// Whether the render path has asked for rows since the last attempt.
     ///
     /// This is what stops the worker outliving the pane. Set by every frame
-    /// that wants the log, cleared by every read the worker completes: once the
+    /// that wants the log, cleared by every attempt the worker makes: once the
     /// operator leaves the tab nothing sets it again, the worker parks on the
     /// condvar, and a session nobody is looking at stops costing a query every
     /// 750 ms for the rest of the process's life.
     asked: bool,
+    /// The earliest the worker may attempt a read again.
+    ///
+    /// Where both cadences actually live: `REFRESH` after a success, `RETRY`
+    /// after a failure. Held here rather than in the worker's sleep duration
+    /// because the render path can end that sleep at any moment, and a backoff
+    /// a keystroke can cancel is not a backoff.
+    next_attempt: Option<Instant>,
 }
 
 /// The cell the render loop reads and the worker writes.
 #[derive(Debug, Default)]
 pub struct Shared {
     published: Mutex<Published>,
-    /// Signalled when `want` changes, so a session switch does not wait out
-    /// [`REFRESH`].
+    /// Signalled when the wanted key changes or a frame starts asking again.
     wake: Condvar,
+    /// How many times [`Shared::read`] has signalled the worker.
+    ///
+    /// Test-only: the alternative is asserting on a condvar, and a missed
+    /// signal is invisible from the outside until it shows up as a pane that
+    /// took 750 ms to notice the cursor moved.
+    #[cfg(test)]
+    signals: std::sync::atomic::AtomicUsize,
 }
 
 /// What the `log` pane has to paint right now.
@@ -123,25 +147,79 @@ impl Shared {
     #[must_use]
     pub fn read(&self, key: &LogKey) -> Log {
         let mut published = self.guard();
-        if published.want.as_ref() != Some(key) {
+        let switched = published.want.as_ref() != Some(key);
+        if switched {
             published.want = Some(key.clone());
         }
-        if !published.asked {
-            published.asked = true;
-            // Woken while this lock is still held; the worker simply blocks on
-            // the mutex until the guard drops at the end of the function. Only
-            // on the FALSE->TRUE edge, because that is the only transition a
-            // parked worker is waiting for — notifying on every frame would be
-            // eighty wakeups a second telling it something it already knows.
+        let woke = !published.asked;
+        published.asked = true;
+        // BOTH edges. `woke` alone is not enough: a switch that happens while a
+        // frame is already asking leaves the worker asleep on the refresh
+        // interval, so the new session's history arrives up to `REFRESH` late
+        // on the one action where the delay is visible. Signalled while this
+        // lock is still held; the worker simply blocks on the mutex until the
+        // guard drops at the end of the function.
+        if switched || woke {
+            #[cfg(test)]
+            self.signals.fetch_add(1, Ordering::Relaxed);
             self.wake.notify_one();
         }
         if published.have.as_ref() == Some(key) {
             return Log::Rows(published.rows.clone());
         }
         match &published.error {
-            Some(reason) => Log::Failed(reason.clone()),
-            None => Log::Reading,
+            Some((failed, reason)) if failed == key => Log::Failed(reason.clone()),
+            // A failure recorded against a DIFFERENT session says nothing about
+            // this one, so this one is still simply unread.
+            _ => Log::Reading,
         }
+    }
+
+    /// How many times a `read` has signalled the worker.
+    #[cfg(test)]
+    fn signals(&self) -> usize {
+        self.signals.load(Ordering::Relaxed)
+    }
+}
+
+/// What the worker should do next.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    /// Read this key now.
+    Read(LogKey),
+    /// Nothing is due yet; sleep at most this long.
+    Wait(Duration),
+    /// Nobody is looking at the pane. Sleep until signalled.
+    Park,
+}
+
+/// Decide the worker's next move.
+///
+/// Pure, and separate from the loop, because every one of the three cadences
+/// this balances — park when unwatched, refresh while watched, back off after a
+/// failure — is a rule about state rather than about threading, and each is
+/// only checkable in isolation.
+fn next_action(published: &Published, now: Instant) -> Action {
+    if !published.asked {
+        return Action::Park;
+    }
+    let Some(want) = published.want.clone() else {
+        // Asked with nothing to ask FOR. Not reachable through `read`, which
+        // always sets a key; treated as "wait" rather than as a spin.
+        return Action::Wait(REFRESH);
+    };
+    // Neither an answer nor a failure for this key yet — this is a session the
+    // worker has never served, so it outranks whatever interval is running. The
+    // failure half matters: without it, a key that just failed would look
+    // unanswered forever and retry in a tight loop.
+    let answered = published.have.as_ref() == Some(&want);
+    let failed = published.error.as_ref().is_some_and(|(key, _)| *key == want);
+    if !answered && !failed {
+        return Action::Read(want);
+    }
+    match published.next_attempt {
+        Some(at) if at > now => Action::Wait(at.saturating_duration_since(now)),
+        _ => Action::Read(want),
     }
 }
 
@@ -188,51 +266,42 @@ fn worker(shared: &Shared) {
     // schema or checkpoint its WAL.
     let mut store: Option<ainb_plugin_notifyd::Store> = None;
     loop {
-        let (want, asked) = {
+        let action = {
             let published = shared.guard();
-            (published.want.clone(), published.asked)
-        };
-        let mut backoff = REFRESH;
-        if let (true, Some(key)) = (asked, want) {
-            match read_once(&mut store, &key) {
-                Ok(rows) => {
-                    let mut published = shared.guard();
-                    published.have = Some(key);
-                    published.rows = rows;
-                    published.error = None;
-                    published.asked = false;
+            let action = next_action(&published, Instant::now());
+            // Decided AND waited on under one guard, so a `read` landing in
+            // between cannot have its signal lost: `wait` releases the mutex
+            // atomically, and that `read` is still blocked on it.
+            match action {
+                Action::Park => {
+                    let _unused = shared.wake.wait(published);
+                    continue;
                 }
-                Err(reason) => {
-                    // Drop the handle: the usual causes (the file was replaced,
-                    // the daemon rebuilt it) are not fixed by reusing it.
-                    store = None;
-                    let mut published = shared.guard();
-                    published.error = Some(reason);
-                    published.asked = false;
-                    backoff = RETRY;
+                Action::Wait(interval) => {
+                    let _unused = shared.wake.wait_timeout(published, interval);
+                    continue;
                 }
+                Action::Read(key) => key,
             }
-        }
-        let published = shared.guard();
-        // A request that arrived while the read was in flight is served now
-        // rather than after a full interval — without this, the pane would show
-        // the previous session for up to `REFRESH` after the cursor moved.
-        if published.asked && published.want != published.have && published.error.is_none() {
-            continue;
-        }
-        if published.asked {
-            // The pane is open and satisfied: sleep the refresh interval, then
-            // read again.
-            let _unused = shared.wake.wait_timeout(published, backoff);
-        } else {
-            // Nobody has asked since the last read, so there is nothing to
-            // refresh FOR. Park until a frame asks again.
-            //
-            // Checked while holding the guard, and `wait` releases it
-            // atomically, so a `read` that lands between the check and the wait
-            // cannot have its notify lost — it would still be blocked on this
-            // mutex.
-            let _unused = shared.wake.wait(published);
+        };
+        match read_once(&mut store, &action) {
+            Ok(rows) => {
+                let mut published = shared.guard();
+                published.have = Some(action);
+                published.rows = rows;
+                published.error = None;
+                published.asked = false;
+                published.next_attempt = Some(Instant::now() + REFRESH);
+            }
+            Err(reason) => {
+                // Drop the handle: the usual causes (the file was replaced, the
+                // daemon rebuilt it) are not fixed by reusing it.
+                store = None;
+                let mut published = shared.guard();
+                published.error = Some((action, reason));
+                published.asked = false;
+                published.next_attempt = Some(Instant::now() + RETRY);
+            }
         }
     }
 }
@@ -364,13 +433,143 @@ mod tests {
     #[test]
     fn a_failed_read_is_reported_rather_than_rendered_as_no_history() {
         let shared = Shared::default();
+        let key = LogKey::new("/tmp/a", None);
         {
             let mut published = shared.guard();
-            published.error = Some("no notification store yet".to_string());
+            published.error = Some((key.clone(), "no notification store yet".to_string()));
         }
         assert_eq!(
-            shared.read(&LogKey::new("/tmp/a", None)),
+            shared.read(&key),
             Log::Failed("no notification store yet".to_string())
         );
+    }
+
+    /// A failure is evidence about the session it was observed on, and about no
+    /// other. Un-keyed, the red "could not be read" line followed the cursor
+    /// onto healthy rows — an outcome painted under the wrong subject, which is
+    /// the class of bug this whole surface exists to remove.
+    #[test]
+    fn a_failure_on_one_session_is_not_reported_against_another() {
+        let shared = Shared::default();
+        let broken = LogKey::new("/tmp/broken", None);
+        let healthy = LogKey::new("/tmp/healthy", None);
+        {
+            let mut published = shared.guard();
+            published.error = Some((broken.clone(), "no notification store yet".to_string()));
+        }
+        assert_eq!(
+            shared.read(&broken),
+            Log::Failed("no notification store yet".to_string()),
+            "the session it actually happened to still reports it"
+        );
+        assert_eq!(
+            shared.read(&healthy),
+            Log::Reading,
+            "and the session beside it is unread, not broken"
+        );
+    }
+
+    /// A switch has to wake a worker that is already asleep on the interval.
+    /// Signalling only on the asked edge leaves it sleeping, so the new
+    /// session's history lands up to `REFRESH` late on the one action where the
+    /// operator is watching for it.
+    #[test]
+    fn a_session_switch_signals_the_worker_even_while_a_frame_is_already_asking() {
+        let shared = Shared::default();
+        let a = LogKey::new("/tmp/a", None);
+        let b = LogKey::new("/tmp/b", None);
+
+        let _unused = shared.read(&a);
+        assert_eq!(shared.signals(), 1, "the first frame wakes a parked worker");
+        let _unused = shared.read(&a);
+        assert_eq!(
+            shared.signals(),
+            1,
+            "and every frame after it says nothing new"
+        );
+
+        let _unused = shared.read(&b);
+        assert_eq!(
+            shared.signals(),
+            2,
+            "but moving the cursor does, or the switch waits out the interval"
+        );
+    }
+
+    /// The backoff has to be a fact about STATE, not about how long the worker
+    /// happens to sleep. Held in the sleep duration, the render path cancelled
+    /// it without meaning to: every frame raises `asked` and signals, so a
+    /// missing store was re-opened on every keystroke.
+    #[test]
+    fn a_failed_read_backs_off_even_while_frames_keep_asking() {
+        let now = Instant::now();
+        let key = LogKey::new("/tmp/a", None);
+        let published = Published {
+            want: Some(key.clone()),
+            have: None,
+            rows: Vec::new(),
+            error: Some((key, "no notification store yet".to_string())),
+            // A frame asked again immediately, which is what the render loop
+            // does four times a second.
+            asked: true,
+            next_attempt: Some(now + RETRY),
+        };
+        match next_action(&published, now) {
+            Action::Wait(left) => assert!(
+                left > REFRESH,
+                "a failed read must wait out RETRY, not the refresh interval: {left:?}"
+            ),
+            other => panic!("a failing store must not be re-opened per frame, got {other:?}"),
+        }
+    }
+
+    /// The other side of the same rule: once the window has passed, the retry
+    /// actually happens.
+    #[test]
+    fn the_retry_fires_once_the_backoff_has_elapsed() {
+        let now = Instant::now();
+        let key = LogKey::new("/tmp/a", None);
+        let published = Published {
+            want: Some(key.clone()),
+            have: None,
+            rows: Vec::new(),
+            error: Some((key.clone(), "no notification store yet".to_string())),
+            asked: true,
+            next_attempt: Some(now - Duration::from_millis(1)),
+        };
+        assert_eq!(next_action(&published, now), Action::Read(key));
+    }
+
+    /// A session the worker has never served outranks whatever interval is
+    /// running: the switch is the one moment the delay is visible.
+    #[test]
+    fn an_unanswered_session_is_read_before_the_interval_elapses() {
+        let now = Instant::now();
+        let switched_to = LogKey::new("/tmp/b", None);
+        let published = Published {
+            want: Some(switched_to.clone()),
+            have: Some(LogKey::new("/tmp/a", None)),
+            rows: vec![row(1)],
+            error: None,
+            asked: true,
+            // Mid-refresh for the PREVIOUS session.
+            next_attempt: Some(now + REFRESH),
+        };
+        assert_eq!(next_action(&published, now), Action::Read(switched_to));
+    }
+
+    /// And an unwatched pane parks, whatever the intervals say.
+    #[test]
+    fn an_unwatched_pane_parks() {
+        let now = Instant::now();
+        let published = Published {
+            want: Some(LogKey::new("/tmp/a", None)),
+            have: None,
+            rows: Vec::new(),
+            error: None,
+            asked: false,
+            next_attempt: None,
+        };
+        assert_eq!(next_action(&published, now), Action::Park);
     }
 }

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -664,6 +664,20 @@ pub struct Session {
     #[serde(skip)]
     pub live_attention: Vec<crate::fleet::attention::SessionAttention>,
 
+    /// Every ERR observed for this session, INCLUDING the ones too old to still
+    /// light a chip on the row.
+    ///
+    /// The row and the `err` tab answer different questions. The row asks "does
+    /// something need me now", which expires (see
+    /// `[ui] attention_err_window_hours`); the pane asks "what went wrong",
+    /// which does not. Kept as a separate list rather than by un-filtering
+    /// `live_attention` at render time, so a retired failure is still
+    /// inspectable without ever being re-promoted onto the row.
+    ///
+    /// Transient — never persisted; set in `AppState::refresh_attention_markers`.
+    #[serde(skip)]
+    pub errors: Vec<crate::fleet::attention::SessionAttention>,
+
     /// The agent's OWN session id, as its hooks report it.
     ///
     /// Not ainb's `id` and not the tmux name: this is the identity the daemon
@@ -902,6 +916,7 @@ impl Session {
             preview_content: None,
             is_attached: false,
             live_attention: Vec::new(),
+            errors: Vec::new(),
             provider_session_id: None,
         }
     }
@@ -932,6 +947,7 @@ impl Session {
             preview_content: None,
             is_attached: false,
             live_attention: Vec::new(),
+            errors: Vec::new(),
             provider_session_id: None,
         }
     }

--- a/ainb-tui/crates/ainb-core/tests/tripwire_config_err_window.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_config_err_window.rs
@@ -1,0 +1,287 @@
+//! Tripwire: the ERR window is reachable from BOTH surfaces a user has.
+//!
+//! `[ui] attention_err_window_hours` decides how long a failure keeps lighting
+//! a session row. A knob that only exists in `config.toml` is a knob most
+//! operators never find, and a knob that only exists in the settings screen
+//! cannot be set by a dotfile or a provisioning script — so it has to be both,
+//! and this drives the real binary to prove it:
+//!
+//!   a seeded `config.toml` value renders on the Settings screen
+//!     → `/` finds the row by its dotted key from anywhere in the tree
+//!     → `Enter` edits it, the row re-renders with the new value
+//!     → `Esc` `Esc` returns to the HomeScreen
+//!     → the edit is on disk, and the seeded value is gone
+//!
+//! Same shape as `tripwire_config_registry_screen.rs`, deliberately: this key
+//! is only correctly wired if it behaves exactly like every other registry row.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// The row under test, and its seeded / edited values. Both are inside the
+/// registry's declared 1..=8760 range, so the edit exercises validation on the
+/// way to disk rather than being rejected before it.
+const ROW_KEY: &str = "ui.attention_err_window_hours";
+const SEED_HOURS: &str = "3";
+const EDITED_HOURS: &str = "9";
+
+const CONFIG_TITLE: &str = "Configuration";
+const HOME_MARKER: &str = "Stats";
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed_isolated_home(home: &Path) -> PathBuf {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            "completed = true\n\
+             completed_at = \"2026-09-04T00:00:00+00:00\"\n\
+             version = \"{ver}\"\n\
+             skipped_dependencies = []\n\
+             git_directories = []\n",
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+
+    let config_path = cfg.join("config.toml");
+    fs::write(
+        &config_path,
+        format!("[ui]\nattention_err_window_hours = {SEED_HOURS}\n"),
+    )
+    .expect("seed config.toml");
+
+    let paths = ainb_plugin_notifyd::Paths::under(home.join(".agents-in-a-box"));
+    fs::create_dir_all(&paths.base).expect("create agents-in-a-box base");
+    ainb_plugin_notifyd::dismiss_prompt(&paths).expect("seed dismissed notify prompt");
+
+    config_path
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn poll_capture<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Re-sends `key` each iteration until `ok` holds. Only safe for idempotent
+/// keys — used here for `o`, a no-op once the screen is open.
+fn poll_capture_resending<F>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    send_key(session, key);
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+        send_key(session, key);
+    }
+    None
+}
+
+fn send_key(session: &str, key: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+}
+
+fn type_literal(session: &str, text: &str) {
+    Command::new("tmux")
+        .args(["send-keys", "-t", session, "-l", text])
+        .status()
+        .expect("tmux type literal");
+}
+
+fn kill(session: &str) {
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", &format!("={session}")])
+        .status();
+}
+
+/// The rendered row for `key`, padding collapsed: `"<key> : <value>"`.
+///
+/// Asserting on this rather than `capture.contains("9")` is the difference
+/// between "the edit landed on this row" and "the digit 9 appears somewhere on
+/// a 200-column screen".
+fn rendered_row(capture: &str, key: &str) -> Option<String> {
+    let line = capture.lines().find(|line| line.contains(key))?;
+    let start = line.find(key)?;
+    let segment = line[start..].trim_end_matches(['\u{2502}', ' ']);
+    Some(segment.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
+#[test]
+fn the_err_window_is_settable_from_the_settings_screen_and_lands_in_config_toml() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-errwindow-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    let config_path = seed_isolated_home(home_tmp.path());
+
+    let session = format!("tripwire-err-window-{}", std::process::id());
+    assert!(
+        Command::new("tmux")
+            .args(["new-session", "-d", "-s", &session, "-x", "200", "-y", "50"])
+            .status()
+            .expect("tmux new-session")
+            .success(),
+        "tmux new-session failed"
+    );
+
+    let cmd = format!(
+        "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home_tmp.path().display(),
+        ainb_bin().display()
+    );
+    Command::new("tmux")
+        .args(["send-keys", "-t", &session, &cmd, "Enter"])
+        .status()
+        .expect("tmux send launch cmd");
+
+    if poll_capture(&session, Instant::now() + Duration::from_secs(60), |c| {
+        c.contains(HOME_MARKER) && c.contains("[i]")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("HomeScreen never rendered; last capture:\n---\n{last}\n---");
+    }
+
+    if poll_capture_resending(
+        &session,
+        "o",
+        Instant::now() + Duration::from_secs(30),
+        |c| c.contains(CONFIG_TITLE),
+    )
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("Settings never opened; last:\n---\n{last}\n---");
+    }
+
+    // 1. The key exists as a registry row and renders the SEEDED value, which
+    //    is what proves the TOML half reached the screen rather than the row
+    //    rendering its own coded default.
+    send_key(&session, "/");
+    thread::sleep(Duration::from_millis(300));
+    type_literal(&session, "attention_err_window_hours");
+    let Some(matched) = poll_capture(&session, Instant::now() + Duration::from_secs(20), |c| {
+        c.contains(ROW_KEY)
+    }) else {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!(
+            "`/` search did not surface {ROW_KEY}; the knob is not a registry \
+             row, so the settings screen can never offer it:\n---\n{last}\n---"
+        );
+    };
+    assert_eq!(
+        rendered_row(&matched, ROW_KEY).as_deref(),
+        Some(format!("{ROW_KEY} : {SEED_HOURS}").as_str()),
+        "the row did not render the value config.toml set:\n---\n{matched}\n---"
+    );
+
+    // 2. Edit it from the screen.
+    send_key(&session, "Enter");
+    if poll_capture(&session, Instant::now() + Duration::from_secs(15), |c| {
+        c.contains("Enter save | Esc cancel")
+    })
+    .is_none()
+    {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!("the edit popup never mounted; last:\n---\n{last}\n---");
+    }
+    for _ in 0..(SEED_HOURS.len() + 4) {
+        send_key(&session, "BSpace");
+    }
+    type_literal(&session, EDITED_HOURS);
+    thread::sleep(Duration::from_millis(200));
+    send_key(&session, "Enter");
+
+    let edited = poll_capture(&session, Instant::now() + Duration::from_secs(20), |c| {
+        rendered_row(c, ROW_KEY).as_deref() == Some(format!("{ROW_KEY} : {EDITED_HOURS}").as_str())
+    });
+    if edited.is_none() {
+        let last = capture_pane(&session);
+        kill(&session);
+        panic!(
+            "the edited row did not re-render as '{ROW_KEY} : {EDITED_HOURS}'; \
+             last:\n---\n{last}\n---"
+        );
+    }
+
+    // 3. Return path: a forward-only test passes while the way back is broken.
+    send_key(&session, "Escape");
+    thread::sleep(Duration::from_millis(400));
+    send_key(&session, "Escape");
+    let back = poll_capture(&session, Instant::now() + Duration::from_secs(20), |c| {
+        c.contains(HOME_MARKER) && !c.contains(CONFIG_TITLE)
+    });
+    let last = capture_pane(&session);
+    kill(&session);
+    assert!(
+        back.is_some(),
+        "Esc did not return to the HomeScreen; last:\n---\n{last}\n---"
+    );
+
+    // 4. The TOML half, the other direction: the screen's edit is on disk and
+    //    the old value is gone — a save that appended would leave both, and the
+    //    next launch would read whichever serde saw first.
+    let on_disk = fs::read_to_string(&config_path).expect("read seeded config.toml");
+    assert!(
+        on_disk.contains(&format!("attention_err_window_hours = {EDITED_HOURS}")),
+        "config.toml did not persist the edit; contents:\n---\n{on_disk}\n---"
+    );
+    assert!(
+        !on_disk.contains(&format!("attention_err_window_hours = {SEED_HOURS}")),
+        "config.toml still carries the old value; contents:\n---\n{on_disk}\n---"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_err_pane.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_err_pane.rs
@@ -1,0 +1,495 @@
+//! Tripwire: `ERR` stops being a chip that lights forever and says nothing.
+//!
+//! Two complaints, one screen:
+//!
+//! 1. "the ERR once it happens is there always even if very old" — a failure
+//!    never cleared, so one bad session eventually painted the whole list red
+//!    and the chip stopped carrying information;
+//! 2. "No way to see the ERR" — the REASON existed (a daemon `error` row's
+//!    payload, `SessionStatus::Error`'s own string) and reached no per-session
+//!    surface at all.
+//!
+//! What has to be true on a real screen, and is not provable from a unit test:
+//!
+//! - a FRESH failure still lights `ERR` on its row;
+//! - a failure older than `[ui] attention_err_window_hours` does NOT;
+//! - the `err` tab is in the strip, opens on the stale row, and shows the
+//!   reason the producer gave;
+//! - and it says WHY the row is quiet about it, so retiring the chip does not
+//!   simply move the mystery.
+//!
+//! Runs against a real hangar daemon on an isolated socket, so both error rows
+//! are ones that actually travelled the wire.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ainb_hangar_store::repo::attention::{AttentionKind, AttentionRepo, NewAttention};
+use serde_json::json;
+
+#[path = "support/fleet_hangar.rs"]
+mod fleet_hangar;
+
+use fleet_hangar::{EnvGuard, FleetHangar};
+
+/// The two failures, and the branch names their rows are labelled with.
+///
+/// Branch names, because that is what the session list actually prints for an
+/// unlabelled session — asserting on a line found by branch is the difference
+/// between "this row has no ERR" and "the string ERR is absent from a
+/// 200-column screen".
+const STALE_BRANCH: &str = "stalefail";
+const FRESH_BRANCH: &str = "freshfail";
+const STALE_REASON: &str = "worktree vanished under the agent";
+const FRESH_REASON: &str = "adapter exited 1: no such model";
+
+/// Comfortably outside the shipped two-hour window, and comfortably inside it.
+const STALE_AGE_MS: i64 = 5 * 60 * 60 * 1000;
+const FRESH_AGE_MS: i64 = 40_000;
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A tmux session killed by EXACT name on drop. `=name` is the SESSION form.
+struct ExactTmuxSession {
+    name: String,
+}
+
+impl ExactTmuxSession {
+    fn create(name: String, command: &[&str]) -> Self {
+        let mut args: Vec<String> =
+            ["new-session", "-d", "-s"].iter().map(|a| (*a).to_string()).collect();
+        args.push(name.clone());
+        args.extend(["-x", "200", "-y", "50"].iter().map(|a| (*a).to_string()));
+        args.extend(command.iter().map(|part| (*part).to_string()));
+        let status = Command::new("tmux").args(&args).status().expect("tmux new-session");
+        assert!(status.success(), "tmux new-session {name} failed");
+        Self { name }
+    }
+}
+
+impl Drop for ExactTmuxSession {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={}", self.name)])
+            .status();
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn send_key(session: &str, key: &str) {
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+    assert!(status.success(), "tmux send-keys {key:?} failed");
+}
+
+fn poll<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Press `key` until `arrived`, then stop pressing and keep polling for `ok`.
+fn poll_until<F, G>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut arrived: G,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+    G: FnMut(&str) -> bool,
+{
+    let mut on_screen = false;
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        on_screen = on_screen || arrived(&cap);
+        if !on_screen {
+            send_key(session, key);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+/// Press `key` up to `attempts` times, stopping as soon as `ok` holds.
+///
+/// Re-checks between presses: a pane can take more than one repaint to settle,
+/// and pressing again in that window walks straight past the pane the caller
+/// was waiting for. Returns every capture it saw on failure, so the panic says
+/// which panes it actually visited.
+fn press_until<F>(
+    session: &str,
+    key: &str,
+    attempts: usize,
+    mut ok: F,
+) -> Result<String, Vec<String>>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut seen = Vec::new();
+    for _ in 0..attempts {
+        for _ in 0..4 {
+            let cap = capture_pane(session);
+            if ok(&cap) {
+                return Ok(cap);
+            }
+            if seen.last() != Some(&cap) {
+                seen.push(cap);
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        send_key(session, key);
+    }
+    Err(seen)
+}
+
+/// The right pane's first content line from each capture.
+fn visited(captures: &[String]) -> String {
+    captures
+        .iter()
+        .filter_map(|cap| cap.lines().nth(4))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n  ")
+}
+
+/// The one rendered line carrying `branch`, which is what the session list
+/// prints for an unlabelled session.
+///
+/// Skips the Session Info panel below the list: that line also carries the
+/// branch, and matching it would test the footer rather than the row.
+fn row_for<'a>(capture: &'a str, branch: &str) -> Option<&'a str> {
+    let info = session_info_line(capture);
+    capture.lines().find(|line| line.contains(branch) && Some(*line) != info)
+}
+
+/// The line inside the `Session Info` box, which names the session under the
+/// cursor. Found by its box title rather than by a status word, so nothing in
+/// the list above can be mistaken for it.
+fn session_info_line(capture: &str) -> Option<&str> {
+    let mut lines = capture.lines();
+    lines.by_ref().find(|line| line.contains("Session Info"))?;
+    lines.next()
+}
+
+/// Move the cursor down until the Session Info box names `branch`.
+///
+/// Polled rather than counted: the list interleaves workspace headers with
+/// session rows, so "two downs" is a fact about today's fixture and this is a
+/// fact about where the cursor actually is.
+fn select_session(session: &str, branch: &str) -> Option<String> {
+    for _ in 0..12 {
+        for _ in 0..4 {
+            let cap = capture_pane(session);
+            if session_info_line(&cap).is_some_and(|line| line.contains(branch)) {
+                return Some(cap);
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        send_key(session, "Down");
+    }
+    None
+}
+
+fn init_git_repo(dir: &Path, branch: &str) {
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "tripwire")
+            .env("GIT_AUTHOR_EMAIL", "tripwire@example.invalid")
+            .env("GIT_COMMITTER_NAME", "tripwire")
+            .env("GIT_COMMITTER_EMAIL", "tripwire@example.invalid")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init", &format!("--initial-branch={branch}")]);
+    fs::write(dir.join("README.md"), "err pane fixture\n").expect("seed a file");
+    git(&["add", "README.md"]);
+    git(&["-c", "commit.gpgsign=false", "commit", "-m", "seed"]);
+}
+
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            "completed = true\n\
+             completed_at = \"2026-09-04T00:00:00+00:00\"\n\
+             version = \"{ver}\"\n\
+             skipped_dependencies = []\n\
+             git_directories = []\n",
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+    fs::write(
+        base.join("install.json"),
+        r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
+    )
+    .expect("seed install.json");
+}
+
+/// Two sessions in one registry: the stale one FIRST, so it is the row under
+/// the cursor when the screen opens and the `err` tab can be reached without
+/// navigating between rows.
+fn seed_session_registry(home: &Path, stale: (&str, &Path), fresh: (&str, &Path)) {
+    let entry = |id: &str, tmux: &str, worktree: &Path| {
+        json!({
+            "session_id": id,
+            "tmux_session_name": tmux,
+            "worktree_path": worktree,
+            "workspace_name": "errpane",
+            "created_at": "2026-09-04T00:00:00Z",
+            "agent_type": "Claude",
+            "skip_permissions": true,
+        })
+    };
+    let registry = json!({
+        "sessions": {
+            stale.0: entry("6f1f5f7e-0000-4000-8000-0000000000e1", stale.0, stale.1),
+            fresh.0: entry("6f1f5f7e-0000-4000-8000-0000000000e2", fresh.0, fresh.1),
+        }
+    });
+    fs::write(
+        home.join(".agents-in-a-box").join("sessions.json"),
+        serde_json::to_vec_pretty(&registry).expect("encode sessions.json"),
+    )
+    .expect("seed sessions.json");
+}
+
+#[test]
+fn a_stale_err_leaves_the_row_and_the_err_pane_says_why() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-errpane-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    let home = home_tmp.path();
+    seed_isolated_home(home);
+
+    let hangar_home = home.join("hangar-home");
+    fs::create_dir_all(&hangar_home).expect("create isolated hangar home");
+    fs::write(
+        hangar_home.join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .expect("dismiss the notification prompt in the daemon home");
+    let _hangar_home_guard = EnvGuard::set("AINB_HANGAR_HOME", &hangar_home);
+    let hangar = FleetHangar::start(&hangar_home);
+
+    let pid = std::process::id();
+    let stale_tree = home.join("stale");
+    let fresh_tree = home.join("fresh");
+    for (dir, branch) in [(&stale_tree, STALE_BRANCH), (&fresh_tree, FRESH_BRANCH)] {
+        fs::create_dir_all(dir).expect("create worktree dir");
+        init_git_repo(dir, branch);
+    }
+    let stale_tmux = format!("tmux_err_stale_{pid}");
+    let fresh_tmux = format!("tmux_err_fresh_{pid}");
+    seed_session_registry(home, (&stale_tmux, &stale_tree), (&fresh_tmux, &fresh_tree));
+
+    // Two real `error` rows through the daemon, differing only in age. Same
+    // producer, same shape, so the ONLY thing that can explain one chip being
+    // on the row and the other not is the window.
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for (id, tree, reason, age) in [
+        ("att-err-stale", &stale_tree, STALE_REASON, STALE_AGE_MS),
+        ("att-err-fresh", &fresh_tree, FRESH_REASON, FRESH_AGE_MS),
+    ] {
+        hangar.block_on(async {
+            AttentionRepo::insert(
+                hangar.pool(),
+                &NewAttention {
+                    id: id.to_string(),
+                    session_id: format!("provider-{id}"),
+                    cwd: tree.to_string_lossy().into_owned(),
+                    workspace_id: None,
+                    kind: AttentionKind::Error,
+                    payload: json!({ "reason": reason }).to_string(),
+                    degraded: false,
+                    created_at: now_ms - age,
+                    raise_transcript: None,
+                    channels: ainb_hangar_proto::ChannelSet::default(),
+                },
+            )
+            .await
+            .expect("seed the error row");
+        });
+    }
+
+    let _stale_pane = ExactTmuxSession::create(stale_tmux, &["sh", "-c", "sleep 900"]);
+    let _fresh_pane = ExactTmuxSession::create(fresh_tmux, &["sh", "-c", "sleep 900"]);
+
+    let tui_tmux = format!("tripwire-errpane-{pid}");
+    let tui = ExactTmuxSession::create(tui_tmux.clone(), &[]);
+    let launch = format!(
+        "HOME={home} AINB_HANGAR_HOME={hangar} AINB_DISABLE_PLUGINS=1 exec {bin} tui",
+        home = home.display(),
+        hangar = hangar_home.display(),
+        bin = ainb_bin().display()
+    );
+    assert!(
+        Command::new("tmux")
+            .args(["send-keys", "-t", &tui_tmux, &launch, "Enter"])
+            .status()
+            .expect("launch ainb tui")
+            .success(),
+        "tmux refused the launch command"
+    );
+
+    assert!(
+        poll(&tui_tmux, Instant::now() + Duration::from_secs(90), |c| {
+            c.contains("Sessions") && c.contains("[s]")
+        })
+        .is_some(),
+        "HomeScreen never rendered:\n{}",
+        capture_pane(&tui_tmux)
+    );
+
+    // Wait for the FRESH row to light. That is also the proof the daemon poll
+    // has landed, so a missing chip on the stale row below is the window and
+    // not a race with `attention/list`.
+    let Some(listed) = poll_until(
+        &tui_tmux,
+        "s",
+        Instant::now() + Duration::from_secs(90),
+        |c| c.contains("Workspaces ("),
+        |c| row_for(c, FRESH_BRANCH).is_some_and(|row| row.contains("ERR")),
+    ) else {
+        panic!(
+            "the fresh failure never lit an ERR chip, so this test cannot tell a \
+             retired chip from a chip that never arrived:\n---\n{}\n---",
+            capture_pane(&tui_tmux)
+        );
+    };
+
+    // THE window proof: same producer, same kind, five hours older, no chip.
+    let stale_row = row_for(&listed, STALE_BRANCH)
+        .unwrap_or_else(|| panic!("the stale session is not on the screen:\n---\n{listed}\n---"));
+    assert!(
+        !stale_row.contains("ERR"),
+        "a five-hour-old failure must not still be lighting its row: {stale_row}\n\
+         ---\n{listed}\n---"
+    );
+
+    // The strip carries the new pane without losing the old ones.
+    for label in ["preview", "ask", "err", "thread", "copilot", "log"] {
+        assert!(
+            listed.contains(label),
+            "the strip must show every tab, dimmed rather than hidden — `{label}` \
+             is missing:\n{listed}"
+        );
+    }
+
+    // THE reason proof, live half: the cursor opens on the fresh row, and its
+    // `err` pane shows the sentence the producer gave — which before this
+    // reached no per-session surface at all.
+    let Some(_on_fresh) = select_session(&tui_tmux, FRESH_BRANCH) else {
+        panic!(
+            "the cursor never reached the fresh session:\n---\n{}\n---",
+            capture_pane(&tui_tmux)
+        );
+    };
+    let fresh_pane =
+        press_until(&tui_tmux, "Tab", 8, |c| c.contains(FRESH_REASON)).unwrap_or_else(|seen| {
+            panic!(
+                "Tab never reached an err pane showing the fresh reason. Panes \
+                 visited:\n  {}\n---\n{}\n---",
+                visited(&seen),
+                capture_pane(&tui_tmux)
+            )
+        });
+    assert!(
+        fresh_pane.contains("ERR"),
+        "the err pane names the state it is explaining:\n{fresh_pane}"
+    );
+    assert!(
+        !fresh_pane.contains("no longer lights"),
+        "a failure that IS on the row must not claim it has retired:\n{fresh_pane}"
+    );
+
+    // THE reason proof, retired half. Same pane, a five-hour-old failure: the
+    // reason is still there, and the pane says why the row is quiet about it —
+    // so retiring the chip does not simply move the mystery somewhere the
+    // operator cannot see it.
+    let Some(_on_stale) = select_session(&tui_tmux, STALE_BRANCH) else {
+        panic!(
+            "the cursor never reached the stale session:\n---\n{}\n---",
+            capture_pane(&tui_tmux)
+        );
+    };
+    let stale_pane =
+        press_until(&tui_tmux, "Tab", 8, |c| c.contains(STALE_REASON)).unwrap_or_else(|seen| {
+            panic!(
+                "Tab never reached an err pane showing the stale reason. Panes \
+                 visited:\n  {}\n---\n{}\n---",
+                visited(&seen),
+                capture_pane(&tui_tmux)
+            )
+        });
+    assert!(
+        stale_pane.contains("no longer lights"),
+        "a retired failure must say why its row is quiet:\n{stale_pane}"
+    );
+    assert!(
+        stale_pane.contains("attention_err_window_hours"),
+        "and name the knob that decides it:\n{stale_pane}"
+    );
+
+    // Return path: Esc leaves the sessions screen rather than stranding the
+    // operator on a pane a forward-only test never had to come back from.
+    send_key(&tui_tmux, "Escape");
+    let back = poll(&tui_tmux, Instant::now() + Duration::from_secs(20), |c| {
+        c.contains("Sessions") && c.contains("[s]") && !c.contains("Workspaces (")
+    });
+    let last = capture_pane(&tui_tmux);
+    drop(tui);
+    assert!(
+        back.is_some(),
+        "Esc did not return to the HomeScreen:\n---\n{last}\n---"
+    );
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_log_tab_responsive.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_log_tab_responsive.rs
@@ -1,0 +1,450 @@
+//! Tripwire: the `log` tab stops reading SQLite inside `terminal.draw`.
+//!
+//! The report was "in the logs folder the app gets hung". It was not a hang —
+//! it was a store read on the RENDER THREAD. `render_session_tab`'s `Log` arm
+//! called `session_tabs::read_log`, which per repaint opened the notifyd store
+//! read-write, re-ran the whole `CREATE ... IF NOT EXISTS` batch, pulled the
+//! newest 4000 rows with their payloads, and closed the connection again.
+//!
+//! Measured with `Store::open` + `recent_since(0, 4000)` against a 138 MB store
+//! (the shape this test seeds): 2 494 ms for the first call and 106-250 ms for
+//! every one after. The loop repaints once per keystroke, so every key an
+//! operator pressed on this tab paid for one of those reads. With the TUI's own
+//! `AINB_PERF_TRACE` on the fixture below, key-to-render went from p50 53 ms /
+//! max 467 ms to p50 6.6 ms / max 45 ms once the read moved off the thread.
+//!
+//! Two things have to be true on a real screen, and neither is provable from a
+//! unit test:
+//!
+//! 1. the pane still shows this session's history — the fix must not have
+//!    bought responsiveness by rendering nothing;
+//! 2. with the pane OPEN on a large store, a burst of keystrokes is answered
+//!    promptly. The burst is the amplifier: the loop paints once per key, so N
+//!    keys cost N reads under the old code and none under the new one.
+//!
+//! Deliberately store-heavy and not daemon-backed: the local notifications
+//! store is the thing being read, and the hangar has no part in it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ainb_plugin_notifyd::{Envelope, Paths, Store};
+use serde_json::json;
+
+/// Rows the store carries. The old read took the newest `200 * 20`, so the
+/// seed has to clear 4000 for the query to be doing its full work.
+const FILLER_ROWS: usize = 4_100;
+
+/// Payload bytes per filler row. 32 KB × 4000 rows is ~130 MB of payload text
+/// that the old path materialised on EVERY frame to render sixty lines.
+const PAYLOAD_BYTES: usize = 32 * 1024;
+
+/// Rows belonging to the session under test, so the pane has real history.
+const MINE_ROWS: usize = 40;
+
+/// The message the pane must render, distinct from the filler.
+const MINE_MESSAGE: &str = "earlier turn ended here";
+
+/// The raw hook event beside it. Only the `log` pane prints this.
+const MINE_EVENT: &str = "Notification:idle_prompt";
+
+/// Inert keys in the responsiveness burst.
+///
+/// `F5` is bound to nothing on this screen, but the loop repaints on ANY input
+/// event — so each one costs exactly one repaint of the log pane and changes
+/// nothing else. That is the multiplier on the per-frame cost.
+///
+/// A burst of `?` would not work: it toggles the help overlay, so the overlay
+/// appears after the FIRST key and the poll would stop before the burst had
+/// drained. The single `?` below goes at the END, where the overlay it opens
+/// can only be reached through all `BURST_KEYS` repaints ahead of it.
+const BURST_KEYS: usize = 200;
+
+/// How long the burst may take to drain.
+///
+/// Measured on this fixture, same machine, same run: 16.6 s with the read on
+/// the render thread, 0.9 s with it on the worker. Five seconds sits between
+/// the two with 5x headroom below and 3x above, rather than splitting the
+/// difference and flaking on whichever side the machine is slow on that day.
+const BURST_DEADLINE: Duration = Duration::from_secs(5);
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+struct ExactTmuxSession {
+    name: String,
+}
+
+impl ExactTmuxSession {
+    fn create(name: String, command: &[&str]) -> Self {
+        let mut args: Vec<String> =
+            ["new-session", "-d", "-s"].iter().map(|a| (*a).to_string()).collect();
+        args.push(name.clone());
+        args.extend(["-x", "200", "-y", "50"].iter().map(|a| (*a).to_string()));
+        args.extend(command.iter().map(|part| (*part).to_string()));
+        let status = Command::new("tmux").args(&args).status().expect("tmux new-session");
+        assert!(status.success(), "tmux new-session {name} failed");
+        Self { name }
+    }
+}
+
+impl Drop for ExactTmuxSession {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &format!("={}", self.name)])
+            .status();
+    }
+}
+
+fn capture_pane(session: &str) -> String {
+    let out = Command::new("tmux")
+        .args(["capture-pane", "-t", session, "-p"])
+        .output()
+        .expect("tmux capture-pane");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn send_key(session: &str, key: &str) {
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", session, key])
+        .status()
+        .expect("tmux send-keys");
+    assert!(status.success(), "tmux send-keys {key:?} failed");
+}
+
+fn poll<F>(session: &str, deadline: Instant, mut ok: F) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    None
+}
+
+fn poll_until<F, G>(
+    session: &str,
+    key: &str,
+    deadline: Instant,
+    mut arrived: G,
+    mut ok: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+    G: FnMut(&str) -> bool,
+{
+    let mut on_screen = false;
+    while Instant::now() < deadline {
+        let cap = capture_pane(session);
+        if ok(&cap) {
+            return Some(cap);
+        }
+        on_screen = on_screen || arrived(&cap);
+        if !on_screen {
+            send_key(session, key);
+        }
+        thread::sleep(Duration::from_millis(400));
+    }
+    None
+}
+
+fn press_until<F>(
+    session: &str,
+    key: &str,
+    attempts: usize,
+    mut ok: F,
+) -> Result<String, Vec<String>>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut seen = Vec::new();
+    for _ in 0..attempts {
+        // Generous: on a big store the OLD code needed most of a second per
+        // frame, and a test that gave up sooner would fail as "never reached
+        // the pane" rather than reporting the slowness it exists to catch.
+        for _ in 0..12 {
+            let cap = capture_pane(session);
+            if ok(&cap) {
+                return Ok(cap);
+            }
+            if seen.last() != Some(&cap) {
+                seen.push(cap);
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+        send_key(session, key);
+    }
+    Err(seen)
+}
+
+fn visited(captures: &[String]) -> String {
+    captures
+        .iter()
+        .filter_map(|cap| cap.lines().nth(4))
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("\n  ")
+}
+
+fn init_git_repo(dir: &Path) {
+    let git = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "tripwire")
+            .env("GIT_AUTHOR_EMAIL", "tripwire@example.invalid")
+            .env("GIT_COMMITTER_NAME", "tripwire")
+            .env("GIT_COMMITTER_EMAIL", "tripwire@example.invalid")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init", "--initial-branch=logtab"]);
+    fs::write(dir.join("README.md"), "log tab fixture\n").expect("seed a file");
+    git(&["add", "README.md"]);
+    git(&["-c", "commit.gpgsign=false", "commit", "-m", "seed"]);
+}
+
+fn seed_isolated_home(home: &Path) {
+    let base = home.join(".agents-in-a-box");
+    let cfg = base.join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            "completed = true\n\
+             completed_at = \"2026-09-04T00:00:00+00:00\"\n\
+             version = \"{ver}\"\n\
+             skipped_dependencies = []\n\
+             git_directories = []\n",
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+    fs::write(
+        base.join("install.json"),
+        r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#,
+    )
+    .expect("seed install.json");
+}
+
+fn seed_session_registry(home: &Path, tmux_name: &str, worktree: &Path) {
+    let entry = json!({
+        "sessions": {
+            tmux_name: {
+                "session_id": "6f1f5f7e-0000-4000-8000-0000000000c1",
+                "tmux_session_name": tmux_name,
+                "worktree_path": worktree,
+                "workspace_name": "logtab",
+                "created_at": "2026-09-04T00:00:00Z",
+                "agent_type": "Claude",
+                "skip_permissions": true,
+            }
+        }
+    });
+    fs::write(
+        home.join(".agents-in-a-box").join("sessions.json"),
+        serde_json::to_vec_pretty(&entry).expect("encode sessions.json"),
+    )
+    .expect("seed sessions.json");
+}
+
+/// A store the size an ainb host actually accumulates.
+///
+/// The filler rows are the point: this pane shows forty lines, and the read it
+/// used to do on every frame had to carry four thousand rows and their payloads
+/// to find them.
+fn seed_big_store(base: &Path, cwd: &Path) {
+    let paths = Paths::under(base);
+    fs::create_dir_all(&paths.base).expect("create notifyd base");
+    let store = Store::open(&paths.db).expect("open notifications.db");
+    let filler = "x".repeat(PAYLOAD_BYTES);
+    let now = chrono::Utc::now().timestamp_millis();
+    for index in 0..FILLER_ROWS {
+        store
+            .insert(&Envelope {
+                protocol_version: 1,
+                agent: "claude".into(),
+                raw_event: "Notification:idle_prompt".into(),
+                session_id: format!("filler-{index}"),
+                // Another worktree entirely: these rows exist to be READ and
+                // discarded, which is exactly what the old query did with them.
+                cwd: "/tmp/ainb-logtab-filler".into(),
+                project: "filler".into(),
+                ts: now - 3_600_000 - (index as i64),
+                payload: json!({ "message": filler }),
+            })
+            .expect("seed filler row");
+    }
+    for index in 0..MINE_ROWS {
+        store
+            .insert(&Envelope {
+                protocol_version: 1,
+                agent: "claude".into(),
+                raw_event: "Notification:idle_prompt".into(),
+                session_id: "logtab-1".into(),
+                cwd: cwd.to_string_lossy().into_owned(),
+                project: "logtab".into(),
+                ts: now - 120_000 - (index as i64),
+                payload: json!({ "message": MINE_MESSAGE }),
+            })
+            .expect("seed session row");
+    }
+}
+
+#[test]
+fn the_log_tab_shows_its_history_without_stalling_the_key_loop() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+
+    let home_tmp = tempfile::Builder::new()
+        .prefix("ainb-logtab-")
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    let home = home_tmp.path();
+    seed_isolated_home(home);
+
+    let pid = std::process::id();
+    let worktree = home.join("logtab");
+    fs::create_dir_all(&worktree).expect("create worktree dir");
+    init_git_repo(&worktree);
+    let agent_tmux = format!("tmux_logtab_{pid}");
+    seed_session_registry(home, &agent_tmux, &worktree);
+
+    // `Paths::from_home` prefers `AINB_HANGAR_HOME` over `$HOME`, and the TUI
+    // is launched with it set below — so the store has to be seeded under the
+    // SAME base or the pane renders its (correct) empty state forever.
+    let hangar_home = home.join("hangar-home");
+    fs::create_dir_all(&hangar_home).expect("create isolated hangar home");
+    fs::write(
+        hangar_home.join("install.json"),
+        r#"{"agents":[],"hook_script":"","prompt_dismissed":true}"#,
+    )
+    .expect("dismiss the notification prompt in the daemon home");
+    let seeded_at = Instant::now();
+    seed_big_store(&hangar_home, &worktree);
+    eprintln!(
+        "seeded {FILLER_ROWS} filler + {MINE_ROWS} session rows in {:?}",
+        seeded_at.elapsed()
+    );
+
+    let _pane = ExactTmuxSession::create(agent_tmux, &["sh", "-c", "sleep 900"]);
+
+    let tui_tmux = format!("tripwire-logtab-{pid}");
+    let tui = ExactTmuxSession::create(tui_tmux.clone(), &[]);
+    let launch = format!(
+        "HOME={home} AINB_HANGAR_HOME={hangar} AINB_DISABLE_PLUGINS=1 exec {bin} tui",
+        home = home.display(),
+        hangar = hangar_home.display(),
+        bin = ainb_bin().display()
+    );
+    assert!(
+        Command::new("tmux")
+            .args(["send-keys", "-t", &tui_tmux, &launch, "Enter"])
+            .status()
+            .expect("launch ainb tui")
+            .success(),
+        "tmux refused the launch command"
+    );
+
+    assert!(
+        poll(&tui_tmux, Instant::now() + Duration::from_secs(90), |c| {
+            c.contains("Sessions") && c.contains("[s]")
+        })
+        .is_some(),
+        "HomeScreen never rendered:\n{}",
+        capture_pane(&tui_tmux)
+    );
+
+    assert!(
+        poll_until(
+            &tui_tmux,
+            "s",
+            Instant::now() + Duration::from_secs(90),
+            |c| c.contains("Workspaces ("),
+            |c| c.contains("preview") && c.contains("log"),
+        )
+        .is_some(),
+        "the sessions screen never rendered its tab strip:\n---\n{}\n---",
+        capture_pane(&tui_tmux)
+    );
+
+    // 1. The pane still does its job. A fix that made the tab fast by making it
+    //    empty would pass a timing assertion on its own.
+    // BOTH tokens, not just the message: `Notification:idle_prompt` also raises
+    // an ASK, and the `ask` pane leads with the same sentence. Only the log
+    // pane prints the raw hook event beside it.
+    let log_pane = press_until(&tui_tmux, "Tab", 8, |c| {
+        c.contains(MINE_MESSAGE) && c.contains(MINE_EVENT)
+    })
+    .unwrap_or_else(|seen| {
+        panic!(
+            "Tab never reached a log pane showing this session's history. \
+             Panes visited:\n  {}\n---\n{}\n---",
+            visited(&seen),
+            capture_pane(&tui_tmux)
+        )
+    });
+    assert!(
+        !log_pane.contains(&"x".repeat(16)),
+        "and only THIS session's rows — the filler payload is on screen:\n{log_pane}"
+    );
+
+    // 2. THE responsiveness proof: queue a burst the loop has to repaint its
+    //    way through, and time how long the pane takes to answer the key at
+    //    the end of it.
+    // ONE `send-keys`, not one per key: the clock has to measure the TUI
+    // draining the burst, and 200 tmux invocations would put most of a second
+    // of process spawning inside the window being asserted on.
+    let mut burst = Command::new("tmux");
+    burst.args(["send-keys", "-t", &tui_tmux]);
+    for _ in 0..BURST_KEYS {
+        burst.arg("F5");
+    }
+    // The one key with a visible effect, queued LAST. Keys are drained in
+    // order, so the overlay it opens cannot appear until every repaint ahead of
+    // it has happened.
+    burst.arg("?");
+    assert!(
+        burst.status().expect("tmux send-keys burst").success(),
+        "tmux refused the burst"
+    );
+    let burst_started = Instant::now();
+    let answered = poll(
+        &tui_tmux,
+        burst_started + BURST_DEADLINE,
+        // The overlay's own border title, so nothing else on a 200-column
+        // screen can satisfy this.
+        |c| c.contains("Help - Press ? or Esc to close"),
+    );
+    let elapsed = burst_started.elapsed();
+    let last = capture_pane(&tui_tmux);
+    drop(tui);
+    assert!(
+        answered.is_some(),
+        "{BURST_KEYS} keystrokes queued on the log tab were not drained within \
+         {BURST_DEADLINE:?} ({elapsed:?} elapsed). The pane is reading the \
+         notifications store on the render thread again.\n---\n{last}\n---"
+    );
+    eprintln!("burst of {BURST_KEYS} keys drained in {elapsed:?}");
+}

--- a/ainb-tui/crates/ainb-core/tests/tripwire_sessions_tab_strip.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_sessions_tab_strip.rs
@@ -4,7 +4,7 @@
 //! Phases 1 and 2 put chips on rows. This is the pane that answers them. What
 //! has to be true on a real screen, and is not provable from a unit test:
 //!
-//! 1. all five labels render, with the unavailable ones DIMMED rather than
+//! 1. all six labels render, with the unavailable ones DIMMED rather than
 //!    hidden — a strip that reflows as sessions change state is a strip nobody
 //!    learns;
 //! 2. `Tab` walks it and skips what is unavailable;
@@ -380,7 +380,10 @@ fn the_tab_strip_opens_every_pane_and_enter_stops_meaning_attach() {
             capture_pane(&tui_tmux)
         );
     };
-    for label in ["preview", "ask", "thread", "copilot", "log"] {
+    // `err` included deliberately: it is dimmed on this fixture (nothing has
+    // failed) and must still be VISIBLE, which is the rule this list exists to
+    // hold. `tripwire_sessions_err_pane` is where it is opened.
+    for label in ["preview", "ask", "err", "thread", "copilot", "log"] {
         assert!(
             strip.contains(label),
             "the strip must show every tab, dimmed rather than hidden — `{label}` \

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/store.rs
@@ -634,6 +634,62 @@ impl Store {
         Ok(out)
     }
 
+    /// One session's non-dismissed notifications, newest first.
+    ///
+    /// The per-session half of [`Self::recent_since`], and the reason it exists
+    /// is a query plan. The `log` tab used to read the newest `limit * 20` rows
+    /// fleet-wide and keep the handful for one cwd, which on a real store meant
+    /// materialising 4000 rows and ~8 MB of payload text to render 60 lines.
+    ///
+    /// `+agent` is not a typo: it is SQLite's "do not use an index for this
+    /// term". Without it the planner prefers `idx_notifications_agent` — which
+    /// every row matches, since a host usually runs one agent — abandons
+    /// `idx_notifications_ts` and sorts the whole table in a temp b-tree.
+    /// Measured on a 546 MB store that plan cost 378-672 ms; forced onto the
+    /// `ts` index the same query is 5-18 ms.
+    pub fn recent_for_cwd(
+        &self,
+        cwd: &str,
+        agent: Option<&str>,
+        since_ms: i64,
+        limit: u32,
+    ) -> Result<Vec<NotificationRecord>, StoreError> {
+        let cwd = cwd.trim_end_matches('/');
+        // Both spellings, because the column is stored verbatim: a hook that
+        // fired in `/w/` and one that fired in `/w` are the same directory and
+        // must land in the same pane.
+        let with_slash = format!("{cwd}/");
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, ts, agent, session_id, cwd, project, raw_event, payload, read, dismissed
+             FROM notifications
+             WHERE ts > ?1 AND dismissed = 0
+               AND (+cwd = ?2 OR +cwd = ?3)
+               AND (?4 IS NULL OR +agent = ?4)
+             ORDER BY ts DESC
+             LIMIT ?5",
+        )?;
+        let rows = stmt.query_map(params![since_ms, cwd, with_slash, agent, limit], |r| {
+            Ok(NotificationRecord {
+                id: r.get(0)?,
+                ts: r.get(1)?,
+                agent: r.get(2)?,
+                session_id: r.get(3)?,
+                cwd: r.get(4)?,
+                project: r.get(5)?,
+                raw_event: r.get(6)?,
+                payload_json: r.get(7)?,
+                read: r.get::<_, i64>(8)? != 0,
+                dismissed: r.get::<_, i64>(9)? != 0,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     // --- event-sourcing (Wave 2) --------------------------------------------
 
     /// Append one event to the append-only `events` log. `row.seq` is


### PR DESCRIPTION
Two reports on the sessions screen: the `log` tab hangs the app, and `ERR` lights forever without ever saying what failed.

## 1. The log tab was reading SQLite inside `terminal.draw`

Not a hang, a per-frame store read. `render_session_tab`'s `Log` arm called `session_tabs::read_log`, which on **every repaint**:

- opened the notifyd store **READ-WRITE** (`SQLITE_OPEN_CREATE`),
- ran `PRAGMA journal_mode=WAL` and the full `CREATE ... IF NOT EXISTS` batch — the TUI applying DDL to a database the daemon owns,
- pulled the newest 4000 rows *with their payloads* to keep the ~60 for one session,
- and closed the connection, which on the last handle **checkpoints the WAL**.

Measured in-process against a byte-copy of a real store (546 MB file, 9 927 notification rows, 73.5 MB WAL):

| | per call |
|---|---|
| frame that inherited the fat WAL | **948 ms** — and it truncated the daemon's 73.5 MB WAL from inside the render pass |
| steady state, notifyd writing | 37–631 ms (typ. 50–120 ms) |

The loop repaints once per keystroke and once per 250 ms app tick, so every key pressed on that tab paid for one of those reads.

**Fix:** the read moves to a worker thread (`fleet/session_log.rs`) holding **one read-only connection**. No per-call open, no DDL, no checkpoint from a render pass. A session switch signals a condvar rather than waiting out the 750 ms refresh. The query itself is now per-session in SQL (`Store::recent_for_cwd`) — with `+agent` to stop the planner abandoning `idx_notifications_ts` for a temp b-tree sort, which measured 378–672 ms against 5–18 ms.

Same fixture, TUI's own `AINB_PERF_TRACE`:

| | draw avg | draw max | key→render p50 | p95 | max |
|---|---|---|---|---|---|
| before | 18.8 ms | 467 ms | 53 ms | 112 ms | 467 ms |
| after | 5.6 ms | 44 ms | **6.6 ms** | 27 ms | **45 ms** |

The pane also stops rendering three different things as "no notifications recorded": *still reading*, *the store could not be read* (named), and *this session genuinely has no history*.

## 2. `ERR` never cleared, and never said why

**The reason was thrown away.** `SessionStatus::Error(reason)` has always carried the sentence explaining what broke; `SessionAttention::local` sets `detail: None`. The only surface it reached was the bottom logs strip, which is not per-session and scrolls.

**The chip never retired.** `SessionStatus::Error` does not resolve by itself, so one failure lit a row for as long as the session existed.

- The chip now carries the reason.
- `[ui] attention_err_window_hours` (default **2**) retires a chip the row has outlived. One rule, applied once after `normalise`, so a daemon `error`/`escalation` row obeys the same window as a local failure.
- Errors are split off **before** the window is applied and kept on the row unwindowed, so retiring the chip hides the alarm and never the reason.
- A new **`err` pane**: `preview | ask | err | thread | copilot | log`. It shows every error including the retired ones, and says why the row is quiet about them plus the knob that decides it.

## Additive

No binding moves. The strip has no per-tab hotkeys, `1`-`9` still attach from every tab, and the new pane is dimmed rather than hidden when nothing has failed, so the strip never reflows. `help.rs` and `tripwire_sessions_tab_strip` updated deliberately for the sixth label.

## Config

One registry row puts the knob in `config.toml` and on the settings screen at once — no second mechanism.

## Verification

`cargo fmt --check` clean. `cargo nextest run -p ainb -p ainb-plugin-notifyd --lib --tests -E 'not binary(/^tripwire_/)'` → **5149 passed, 0 failed, 17 skipped**. Every commit in the series compiles standalone.

Three new permanent tripwires drive the real binary in tmux, each falsified by reverting the guard it protects:

| tripwire | falsified by | red result |
|---|---|---|
| `tripwire_sessions_log_tab_responsive` | read back inside `render_session_tab` | 200-key burst drained in **16.6 s** vs 0.9 s (5 s deadline) |
| `tripwire_sessions_err_pane` | dropping the window filter | `ERR 5h` back on the stale row |
| " | `SessionTab::Err` painting nothing | "Tab never reached an err pane showing the fresh reason" |
| `tripwire_config_err_window` | demoting the registry row to hidden | "`/` search did not surface ui.attention_err_window_hours" |

Eleven unit tests added alongside, each also driven red before being restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **ERR** sessions tab showing failure reasons, sources, and historical errors.
  - Added configurable control for how long failure indicators remain visible on session rows.
  - Added background loading for session logs to keep navigation and keyboard input responsive.
  - Added filtering for session recovery, with keyboard navigation and shortcut isolation.
  - Added support for displaying interactive user questions with their available options.
- **Bug Fixes**
  - Older failures remain accessible in the ERR tab after row indicators expire.
- **Documentation**
  - Updated in-app help to include the new ERR tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->