### PR TITLE
fix(fleet): attach the notch's copilot chat to the session already holding its scope

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/fleet/acp.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/acp.rs
@@ -45,7 +45,10 @@ async fn create(matches: &clap::ArgMatches, format: OutputFormat) -> Result<()> 
     let result = client()
         .acp_session_create(FleetAcpSessionCreateParams {
             provider: Some(provider),
-            cwd,
+            // Always named here, unlike the chat page's attach: this subcommand
+            // exists to CREATE a session, and its `--cwd` is required above, so
+            // there is no operator intent to resolve from a standing one.
+            cwd: Some(cwd),
             scope_key: matches.get_one::<String>("scope").cloned(),
         })
         .await;

--- a/ainb-tui/crates/ainb-core/src/fleet/control.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/control.rs
@@ -219,31 +219,35 @@ pub fn chat_page_blocking(
         let cwd = std::env::current_dir()
             .map(|cwd| cwd.display().to_string())
             .unwrap_or_else(|_| ".".to_string());
-        let mint = |provider: Option<String>| {
+        let mint = |provider: Option<String>, cwd: Option<String>| {
             client.acp_session_create(ainb_hangar_proto::fleet::FleetAcpSessionCreateParams {
                 provider,
-                cwd: cwd.clone(),
+                cwd,
                 scope_key: Some(scope.clone()),
             })
         };
-        // Deliberately unnamed: this call wants THE copilot session, not a
-        // particular engine. Naming one reverted an adapter the operator had
-        // swapped, and once the scope was held by that other adapter the mint
-        // was refused outright, so opening the chat page after a swap failed
-        // instead of attaching.
-        let created = match mint(None).await {
-            // A daemon older than this binary still REQUIRES `provider`, and an
-            // absent one is a missing field it refuses. That is the ordinary
-            // upgrade-the-binary-keep-the-daemon window, and leaving it would
-            // make the copilot page unopenable across it. Retried once naming
-            // the built-in adapter, which is exactly what this call sent before
-            // the parameter became optional: no worse than it was, against a
-            // daemon that cannot do better.
-            Err(error) if names_the_provider_field(&error.to_string()) => {
-                mint(Some(LEGACY_DAEMON_ADAPTER.to_string())).await
-            }
-            other => other,
-        };
+        // Deliberately unnamed, BOTH halves: this call wants THE copilot
+        // session, not a particular engine rooted at a particular directory.
+        // Naming an adapter reverted one the operator had swapped, and naming a
+        // cwd was refused outright the moment the scope was held by a session
+        // opened from a different directory, which is every TUI launched from
+        // anywhere but the first one.
+        let mut created = mint(None, None).await;
+        // Rung 2: a daemon built before `cwd` became optional REQUIRES one, and
+        // a current daemon asks for it when the scope has no live session to
+        // take a root from. Both are answered by naming this process's own
+        // directory, which is exactly what this call sent before.
+        if matches!(&created, Err(error) if names_missing_field(&error.to_string(), "cwd")) {
+            created = mint(None, Some(cwd.clone())).await;
+        }
+        // Rung 3: older still, `provider` is required too. That is the ordinary
+        // upgrade-the-binary-keep-the-daemon window, and leaving it would make
+        // the copilot page unopenable across it. Named as the built-in adapter,
+        // which is what this call sent before the parameter became optional: no
+        // worse than it was, against a daemon that cannot do better.
+        if matches!(&created, Err(error) if names_missing_field(&error.to_string(), "provider")) {
+            created = mint(Some(LEGACY_DAEMON_ADAPTER.to_string()), Some(cwd.clone())).await;
+        }
         let (target_session_key, session_detail, turn_deadline_ms) = match created {
             // The pool's turn ceiling rides back on the mint and is the only
             // door it has onto a client, so it is carried through to the pane
@@ -755,21 +759,36 @@ pub fn copilot_configure_blocking(
 /// arbitrary.
 const LEGACY_DAEMON_ADAPTER: &str = "claude-agent-acp";
 
-/// Whether a daemon refusal is the older daemon rejecting an ABSENT `provider`.
+/// Whether a daemon refusal is that daemon asking for `field` to be NAMED.
 ///
 /// Matched on the wording because that is all a JSON-RPC `invalid_params`
-/// carries. Deliberately narrow: it gates one retry that is harmless when the
-/// guess is wrong, and a new daemon never produces this message at all, having
-/// made the field optional.
-fn names_the_provider_field(error: &str) -> bool {
+/// carries, and ANCHORED to the field name rather than looking for two loose
+/// substrings. That is not fussiness: `parse_params` formats every refusal as
+/// `expected {shape}: {serde error}` and the SHAPE HINT names every field, so
+/// a legacy daemon refusing an absent provider says
+/// `expected { provider, cwd, scope_key? }: missing field \`provider\``, which
+/// contains both "cwd" and "missing". A matcher looking for those two
+/// separately fires the cwd rung on a provider refusal, spending it on a
+/// request the daemon never made.
+///
+/// Exactly two shapes are accepted, and nothing else:
+///
+/// * ``missing field `<field>` ``, serde's own, from a daemon built before the
+///   field became optional. The backticks are part of the match: without them
+///   the shape hint alone satisfies it.
+/// * `<field> is required`, the current daemon's own refusal, which is not a
+///   skew at all but is answered by the same retry: name it.
+///
+/// Everything else propagates, which is the point. A scope already held names
+/// the field too (`... whose cwd is "/work/api"`), as does an unknown adapter,
+/// and both are real refusals whose wording is the operator's only clue. An
+/// `invalid type` arm is deliberately absent as well (a caller sending a number
+/// is a client bug, and retrying it with a guessed value would mask it).
+fn names_missing_field(error: &str, field: &str) -> bool {
     let error = error.to_ascii_lowercase();
-    // `missing` only. The field is `skip_serializing_if = "Option::is_none"`,
-    // so an omitted provider is absent from the frame rather than `null`, and
-    // an older daemon reports it as a MISSING field. An `invalid type` arm was
-    // unreachable from this call site and could only have masked a genuine
-    // client bug — a caller sending a number — by retrying it against the
-    // built-in adapter.
-    error.contains("provider") && error.contains("missing")
+    let field = field.to_ascii_lowercase();
+    error.contains(&format!("missing field `{field}`"))
+        || error.contains(&format!("{field} is required"))
 }
 
 #[cfg(test)]
@@ -829,33 +848,116 @@ mod tests {
     use super::*;
     use crate::fleet::types::{Session, SessionSource};
 
-    /// The retry fires for an older daemon's refusal of an absent `provider`,
-    /// and for nothing else — an unknown-adapter refusal names the provider too
-    /// and must NOT be retried with a different one.
+    /// The two refusals a REAL daemon sends when it wants `provider` named,
+    /// verbatim.
+    ///
+    /// Verbatim matters more than it looks. `parse_params` wraps every serde
+    /// error as `expected {shape}: {error}`, and the shape hint lists the other
+    /// fields, so these strings contain the word "cwd" as well. A matcher that
+    /// looked for "cwd" and "missing" separately called this a cwd refusal and
+    /// spent the cwd rung on it; the tests that said otherwise were feeding
+    /// messages no daemon emits.
+    const LEGACY_MISSING_PROVIDER: &str = "daemon rpc error -32602: expected { provider, cwd, scope_key? }: \
+         missing field `provider`";
+    const CWD_REQUIRED_DAEMON_MISSING_PROVIDER: &str = "daemon rpc error -32602: expected { provider?, cwd, scope_key? }: \
+         missing field `provider`";
+    /// What a daemon built before `cwd` became optional sends.
+    const LEGACY_MISSING_CWD: &str = "daemon rpc error -32602: expected { provider?, cwd, scope_key? }: \
+         missing field `cwd`";
+    /// What THIS daemon sends when the create has no live session to take a
+    /// root from. Not a skew, but answered by the same retry.
+    const CWD_REQUIRED: &str = "daemon rpc error -32602: cwd is required unless the named scope \
+         already has a live session to take its root from";
+
+    /// Rung 3 fires for a daemon that asks for `provider`, and for nothing
+    /// else. An unknown-adapter refusal names the provider too and must NOT be
+    /// retried with a different one.
     #[test]
     fn only_a_missing_provider_field_triggers_the_legacy_retry() {
-        assert!(names_the_provider_field(
-            "invalid params: missing field `provider`"
-        ));
         assert!(
-            !names_the_provider_field(
-                "invalid params: invalid type: number, expected a string at provider"
+            names_missing_field(LEGACY_MISSING_PROVIDER, "provider"),
+            "the daemon that requires both fields"
+        );
+        assert!(
+            names_missing_field(CWD_REQUIRED_DAEMON_MISSING_PROVIDER, "provider"),
+            "the daemon that made provider optional but still requires cwd"
+        );
+        assert!(
+            !names_missing_field(
+                "daemon rpc error -32602: expected { provider?, cwd?, scope_key? }: \
+                 invalid type: integer `7`, expected a string",
+                "provider"
             ),
             "a caller sending the wrong type is a client bug, not a daemon skew, \
              and must not be retried against a different adapter"
         );
         assert!(
-            !names_the_provider_field(
-                "unknown adapter \"gemini-acp\"; fleet/adapter_list names the ones this daemon can spawn"
+            !names_missing_field(
+                "unknown adapter \"gemini-acp\"; fleet/adapter_list names the ones this daemon can spawn",
+                "provider"
             ),
             "an adapter the daemon does not know is a real refusal, not a skew"
         );
         assert!(
-            !names_the_provider_field(
-                "scope_key \"channel:c1\" is already held by a session whose provider is codex-acp"
+            !names_missing_field(
+                "scope_key \"channel:c1\" is already held by a session whose provider is codex-acp",
+                "provider"
             ),
             "a held scope must not be retried with the built-in adapter"
         );
+    }
+
+    /// Rung 2 fires for BOTH daemons that want a cwd named: one built before
+    /// the field was optional, and a current one with no live session to take a
+    /// root from. Neither is answerable any other way.
+    #[test]
+    fn a_daemon_asking_for_a_cwd_triggers_the_second_rung_but_a_held_scope_does_not() {
+        assert!(
+            names_missing_field(LEGACY_MISSING_CWD, "cwd"),
+            "a daemon built before cwd became optional"
+        );
+        assert!(
+            names_missing_field(CWD_REQUIRED, "cwd"),
+            "the current daemon with nothing to resolve the root from"
+        );
+        assert!(
+            !names_missing_field(
+                "scope_key \"channel:c1\" is already held by a session whose cwd is \
+                 \"/work/api\", not \"/work/web\"; stop it before creating a different one",
+                "cwd"
+            ),
+            "a held scope is a real refusal whose wording is the operator's only clue"
+        );
+        assert!(
+            !names_missing_field("cwd must not be empty", "cwd"),
+            "a blank cwd is a client bug, not a daemon asking to be told"
+        );
+    }
+
+    /// The rungs do not answer each other's refusals.
+    ///
+    /// This is the assertion the loose matcher failed. Both legacy refusals
+    /// carry the word "cwd" inside `parse_params`'s shape hint, so a client
+    /// that read them as a cwd request would name a directory at a daemon that
+    /// asked for an adapter, get the same refusal, and only then climb to the
+    /// rung that would have worked.
+    #[test]
+    fn a_refusal_for_one_field_never_satisfies_the_other_rung() {
+        for refusal in [
+            LEGACY_MISSING_PROVIDER,
+            CWD_REQUIRED_DAEMON_MISSING_PROVIDER,
+        ] {
+            assert!(
+                !names_missing_field(refusal, "cwd"),
+                "the shape hint names cwd, but the daemon asked for a provider: {refusal}"
+            );
+        }
+        for refusal in [LEGACY_MISSING_CWD, CWD_REQUIRED] {
+            assert!(
+                !names_missing_field(refusal, "provider"),
+                "a daemon asking for a root must not be answered with an adapter: {refusal}"
+            );
+        }
     }
 
     fn seed_git_repository(path: &Path) -> (git2::Repository, git2::Oid) {

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -6167,7 +6167,7 @@ async fn handle_fleet_acp_session_create(
     use crate::acp_session::EnsureError;
 
     require_fleet_capability(FLEET_CAPABILITY_ACP_SPAWN)?;
-    let params: FleetAcpSessionCreateParams = parse_params(req, "{ provider?, cwd, scope_key? }")?;
+    let params: FleetAcpSessionCreateParams = parse_params(req, "{ provider?, cwd?, scope_key? }")?;
     // `task:<id>` belongs to the task executor (`crate::acp_task`). A chat
     // session minted there would make that task's later run fail `ScopeHeld`
     // (terminal, `SpawnError`, no retry) and would make the pool stamp this
@@ -6179,35 +6179,91 @@ async fn handle_fleet_acp_session_create(
             crate::acp_task::TASK_SCOPE_PREFIX
         )));
     }
+    // Blank is omitted, for BOTH fields and by the same rule: whitespace names
+    // no adapter and roots no session, so a caller that sent one asked for
+    // nothing rather than for the empty string. Treating them differently left
+    // a trap, because a blank cwd used to reach `ensure` as a hard refusal that
+    // neither client retry ladder can match, so a caller that sent one had no
+    // rung to spend and simply stuck.
+    //
+    // Resolved before the read below so the read's guard and the two
+    // resolutions cannot disagree about what "named" means.
+    let named_provider = params.provider.as_deref().map(str::trim).filter(|name| !name.is_empty());
+    let named_cwd = params.cwd.as_deref().map(str::trim).filter(|root| !root.is_empty());
+    // The scope's standing session, read ONCE for both fields below: they are
+    // two halves of the same question ("what does this scope already run, and
+    // where"), and asking it twice would put a second SELECT on a call a chat
+    // client makes to attach.
+    //
+    // Skipped entirely when the caller named both, which is the point of this
+    // whole change: `ensure` compares what it was given against the incumbent
+    // anyway, so reading the row here would add a SELECT to the very call this
+    // work exists to take off a contended database. Also absent when no scope
+    // was named, because a private scope is minted per session and therefore
+    // never has an incumbent.
+    //
+    // Read OUTSIDE the transaction `ensure` opens later, so the incumbent can
+    // be torn down in between and the mint then roots a fresh session at a dead
+    // session's cwd. That is the intended answer rather than a hole to close:
+    // it is the directory the operator's conversation was opened in, which is
+    // the only root a client that named none could have meant, and closing the
+    // window would mean holding a write transaction across the whole resolve.
+    // The provider path had the same window before this change.
+    let held = match params.scope_key.as_deref() {
+        Some(scope) if named_provider.is_none() || named_cwd.is_none() => {
+            FleetAcpSessionRepo::get_live_by_scope(pool, scope)
+                .await
+                .map_err(|error| store_err(&error))?
+        }
+        _ => None,
+    };
     // An omitted provider means "whatever this scope already runs". Resolved
     // here because only the daemon can answer it: a client that guessed reverted
     // a swapped engine, and `ensure` refuses a live scope whose adapter differs
     // from the one asked for, so the guess did not even fail quietly.
-    let provider = match params.provider.as_deref().map(str::trim).filter(|name| !name.is_empty()) {
+    let provider = match named_provider {
         Some(named) => named.to_string(),
-        None => {
-            let held = match params.scope_key.as_deref() {
-                Some(scope) => FleetAcpSessionRepo::get_live_by_scope(pool, scope)
-                    .await
-                    .map_err(|error| store_err(&error))?
-                    .map(|row| row.provider),
-                None => None,
-            };
-            held.unwrap_or_else(|| ainb_acp::config::CLAUDE_ADAPTER.to_string())
-        }
+        None => held.as_ref().map_or_else(
+            || ainb_acp::config::CLAUDE_ADAPTER.to_string(),
+            |row| row.provider.clone(),
+        ),
     };
-    let row = crate::acp_session::ensure(
-        pool,
-        events,
-        &provider,
-        &params.cwd,
-        params.scope_key.as_deref(),
-    )
-    .await
-    .map_err(|error| match error {
-        EnsureError::Store(_) => internal(&error.to_string()),
-        _ => invalid_params(&error.to_string()),
-    })?;
+    // An omitted cwd means the same thing about the root, and fails the same
+    // way when guessed: a menu-bar client naming `$HOME` against a scope opened
+    // from a worktree was refused `ScopeHeld` on every poll, with nobody to
+    // send to as a result.
+    //
+    // With no incumbent there is nothing to resolve FROM, and the daemon's own
+    // working directory is not a root anybody chose: a session minted there
+    // would run every later prompt against whatever directory the daemon
+    // happened to start in. Refused instead, which tells the client to name
+    // one. `acp_session::ensure` keeps its own empty-cwd guard for the task
+    // path, which does not come through this door.
+    //
+    // The refusal is worded for BOTH ways of reaching it, because a create that
+    // named no scope at all is minting a private one and can never have an
+    // incumbent: saying "the scope has no live session" would have described a
+    // scope that was never sent. "cwd is required" is the part both client
+    // ladders anchor on, so it stays intact whatever follows it.
+    let cwd = match named_cwd {
+        Some(named) => named.to_string(),
+        None => match held.as_ref() {
+            Some(row) => row.cwd.clone(),
+            None => {
+                return Err(invalid_params(
+                    "cwd is required unless the named scope already has a live session \
+                     to take its root from",
+                ));
+            }
+        },
+    };
+    let row =
+        crate::acp_session::ensure(pool, events, &provider, &cwd, params.scope_key.as_deref())
+            .await
+            .map_err(|error| match error {
+                EnsureError::Store(_) => internal(&error.to_string()),
+                _ => invalid_params(&error.to_string()),
+            })?;
     // The turn deadline rides back on the mint because this is the ONE call a
     // chat client makes before it can have a PENDING leg at all, and the value
     // is otherwise daemon-private: a client reading `AINB_ACP_TURN_DEADLINE_MS`

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet_chat.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_fleet_chat.rs
@@ -1209,6 +1209,229 @@ async fn a_create_with_no_provider_keeps_the_scopes_own_adapter() {
     );
 }
 
+/// A create that names NEITHER half attaches to the scope's standing session,
+/// keeping its adapter AND its root.
+///
+/// The cwd half is the one that made the macOS notch unusable: it named
+/// `$HOME` on every one-second poll while the live copilot scope was held by a
+/// session opened from a worktree, so every poll was refused `ScopeHeld`, the
+/// pane fell back to a copilot channel's (always empty) recipient list, and the
+/// composer had nobody to send to. A client attaching to a conversation cannot
+/// know where that conversation was opened, so the daemon answers it.
+#[tokio::test]
+async fn a_create_with_neither_half_attaches_to_the_standing_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, _sink) = start_server(dir.path()).await;
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let created = client
+        .call(
+            methods::FLEET_CHANNEL_CREATE,
+            json!({ "kind": "copilot", "name": "#copilot" }),
+        )
+        .await;
+    let scope = created["result"]["channel"]["scope_key"].as_str().unwrap().to_string();
+    // Held with a root NO client could guess, which is the live shape: the
+    // session was opened from a worktree, not from the attaching app's home.
+    let session = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "codex-acp", "cwd": "/work/worktree", "scope_key": scope }),
+        )
+        .await;
+    assert!(session["error"].is_null(), "{session}");
+    let session_key = session["result"]["session_key"].as_str().unwrap().to_string();
+
+    let attached = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "scope_key": scope }),
+        )
+        .await;
+    assert!(
+        attached["error"].is_null(),
+        "an attach that names neither half must not be refused: {attached}"
+    );
+    assert_eq!(
+        attached["result"]["session_key"], session_key,
+        "it must answer with the session the scope already holds"
+    );
+    let (provider, cwd): (String, String) =
+        sqlx::query_as("SELECT provider, cwd FROM fleet_acp_session WHERE session_key = ?")
+            .bind(&session_key)
+            .fetch_one(store.pool())
+            .await
+            .unwrap();
+    assert_eq!(provider, "codex-acp", "the operator's adapter stands");
+    assert_eq!(cwd, "/work/worktree", "and so does the session's root");
+}
+
+/// An omitted cwd on a scope with NO live session is refused, because the
+/// daemon has no root to resolve and may not invent one.
+///
+/// Inventing one (the daemon's own working directory, or the caller's home)
+/// would mint a session whose every later prompt runs against a repository
+/// nobody chose, and the mint would answer 200 while doing it. The refusal is
+/// what tells a client to name a directory, and it is the rung the TUI and the
+/// notch both retry on.
+#[tokio::test]
+async fn an_omitted_cwd_on_a_fresh_scope_is_refused_rather_than_rooted_by_the_daemon() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, _store, _sink) = start_server(dir.path()).await;
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let created = client
+        .call(
+            methods::FLEET_CHANNEL_CREATE,
+            json!({ "kind": "copilot", "name": "#copilot" }),
+        )
+        .await;
+    let scope = created["result"]["channel"]["scope_key"].as_str().unwrap().to_string();
+
+    let refused = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "scope_key": scope }),
+        )
+        .await;
+    assert_eq!(refused["error"]["code"], -32602, "{refused}");
+    let message = refused["error"]["message"].as_str().unwrap_or_default();
+    // The EXACT phrase, not "cwd" and "required" somewhere in the string. Both
+    // client ladders anchor on this, and `parse_params` puts the whole shape
+    // hint (which names every field) in front of any serde error, so a looser
+    // assertion here would pass against a message that names a different field.
+    assert!(
+        message.contains("cwd is required"),
+        "the refusal must carry the phrase both client ladders match on: {refused}"
+    );
+
+    // The same refusal, reached the OTHER way: no scope at all. A create with
+    // no scope mints a private one, so it can never have an incumbent, and a
+    // refusal that spoke of "the scope" would describe one that was never sent.
+    let unscoped = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "codex-acp" }),
+        )
+        .await;
+    assert_eq!(unscoped["error"]["code"], -32602, "{unscoped}");
+    let message = unscoped["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("cwd is required"),
+        "a private-scope create needs the same phrase: {unscoped}"
+    );
+    assert!(
+        !message.contains("the scope has no live session"),
+        "no scope was sent, so the refusal must not describe one: {unscoped}"
+    );
+
+    // A BLANK cwd is the same request spelled with whitespace, and gets the
+    // same refusal. It used to reach `ensure` as "cwd must not be empty", which
+    // neither client ladder can match, so a caller that sent one had no rung to
+    // spend and simply stuck.
+    let blank = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "cwd": "   ", "scope_key": scope }),
+        )
+        .await;
+    assert_eq!(blank["error"]["code"], -32602, "{blank}");
+    assert!(
+        blank["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cwd is required"),
+        "a blank cwd must land on the rung a client can answer: {blank}"
+    );
+}
+
+/// A blank cwd on a HELD scope attaches, exactly as an absent one does.
+///
+/// The two fields obey one rule: blank is omitted. Before this they disagreed,
+/// and the disagreement was invisible until a client sent an empty string.
+#[tokio::test]
+async fn a_blank_cwd_attaches_to_the_standing_session_like_an_absent_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, _store, _sink) = start_server(dir.path()).await;
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let created = client
+        .call(
+            methods::FLEET_CHANNEL_CREATE,
+            json!({ "kind": "copilot", "name": "#copilot" }),
+        )
+        .await;
+    let scope = created["result"]["channel"]["scope_key"].as_str().unwrap().to_string();
+    let session = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "codex-acp", "cwd": "/work/worktree", "scope_key": scope }),
+        )
+        .await;
+    let session_key = session["result"]["session_key"].as_str().unwrap().to_string();
+
+    let attached = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "", "cwd": "", "scope_key": scope }),
+        )
+        .await;
+    assert!(attached["error"].is_null(), "{attached}");
+    assert_eq!(
+        attached["result"]["session_key"], session_key,
+        "blank must mean omitted for BOTH fields, not just the provider"
+    );
+}
+
+/// A create that names BOTH halves never reads the incumbent row.
+///
+/// The whole point of making the fields optional was taking load off a
+/// contended database, and a resolution that always reads the scope's live
+/// session would have added a SELECT to the call instead. `ensure` compares
+/// what it was given against the incumbent anyway, so the read is pure waste
+/// when there is nothing to resolve.
+///
+/// Proved through the OUTCOME rather than a query counter: a fully named create
+/// against a held scope still gets `ScopeHeld` naming the incumbent, which is
+/// the behaviour the read would otherwise have been serving.
+#[tokio::test]
+async fn a_create_that_names_both_halves_still_refuses_a_scope_held_by_another() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, _store, _sink) = start_server(dir.path()).await;
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let created = client
+        .call(
+            methods::FLEET_CHANNEL_CREATE,
+            json!({ "kind": "copilot", "name": "#copilot" }),
+        )
+        .await;
+    let scope = created["result"]["channel"]["scope_key"].as_str().unwrap().to_string();
+    let session = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "codex-acp", "cwd": "/work/worktree", "scope_key": scope }),
+        )
+        .await;
+    assert!(session["error"].is_null(), "{session}");
+
+    let refused = client
+        .call(
+            methods::FLEET_ACP_SESSION_CREATE,
+            json!({ "provider": "codex-acp", "cwd": "/elsewhere", "scope_key": scope }),
+        )
+        .await;
+    let message = refused["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("/work/worktree"),
+        "the refusal must still name the root that holds the scope: {refused}"
+    );
+    assert!(
+        !message.contains("cwd is required"),
+        "a named cwd is never the missing-field refusal: {refused}"
+    );
+}
+
 /// A swap whose replacement cannot be minted must leave the channel where it
 /// started, not with no live session at all.
 ///

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1447,21 +1447,44 @@ pub struct FleetMessage {
 }
 
 /// Parameters for `fleet/acp_session_create`.
+///
+/// `provider` and `cwd` obey ONE rule between them: absent (or blank, which is
+/// the same request spelled with whitespace) means "whatever this scope already
+/// has", and the daemon answers from the scope's live session. Naming either is
+/// how a get-or-create turns into a refusal, because `acp_session::ensure`
+/// rejects a live scope whose adapter or root differs from the one asked for.
+/// So a caller that wants THE conversation on a scope, rather than a particular
+/// engine in a particular directory, names neither.
+///
+/// They differ only in what happens with no live session to answer from: the
+/// daemon can fall back to a built-in adapter, but it has no root to fall back
+/// to, so an absent `cwd` is refused there rather than guessed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetAcpSessionCreateParams {
     /// Adapter token validated against the daemon's adapter registry.
     ///
-    /// Absent means "whatever this scope already runs": the daemon answers
-    /// with the scope's live session's adapter, and falls back to the built-in
-    /// Claude adapter only when the scope has no session at all. A caller that
-    /// wants the session rather than a particular engine must omit this —
-    /// naming a guess is how a get-or-create reverted an engine the operator
+    /// Absent or blank means "whatever this scope already runs": the daemon
+    /// answers with the scope's live session's adapter, and falls back to the
+    /// built-in Claude adapter only when the scope has no session at all.
+    /// Naming a guess is how a get-or-create reverted an engine the operator
     /// had swapped, and, once the scope was held by a different adapter, was
     /// refused outright as `ScopeHeld`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     /// Working directory for the ACP session.
-    pub cwd: String,
+    ///
+    /// Absent or blank means "the scope's held session", exactly as for
+    /// `provider`: the daemon answers with the live session's own root. It is
+    /// REFUSED with `invalid_params` when there is no live session on the
+    /// scope, because the only root the daemon could otherwise supply is its
+    /// own working directory, which nobody chose.
+    ///
+    /// Omitting it is what a chat client wants. A client that names its own
+    /// directory is refused the moment the session it is attaching to was
+    /// opened from somewhere else, which is the ordinary case for a menu-bar
+    /// app naming `$HOME` against a session rooted in a worktree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
     /// Scope to bind; the daemon mints `session:<session_key>` when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope_key: Option<String>,
@@ -2551,14 +2574,22 @@ mod tests {
     fn message_family_params_and_results_round_trip() {
         round_trip(&FleetAcpSessionCreateParams {
             provider: Some("claude-agent-acp".to_string()),
-            cwd: "/repo".to_string(),
+            cwd: Some("/repo".to_string()),
             scope_key: None,
         });
         // An omitted provider is the shape the chat page sends: it wants the
         // scope's session, not a named engine.
         round_trip(&FleetAcpSessionCreateParams {
             provider: None,
-            cwd: "/repo".to_string(),
+            cwd: Some("/repo".to_string()),
+            scope_key: Some("channel:c1".to_string()),
+        });
+        // Neither named: the whole get-or-create, which is what a chat client
+        // attaching to a standing session sends. Naming either half is how the
+        // notch was refused by a scope held from a different directory.
+        round_trip(&FleetAcpSessionCreateParams {
+            provider: None,
+            cwd: None,
             scope_key: Some("channel:c1".to_string()),
         });
         round_trip(&FleetAcpSessionCreateResult {
@@ -2625,6 +2656,37 @@ mod tests {
         round_trip(&FleetMessageEventParams {
             message: sample_message(),
         });
+    }
+
+    /// A get-or-create names NEITHER half on the wire, and an older frame that
+    /// names both still decodes.
+    ///
+    /// The absence is the contract, not merely a `None` in Rust: a client that
+    /// sent `"cwd": null` would be indistinguishable here but is a different
+    /// frame for the Swift and TypeScript clients that hand-build it, and the
+    /// daemon's own hint string promises the key may simply be left out.
+    #[test]
+    fn an_acp_create_that_names_neither_half_omits_both_keys() {
+        let attach = serde_json::to_value(FleetAcpSessionCreateParams {
+            provider: None,
+            cwd: None,
+            scope_key: Some("channel:c1".to_string()),
+        })
+        .expect("params serialize");
+        assert_eq!(
+            attach,
+            serde_json::json!({ "scope_key": "channel:c1" }),
+            "an attach frame carries the scope and nothing else"
+        );
+
+        let named: FleetAcpSessionCreateParams = serde_json::from_value(serde_json::json!({
+            "provider": "codex-acp",
+            "cwd": "/repo",
+            "scope_key": "channel:c1"
+        }))
+        .expect("a frame from a client built before either field became optional");
+        assert_eq!(named.provider.as_deref(), Some("codex-acp"));
+        assert_eq!(named.cwd.as_deref(), Some("/repo"));
     }
 
     #[test]

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -124,6 +124,37 @@ final class FleetStore: ObservableObject {
     private var hasEstablishedLiveConnection = false
     private var liveConnectionStartedAt: Date?
     private var hasAppliedAuthoritativeSnapshot = false
+    /// The ACP session each chat scope was minted against, so the mint happens
+    /// ONCE per scope instead of once per poll.
+    ///
+    /// `fleet/acp_session_create` is idempotent, but idempotent is not free: on
+    /// the daemon side every call is an INSERT inside a write transaction that
+    /// hits the live-scope unique index and then reads the incumbent back. At
+    /// the one-second chat poll that was 86,400 write transactions a day
+    /// against a database whose readers answer in 0.1s while this call was
+    /// timing out at 5s under lock contention. Nothing about a standing session
+    /// changes between polls, so nothing needs to be asked.
+    ///
+    /// Cleared whenever the answer could have gone stale: a new connection
+    /// (`beginConnection`, the daemon may have restarted and torn the session
+    /// down) and a send whose leg came back REJECTED (the session is gone,
+    /// re-mint on the next page).
+    ///
+    /// ponytail: per connection, not per session lifetime. A session evicted by
+    /// the pool while this app sits idle is only noticed at the next send, and
+    /// that send is the one that reports REJECTED. Live `fleet/message_event`
+    /// (PR B) is where a torn-down session becomes visible without a send.
+    private var copilotSessionKeyByScope: [String: String] = [:]
+    /// Bumped by every invalidation, so a page that was already in flight when
+    /// one happened cannot put the forgotten key back.
+    ///
+    /// A page is four round trips long, and the poll loop and the send path
+    /// each run in their own Task on this actor. Without this, a poll that
+    /// started before a send reported REJECTED would finish after the
+    /// invalidation and write its now-dead key back over the empty slot, so the
+    /// operator's next message went to the same dead session. That is the exact
+    /// failure the invalidation exists to prevent, arriving one poll later.
+    private var copilotCacheGeneration: UInt = 0
     private let maximumReconnectAttempts = 3
     private let reconnectResetInterval: TimeInterval = 30
 
@@ -657,7 +688,7 @@ final class FleetStore: ObservableObject {
             // this runs once a second and an unconditional @Published write
             // re-evaluates the whole window subtree even when nothing moved.
             // `FleetChatSurface` is Equatable, so the comparison is free.
-            let paged = try await Self.pageChat(using: connection, canWrite: canWrite)
+            let paged = try await pagedChat(using: connection)
             if chat != paged { chat = paged }
         } catch {
             controlNotice = "Chat refresh refused: \(String(describing: error))"
@@ -700,11 +731,19 @@ final class FleetStore: ObservableObject {
                     requestID: requestID
                 ))
                 self.controlNotice = FleetChatLabels.deliverySummary(result.deliveries)
+                // A leg refused because the session is GONE is the one signal
+                // this surface gets that its remembered key is dead. Forgetting
+                // it here is what makes the NEXT page mint a live one instead
+                // of sending into the same dead key forever. Transient
+                // refusals deliberately keep the mint.
+                if Self.reportsSessionGone(target, in: result.deliveries) {
+                    self.forgetCopilotSession(inScope: scopeKey)
+                }
             } catch {
                 self.controlNotice = "Chat send refused: \(String(describing: error))"
                 return
             }
-            self.chat = (try? await Self.pageChat(using: connection, canWrite: self.canWrite)) ?? self.chat
+            self.chat = (try? await self.pagedChat(using: connection)) ?? self.chat
         }
     }
 
@@ -737,7 +776,7 @@ final class FleetStore: ObservableObject {
             } catch {
                 self.controlNotice = "Confirm answer refused: \(String(describing: error))"
             }
-            self.chat = (try? await Self.pageChat(using: connection, canWrite: self.canWrite)) ?? self.chat
+            self.chat = (try? await self.pagedChat(using: connection)) ?? self.chat
         }
     }
 
@@ -747,8 +786,22 @@ final class FleetStore: ObservableObject {
     /// explained absence: a daemon built between phases answers -32601 for
     /// them, and a chat that refuses to render its conversation over that is a
     /// worse surface than one that says which half is missing.
-    private static func pageChat(using connection: FleetConnection, canWrite: Bool) async throws -> FleetChatSurface {
+    ///
+    /// `mintedSessionKeyByScope` is what keeps the mint OFF the poll: a scope
+    /// already minted against this connection skips `fleet/acp_session_create`
+    /// entirely. See `copilotSessionKeyByScope` for why that matters.
+    ///
+    /// `minted` says whether the target IS that session, so only a real mint is
+    /// cached. The fallbacks are not: a channel's first recipient is a guess
+    /// this page makes when the mint was REFUSED, and caching it would make the
+    /// refusal permanent for the life of the connection.
+    private static func pageChat(
+        using connection: FleetConnection,
+        canWrite: Bool,
+        mintedSessionKeyByScope: [String: String]
+    ) async throws -> (surface: FleetChatSurface, minted: Bool) {
         var surface = FleetChatSurface()
+        var minted = false
         let channels = try await connection.channelList().channels
         // Newest-wins, matching the TUI: a race that created two copilot
         // channels must not leave the two clients reading different ones.
@@ -765,7 +818,7 @@ final class FleetStore: ObservableObject {
             ).channel
         } else {
             surface.sessionDetail = "No copilot channel yet, and this connection may not create one."
-            return surface
+            return (surface, minted)
         }
         surface.scopeKey = channel.scopeKey
 
@@ -775,13 +828,17 @@ final class FleetStore: ObservableObject {
         // The call is idempotent per live scope. The daemon's refusal is KEPT
         // rather than swallowed: its wording is the only actionable thing an
         // operator gets when a client in another directory already claimed it.
-        if canWrite {
+        if let cached = mintedSessionKeyByScope[channel.scopeKey] {
+            surface.targetSessionKey = cached
+            minted = true
+        } else if canWrite {
             do {
-                surface.targetSessionKey = try await connection.acpSessionCreate(FleetAcpSessionCreateParams(
-                    provider: copilotDefaultProvider,
-                    cwd: FileManager.default.homeDirectoryForCurrentUser.path,
-                    scopeKey: channel.scopeKey
-                )).sessionKey
+                surface.targetSessionKey = try await Self.mintCopilotSession(
+                    scopeKey: channel.scopeKey,
+                    home: FileManager.default.homeDirectoryForCurrentUser.path,
+                    create: { try await connection.acpSessionCreate($0) }
+                ).sessionKey
+                minted = true
             } catch {
                 surface.targetSessionKey = channel.recipients.first
                 surface.sessionDetail = String(describing: error)
@@ -812,11 +869,174 @@ final class FleetStore: ObservableObject {
             afterSeq: nil,
             limit: fleetActivityListMax
         )).activities) ?? []
+        return (surface, minted)
+    }
+
+    /// The delivery details that mean the remembered session is GONE.
+    ///
+    /// The daemon's own tokens: `session_gone` from the ACP pool, plus
+    /// `target_unknown` (no such row) and `target_not_running` (the row exists
+    /// but its session exited) from the delivery leg. Every other REJECTED
+    /// token describes a session that is still there. `breaker_open` and
+    /// `queue_full` are transient back-pressure, and `task_scope_refused` is a
+    /// scope this surface never addresses, so forgetting the mint on any of
+    /// them would spend the write transaction this whole cache exists to
+    /// remove, on a session that would have answered the next prompt.
+    private static let sessionGoneDetails: Set<String> = [
+        "session_gone", "target_unknown", "target_not_running",
+    ]
+
+    /// Whether the daemon says the leg addressed to `target` failed because
+    /// that session no longer exists.
+    ///
+    /// REJECTED only, not every non-DELIVERED state: a PENDING leg is an ACP
+    /// turn that has not finished yet, which is the normal answer to a copilot
+    /// prompt.
+    ///
+    /// An absent or unrecognised detail is NOT a reason to forget. A daemon
+    /// that grows a new rejection token this build has never heard of would
+    /// otherwise re-mint on every send, which is the failure mode the cache was
+    /// added to remove, arriving silently through a wire change.
+    static func reportsSessionGone(_ target: String, in deliveries: [FleetMessageDelivery]) -> Bool {
+        deliveries.contains { delivery in
+            guard delivery.sessionKey == target, delivery.state == .rejected,
+                  let detail = delivery.detail else { return false }
+            return sessionGoneDetails.contains(
+                detail.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            )
+        }
+    }
+
+    /// Forget the session remembered for `scope`, so the next page mints a live
+    /// one, and invalidate any page already in flight.
+    ///
+    /// Both halves matter. Removing the key alone loses the race against a page
+    /// that read the cache before this call and writes back after it.
+    func forgetCopilotSession(inScope scope: String) {
+        copilotCacheGeneration &+= 1
+        copilotSessionKeyByScope.removeValue(forKey: scope)
+    }
+
+    /// One page, with the copilot mint remembered for the next one.
+    ///
+    /// Every caller of `pageChat` goes through here so the cache cannot be
+    /// updated by one path and not another.
+    ///
+    /// The generation is captured BEFORE the page and checked after: four round
+    /// trips is long enough for a send to report a dead session and forget it,
+    /// and a page that finished afterwards must not restore what it read at the
+    /// start. It still renders its own result; only the remembering is dropped,
+    /// so the next page asks the daemon again.
+    private func pagedChat(using connection: FleetConnection) async throws -> FleetChatSurface {
+        let generation = copilotCacheGeneration
+        let (surface, minted) = try await Self.pageChat(
+            using: connection,
+            canWrite: canWrite,
+            mintedSessionKeyByScope: copilotSessionKeyByScope
+        )
+        if minted,
+           copilotCacheGeneration == generation,
+           let scope = surface.scopeKey,
+           let sessionKey = surface.targetSessionKey {
+            copilotSessionKeyByScope[scope] = sessionKey
+        }
         return surface
+    }
+
+    /// Get-or-create the copilot session for `scopeKey`, naming as little as
+    /// the daemon in front of us will accept.
+    ///
+    /// Three rungs, cheapest first, each one adding back a field only because
+    /// the daemon said it needs it:
+    ///
+    /// 1. neither `provider` nor `cwd`. What this client actually wants: THE
+    ///    session on this scope, whatever engine it runs and wherever it was
+    ///    opened. A menu-bar app cannot know either, and guessing was fatal:
+    ///    naming `$HOME` against a scope held by a session opened from a
+    ///    worktree is refused `ScopeHeld` on every poll, which left the
+    ///    composer with nobody to send to.
+    /// 2. `cwd` named as `home`. Either a daemon built before the field became
+    ///    optional, or a current one saying the scope has no live session to
+    ///    take a root from. Both are answered by naming one, and for a fresh
+    ///    copilot channel the operator's home is the honest root.
+    /// 3. `provider` named too, the legacy adapter. A daemon older still, in
+    ///    the ordinary upgrade-the-app-keep-the-daemon window. Exactly what
+    ///    this call sent before either field became optional, so it is no worse
+    ///    than it was against a daemon that cannot do better.
+    ///
+    /// Any other refusal propagates untouched, including a held scope: its
+    /// wording names the directory that holds it, and retrying would replace
+    /// the only actionable thing the operator gets with the same refusal twice.
+    static func mintCopilotSession(
+        scopeKey: String,
+        home: String,
+        create: (FleetAcpSessionCreateParams) async throws -> FleetAcpSessionCreateResult
+    ) async throws -> FleetAcpSessionCreateResult {
+        var refusal: Error
+        do {
+            return try await create(
+                FleetAcpSessionCreateParams(provider: nil, cwd: nil, scopeKey: scopeKey)
+            )
+        } catch {
+            refusal = error
+        }
+        if daemonRefusalNames(refusal, field: "cwd") {
+            do {
+                return try await create(
+                    FleetAcpSessionCreateParams(provider: nil, cwd: home, scopeKey: scopeKey)
+                )
+            } catch {
+                refusal = error
+            }
+        }
+        if daemonRefusalNames(refusal, field: "provider") {
+            return try await create(FleetAcpSessionCreateParams(
+                provider: copilotDefaultProvider,
+                cwd: home,
+                scopeKey: scopeKey
+            ))
+        }
+        throw refusal
+    }
+
+    /// Whether a daemon refusal is that daemon asking for `field` to be NAMED.
+    ///
+    /// The Swift half of the TUI's `names_missing_field`, anchored to the field
+    /// name rather than looking for two loose substrings, and for the same
+    /// reason: the daemon formats every parse refusal as
+    /// `expected {shape}: {serde error}`, and the SHAPE HINT names every field.
+    /// So a legacy daemon refusing an absent provider says
+    /// `expected { provider, cwd, scope_key? }: missing field \`provider\``,
+    /// which contains both "cwd" and "missing". A matcher looking for those
+    /// separately fires the cwd rung on a provider refusal and spends it on a
+    /// request the daemon never made.
+    ///
+    /// Exactly two shapes count:
+    ///
+    /// - ``missing field `<field>` ``, serde's own, backticks included. Without
+    ///   them the shape hint alone would satisfy the match.
+    /// - `<field> is required`, this daemon's own refusal.
+    ///
+    /// Only an RPC refusal counts at all, so a dead socket never spends a rung,
+    /// and a refusal that names the field for a REAL reason (an unknown
+    /// adapter, a scope held at another root) matches neither shape and
+    /// propagates with its wording intact.
+    private static func daemonRefusalNames(_ error: Error, field: String) -> Bool {
+        guard case let FleetConnectionError.rpc(refusal) = error else { return false }
+        let message = refusal.message.lowercased()
+        let field = field.lowercased()
+        return message.contains("missing field `\(field)`") || message.contains("\(field) is required")
     }
 
     private func beginConnection() {
         connectionGeneration &+= 1
+        // A new connection may be a new DAEMON: a restart tears every ACP
+        // session down, so a key remembered from the last one addresses
+        // nothing. Re-minting costs one call per scope; sending to a dead key
+        // costs the operator their message. The generation bump also disowns a
+        // page still in flight against the connection being replaced.
+        copilotCacheGeneration &+= 1
+        copilotSessionKeyByScope.removeAll()
         let generation = connectionGeneration
         let currentConnection = connection
         connection = nil

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -1093,25 +1093,55 @@ struct FleetMessageEventParams: Codable, Equatable {
     let message: FleetMessage
 }
 
-/// Adapter token the copilot channel's ACP session is opened with.
+/// Adapter token named ONLY on the legacy rung of the mint ladder.
 ///
-/// The same string the TUI uses (`COPILOT_DEFAULT_PROVIDER`). The daemon binds
-/// a scope to the adapter the FIRST `fleet/acp_session_create` names, so two
-/// clients naming different providers for `#copilot` means whichever opened the
-/// chat first decides and the other is refused.
+/// The same string the TUI keeps for the same reason (`LEGACY_DAEMON_ADAPTER`):
+/// a daemon built before `provider` became optional refuses an absent one, and
+/// this is what this client sent before that. It is NOT what a normal attach
+/// names. The daemon binds a scope to the adapter the FIRST
+/// `fleet/acp_session_create` names, so naming a guess reverts an engine the
+/// operator swapped and is refused outright once the scope is held by another.
 let copilotDefaultProvider = "claude-agent-acp"
 
+/// Parameters for `fleet/acp_session_create`.
+///
+/// Both `provider` and `cwd` are OMITTED from the frame when nil, never sent as
+/// `null`: absent is what the daemon reads as "whatever this scope already
+/// runs, wherever it already runs it", and that is the only shape that attaches
+/// to a session opened from a directory this client cannot know.
 struct FleetAcpSessionCreateParams: Encodable, Equatable {
-    let provider: String
-    let cwd: String
+    let provider: String?
+    let cwd: String?
     let scopeKey: String?
+
     private enum CodingKeys: String, CodingKey { case provider, cwd, scopeKey = "scope_key" }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(provider, forKey: .provider)
+        try container.encodeIfPresent(cwd, forKey: .cwd)
+        try container.encodeIfPresent(scopeKey, forKey: .scopeKey)
+    }
 }
 
 struct FleetAcpSessionCreateResult: Codable, Equatable {
     let sessionKey: String
     let scopeKey: String
-    private enum CodingKeys: String, CodingKey { case sessionKey = "session_key", scopeKey = "scope_key" }
+    /// The pool's wall-clock ceiling on ONE turn, in milliseconds.
+    ///
+    /// Daemon-private otherwise: it lives on the daemon's pool config, so a
+    /// client reading the environment variable that moves it would be reading
+    /// its own process. Absent from a daemon built before it, and absent is not
+    /// 30 minutes: a pane that gets nil says nothing about a deadline rather
+    /// than inventing one. Nothing displays it yet; decoding it is what pins
+    /// the contract before the pane that bounds a PENDING leg needs it.
+    let turnDeadlineMs: Int64?
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionKey = "session_key"
+        case scopeKey = "scope_key"
+        case turnDeadlineMs = "turn_deadline_ms"
+    }
 }
 
 struct FleetChannel: Codable, Equatable {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
@@ -348,7 +348,262 @@ final class FleetChatPresentationTests: XCTestCase {
         XCTAssertEqual(copilotDefaultProvider, "claude-agent-acp")
     }
 
+    // MARK: - Copilot mint ladder
+
+    /// The refusals a REAL daemon sends, verbatim.
+    ///
+    /// `parse_params` wraps every serde error as `expected {shape}: {error}`,
+    /// and the shape hint lists the OTHER fields, so a refusal about the
+    /// provider carries the word "cwd" as well. Feeding invented one-line
+    /// messages here is how a matcher that answered a provider refusal by
+    /// naming a directory kept a green suite.
+    private static let legacyMissingProvider =
+        "expected { provider, cwd, scope_key? }: missing field `provider`"
+    private static let cwdEraDaemonMissingProvider =
+        "expected { provider?, cwd, scope_key? }: missing field `provider`"
+    private static let legacyMissingCwd =
+        "expected { provider?, cwd, scope_key? }: missing field `cwd`"
+    /// This daemon's own refusal when a create has no live session to take a
+    /// root from. Not a skew, but answered by the same retry.
+    private static let cwdRequired =
+        "cwd is required unless the named scope already has a live session to take its root from"
+
+    /// Rung 1 is what a modern daemon gets, and it names NOTHING.
+    ///
+    /// Naming either half is how this client was refused on every poll: the
+    /// live copilot scope is held by a session opened from a worktree, and an
+    /// app that names the operator's home directory is told the scope is held
+    /// with a different cwd, forever.
+    @MainActor
+    func testTheFirstRungNamesNeitherProviderNorCwd() async throws {
+        let recorder = MintRecorder()
+        let created = try await FleetStore.mintCopilotSession(
+            scopeKey: "channel:c1",
+            home: "/Users/operator",
+            create: recorder.answer
+        )
+
+        XCTAssertEqual(created.sessionKey, "acp:01J0KEY")
+        XCTAssertEqual(recorder.sent.count, 1, "a daemon that answers must not be asked twice")
+        let attach = try XCTUnwrap(recorder.sent.first)
+        XCTAssertNil(attach.provider, "the engine is the operator's choice, not this client's")
+        XCTAssertNil(attach.cwd, "the root is the session's, and this client cannot know it")
+        XCTAssertEqual(attach.scopeKey, "channel:c1")
+    }
+
+    /// Rung 2: a daemon that asks for a cwd gets one, and only then.
+    ///
+    /// Both refusals are fed VERBATIM as the daemon sends them, wrapped in the
+    /// `expected {shape}: {error}` envelope every parse failure carries. That
+    /// envelope is the whole reason the matcher is anchored: its shape hint
+    /// names every field, so a legacy refusal about the provider mentions "cwd"
+    /// too.
+    @MainActor
+    func testACwdIsNamedOnlyWhenTheDaemonAsksForOne() async throws {
+        for refusal in [Self.legacyMissingCwd, Self.cwdRequired] {
+            let recorder = MintRecorder(refuseUntilAttempt: 2, message: refusal)
+            _ = try await FleetStore.mintCopilotSession(
+                scopeKey: "channel:c1",
+                home: "/Users/operator",
+                create: recorder.answer
+            )
+
+            XCTAssertEqual(recorder.sent.count, 2, "\(refusal): one retry, not a loop")
+            let rooted = try XCTUnwrap(recorder.sent.last)
+            XCTAssertEqual(rooted.cwd, "/Users/operator", "\(refusal)")
+            XCTAssertNil(rooted.provider, "\(refusal): the engine is still not this client's to name")
+        }
+    }
+
+    /// Rung 3: the legacy daemon, which requires both fields, gets the frame
+    /// this client sent before either became optional.
+    ///
+    /// Both legacy generations are covered: the one that requires provider and
+    /// cwd, and the one that made provider optional but still requires cwd, and
+    /// therefore answers an attach by naming provider first.
+    @MainActor
+    func testTheLegacyRungNamesBothFieldsForADaemonThatRequiresThem() async throws {
+        for refusal in [Self.legacyMissingProvider, Self.cwdEraDaemonMissingProvider] {
+            let recorder = MintRecorder(refuseUntilAttempt: 2, message: refusal)
+            _ = try await FleetStore.mintCopilotSession(
+                scopeKey: "channel:c1",
+                home: "/Users/operator",
+                create: recorder.answer
+            )
+
+            XCTAssertEqual(
+                recorder.sent.count, 2,
+                "\(refusal): a refusal naming provider must skip the cwd rung, not spend it"
+            )
+            let named = try XCTUnwrap(recorder.sent.last)
+            XCTAssertEqual(named.provider, copilotDefaultProvider, "\(refusal)")
+            XCTAssertEqual(named.cwd, "/Users/operator", "\(refusal)")
+        }
+    }
+
+    /// A refusal for one field never satisfies the other rung.
+    ///
+    /// This is the assertion a loose two-substring matcher failed while its
+    /// tests passed, because those tests fed messages no daemon emits. Here the
+    /// SECOND frame is the assertion: a provider refusal must be answered by
+    /// naming the provider, never by naming a directory the daemon did not ask
+    /// for.
+    @MainActor
+    func testAProviderRefusalIsNeverAnsweredByNamingADirectoryAlone() async throws {
+        for refusal in [Self.legacyMissingProvider, Self.cwdEraDaemonMissingProvider] {
+            let recorder = MintRecorder(refuseUntilAttempt: 2, message: refusal)
+            _ = try await FleetStore.mintCopilotSession(
+                scopeKey: "channel:c1",
+                home: "/Users/operator",
+                create: recorder.answer
+            )
+
+            let retry = try XCTUnwrap(recorder.sent.last)
+            XCTAssertNotNil(
+                retry.provider,
+                "the shape hint names cwd, but the daemon asked for a provider: \(refusal)"
+            )
+        }
+    }
+
+    /// And the reverse: a daemon asking for a root must not be answered with an
+    /// adapter it never asked about, which would revert an engine the operator
+    /// swapped.
+    @MainActor
+    func testACwdRefusalIsNeverAnsweredByNamingAnAdapter() async throws {
+        for refusal in [Self.legacyMissingCwd, Self.cwdRequired] {
+            let recorder = MintRecorder(refuseUntilAttempt: 2, message: refusal)
+            _ = try await FleetStore.mintCopilotSession(
+                scopeKey: "channel:c1",
+                home: "/Users/operator",
+                create: recorder.answer
+            )
+
+            let retry = try XCTUnwrap(recorder.sent.last)
+            XCTAssertNil(retry.provider, "\(refusal)")
+            XCTAssertEqual(retry.cwd, "/Users/operator", "\(refusal)")
+        }
+    }
+
+    /// A held scope is a REAL refusal and must propagate untouched.
+    ///
+    /// Its wording names the directory that holds the scope, which is the only
+    /// actionable thing the operator gets. Retrying would spend a rung to
+    /// receive the same refusal and would replace that wording with itself.
+    @MainActor
+    func testAHeldScopeIsReportedRatherThanRetried() async {
+        let recorder = MintRecorder(
+            refuseUntilAttempt: .max,
+            message: "scope_key \"channel:c1\" is already held by a session whose cwd is "
+                + "\"/work/api\", not \"/Users/operator\"; stop it before creating a different one"
+        )
+
+        do {
+            _ = try await FleetStore.mintCopilotSession(
+                scopeKey: "channel:c1",
+                home: "/Users/operator",
+                create: recorder.answer
+            )
+            XCTFail("a held scope is not something this client can retry its way out of")
+        } catch {
+            XCTAssertEqual(recorder.sent.count, 1, "no rung may be spent on a real refusal")
+            XCTAssertTrue(
+                String(describing: error).contains("/work/api"),
+                "the directory that holds the scope must reach the operator: \(error)"
+            )
+        }
+    }
+
+    /// The predicate that forgets a remembered session fires only for the
+    /// daemon's DEAD-SESSION tokens, on the target's own leg.
+    ///
+    /// The tokens are the daemon's, not invented here: `session_gone` comes
+    /// from the ACP pool, `target_unknown` and `target_not_running` from the
+    /// delivery leg.
+    @MainActor
+    func testOnlyADeadSessionRejectionForgetsTheRememberedSession() throws {
+        for detail in ["session_gone", "target_unknown", "target_not_running"] {
+            let legs = try Self.deliveries(
+                #"{"session_key":"acp:1","state":"REJECTED","detail":"\#(detail)"}"#
+            )
+            XCTAssertTrue(FleetStore.reportsSessionGone("acp:1", in: legs), detail)
+            XCTAssertFalse(
+                FleetStore.reportsSessionGone("acp:2", in: legs),
+                "\(detail): another target's refusal says nothing about ours"
+            )
+        }
+
+        XCTAssertFalse(
+            FleetStore.reportsSessionGone(
+                "acp:1",
+                in: try Self.deliveries(#"{"session_key":"acp:1","state":"PENDING"}"#)
+            ),
+            "a turn still running is the normal case, not a dead session"
+        )
+        XCTAssertFalse(
+            FleetStore.reportsSessionGone(
+                "acp:1",
+                in: try Self.deliveries(#"{"session_key":"acp:1","state":"DELIVERED"}"#)
+            )
+        )
+    }
+
+    /// A session that is still ALIVE keeps its mint.
+    ///
+    /// `queue_full` and `breaker_open` are transient back-pressure from a pool
+    /// that still holds the session, and `task_scope_refused` names a scope
+    /// this surface never addresses. Forgetting on any of them would spend the
+    /// write transaction the cache exists to remove, on a session that would
+    /// have answered the next prompt.
+    @MainActor
+    func testATransientRejectionKeepsTheRememberedSession() throws {
+        for detail in ["queue_full", "breaker_open", "task_scope_refused", "provider_at_capacity"] {
+            XCTAssertFalse(
+                FleetStore.reportsSessionGone(
+                    "acp:1",
+                    in: try Self.deliveries(
+                        #"{"session_key":"acp:1","state":"REJECTED","detail":"\#(detail)"}"#
+                    )
+                ),
+                "\(detail) is not a dead session and must not cost a re-mint"
+            )
+        }
+    }
+
+    /// A refusal this build cannot name is not a reason to forget.
+    ///
+    /// Fail-closed on the cheap side: a daemon that grows a token this build
+    /// has never heard of would otherwise re-mint on every send, reintroducing
+    /// the per-send write transaction silently, through a wire change nobody
+    /// here would see. An absent detail is the same case.
+    @MainActor
+    func testAnUnrecognisedOrAbsentDetailKeepsTheRememberedSession() throws {
+        XCTAssertFalse(
+            FleetStore.reportsSessionGone(
+                "acp:1",
+                in: try Self.deliveries(
+                    #"{"session_key":"acp:1","state":"REJECTED","detail":"some_future_token"}"#
+                )
+            ),
+            "an unknown token must not be read as a dead session"
+        )
+        XCTAssertFalse(
+            FleetStore.reportsSessionGone(
+                "acp:1",
+                in: try Self.deliveries(#"{"session_key":"acp:1","state":"REJECTED"}"#)
+            ),
+            "a refusal with no reason says nothing about the session"
+        )
+    }
+
     // MARK: - Helpers
+
+    private static func deliveries(_ legs: String) throws -> [FleetMessageDelivery] {
+        try FleetWire.decoder().decode(
+            FleetMessageSendResult.self,
+            from: Data(#"{"message_id":"01J0MSG","deliveries":[\#(legs)]}"#.utf8)
+        ).deliveries
+    }
 
     private func assertLabelsAreDistinctAndNamed<Value: Hashable>(
         _ values: [Value],
@@ -403,5 +658,36 @@ final class FleetChatPresentationTests: XCTestCase {
         return try Data(contentsOf: repository
             .appendingPathComponent("ainb-tui/crates/ainb-hangar-proto/fixtures/chat")
             .appendingPathComponent(name))
+    }
+}
+
+/// A stand-in for `fleet/acp_session_create` that records what each rung sent.
+///
+/// The ladder is tested through this rather than through a socket because what
+/// is under test is WHICH frame goes out for a given refusal, and a socket adds
+/// a daemon's opinion to an assertion about this client's decision.
+@MainActor
+private final class MintRecorder {
+    private(set) var sent: [FleetAcpSessionCreateParams] = []
+    private let refuseUntilAttempt: Int
+    private let message: String
+
+    /// `refuseUntilAttempt` is the first attempt that SUCCEEDS; every earlier
+    /// one is refused with `message`.
+    init(refuseUntilAttempt: Int = 1, message: String = "") {
+        self.refuseUntilAttempt = refuseUntilAttempt
+        self.message = message
+    }
+
+    func answer(_ params: FleetAcpSessionCreateParams) async throws -> FleetAcpSessionCreateResult {
+        sent.append(params)
+        guard sent.count >= refuseUntilAttempt else {
+            throw FleetConnectionError.rpc(RPCError(code: -32602, message: message, data: nil))
+        }
+        return FleetAcpSessionCreateResult(
+            sessionKey: "acp:01J0KEY",
+            scopeKey: params.scopeKey ?? "session:acp:01J0KEY",
+            turnDeadlineMs: 1_800_000
+        )
     }
 }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -880,6 +880,270 @@ final class FleetConnectionTests: XCTestCase {
         )
     }
 
+    /// The copilot session is minted ONCE per connection, not once per poll,
+    /// and a leg refused because the SESSION IS GONE is what makes the next
+    /// page mint again.
+    ///
+    /// This is the bug the cache exists for, counted on the wire rather than
+    /// asserted about a dictionary. `fleet/acp_session_create` is idempotent
+    /// but not free: daemon-side every call is an INSERT inside a write
+    /// transaction that hits the live-scope unique index and reads the
+    /// incumbent back, and the chat pane polls once a second, so this surface
+    /// was opening 86,400 write transactions a day against a database whose
+    /// reads answer in 0.1s while this call timed out at 5s.
+    func testCopilotSessionIsMintedOncePerConnectionUntilTheSessionIsGone() async throws {
+        try await runMintCacheScenario(rejectionDetail: "target_not_running", mintsAfterSend: 2)
+    }
+
+    /// A TRANSIENT refusal keeps the mint.
+    ///
+    /// `queue_full` is a pool that is busy, not a session that is gone, and the
+    /// daemon still holds the session behind it. Re-minting here would pay the
+    /// write transaction this cache exists to remove on a session that is
+    /// about to answer the next prompt perfectly well.
+    func testATransientRejectionDoesNotCostAReMint() async throws {
+        try await runMintCacheScenario(rejectionDetail: "queue_full", mintsAfterSend: 1)
+    }
+
+    /// Two pages, then one send that comes back REJECTED with `rejectionDetail`,
+    /// asserting how many mints the whole sequence cost.
+    ///
+    /// Shared so the two outcomes cannot drift apart: what differs between them
+    /// is ONE daemon token, and everything else about the flow is identical.
+    private func runMintCacheScenario(rejectionDetail: String, mintsAfterSend: Int) async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let serverDone = expectation(description: "chat server finished")
+        let serverResult = SocketServerResult()
+        let mints = ChatServerCounts(rejectionDetail: rejectionDetail)
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: []),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: []),
+                    capabilityIDs: [
+                        "fleet.chat.read", "fleet.chat.write",
+                        "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
+                    ]
+                )
+                while true {
+                    try Self.answerChatRequest(
+                        try Self.readRequest(from: serverDescriptor),
+                        to: serverDescriptor,
+                        counts: mints
+                    )
+                }
+            } catch StoreServerError.closed {
+                // The client hung up at the end of the test. Not a failure.
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return store.canWrite
+            }
+        }
+        XCTAssertTrue(live, "the fixture never reached a live, writable connection")
+
+        await store.refreshChatOnce()
+        await MainActor.run { XCTAssertEqual(store.chat.targetSessionKey, "acp:1") }
+        XCTAssertEqual(mints.acpCreates, 1, "the first page has to mint")
+
+        await store.refreshChatOnce()
+        await MainActor.run { XCTAssertEqual(store.chat.targetSessionKey, "acp:1") }
+        XCTAssertEqual(
+            mints.acpCreates, 1,
+            "a second page must reuse the remembered session, not reopen a write transaction"
+        )
+
+        await MainActor.run { store.sendChatMessage("hello") }
+        let reported = await Self.waitUntil {
+            await MainActor.run { store.controlNotice?.contains("not delivered") == true }
+        }
+        XCTAssertTrue(reported, "the rejected leg must reach the operator")
+        // The send re-pages itself, so waiting for the notice is not enough:
+        // wait for the page that follows it to have run.
+        let repaged = await Self.waitUntil {
+            await MainActor.run { store.pendingIntentID == nil }
+        }
+        XCTAssertTrue(repaged, "the send never finished its own re-page")
+        XCTAssertEqual(
+            mints.acpCreates, mintsAfterSend,
+            "\(rejectionDetail): wrong number of mints after the send"
+        )
+
+        await MainActor.run { store.stop() }
+        await fulfillment(of: [serverDone], timeout: 5)
+        try serverResult.throwIfRecorded()
+    }
+
+    /// A page already in flight when the cache is invalidated must NOT put the
+    /// forgotten session back.
+    ///
+    /// A page is four round trips, and the poll loop and the send path each run
+    /// in their own Task on the main actor, so they interleave. Without a
+    /// generation check the sequence is: poll reads the cached key, send
+    /// reports REJECTED and forgets it, poll finishes and writes the dead key
+    /// back. The operator's next message then goes to the same dead session,
+    /// which is the exact failure the invalidation exists to prevent, arriving
+    /// one poll later and looking like the fix never worked.
+    ///
+    /// Driven by holding the daemon inside the page rather than by hoping the
+    /// interleaving happens, so this fails deterministically without the guard.
+    func testAPageInFlightDuringAnInvalidationDoesNotRestoreTheForgottenSession() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let serverDone = expectation(description: "chat server finished")
+        let serverResult = SocketServerResult()
+        let mints = ChatServerCounts()
+        let gate = ChatServerGate()
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: []),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: []),
+                    capabilityIDs: [
+                        "fleet.chat.read", "fleet.chat.write",
+                        "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
+                    ]
+                )
+                while true {
+                    try Self.answerChatRequest(
+                        try Self.readRequest(from: serverDescriptor),
+                        to: serverDescriptor,
+                        counts: mints,
+                        gate: gate
+                    )
+                }
+            } catch StoreServerError.closed {
+                // The client hung up at the end of the test. Not a failure.
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return store.canWrite
+            }
+        }
+        XCTAssertTrue(live, "the fixture never reached a live, writable connection")
+
+        await store.refreshChatOnce()
+        XCTAssertEqual(mints.acpCreates, 1, "the first page fills the cache")
+
+        // A second page, stopped in the middle: past the cache read, before the
+        // write-back.
+        gate.arm()
+        let paging = Task { await store.refreshChatOnce() }
+        let stopped = await Self.waitUntil { gate.hasReached }
+        XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+
+        // What a REJECTED send does, on the actor, while that page is waiting.
+        await MainActor.run { store.forgetCopilotSession(inScope: "channel:c1") }
+        gate.letGo()
+        await paging.value
+
+        // The page finished after the invalidation, so the next one must ask
+        // the daemon again rather than reusing what that page had read.
+        await store.refreshChatOnce()
+        XCTAssertEqual(
+            mints.acpCreates, 2,
+            "the in-flight page restored a session the operator had already been told is dead"
+        )
+
+        await MainActor.run { store.stop() }
+        await fulfillment(of: [serverDone], timeout: 5)
+        try serverResult.throwIfRecorded()
+    }
+
+    /// Answer one chat-page RPC with a canned result, counting the mints.
+    ///
+    /// Dispatched by METHOD rather than by position, so the test asserts how
+    /// many times the store asked rather than pinning an exact call order that
+    /// a later page change would have to rewrite.
+    private static func answerChatRequest(
+        _ request: [String: Any],
+        to descriptor: Int32,
+        counts: ChatServerCounts,
+        gate: ChatServerGate? = nil
+    ) throws {
+        switch request["method"] as? String {
+        case "fleet/channel_list":
+            try writeResponse(to: descriptor, request: request, result: ["channels": [[
+                "id": "c1",
+                "kind": "copilot",
+                "name": "copilot",
+                "scope_key": "channel:c1",
+                "recipients": [],
+                "created_at": 1,
+            ]]])
+        case "fleet/acp_session_create":
+            counts.recordAcpCreate()
+            try writeResponse(to: descriptor, request: request, result: [
+                "session_key": "acp:1",
+                "scope_key": "channel:c1",
+                "turn_deadline_ms": 1_800_000,
+            ])
+        case "fleet/message_list":
+            // The page's first call AFTER the mint decision, which makes it the
+            // window a test needs to invalidate the cache in.
+            gate?.pauseIfArmed()
+            try writeResponse(to: descriptor, request: request, result: ["messages": []])
+        case "fleet/confirm_list":
+            try writeResponse(to: descriptor, request: request, result: ["confirms": []])
+        case "fleet/activity_list":
+            try writeResponse(to: descriptor, request: request, result: ["activities": []])
+        case "fleet/message_send":
+            try writeResponse(to: descriptor, request: request, result: [
+                "message_id": "01J0MSG",
+                "deliveries": [[
+                    "session_key": "acp:1",
+                    "state": "REJECTED",
+                    "detail": counts.rejectionDetail,
+                ]],
+            ])
+        default:
+            try writeError(to: descriptor, request: request)
+        }
+    }
+
     private static func testLocation() throws -> HangarLocation {
         let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let tokenDirectory = home.appendingPathComponent("hangar", isDirectory: true)
@@ -1107,5 +1371,79 @@ private final class SocketServerResult: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         if let error { throw error }
+    }
+}
+
+/// How many times the scripted chat daemon was asked for each thing.
+///
+/// The mint count is the assertion the copilot cache exists to make: it is a
+/// WRITE transaction daemon-side, so "how often was it asked" is the whole
+/// question, and only the wire can answer it.
+private final class ChatServerCounts: @unchecked Sendable {
+    private let lock = NSLock()
+    private var acpCreateCount = 0
+    /// The daemon token the scripted `message_send` refuses with. Settable
+    /// because whether a refusal forgets the mint depends entirely on WHICH
+    /// token it carries, not on the REJECTED state.
+    let rejectionDetail: String
+
+    init(rejectionDetail: String = "target_not_running") {
+        self.rejectionDetail = rejectionDetail
+    }
+
+    var acpCreates: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return acpCreateCount
+    }
+
+    func recordAcpCreate() {
+        lock.lock()
+        acpCreateCount += 1
+        lock.unlock()
+    }
+}
+
+/// Lets a test stop the scripted chat daemon in the middle of one page.
+///
+/// One-shot, and armed per page rather than always on: a page that could not
+/// finish would hang the poll loop for every other assertion in the file. The
+/// reached flag is polled rather than waited on so the test never blocks a
+/// cooperative thread; only the server's own dispatch queue blocks, which is
+/// what "the daemon is slow" means here.
+private final class ChatServerGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var armed = false
+    private var reached = false
+    private let release = DispatchSemaphore(value: 0)
+
+    var hasReached: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return reached
+    }
+
+    func arm() {
+        lock.lock()
+        armed = true
+        reached = false
+        lock.unlock()
+    }
+
+    func letGo() {
+        release.signal()
+    }
+
+    /// Called on the server thread. Blocks that thread, once, if armed.
+    func pauseIfArmed() {
+        lock.lock()
+        let isArmed = armed
+        armed = false
+        if isArmed { reached = true }
+        lock.unlock()
+        guard isArmed else { return }
+        // Bounded: a test that never releases fails on its own assertions
+        // rather than hanging the suite.
+        _ = release.wait(timeout: .now() + 5)
     }
 }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
@@ -380,6 +380,84 @@ final class FleetDaemonContractTests: XCTestCase {
         }
     }
 
+    /// The attach this client actually sends, against a real daemon: a create
+    /// naming NEITHER `provider` nor `cwd` answers with the session the scope
+    /// already holds.
+    ///
+    /// The Swift-side unit tests prove which frame each rung builds; only this
+    /// proves the daemon reads that frame the way this client means it. It is
+    /// the whole fix: the live copilot scope is held by a session opened from a
+    /// worktree, and a menu-bar app naming `$HOME` was refused `ScopeHeld` on
+    /// every one-second poll, leaving the composer with nobody to send to.
+    func testRealDaemonAttachesToAHeldScopeWhenNeitherHalfIsNamed() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let channel = try await connection.channelCreate(
+            FleetChannelCreateParams(kind: .copilot, name: "copilot", recipients: nil)
+        ).channel
+        // Held at a root no client could guess, which is the live shape.
+        let opened = try await connection.acpSessionCreate(FleetAcpSessionCreateParams(
+            provider: copilotDefaultProvider,
+            cwd: "/work/worktree",
+            scopeKey: channel.scopeKey
+        ))
+
+        let attached = try await connection.acpSessionCreate(
+            FleetAcpSessionCreateParams(provider: nil, cwd: nil, scopeKey: channel.scopeKey)
+        )
+        XCTAssertEqual(
+            attached.sessionKey, opened.sessionKey,
+            "an attach naming neither half must answer with the standing session"
+        )
+        XCTAssertEqual(attached.scopeKey, channel.scopeKey)
+    }
+
+    /// A scope with NO live session refuses the same frame, naming the field,
+    /// because the daemon has no root to resolve and may not invent one.
+    ///
+    /// This is rung 2's trigger. The wording is load-bearing: the client's
+    /// ladder matches on the field name plus "required", so a daemon that
+    /// reworded this to something that names neither would leave a fresh
+    /// copilot channel unopenable rather than retried with a directory.
+    @MainActor
+    func testRealDaemonRefusesAnOmittedCwdOnAScopeWithNoSession() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let channel = try await connection.channelCreate(
+            FleetChannelCreateParams(kind: .copilot, name: "copilot", recipients: nil)
+        ).channel
+
+        do {
+            _ = try await connection.acpSessionCreate(
+                FleetAcpSessionCreateParams(provider: nil, cwd: nil, scopeKey: channel.scopeKey)
+            )
+            XCTFail("the daemon must not root a session it was given no root for")
+        } catch let FleetConnectionError.rpc(refusal) {
+            XCTAssertEqual(refusal.code, -32602, "\(refusal)")
+            // The EXACT phrase the ladder anchors on, not "cwd" and "required"
+            // loose in the string: the daemon prefixes parse failures with a
+            // shape hint that names every field, so a loose assertion here
+            // would pass against a refusal about a different one.
+            XCTAssertTrue(refusal.message.contains("cwd is required"), "\(refusal)")
+        }
+
+        // And the rung that answers it lands, which is what the ladder does
+        // next: the same scope, now named.
+        let rooted = try await FleetStore.mintCopilotSession(
+            scopeKey: channel.scopeKey,
+            home: "/work/fresh",
+            create: { try await connection.acpSessionCreate($0) }
+        )
+        XCTAssertEqual(rooted.scopeKey, channel.scopeKey)
+        XCTAssertFalse(rooted.sessionKey.isEmpty)
+    }
+
     private static func nextFleetEvent(from stream: AsyncStream<FleetIncoming>) async throws -> FleetEvent {
         var iterator = stream.makeAsyncIterator()
         while let incoming = await iterator.next() {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetWireForwardCompatibilityTests.swift
@@ -139,6 +139,67 @@ final class FleetWireForwardCompatibilityTests: XCTestCase {
         XCTAssertTrue(FleetRosterPresentation.matches(session, search: "opus", filters: .all))
     }
 
+    // MARK: - ACP session create
+
+    /// An attach names NEITHER half, and the frame must carry neither key.
+    ///
+    /// The absence IS the request: the daemon reads an absent `provider` and an
+    /// absent `cwd` as "whatever this scope already runs, wherever it already
+    /// runs it". A `null` would be a different frame for a daemon that decodes
+    /// this by key presence, and naming either half is what got this client
+    /// refused `ScopeHeld` by a session opened from a worktree while the app
+    /// named the operator's home directory.
+    func testAnAttachFrameCarriesTheScopeAndNothingElse() throws {
+        let params = FleetAcpSessionCreateParams(provider: nil, cwd: nil, scopeKey: "channel:c1")
+        let encoded = try Self.encodedObject(params)
+        XCTAssertEqual(encoded.keys.sorted(), ["scope_key"])
+        XCTAssertEqual(encoded["scope_key"] as? String, "channel:c1")
+    }
+
+    /// The legacy rung still produces the shape it always did, key for key: it
+    /// is the frame a daemon built before either field became optional expects,
+    /// and that daemon cannot be asked to be tolerant.
+    func testANamedCreateStillProducesTheOlderFrame() throws {
+        let params = FleetAcpSessionCreateParams(
+            provider: "claude-agent-acp",
+            cwd: "/Users/operator",
+            scopeKey: "channel:c1"
+        )
+        let encoded = try Self.encodedObject(params)
+        XCTAssertEqual(encoded.keys.sorted(), ["cwd", "provider", "scope_key"])
+        XCTAssertEqual(encoded["provider"] as? String, "claude-agent-acp")
+        XCTAssertEqual(encoded["cwd"] as? String, "/Users/operator")
+        XCTAssertEqual(encoded["scope_key"] as? String, "channel:c1")
+    }
+
+    /// The encoded frame as its keys and values, so these tests pin the WIRE
+    /// rather than Foundation's slash escaping or key ordering.
+    private static func encodedObject(_ value: some Encodable) throws -> [String: Any] {
+        let data = try FleetWire.encoder().encode(value)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// The turn deadline is optional in both directions: a daemon built before
+    /// it omits the key, and nil must mean "this daemon said nothing" rather
+    /// than a decode failure or an invented 30 minutes.
+    func testAcpCreateResultDecodesWithAndWithoutTheTurnDeadline() throws {
+        let without = try FleetWire.decoder().decode(
+            FleetAcpSessionCreateResult.self,
+            from: Data(#"{"session_key":"acp:01J0KEY","scope_key":"channel:c1"}"#.utf8)
+        )
+        XCTAssertEqual(without.sessionKey, "acp:01J0KEY")
+        XCTAssertEqual(without.scopeKey, "channel:c1")
+        XCTAssertNil(without.turnDeadlineMs, "an absent deadline is not a default one")
+
+        let with = try FleetWire.decoder().decode(
+            FleetAcpSessionCreateResult.self,
+            from: Data(
+                #"{"session_key":"acp:01J0KEY","scope_key":"channel:c1","turn_deadline_ms":1800000}"#.utf8
+            )
+        )
+        XCTAssertEqual(with.turnDeadlineMs, 1_800_000)
+    }
+
     private static func sessionJSON(extra: String = "") -> String {
         """
         {"session_key":"claude:s1","provider":"claude","provider_session_id":null,

--- a/docs/plans/2026-09-07-notch-gaps.md
+++ b/docs/plans/2026-09-07-notch-gaps.md
@@ -1,0 +1,67 @@
+# Plan: close the notch gaps (apps/ainb-fleet-macos)
+
+**Date:** 2026-09-07
+**Decision:** Stevie picked "close the gaps" over freezing the Swift app for the Tauri desktop.
+**Format:** diagram-first, table-second, no prose paragraphs.
+
+## Where the notch stands against the daemon
+
+```
+┌──────────────┐  hangar.sock   ┌──────────────────────┐
+│ AINBFleet    │───────────────▶│ hangar daemon 1.25.0 │
+│ Swift notch  │ negotiate v2   │ = HEAD on proto      │
+└──────┬───────┘                └──────────┬───────────┘
+       │ uses: snapshot, fleet/event,      │ has, notch ignores:
+       │ chat poll 1/s (5 RPCs incl. a     ▼
+       │ WRITE tx), quota, usage, atc  ┌──────────────────────┐
+       │                               │ message_subscribe    │ live chat push
+       │                               │ transcript_subscribe │ ACP stream
+       │                               │ reconcile_structured │ stale interview
+       │                               │ adapter_list         │ copilot dial
+       │                               │ copilot_configure    │
+       │                               └──────────────────────┘
+```
+
+## Evidence gathered today
+
+| Fact | Where |
+|------|-------|
+| Wire enums identical Swift vs Rust; contract CI green on main through 09-07 | `FleetWire.swift`, `fleet.rs`, workflow runs |
+| Proto drift since notch last synced is additive only (`provider` optional, `turn_deadline_ms`) | `git diff b95dcf08..HEAD -- ainb-hangar-proto` |
+| Notch names `provider: "claude-agent-acp"` and `cwd: $HOME` on EVERY 1 s chat poll | `FleetStore.pageChat` |
+| Daemon refuses a named provider or cwd that differs from the held scope (`ScopeHeld`) | `acp_session.rs:178` |
+| TUI already omits `provider` for that reason (commit 5de2c20e); still names `cwd` | `fleet/control.rs:221` |
+| Live copilot scope is held with cwd = a worktree dir, so the notch is refused right now | `hangar.db fleet_acp_session` |
+| Each idempotent create is an INSERT inside a write tx (unique-violation replay) | `fleet_acp_session.rs:515` |
+| Daemon is in a `database is locked` storm all day (300 to 1300 per hour) | `hangar/logs/hangar-daemon.stderr.log` |
+| `acp_session_create` times out at 5 s live; `channel_list` and `adapter_list` answer in 0.1 s | CLI timing |
+| One connection may hold fleet + message + transcript forwarders at once | `rpc/mod.rs:600-665` |
+| After `message_subscribe` the same socket gets `message_event`, `confirm_event`, `activity_event` | `copilot.rs`, `spawn_notification_forwarder` |
+| Swift already decodes MessageEvent, ConfirmEvent, ActivityEvent, CopilotConfigure frames | `FleetWire.swift:1092+` |
+| Only the CLI (`msg follow`, `transcript follow`) consumes live subscriptions today | `cli/fleet/msg.rs`, `cli/fleet/acp.rs` |
+| No read RPC for the current copilot engine; TUI dial defaults to first adapter until Applied | `copilot_dial.rs:172` |
+
+## PRs
+
+| id | branch | scope | files | proof | after |
+|----|--------|-------|-------|-------|-------|
+| A | `f/notch-copilot-scope-reuse` | omit `provider` and `cwd` on create (daemon: `cwd` optional, reuse held); mint once per scope, not per poll; legacy retry ladder | proto `fleet.rs`, `rpc/mod.rs`, `control.rs`, `FleetWire.swift`, `FleetStore.swift` | daemon test, Swift wire + contract tests | none |
+| B | `f/notch-chat-live-push` | `fleet/message_subscribe` on the live socket; fold `message_event`, `confirm_event`, `activity_event` into `chat`; poll drops to a 30 s safety net | `FleetConnection.swift`, `FleetStore.swift`, `FleetChatPaneView.swift`, `FleetWire.swift` | contract test: send on one socket, event on the other | A |
+| C | `f/notch-acp-transcript` | `transcript_list` + `transcript_subscribe`; Swift port of the `acp.*` classifier arms; transcript section in the chat pane | `FleetConnection.swift`, `FleetStore.swift`, new `FleetTranscriptPresentation.swift`, `FleetChatPaneView.swift` | classifier unit tests mirroring `transcript.rs`; contract ack test | B |
+| D | `f/notch-reconcile-interview` | `ControlAction.reconcileStructured`; store intent gated like the TUI; "Verify" button on the interview card | `FleetWire.swift`, `FleetStore.swift`, `FleetDesktopController.swift` | encode test, receipt notice test | A |
+| E | `f/notch-copilot-dial` | `adapter_list` + `copilot_configure`; engine, mode, model, effort dial in the chat header | `FleetConnection.swift`, `FleetStore.swift`, `FleetChatPaneView.swift`, `FleetChatPresentation.swift` | contract tests against fixture daemon | B |
+
+## Sequence
+
+```
+A ──▶ B ──▶ C
+ └──▶ D      └──▶ E
+```
+
+Each PR: superstar-engineer builds, code-reviewer reviews, fixes land, CI green, merge commit.
+
+## Out of scope
+
+- `fleet/copilot_gate`: called by the copilot ACP tool gate, not by a UI client.
+- The lock storm itself: separate daemon work (retention on `fleet_provider_event`).
+- Tauri desktop: `docs/plans/2026-09-04-desktop-shared-core-spec.md`, untouched.


### PR DESCRIPTION
## What this fixes

The macOS menu-bar app's copilot chat could not send. It minted an ACP session on every one-second poll, naming the built-in adapter and `$HOME`. The daemon refuses a create whose provider or cwd differs from the one already holding that scope, so on any machine where the copilot scope was opened from a worktree (the ordinary case), every attempt was refused. The pane fell back to a copilot channel's empty recipient list, and Send was dead.

Each attempt was also a write transaction against `hangar.db`, once a second, for as long as the pane stayed open.

## Reproduced and verified against a real daemon

Run on a throwaway `AINB_HANGAR_HOME`, with the scope held from a worktree directory:

| Frame sent | Before | After |
|---|---|---|
| `provider` + `cwd: $HOME` (what the app sent) | refused, `scope_key ... is already held by a session whose cwd is ...` | unchanged, still refused |
| only `scope_key` (what it sends now) | refused, missing field `cwd` | attaches to the held session key |
| `cwd: ""` | hard `EmptyCwd` refusal, no retry rung matches it | attaches, blank is an omission |
| fresh scope, no `cwd` | n/a | `cwd is required unless the named scope already has a live session to take its root from` |

## The change

- **proto**: `cwd` becomes optional, matching `provider`. Absent means the scope's held session.
- **daemon**: one held-row lookup resolves both fields, skipped entirely when the caller named both. A blank string is trimmed to an omission for `cwd` as it already was for `provider`.
- **TUI and CLI**: the chat page omits `cwd` too. The older-daemon retry ladder is anchored on the field name. It matched two loose substrings, but every refusal is wrapped as `expected {shape}: {error}` and the shape hint names every field, so a missing-provider refusal also contained the word `cwd` and spent the wrong rung.
- **Swift**: the frame omits both fields, the mint is remembered per scope for the life of the connection, and is forgotten only when a delivery leg reports the session actually gone (`session_gone`, `target_unknown`, `target_not_running`). `breaker_open` and `queue_full` are transient on a live session and no longer cost a re-mint. A generation counter disowns a page still in flight when an invalidation lands mid-page.

## Tests

| Suite | Result |
|---|---|
| `cargo test -p ainb-hangar-proto` | 0 failed |
| `cargo test -p ainb-hangar-daemon --test rpc_fleet_chat` | 19 passed |
| `cargo test -p ainb --lib fleet::control` | 12 passed |
| `cargo clippy -p ainb-hangar-daemon -p ainb-hangar-proto --all-targets` | exit 0 |
| `xcodebuild test -only-testing:FleetRPCTests` | 170 executed, 0 failures, 0 skips |
| `xcodebuild build -configuration Debug` | succeeded |

The two new contract tests spawn the real `fleet_fixture_daemon` rather than a stub, and do not skip.

Both fixes were falsified before being kept: reverting the cwd trim fails two daemon tests, coarsening the rejection predicate back to any REJECTED fails five Swift assertions, and removing the generation guard fails the race test.

## Deployment note

Both halves must ship together. The app alone cannot fix this against a released daemon, because a daemon without the optional `cwd` still compares the one it is given.

## Not verified

No GUI-driven click of the chat pane. XCUITest cannot start on the dev machine used here (`Timed out while enabling automation mode`), so the proof above is at the wire and the store, not the pane. `docs/plans/2026-09-07-notch-gaps.md` records the remaining notch gaps and the PRs that close them.
