### PR TITLE
fix(codex): degrade a wedged hangar store instead of deleting the worktree

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3420,11 +3420,14 @@ pub struct AppState {
     pub last_panel_close_version: Option<u64>,
     // Notification system
     pub notifications: Vec<Notification>,
-    /// Sessions already told they started without shared Codex remote control.
+    /// Sessions already told, on their CURRENT launch, that they started
+    /// without shared Codex remote control.
     ///
-    /// The dedup key for `notify_codex_degraded`. Kept here rather than checked
-    /// against the live notification list because notifications EXPIRE: a
-    /// message-equality check would let the same fact reappear minutes later.
+    /// The dedup key for `notify_codex_degraded`, cleared by
+    /// `begin_codex_launch` so the scope is one launch and not the session's
+    /// whole life. Kept here rather than checked against the live notification
+    /// list because notifications EXPIRE: a message-equality check would let
+    /// the same fact reappear minutes later.
     codex_degrade_announced: std::collections::HashSet<Uuid>,
     // Pending event to be processed in next loop iteration
     pub pending_event: Option<crate::app::events::AppEvent>,
@@ -10228,6 +10231,10 @@ impl AppState {
             session_id, trigger_key
         );
 
+        // A resume is a new launch on an id this session already had, so the
+        // previous launch's notice must not silence this one.
+        self.begin_codex_launch(session_id);
+
         // Resolve metadata up-front so we can audit even if subsequent steps fail.
         let store = SessionStore::load();
         let metadata = store.sessions().values().find(|m| m.session_id == session_id).cloned();
@@ -11660,16 +11667,31 @@ impl AppState {
         self.add_notification(Notification::info(message));
     }
 
-    /// Say ONCE, on screen, that a Codex session started without shared remote
+    /// Start a new launch for this session, so its degrade can be announced
+    /// again.
+    ///
+    /// The dedup in [`Self::notify_codex_degraded`] is per LAUNCH, not per
+    /// session, and resume and restart both reuse the session id they were
+    /// handed. Without this reset, a user who saw the notice, restarted the
+    /// Hangar daemon and relaunched into a STILL-wedged store would be told
+    /// nothing at all — silence reading as success on the one action they took
+    /// to fix it. Only `create` is exempt, and only because it mints a fresh
+    /// id, so per-session and per-launch already coincide there.
+    pub fn begin_codex_launch(&mut self, session_id: Uuid) {
+        self.codex_degrade_announced.remove(&session_id);
+    }
+
+    /// Say ONCE per launch, on screen, that a Codex session started without shared remote
     /// control, and why.
     ///
     /// Informational, not an error: the session DID start. The launch is not
     /// retried and nothing was lost except the shared thread, so an error
     /// notification would misdescribe an outcome the user can simply live with.
     ///
-    /// Once per session, enforced here rather than at the call sites, so a
+    /// Once per LAUNCH, enforced here rather than at the call sites, so a
     /// future poll loop that reaches this cannot turn a one-off fact into a
-    /// recurring banner. A notice that repeats is one the user learns to skip.
+    /// recurring banner. A notice that repeats within one launch is one the
+    /// user learns to skip; a launch that degrades in silence is worse.
     pub fn notify_codex_degraded(
         &mut self,
         session_id: Uuid,
@@ -12602,6 +12624,12 @@ impl AppState {
         use crate::config::CliProvider;
         use crate::interactive::InteractiveSessionManager;
         use crate::models::session::SessionAgentType;
+
+        // A restart is a new launch on an id this session already had. This is
+        // the exact sequence the reset exists for: the user saw the notice,
+        // restarted the Hangar daemon, and hit restart. If the store is still
+        // wedged they must be told again, not met with silence.
+        self.begin_codex_launch(session_id);
 
         let session = self
             .find_session(session_id)
@@ -14952,13 +14980,15 @@ mod codex_degrade_notice_tests {
         );
     }
 
-    /// Announced once per session, however many times the launch path runs.
+    /// Announced once per LAUNCH, however many times that launch's path runs.
     ///
     /// This is the regression the dedup exists for: a notice that reappears on
     /// every pass trains the user to dismiss it unread, which is worse than
-    /// never showing it. Driving the call twice stands in for the second pass.
+    /// never showing it. Driving the call three times stands in for those
+    /// passes; `a_relaunch_of_the_same_session_is_announced_again` pins the
+    /// other side, that the dedup does not outlive the launch.
     #[test]
-    fn a_degraded_launch_is_announced_once_per_session() {
+    fn a_degraded_launch_is_announced_once_within_one_launch() {
         let mut state = AppState::new();
         let session = Uuid::new_v4();
         let before = state.notifications.len();
@@ -14980,6 +15010,46 @@ mod codex_degrade_notice_tests {
             added[0].message.contains(SharedThreadDegrade::StoreBusy.cause()),
             "the single notice must still name the cause: {}",
             added[0].message
+        );
+    }
+
+    /// A RELAUNCH of the same session announces again.
+    ///
+    /// The sequence this exists for, in the user's order: the store is wedged
+    /// and the notice fires; the user reads it and restarts the Hangar daemon;
+    /// the user hits restart on the session; the store is still wedged, because
+    /// the write lock has been seen holding for the better part of an hour.
+    ///
+    /// Resume and restart both reuse the session id they are handed
+    /// (`AsyncAction::ResumeSession(session_id, ..)`, `restart_cli_in_tmux(
+    /// session_id)`), so a dedup keyed on the session alone would answer that
+    /// second launch with silence — and silence, right after the one action the
+    /// user took to fix it, reads as success.
+    #[test]
+    fn a_relaunch_of_the_same_session_is_announced_again() {
+        let mut state = AppState::new();
+        let session = Uuid::new_v4();
+        let before = state.notifications.len();
+
+        // Launch 1: degraded, announced, and not re-announced within itself.
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+
+        // The user restarts the daemon and relaunches the SAME session.
+        state.begin_codex_launch(session);
+
+        // Launch 2: still degraded, so it must be announced again.
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+
+        let announced = state.notifications[before..]
+            .iter()
+            .filter(|n| n.message.contains("without shared remote control"))
+            .count();
+        assert_eq!(
+            announced, 2,
+            "two launches that both degraded must produce two notices, one each; \
+             got {announced}"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -10297,10 +10297,11 @@ impl AppState {
             };
 
             // `None` covers both "not a Codex session" and "shared remote
-            // control is unavailable on this hangar home" (already warned
-            // about). Both resume the session with plain provider argv.
+            // control is unavailable on this hangar home". Both resume the
+            // session with plain provider argv; the degrade reason rides back
+            // so the resume can say WHY on screen, not only in the log.
             let mut codex_remote = if metadata.agent_type == SessionAgentType::Codex {
-                crate::interactive::session_manager::ensure_codex_remote_thread(
+                let outcome = crate::interactive::session_manager::ensure_codex_remote_thread(
                     metadata.session_id,
                     &metadata.worktree_path,
                     model.as_deref(),
@@ -10308,7 +10309,8 @@ impl AppState {
                     metadata.headroom_enabled,
                     metadata.codex_thread_id.clone(),
                 )
-                .await?
+                .await?;
+                outcome.thread()
             } else {
                 None
             };
@@ -10329,7 +10331,7 @@ impl AppState {
                 .await?;
 
             if codex_remote.as_ref().is_some_and(|remote| remote.thread_id.is_none()) {
-                codex_remote = crate::interactive::session_manager::claim_codex_remote_thread(
+                let outcome = crate::interactive::session_manager::claim_codex_remote_thread(
                     metadata.session_id,
                     &metadata.worktree_path,
                     model.as_deref(),
@@ -10338,6 +10340,7 @@ impl AppState {
                     &metadata.tmux_session_name,
                 )
                 .await?;
+                codex_remote = outcome.thread();
             }
             if let Some(thread_id) =
                 codex_remote.as_ref().and_then(|remote| remote.thread_id.as_deref())
@@ -11643,7 +11646,6 @@ impl AppState {
     pub fn add_info_notification(&mut self, message: String) {
         self.add_notification(Notification::info(message));
     }
-
     /// Explain that a read-only preview cannot provide tmux copy-mode without
     /// filling the notification queue while a scroll key repeats.
     pub fn notify_live_preview_no_scrollback(&mut self) {
@@ -12613,10 +12615,11 @@ impl AppState {
         };
         let headroom_enabled = metadata.map(|m| m.headroom_enabled).unwrap_or(false);
         // `None` covers both "not a Codex session" and "shared remote control
-        // is unavailable on this hangar home" (already warned about). Both
-        // restart the session with plain provider argv.
+        // is unavailable on this hangar home". Both restart the session with
+        // plain provider argv; the degrade reason rides back so the restart can
+        // say WHY on screen, not only in the log.
         let mut codex_remote = if agent_type == SessionAgentType::Codex {
-            crate::interactive::session_manager::ensure_codex_remote_thread(
+            let outcome = crate::interactive::session_manager::ensure_codex_remote_thread(
                 session_id,
                 std::path::Path::new(&workspace_path),
                 model.as_deref(),
@@ -12624,7 +12627,8 @@ impl AppState {
                 headroom_enabled,
                 metadata.and_then(|m| m.codex_thread_id.clone()),
             )
-            .await?
+            .await?;
+            outcome.thread()
         } else {
             None
         };
@@ -12651,7 +12655,7 @@ impl AppState {
             .await?;
 
         if codex_remote.as_ref().is_some_and(|remote| remote.thread_id.is_none()) {
-            codex_remote = crate::interactive::session_manager::claim_codex_remote_thread(
+            let outcome = crate::interactive::session_manager::claim_codex_remote_thread(
                 session_id,
                 std::path::Path::new(&workspace_path),
                 model.as_deref(),
@@ -12660,6 +12664,7 @@ impl AppState {
                 &tmux_session_name,
             )
             .await?;
+            codex_remote = outcome.thread();
         }
         if let Some(thread_id) =
             codex_remote.as_ref().and_then(|remote| remote.thread_id.as_deref())

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -9520,6 +9520,8 @@ impl AppState {
                     logs.push("Interactive session created successfully!".to_string());
                 }
 
+                self.announce_created_session_degrade(&interactive_session);
+
                 // Convert to Session model and add to workspaces
                 let mut session = interactive_session.to_session_model();
                 if let Some(label) =
@@ -11665,6 +11667,30 @@ impl AppState {
     /// Add an info notification
     pub fn add_info_notification(&mut self, message: String) {
         self.add_notification(Notification::info(message));
+    }
+
+    /// Announce a freshly created session's degrade, if it had one.
+    ///
+    /// A FIRST launch is the most common way to meet the degrade, and it was
+    /// the one path that stayed silent: resume and restart announce from their
+    /// own locals, while the create paths only ever wrote the reason onto
+    /// `InteractiveSession` and left it there, unread. A field with no consumer
+    /// looks like a feature and is not one.
+    ///
+    /// No [`Self::begin_codex_launch`] here: `create` mints its id moments
+    /// before this runs (`Uuid::new_v4()`), so nothing has ever been announced
+    /// against it and there is no stale entry to clear.
+    ///
+    /// Split out from the create path so it can be driven directly. The create
+    /// path itself needs real git and real tmux, which is exactly how the
+    /// missing consumer stayed invisible.
+    pub fn announce_created_session_degrade(
+        &mut self,
+        session: &crate::interactive::session_manager::InteractiveSession,
+    ) {
+        if let Some(degrade) = session.codex_degrade {
+            self.notify_codex_degraded(session.session_id, degrade);
+        }
     }
 
     /// Start a new launch for this session, so its degrade can be announced
@@ -15051,6 +15077,78 @@ mod codex_degrade_notice_tests {
             "two launches that both degraded must produce two notices, one each; \
              got {announced}"
         );
+    }
+
+    /// A FIRST launch that degraded is announced too.
+    ///
+    /// The create paths write the reason onto `InteractiveSession` and used to
+    /// stop there: nothing read the field, so the most common way to meet the
+    /// degrade (launching a new Codex session) was the one that said nothing on
+    /// screen. Resume and restart were covered; create was not.
+    #[test]
+    fn a_first_launch_that_degraded_is_announced() {
+        let mut state = AppState::new();
+        let session = degraded_session(Some(SharedThreadDegrade::StoreBusy));
+        let before = state.notifications.len();
+
+        state.announce_created_session_degrade(&session);
+
+        let added: Vec<_> = state.notifications[before..]
+            .iter()
+            .filter(|n| n.message.contains("without shared remote control"))
+            .collect();
+        assert_eq!(
+            added.len(),
+            1,
+            "a degraded first launch must say so on screen, got: {added:?}"
+        );
+        assert!(
+            added[0].message.contains(SharedThreadDegrade::StoreBusy.cause()),
+            "and must name the cause: {}",
+            added[0].message
+        );
+    }
+
+    /// A first launch that got its shared thread says nothing.
+    ///
+    /// The guard on the guard: announcing unconditionally would put a banner on
+    /// every healthy Codex launch, which is the fastest way to teach the user to
+    /// ignore the one that matters.
+    #[test]
+    fn a_healthy_first_launch_is_silent() {
+        let mut state = AppState::new();
+        let session = degraded_session(None);
+        let before = state.notifications.len();
+
+        state.announce_created_session_degrade(&session);
+
+        let added = state.notifications[before..]
+            .iter()
+            .filter(|n| n.message.contains("without shared remote control"))
+            .count();
+        assert_eq!(added, 0, "a healthy launch must not be announced");
+    }
+
+    /// An `InteractiveSession` as the create paths build it, carrying `degrade`.
+    fn degraded_session(
+        degrade: Option<SharedThreadDegrade>,
+    ) -> crate::interactive::session_manager::InteractiveSession {
+        crate::interactive::session_manager::InteractiveSession {
+            session_id: Uuid::new_v4(),
+            worktree_path: std::path::PathBuf::from("/tmp/wt"),
+            source_repository: std::path::PathBuf::from("/tmp/repo"),
+            tmux_session_name: "tmux_wt_main".to_string(),
+            branch_name: "main".to_string(),
+            workspace_name: "repo".to_string(),
+            created_at: chrono::Utc::now(),
+            agent_type: crate::models::session::SessionAgentType::Codex,
+            skip_permissions: false,
+            model: None,
+            headroom_enabled: false,
+            rtk_enabled: false,
+            codex_thread_id: None,
+            codex_degrade: degrade,
+        }
     }
 
     /// The dedup is per session, not global: a second degraded session is a

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -3420,6 +3420,12 @@ pub struct AppState {
     pub last_panel_close_version: Option<u64>,
     // Notification system
     pub notifications: Vec<Notification>,
+    /// Sessions already told they started without shared Codex remote control.
+    ///
+    /// The dedup key for `notify_codex_degraded`. Kept here rather than checked
+    /// against the live notification list because notifications EXPIRE: a
+    /// message-equality check would let the same fact reappear minutes later.
+    codex_degrade_announced: std::collections::HashSet<Uuid>,
     // Pending event to be processed in next loop iteration
     pub pending_event: Option<crate::app::events::AppEvent>,
 
@@ -4111,6 +4117,7 @@ impl Default for AppState {
             previous_screen: None,
             last_panel_close_version: None,
             notifications: Vec::new(),
+            codex_degrade_announced: std::collections::HashSet::new(),
             pending_event: None,
 
             // Initialize quick commit state
@@ -10300,6 +10307,7 @@ impl AppState {
             // control is unavailable on this hangar home". Both resume the
             // session with plain provider argv; the degrade reason rides back
             // so the resume can say WHY on screen, not only in the log.
+            let mut codex_degrade = None;
             let mut codex_remote = if metadata.agent_type == SessionAgentType::Codex {
                 let outcome = crate::interactive::session_manager::ensure_codex_remote_thread(
                     metadata.session_id,
@@ -10310,6 +10318,7 @@ impl AppState {
                     metadata.codex_thread_id.clone(),
                 )
                 .await?;
+                codex_degrade = outcome.degrade();
                 outcome.thread()
             } else {
                 None
@@ -10340,6 +10349,7 @@ impl AppState {
                     &metadata.tmux_session_name,
                 )
                 .await?;
+                codex_degrade = outcome.degrade().or(codex_degrade);
                 codex_remote = outcome.thread();
             }
             if let Some(thread_id) =
@@ -10349,6 +10359,9 @@ impl AppState {
                     metadata.session_id,
                     thread_id.to_string(),
                 )?;
+            }
+            if let Some(degrade) = codex_degrade {
+                self.notify_codex_degraded(metadata.session_id, degrade);
             }
 
             // Re-register live tmux handle and flip status to Running.
@@ -11646,6 +11659,28 @@ impl AppState {
     pub fn add_info_notification(&mut self, message: String) {
         self.add_notification(Notification::info(message));
     }
+
+    /// Say ONCE, on screen, that a Codex session started without shared remote
+    /// control, and why.
+    ///
+    /// Informational, not an error: the session DID start. The launch is not
+    /// retried and nothing was lost except the shared thread, so an error
+    /// notification would misdescribe an outcome the user can simply live with.
+    ///
+    /// Once per session, enforced here rather than at the call sites, so a
+    /// future poll loop that reaches this cannot turn a one-off fact into a
+    /// recurring banner. A notice that repeats is one the user learns to skip.
+    pub fn notify_codex_degraded(
+        &mut self,
+        session_id: Uuid,
+        degrade: crate::interactive::session_manager::SharedThreadDegrade,
+    ) {
+        if !self.codex_degrade_announced.insert(session_id) {
+            return;
+        }
+        self.add_info_notification(degrade.notice());
+    }
+
     /// Explain that a read-only preview cannot provide tmux copy-mode without
     /// filling the notification queue while a scroll key repeats.
     pub fn notify_live_preview_no_scrollback(&mut self) {
@@ -12618,6 +12653,7 @@ impl AppState {
         // is unavailable on this hangar home". Both restart the session with
         // plain provider argv; the degrade reason rides back so the restart can
         // say WHY on screen, not only in the log.
+        let mut codex_degrade = None;
         let mut codex_remote = if agent_type == SessionAgentType::Codex {
             let outcome = crate::interactive::session_manager::ensure_codex_remote_thread(
                 session_id,
@@ -12628,6 +12664,7 @@ impl AppState {
                 metadata.and_then(|m| m.codex_thread_id.clone()),
             )
             .await?;
+            codex_degrade = outcome.degrade();
             outcome.thread()
         } else {
             None
@@ -12664,6 +12701,7 @@ impl AppState {
                 &tmux_session_name,
             )
             .await?;
+            codex_degrade = outcome.degrade().or(codex_degrade);
             codex_remote = outcome.thread();
         }
         if let Some(thread_id) =
@@ -12673,6 +12711,9 @@ impl AppState {
                 session_id,
                 thread_id.to_string(),
             )?;
+        }
+        if let Some(degrade) = codex_degrade {
+            self.notify_codex_degraded(session_id, degrade);
         }
 
         if let Some(session) = self.find_session_mut(session_id) {
@@ -14850,5 +14891,115 @@ mod docker_probe_shared_static_test {
         }
 
         invalidate_docker_probe_cache(&DOCKER_PROBE);
+    }
+}
+
+#[cfg(test)]
+mod codex_degrade_notice_tests {
+    //! The on-screen half of the Codex degrade: a session that starts without
+    //! shared remote control says so, says WHY, and says it exactly once.
+    //!
+    //! The classification these sit on top of is pinned in `session_manager`.
+    //! What is pinned here is the thing a classifier test cannot show: that the
+    //! fact reaches the notification strip, and that a second pass over the
+    //! same session does not add a second banner.
+
+    use uuid::Uuid;
+
+    use super::AppState;
+    use crate::interactive::session_manager::SharedThreadDegrade;
+
+    /// Every cause names both what happened and what it cost.
+    ///
+    /// "No shared remote control" on its own is the message that sent the user
+    /// to a 30 MB daemon log for a fact Ainb already had, so the cause is not
+    /// optional in any variant.
+    #[test]
+    fn every_degrade_notice_names_its_cause_and_its_cost() {
+        for degrade in [
+            SharedThreadDegrade::EphemeralHome,
+            SharedThreadDegrade::NoDaemon,
+            SharedThreadDegrade::StoreBusy,
+        ] {
+            let notice = degrade.notice();
+            assert!(
+                notice.contains(degrade.cause()),
+                "{degrade:?} must name its cause: {notice}"
+            );
+            assert!(
+                notice.contains("without shared remote control"),
+                "{degrade:?} must name what the session lost: {notice}"
+            );
+            assert!(
+                notice.contains("cannot join this conversation"),
+                "{degrade:?} must say who is shut out: {notice}"
+            );
+        }
+        // The three causes must be distinguishable on screen, or naming the
+        // cause buys nothing.
+        let causes = [
+            SharedThreadDegrade::EphemeralHome.cause(),
+            SharedThreadDegrade::NoDaemon.cause(),
+            SharedThreadDegrade::StoreBusy.cause(),
+        ];
+        let mut unique = causes.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            causes.len(),
+            "each cause must read differently"
+        );
+    }
+
+    /// Announced once per session, however many times the launch path runs.
+    ///
+    /// This is the regression the dedup exists for: a notice that reappears on
+    /// every pass trains the user to dismiss it unread, which is worse than
+    /// never showing it. Driving the call twice stands in for the second pass.
+    #[test]
+    fn a_degraded_launch_is_announced_once_per_session() {
+        let mut state = AppState::new();
+        let session = Uuid::new_v4();
+        let before = state.notifications.len();
+
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+        state.notify_codex_degraded(session, SharedThreadDegrade::StoreBusy);
+
+        let added: Vec<_> = state.notifications[before..]
+            .iter()
+            .filter(|n| n.message.contains("without shared remote control"))
+            .collect();
+        assert_eq!(
+            added.len(),
+            1,
+            "three passes over one session must leave ONE notice, got: {added:?}"
+        );
+        assert!(
+            added[0].message.contains(SharedThreadDegrade::StoreBusy.cause()),
+            "the single notice must still name the cause: {}",
+            added[0].message
+        );
+    }
+
+    /// The dedup is per session, not global: a second degraded session is a
+    /// second fact the user has not been told yet.
+    #[test]
+    fn a_second_session_gets_its_own_notice() {
+        let mut state = AppState::new();
+        let before = state.notifications.len();
+
+        state.notify_codex_degraded(Uuid::new_v4(), SharedThreadDegrade::NoDaemon);
+        state.notify_codex_degraded(Uuid::new_v4(), SharedThreadDegrade::NoDaemon);
+
+        let added = state.notifications[before..]
+            .iter()
+            .filter(|n| n.message.contains("without shared remote control"))
+            .count();
+        assert_eq!(
+            added, 2,
+            "two distinct sessions must each be announced once"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -16,12 +16,30 @@ use super::RunArgs;
 use crate::config::CliProvider;
 use crate::git::worktree_manager::WorktreeManager;
 use crate::interactive::session_manager::{
-    InteractiveSessionManager, ModelSource, SessionMetadata, SessionStore, WorktreeRollback,
-    claim_codex_remote_thread, discard_codex_remote_thread, ensure_codex_remote_thread,
-    rollback_failed_interactive_launch,
+    CodexRemote, InteractiveSessionManager, ModelSource, SessionMetadata, SessionStore,
+    WorktreeRollback, claim_codex_remote_thread, discard_codex_remote_thread,
+    ensure_codex_remote_thread, rollback_failed_interactive_launch,
 };
 use crate::models::session::{SessionAgentType, is_default_model};
 use crate::tmux::TmuxSession;
+
+/// The degrade notice for this outcome, or `None` when there is nothing to say
+/// or it has already been said.
+///
+/// One launch can report the SAME degrade twice: `claim_codex_remote_thread`
+/// re-runs the ensure internally, so both call sites see it and both used to
+/// print, putting the identical sentence on stderr two times. The guard lives
+/// in the one function that decides, not at the call sites, for the reason
+/// `AppState::notify_codex_degraded` holds the TUI's: a call site that has to
+/// remember to check is a call site that eventually forgets.
+fn degrade_notice_once(announced: &mut bool, outcome: &CodexRemote) -> Option<String> {
+    if *announced {
+        return None;
+    }
+    let degrade = outcome.degrade()?;
+    *announced = true;
+    Some(degrade.notice())
+}
 
 /// Execute the run command
 pub async fn execute(args: RunArgs) -> Result<()> {
@@ -122,6 +140,8 @@ pub async fn execute(args: RunArgs) -> Result<()> {
     }
 
     // Step 6: Allocate the daemon-owned remote thread before tmux starts.
+    // One launch, one notice, however many times the outcome reports it.
+    let mut degrade_announced = false;
     let codex_remote = if provider == CliProvider::Codex {
         match ensure_codex_remote_thread(
             session_id,
@@ -141,8 +161,8 @@ pub async fn execute(args: RunArgs) -> Result<()> {
             // without. The reason is printed rather than only logged: `ainb
             // run` has no notification strip, and stderr is its equivalent.
             Ok(outcome) => {
-                if let Some(degrade) = outcome.degrade() {
-                    eprintln!("{}", degrade.notice());
+                if let Some(notice) = degrade_notice_once(&mut degrade_announced, &outcome) {
+                    eprintln!("{notice}");
                 }
                 outcome.thread()
             }
@@ -234,8 +254,8 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         .await
         {
             Ok(outcome) => {
-                if let Some(degrade) = outcome.degrade() {
-                    eprintln!("{}", degrade.notice());
+                if let Some(notice) = degrade_notice_once(&mut degrade_announced, &outcome) {
+                    eprintln!("{notice}");
                 }
                 outcome.thread()
             }
@@ -787,6 +807,61 @@ fn attach_to_session(session_name: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::cli::Tool;
+
+    /// One launch prints the degrade notice once, not once per reporting site.
+    ///
+    /// `ensure` and `claim` both report the SAME degrade for one launch,
+    /// because the claim re-runs the ensure internally. Printing at each site
+    /// put the identical sentence on stderr twice, which is the CLI half of the
+    /// guarantee `AppState::notify_codex_degraded` already gave the TUI.
+    #[test]
+    fn one_launch_prints_its_degrade_notice_once() {
+        use crate::interactive::session_manager::{CodexRemote, SharedThreadDegrade};
+
+        let mut announced = false;
+        let ensure = CodexRemote::Degraded(SharedThreadDegrade::StoreBusy);
+        let claim = CodexRemote::Degraded(SharedThreadDegrade::StoreBusy);
+
+        let first = degrade_notice_once(&mut announced, &ensure);
+        let second = degrade_notice_once(&mut announced, &claim);
+
+        assert!(
+            first.is_some_and(|notice| notice.contains(SharedThreadDegrade::StoreBusy.cause())),
+            "the first report must produce the notice, naming its cause"
+        );
+        assert_eq!(
+            second, None,
+            "the second report of the SAME launch must stay quiet, or the user reads \
+             the identical sentence twice"
+        );
+    }
+
+    /// A launch that got its shared thread prints nothing, and stays printable
+    /// if a later report degrades.
+    #[test]
+    fn a_healthy_outcome_prints_nothing_and_does_not_arm_the_guard() {
+        use crate::interactive::session_manager::{CodexRemote, SharedThreadDegrade};
+
+        let mut announced = false;
+        let healthy = CodexRemote::Shared(ainb_hangar_proto::fleet::CodexSessionEnsureResult {
+            thread_id: Some("thread-1".to_string()),
+            endpoint: "/tmp/hangar.sock".to_string(),
+        });
+
+        assert_eq!(
+            degrade_notice_once(&mut announced, &healthy),
+            None,
+            "a healthy outcome has nothing to announce"
+        );
+        // The guard must not have been armed by silence: an ensure that
+        // succeeded followed by a claim that degrades still owes the user a
+        // notice.
+        let later = CodexRemote::Degraded(SharedThreadDegrade::NoDaemon);
+        assert!(
+            degrade_notice_once(&mut announced, &later).is_some(),
+            "a degrade reported after a healthy step must still be announced"
+        );
+    }
 
     use crate::test_support::git_bin;
 

--- a/ainb-tui/crates/ainb-core/src/cli/run.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/run.rs
@@ -133,13 +133,19 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         )
         .await
         {
-            // `Ok(None)` is a launch WITHOUT shared remote control (an
-            // ephemeral hangar home, already warned about). It takes the same
-            // path a non-Codex session takes: plain provider argv, no
+            // A degraded outcome is a launch WITHOUT shared remote control (an
+            // ephemeral hangar home, no daemon, or a busy store). It takes the
+            // same path a non-Codex session takes: plain provider argv, no
             // rollback, no error. Failing here instead deleted the worktree
             // created three steps ago over a feature the session can run
-            // without.
-            Ok(remote) => remote,
+            // without. The reason is printed rather than only logged: `ainb
+            // run` has no notification strip, and stderr is its equivalent.
+            Ok(outcome) => {
+                if let Some(degrade) = outcome.degrade() {
+                    eprintln!("{}", degrade.notice());
+                }
+                outcome.thread()
+            }
             Err(error) => {
                 rollback_failed_interactive_launch(session_id, None, rollback_worktree()).await;
                 return Err(error)
@@ -227,7 +233,12 @@ pub async fn execute(args: RunArgs) -> Result<()> {
         )
         .await
         {
-            Ok(remote) => remote,
+            Ok(outcome) => {
+                if let Some(degrade) = outcome.degrade() {
+                    eprintln!("{}", degrade.notice());
+                }
+                outcome.thread()
+            }
             Err(error) => {
                 rollback_failed_interactive_launch(
                     session_id,

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -328,10 +328,6 @@ where
             warn!("{}", busy_store_warning(&error));
             Ok(None)
         }
-        // The daemon answered, and answered that it could not reach its store.
-        // Same cost as no daemon at all (the shared thread, nothing else), so
-        // the same degrade: a wedged store must not turn a launch into a
-        // failure whose cleanup deletes the worktree the launch just cloned.
         Err(error) => {
             let message = format_codex_remote_control_failure(&error.to_string());
             warn!(error = %error, "{message}");

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -170,12 +170,18 @@ fn resolved_hangar_home() -> String {
 /// Whether a daemon error means there is no daemon to talk to at all, as
 /// opposed to a daemon that answered and the exchange then went wrong.
 ///
-/// Only the first class may degrade. `NoHome` and `Token` are what
+/// `NoHome` and `Token` are what
 /// [`crate::fleet::bridge::daemon::DaemonClient::from_env`] reports when the
 /// home is unresolvable or the token file is absent, which is what a home no
 /// daemon has ever booted on looks like; `Connect` is the dial itself finding
-/// nothing listening. Everything else (`Rpc`, `Decode`, `Io`, `Timeout`) means
-/// the daemon IS there, so it stays a hard failure the user is told to act on.
+/// nothing listening.
+///
+/// This predicate is about REACHABILITY only. A daemon that answered is not
+/// unreachable, so `Rpc`, `Decode`, `Io` and `Timeout` all stay hard failures
+/// here. Exactly one of them degrades, and it is classified separately by
+/// [`daemon_store_unavailable`] rather than widened into this one, so that
+/// "nothing is listening" and "the store is busy" keep telling the user
+/// different things.
 fn daemon_unreachable(error: &crate::fleet::bridge::daemon::DaemonError) -> bool {
     use crate::fleet::bridge::daemon::DaemonError;
     matches!(
@@ -191,6 +197,41 @@ fn unreachable_daemon_warning(error: &crate::fleet::bridge::daemon::DaemonError)
     format!(
         "no Hangar daemon answered ({error}); launching this Codex session without shared \
          remote control - the phone and any other app-server client cannot join its conversation"
+    )
+}
+
+/// Whether the daemon answered that its store was too contended to serve.
+///
+/// One code, matched exactly. `STORE_UNAVAILABLE` is the daemon's word for "the
+/// request was fine, `SQLite` was busy, nothing was read or written" — a fault
+/// in a component that is load-bearing for the SHARED thread and nothing else,
+/// so it costs this session exactly what an absent daemon costs it.
+///
+/// Deliberately NOT `-32603`: that is the daemon's catch-all and also carries
+/// "Ainb Codex remote control unavailable: still starting", which must stay a
+/// hard failure the user acts on. Widening this to the catch-all would swallow
+/// it — `still_starting_stays_a_hard_failure` is the pin.
+///
+/// Matched on the code and never on the message: a busy store surfaces as
+/// `database is locked` under result code 5 on one platform and 517 on another,
+/// and 517 is a different bug class that this must not degrade over.
+fn daemon_store_unavailable(error: &crate::fleet::bridge::daemon::DaemonError) -> bool {
+    use crate::fleet::bridge::daemon::DaemonError;
+    matches!(error, DaemonError::Rpc { code, .. } if *code == ainb_hangar_proto::STORE_UNAVAILABLE)
+}
+
+/// What the user is told when the daemon's store is too busy to serve.
+///
+/// Names the cause and the consequence, and offers NO retry: the launch it is
+/// attached to SUCCEEDED without shared remote control, so there is nothing to
+/// try again. Retrying is what used to run the failed-session cleanup over a
+/// worktree that had just been cloned.
+fn busy_store_warning(error: &crate::fleet::bridge::daemon::DaemonError) -> String {
+    format!(
+        "the Hangar store is too busy to answer ({error}); this Codex session started WITHOUT \
+         shared remote control - the phone and any other app-server client cannot join its \
+         conversation. Nothing to retry: the session is running. Restart the Hangar daemon to \
+         restore shared remote control for later sessions"
     )
 }
 
@@ -279,6 +320,18 @@ where
             warn!("{}", unreachable_daemon_warning(&error));
             Ok(None)
         }
+        // The daemon answered, and answered that it could not reach its store.
+        // Same cost as no daemon at all (the shared thread, nothing else), so
+        // the same degrade: a wedged store must not turn a launch into a
+        // failure whose cleanup deletes the worktree the launch just cloned.
+        Err(error) if daemon_store_unavailable(&error) => {
+            warn!("{}", busy_store_warning(&error));
+            Ok(None)
+        }
+        // The daemon answered, and answered that it could not reach its store.
+        // Same cost as no daemon at all (the shared thread, nothing else), so
+        // the same degrade: a wedged store must not turn a launch into a
+        // failure whose cleanup deletes the worktree the launch just cloned.
         Err(error) => {
             let message = format_codex_remote_control_failure(&error.to_string());
             warn!(error = %error, "{message}");
@@ -5032,6 +5085,102 @@ trust_level = "trusted"
         assert!(
             failure.to_string().contains("Codex unavailable"),
             "the user must get the short next action: {failure:#}"
+        );
+    }
+
+    /// A daemon whose STORE is wedged costs the session its shared thread and
+    /// nothing else, so the launch continues.
+    ///
+    /// This is the failure that hit a real machine after the connect degrade
+    /// shipped: the daemon was running and its socket was bound, so nothing
+    /// looked unreachable, but every write timed out on a held `SQLite` write
+    /// lock. The RPC error became "Codex remote control unavailable ... then
+    /// retry", and that retry is what runs the failed-session cleanup over a
+    /// worktree the launch had just cloned.
+    ///
+    /// Asserting the LAUNCH, not just the classification: a degrade that is
+    /// computed and then ignored still passes a classifier-only test.
+    #[tokio::test]
+    async fn a_wedged_store_launches_codex_without_a_remote_thread() {
+        use crate::cli::hangar::DaemonAutostart;
+        use crate::fleet::bridge::daemon::DaemonError;
+
+        let error = DaemonError::Rpc {
+            code: ainb_hangar_proto::STORE_UNAVAILABLE,
+            message: "read Interactive Codex thread: error returned from database: \
+                      (code: 5) database is locked"
+                .to_string(),
+        };
+        let warning = super::busy_store_warning(&error);
+
+        let remote = super::ensure_codex_remote_thread_with(
+            // A durable home and a daemon that started, so neither the
+            // ephemeral degrade nor the unreachable degrade can be what
+            // rescues this launch.
+            || DaemonAutostart::Started,
+            || panic!("a durable home must not be reported as ephemeral"),
+            || async { Err(error) },
+        )
+        .await
+        .unwrap_or_else(|failure| panic!("a wedged store must not fail the launch: {failure:#}"));
+
+        assert!(
+            remote.is_none(),
+            "the session must launch with no shared remote thread: {warning}"
+        );
+        assert!(
+            warning.contains("too busy"),
+            "the warning must name the cause: {warning}"
+        );
+        assert!(
+            warning.contains("shared remote control"),
+            "the warning must name what the session loses: {warning}"
+        );
+        assert!(
+            warning.contains("Nothing to retry"),
+            "the launch SUCCEEDED, so the warning must say so outright: {warning}"
+        );
+        // The advice forms the other branches use, none of which may appear
+        // here: retrying is what runs the cleanup over the cloned worktree.
+        for advice in ["then retry", "Retry session", "retry in"] {
+            assert!(
+                !warning.contains(advice),
+                "the warning must not advise a retry ({advice:?}): {warning}"
+            );
+        }
+    }
+
+    /// A daemon whose Codex transport is still warming up stays a HARD failure.
+    ///
+    /// The pin on the degrade. `still starting` is answered with the daemon's
+    /// catch-all `-32603`, one code away from the store-unavailable degrade,
+    /// and it is genuinely worth retrying in a few seconds. A future widening
+    /// of `daemon_store_unavailable` to the catch-all would swallow it and
+    /// hand the user a session whose shared thread never appears.
+    #[tokio::test]
+    async fn still_starting_stays_a_hard_failure() {
+        use crate::cli::hangar::DaemonAutostart;
+        use crate::fleet::bridge::daemon::DaemonError;
+
+        let failure = super::ensure_codex_remote_thread_with(
+            || DaemonAutostart::Started,
+            || panic!("a durable home must not be reported as ephemeral"),
+            || async {
+                Err(DaemonError::Rpc {
+                    // -32603, the daemon's INTERNAL_ERROR: deliberately NOT the
+                    // code the degrade admits.
+                    code: -32603,
+                    message: "Ainb Codex remote control unavailable: still starting".to_string(),
+                })
+            },
+        )
+        .await
+        .expect_err("a warming-up Codex transport must still fail the launch");
+
+        assert!(
+            failure.to_string().contains("Retry session in 5 seconds"),
+            "the user must be told to retry, which is only safe because this is NOT \
+             the wedged-store path: {failure:#}"
         );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -66,6 +66,12 @@ pub struct InteractiveSession {
     pub headroom_enabled: bool,       // Route this session's CLI through the local Headroom proxy
     pub rtk_enabled: bool,            // RTK PreToolUse hook wired in session's worktree
     pub codex_thread_id: Option<String>, // Exact shared app-server thread for Codex sessions
+    /// Why this launch has no shared thread, when it has none.
+    ///
+    /// Transient, not persisted: it describes THIS launch, and a later one on a
+    /// recovered daemon would be lying if it inherited the value. `None` means
+    /// either a shared thread exists or the session is not Codex.
+    pub codex_degrade: Option<SharedThreadDegrade>,
 }
 
 /// How the persisted model value should be interpreted.
@@ -235,13 +241,87 @@ fn busy_store_warning(error: &crate::fleet::bridge::daemon::DaemonError) -> Stri
     )
 }
 
+/// Why a Codex session runs WITHOUT shared remote control.
+///
+/// The launch succeeded in every one of these cases. The variant names what it
+/// cost and why, so the on-screen notice can say the cause out loud instead of
+/// sending the user to the daemon log for a fact Ainb already had.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SharedThreadDegrade {
+    /// The hangar home is ephemeral, so no daemon will ever serve it.
+    EphemeralHome,
+    /// Nothing answered on the socket: no home, no token, or no listener.
+    NoDaemon,
+    /// The daemon answered that its store was too contended to serve.
+    StoreBusy,
+}
+
+impl SharedThreadDegrade {
+    /// The cause, in the few words a notification line has room for.
+    #[must_use]
+    pub const fn cause(self) -> &'static str {
+        match self {
+            Self::EphemeralHome => "ephemeral hangar home",
+            Self::NoDaemon => "no Hangar daemon",
+            Self::StoreBusy => "Hangar store busy",
+        }
+    }
+
+    /// The on-screen sentence: what happened, and what it cost.
+    ///
+    /// The log keeps the long form (the resolved home, the transport error, the
+    /// SQLite code); this is the short form, and it still names the cause,
+    /// because "no shared remote control" alone is the message that sent the
+    /// user back to a 30 MB log.
+    #[must_use]
+    pub fn notice(self) -> String {
+        format!(
+            "Codex started without shared remote control ({}) - the phone and other \
+             app-server clients cannot join this conversation",
+            self.cause()
+        )
+    }
+}
+
+/// What establishing the shared Codex thread produced for one launch.
+///
+/// Replaces a bare `Option`: `None` said the session had no shared thread but
+/// not WHY, so every caller that wanted to tell the user had to go and ask the
+/// log. The degrade reason rides back with the outcome instead.
+#[derive(Debug)]
+pub(crate) enum CodexRemote {
+    /// The daemon owns a shared thread for this session.
+    Shared(ainb_hangar_proto::fleet::CodexSessionEnsureResult),
+    /// The session runs without one, for this reason.
+    Degraded(SharedThreadDegrade),
+}
+
+impl CodexRemote {
+    /// The reason this launch has no shared thread, if it has none.
+    pub(crate) const fn degrade(&self) -> Option<SharedThreadDegrade> {
+        match self {
+            Self::Shared(_) => None,
+            Self::Degraded(reason) => Some(*reason),
+        }
+    }
+
+    /// The shared thread, if there is one.
+    pub(crate) fn thread(self) -> Option<ainb_hangar_proto::fleet::CodexSessionEnsureResult> {
+        match self {
+            Self::Shared(remote) => Some(remote),
+            Self::Degraded(_) => None,
+        }
+    }
+}
+
 /// Create or resume one exact shared Codex app-server thread for Interactive.
 ///
-/// `Ok(None)` is a successful launch WITHOUT shared remote control: the reason
-/// has already been warned about, and the session runs the provider CLI
-/// directly, which is the same path a non-Codex session and a Codex session
-/// with the feature disabled take. Callers must not treat it as a failure, and
-/// in particular must not roll back a worktree over it.
+/// [`CodexRemote::Degraded`] is a successful launch WITHOUT shared remote
+/// control: the reason has already been warned about, it rides back on the
+/// outcome so the caller can say it on screen, and the session runs the
+/// provider CLI directly, which is the same path a non-Codex session and a
+/// Codex session with the feature disabled take. Callers must not treat it as
+/// a failure, and in particular must not roll back a worktree over it.
 pub(crate) async fn ensure_codex_remote_thread(
     session_id: Uuid,
     cwd: &std::path::Path,
@@ -249,7 +329,7 @@ pub(crate) async fn ensure_codex_remote_thread(
     skip_permissions: bool,
     headroom_enabled: bool,
     existing_thread_id: Option<String>,
-) -> anyhow::Result<Option<ainb_hangar_proto::fleet::CodexSessionEnsureResult>> {
+) -> anyhow::Result<CodexRemote> {
     if headroom_enabled {
         anyhow::bail!(
             "Codex Headroom is unavailable with shared remote control; disable Headroom for this session"
@@ -294,7 +374,7 @@ async fn ensure_codex_remote_thread_with<Ensure, Exchange>(
     autostart: impl FnOnce() -> crate::cli::hangar::DaemonAutostart,
     home: impl FnOnce() -> String,
     ensure: Ensure,
-) -> anyhow::Result<Option<ainb_hangar_proto::fleet::CodexSessionEnsureResult>>
+) -> anyhow::Result<CodexRemote>
 where
     Ensure: FnOnce() -> Exchange,
     Exchange: std::future::Future<
@@ -305,10 +385,10 @@ where
         >,
 {
     if !shared_remote_control_available(autostart(), home) {
-        return Ok(None);
+        return Ok(CodexRemote::Degraded(SharedThreadDegrade::EphemeralHome));
     }
     match ensure().await {
-        Ok(remote) => Ok(Some(remote)),
+        Ok(remote) => Ok(CodexRemote::Shared(remote)),
         // No daemon answered: an unresolvable home, no token file, or nothing
         // listening on the socket. The daemon is load-bearing for the SHARED
         // thread and nothing else, so this costs the session exactly the same
@@ -318,7 +398,7 @@ where
         // had just created.
         Err(error) if daemon_unreachable(&error) => {
             warn!("{}", unreachable_daemon_warning(&error));
-            Ok(None)
+            Ok(CodexRemote::Degraded(SharedThreadDegrade::NoDaemon))
         }
         // The daemon answered, and answered that it could not reach its store.
         // Same cost as no daemon at all (the shared thread, nothing else), so
@@ -326,7 +406,7 @@ where
         // failure whose cleanup deletes the worktree the launch just cloned.
         Err(error) if daemon_store_unavailable(&error) => {
             warn!("{}", busy_store_warning(&error));
-            Ok(None)
+            Ok(CodexRemote::Degraded(SharedThreadDegrade::StoreBusy))
         }
         Err(error) => {
             let message = format_codex_remote_control_failure(&error.to_string());
@@ -358,8 +438,9 @@ fn format_codex_remote_control_failure(cause: &str) -> &'static str {
 /// Wait briefly for the freshly started remote terminal to publish its exact
 /// thread identity through the daemon's app-server event stream.
 ///
-/// `Ok(None)` carries the same meaning as in [`ensure_codex_remote_thread`]:
-/// shared remote control is unavailable and the session runs without it.
+/// [`CodexRemote::Degraded`] carries the same meaning as in
+/// [`ensure_codex_remote_thread`]: shared remote control is unavailable and the
+/// session runs without it.
 pub(crate) async fn claim_codex_remote_thread(
     session_id: Uuid,
     cwd: &std::path::Path,
@@ -367,11 +448,11 @@ pub(crate) async fn claim_codex_remote_thread(
     skip_permissions: bool,
     headroom_enabled: bool,
     tmux_session: &str,
-) -> anyhow::Result<Option<ainb_hangar_proto::fleet::CodexSessionEnsureResult>> {
+) -> anyhow::Result<CodexRemote> {
     let exact_target = format!("={tmux_session}");
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
-        let Some(remote) = ensure_codex_remote_thread(
+        let outcome = ensure_codex_remote_thread(
             session_id,
             cwd,
             model,
@@ -379,15 +460,17 @@ pub(crate) async fn claim_codex_remote_thread(
             headroom_enabled,
             None,
         )
-        .await?
-        else {
+        .await?;
+        let remote = match outcome {
             // Shared remote control is unavailable, so there is no thread to
-            // wait for. Report that once rather than spending the 10s deadline
-            // re-asking a question whose answer cannot change.
-            return Ok(None);
+            // wait for. Report that once, carrying the reason, rather than
+            // spending the 10s deadline re-asking a question whose answer
+            // cannot change.
+            CodexRemote::Degraded(reason) => return Ok(CodexRemote::Degraded(reason)),
+            CodexRemote::Shared(remote) => remote,
         };
         if remote.thread_id.is_some() {
-            return Ok(Some(remote));
+            return Ok(CodexRemote::Shared(remote));
         }
         // Checked BEFORE the deadline, because the common failure is not slow,
         // it is instant: Codex prints one line and exits inside a second. It
@@ -1200,6 +1283,10 @@ impl InteractiveSessionManager {
             }
         }
 
+        // Why this session has no shared thread, when it has none: carried onto
+        // the session so the TUI can say the cause on screen instead of leaving
+        // it in the daemon log.
+        let mut codex_degrade = None;
         let codex_remote = if agent_type == SessionAgentType::Codex {
             match ensure_codex_remote_thread(
                 session_id,
@@ -1211,7 +1298,10 @@ impl InteractiveSessionManager {
             )
             .await
             {
-                Ok(remote) => remote,
+                Ok(outcome) => {
+                    codex_degrade = outcome.degrade();
+                    outcome.thread()
+                }
                 Err(error) => {
                     rollback_failed_interactive_launch(
                         session_id,
@@ -1294,7 +1384,12 @@ impl InteractiveSessionManager {
             )
             .await
             {
-                Ok(remote) => remote,
+                Ok(outcome) => {
+                    // A claim that degrades is still a degrade: keep the reason
+                    // the claim reports, so the notice names it.
+                    codex_degrade = outcome.degrade().or(codex_degrade);
+                    outcome.thread()
+                }
                 Err(error) => {
                     rollback_failed_interactive_launch(
                         session_id,
@@ -1326,6 +1421,7 @@ impl InteractiveSessionManager {
             headroom_enabled,
             rtk_enabled,
             codex_thread_id: codex_remote.as_ref().and_then(|remote| remote.thread_id.clone()),
+            codex_degrade,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -1461,6 +1557,10 @@ impl InteractiveSessionManager {
             }
         }
 
+        // Why this session has no shared thread, when it has none: carried onto
+        // the session so the TUI can say the cause on screen instead of leaving
+        // it in the daemon log.
+        let mut codex_degrade = None;
         let codex_remote = if agent_type == SessionAgentType::Codex {
             match ensure_codex_remote_thread(
                 session_id,
@@ -1472,7 +1572,10 @@ impl InteractiveSessionManager {
             )
             .await
             {
-                Ok(remote) => remote,
+                Ok(outcome) => {
+                    codex_degrade = outcome.degrade();
+                    outcome.thread()
+                }
                 Err(error) => {
                     rollback_failed_interactive_launch(session_id, None, rollback_worktree).await;
                     return Err(error
@@ -1552,7 +1655,12 @@ impl InteractiveSessionManager {
             )
             .await
             {
-                Ok(remote) => remote,
+                Ok(outcome) => {
+                    // A claim that degrades is still a degrade: keep the reason
+                    // the claim reports, so the notice names it.
+                    codex_degrade = outcome.degrade().or(codex_degrade);
+                    outcome.thread()
+                }
                 Err(error) => {
                     rollback_failed_interactive_launch(
                         session_id,
@@ -1585,6 +1693,7 @@ impl InteractiveSessionManager {
             headroom_enabled,
             rtk_enabled,
             codex_thread_id: codex_remote.as_ref().and_then(|remote| remote.thread_id.clone()),
+            codex_degrade,
         };
 
         self.active_sessions.insert(session_id, session.clone());
@@ -1732,6 +1841,9 @@ impl InteractiveSessionManager {
                     headroom_enabled: metadata.headroom_enabled,
                     rtk_enabled: metadata.rtk_enabled,
                     codex_thread_id: metadata.codex_thread_id.clone(),
+                    // Rediscovery, not a launch: nothing was attempted, so
+                    // there is no degrade to announce.
+                    codex_degrade: None,
                 });
             } else {
                 debug!(
@@ -1784,6 +1896,8 @@ impl InteractiveSessionManager {
                     headroom_enabled: false,
                     rtk_enabled: false,
                     codex_thread_id: None,
+                    // Rediscovery, not a launch: see above.
+                    codex_degrade: None,
                 });
             }
         }
@@ -4994,10 +5108,11 @@ trust_level = "trusted"
         .await
         .expect("an ephemeral home must not fail the launch");
 
-        assert!(
-            remote.is_none(),
+        assert_eq!(
+            remote.degrade(),
+            Some(super::SharedThreadDegrade::EphemeralHome),
             "the session must launch with no shared remote thread, exactly as one with the \
-             feature disabled does"
+             feature disabled does, and name the ephemeral home as the reason"
         );
     }
 
@@ -5044,8 +5159,9 @@ trust_level = "trusted"
             .await
             .unwrap_or_else(|failure| panic!("{warning} must not fail the launch: {failure:#}"));
 
-            assert!(
-                remote.is_none(),
+            assert_eq!(
+                remote.degrade(),
+                Some(super::SharedThreadDegrade::NoDaemon),
                 "the session must launch with no shared remote thread: {warning}"
             );
             assert!(
@@ -5120,9 +5236,11 @@ trust_level = "trusted"
         .await
         .unwrap_or_else(|failure| panic!("a wedged store must not fail the launch: {failure:#}"));
 
-        assert!(
-            remote.is_none(),
-            "the session must launch with no shared remote thread: {warning}"
+        assert_eq!(
+            remote.degrade(),
+            Some(super::SharedThreadDegrade::StoreBusy),
+            "the session must launch with no shared remote thread, and name the busy \
+             store as the reason: {warning}"
         );
         assert!(
             warning.contains("too busy"),

--- a/ainb-tui/crates/ainb-core/tests/tripwire_cli_run_codex_degraded.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_cli_run_codex_degraded.rs
@@ -185,6 +185,25 @@ fn a_codex_run_without_a_shared_thread_launches_and_keeps_its_worktree() {
         String::from_utf8_lossy(&out.stderr)
     );
 
+    // The user is TOLD, on the surface they are looking at, that this launch
+    // has no shared thread and why. `ainb run` has no notification strip, so
+    // stderr is its equivalent of the TUI banner. Without this the degrade is
+    // silent: the session works, the phone never joins, and nothing on screen
+    // ever connects those two facts.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("without shared remote control"),
+        "a degraded run must say so on screen: {stderr}"
+    );
+    assert!(
+        stderr.contains("ephemeral hangar home"),
+        "the notice must name the CAUSE, not just the loss: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot join this conversation"),
+        "the notice must name what it cost: {stderr}"
+    );
+
     // The worktree the run created is still there. This is the assertion the
     // incident is about: the old failure path ran failed-session cleanup, which
     // resolves `by-session/<uuid>` and deletes what it points at.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -3860,7 +3860,7 @@ async fn codex_event_watermark(pool: &SqlitePool) -> Result<i64, RpcError> {
     sqlx::query_scalar("SELECT COALESCE(MAX(ingest_order), 0) FROM fleet_provider_event")
         .fetch_one(pool)
         .await
-        .map_err(|error| internal(&format!("read Codex event cursor: {error}")))
+        .map_err(|error| store_error("read Codex event cursor", &error))
 }
 
 async fn reserve_pending_codex_thread(
@@ -3881,7 +3881,7 @@ async fn reserve_pending_codex_thread(
         )
         .execute(pool)
         .await
-        .map_err(|error| internal(&format!("expire pending Codex launch: {error}")))?;
+        .map_err(|error| store_error("expire pending Codex launch", &error))?;
         let watermark = codex_event_watermark(pool).await?;
         let inserted = sqlx::query(
             "INSERT INTO interactive_codex_thread \
@@ -3908,9 +3908,7 @@ async fn reserve_pending_codex_thread(
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
             Err(error) => {
-                return Err(internal(&format!(
-                    "reserve Interactive Codex thread: {error}"
-                )));
+                return Err(store_error("reserve Interactive Codex thread", &error));
             }
         }
     }
@@ -3934,7 +3932,7 @@ async fn claim_pending_codex_thread(
     .bind(watermark)
     .fetch_all(pool)
     .await
-    .map_err(|error| internal(&format!("read pending Codex thread: {error}")))?;
+    .map_err(|error| store_error("read pending Codex thread", &error))?;
     for payload in payloads {
         let Some(thread_id) = codex_started_thread_id(&payload, cwd) else {
             continue;
@@ -3947,7 +3945,7 @@ async fn claim_pending_codex_thread(
         .bind(session_id)
         .execute(pool)
         .await
-        .map_err(|error| internal(&format!("claim Interactive Codex thread: {error}")))?;
+        .map_err(|error| store_error("claim Interactive Codex thread", &error))?;
         if claimed.rows_affected() == 1 {
             return Ok(Some(thread_id));
         }
@@ -13274,6 +13272,66 @@ mod tests {
         assert_eq!(
             fault.code, INTERNAL_ERROR,
             "only contention may be coded unavailable: {fault:?}"
+        );
+    }
+
+    /// The FRESH-LAUNCH branch of `codex/session_ensure` also codes a busy
+    /// store as unavailable.
+    ///
+    /// `store_error` being correct proves nothing about a branch that never
+    /// calls it. A session with no existing thread row goes through
+    /// `reserve_pending_codex_thread`, which is a WRITE and therefore the
+    /// branch a held write lock actually hits, and it was left on the
+    /// `-32603` catch-all after the first pass through this handler. On that
+    /// code the TUI hard-fails and its cleanup deletes the worktree — the
+    /// exact outcome this whole change exists to prevent, surviving on the
+    /// most common path of all: the first launch.
+    #[tokio::test]
+    async fn the_fresh_launch_branch_codes_a_busy_store_unavailable() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let options = SqliteConnectOptions::new()
+            .filename(dir.path().join("ensure.db"))
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_millis(0));
+
+        let pool = SqlitePool::connect_with(options.clone()).await.expect("pool");
+        for ddl in [
+            "CREATE TABLE interactive_codex_thread (session_id TEXT PRIMARY KEY, thread_id TEXT, \
+             cwd TEXT, model TEXT, skip_permissions INTEGER, event_watermark INTEGER, \
+             reserved_at INTEGER)",
+            "CREATE TABLE fleet_provider_event (ingest_order INTEGER PRIMARY KEY, provider TEXT, \
+             source TEXT, event_type TEXT, raw_payload TEXT)",
+        ] {
+            sqlx::query(ddl).execute(&pool).await.expect("schema");
+        }
+
+        // Another connection owns the write lock, exactly as a contended
+        // daemon does.
+        let holder = SqlitePool::connect_with(options).await.expect("holder pool");
+        let mut held = holder.acquire().await.expect("hold a connection");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *held)
+            .await
+            .expect("take the write lock");
+
+        let params = ainb_hangar_proto::fleet::CodexSessionEnsureParams {
+            session_id: "session-under-a-locked-store".to_string(),
+            cwd: "/tmp/does-not-matter".to_string(),
+            model: None,
+            thread_id: None,
+            skip_permissions: false,
+        };
+        let failure = reserve_pending_codex_thread(&pool, &params, "/tmp/does-not-matter")
+            .await
+            .expect_err("a held write lock must fail the reservation");
+
+        assert_eq!(
+            failure.code, STORE_UNAVAILABLE,
+            "the fresh-launch branch must degrade, not hard-fail and delete a worktree: \
+             {failure:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -83,6 +83,21 @@ const INTERNAL_ERROR: i32 = -32603;
 /// implementation-defined server-error band, deliberately distinct from
 /// `INVALID_PARAMS` so a UI can tell "you may not" from "you asked wrong".
 const PERMISSION_DENIED: i32 = -32000;
+/// Application-defined "the store could not be reached": the request was
+/// well-formed and would have succeeded, but `SQLite` reported lock contention
+/// (see [`ainb_hangar_store::repo::fleet::is_lock_contention`]) so nothing was
+/// read or written.
+///
+/// Distinct from [`INTERNAL_ERROR`] on purpose. `-32603` is this daemon's
+/// catch-all and also carries "Ainb Codex remote control unavailable: still
+/// starting", which a caller MUST keep treating as a loud, actionable failure.
+/// A caller that degrades needs to name the one condition it is willing to
+/// degrade over, and a wire code is the only signal that survives a `SQLite`
+/// message reword or an extended result code the text does not mention.
+///
+/// The number itself lives in `ainb-hangar-proto` because the TUI branches on
+/// it; this alias keeps the daemon's other codes reading alike.
+const STORE_UNAVAILABLE: i32 = ainb_hangar_proto::STORE_UNAVAILABLE;
 /// Soft cap on one request body. Snapshot requests are tiny.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
@@ -3682,7 +3697,7 @@ async fn handle_codex_session_ensure(
     .bind(&params.session_id)
     .fetch_optional(pool)
     .await
-    .map_err(|error| internal(&format!("read Interactive Codex thread: {error}")))?;
+    .map_err(|error| store_error("read Interactive Codex thread", &error))?;
     let thread_id = match existing {
         Some((Some(thread_id), resumable, _)) => {
             if let Some(requested) = params.thread_id.as_deref().filter(|id| !id.trim().is_empty())
@@ -3701,7 +3716,7 @@ async fn handle_codex_session_ensure(
                     .bind(&params.session_id)
                     .execute(pool)
                     .await
-                    .map_err(|error| internal(&format!("mark Codex thread resumable: {error}")))?;
+                    .map_err(|error| store_error("mark Codex thread resumable", &error))?;
                     Some(thread_id)
                 }
                 Err(error) if resumable == 0 && error.to_string().contains("no rollout found") => {
@@ -3715,7 +3730,7 @@ async fn handle_codex_session_ensure(
                     .bind(&params.session_id)
                     .execute(pool)
                     .await
-                    .map_err(|error| internal(&format!("reset empty Codex thread: {error}")))?;
+                    .map_err(|error| store_error("reset empty Codex thread", &error))?;
                     None
                 }
                 Err(error) => return Err(internal(&format!("resume Codex thread: {error}"))),
@@ -3754,7 +3769,7 @@ async fn handle_codex_session_ensure(
                 .bind(params.skip_permissions)
                 .execute(pool)
                 .await
-                .map_err(|error| internal(&format!("persist Interactive Codex thread: {error}")))?;
+                .map_err(|error| store_error("persist Interactive Codex thread", &error))?;
                 Some(thread_id.to_string())
             }
             None => {
@@ -11756,6 +11771,23 @@ fn internal(message: &str) -> RpcError {
     }
 }
 
+/// An error from a store call, coded by whether the store was reachable at all.
+///
+/// Lock contention becomes [`STORE_UNAVAILABLE`]; everything else keeps
+/// [`INTERNAL_ERROR`]. `context` names the call for the log either way, so the
+/// message a human reads does not change with the code a caller branches on.
+fn store_error(context: &str, error: &sqlx::Error) -> RpcError {
+    RpcError {
+        code: if ainb_hangar_store::repo::fleet::is_lock_contention(error) {
+            STORE_UNAVAILABLE
+        } else {
+            INTERNAL_ERROR
+        },
+        message: format!("{context}: {error}"),
+        data: None,
+    }
+}
+
 /// Map a [`SkillRepoError`] onto an RPC error: the cross-workspace guard is a
 /// client error (`INVALID_PARAMS`, the caller used a foreign id), every other
 /// fault is an internal store error.
@@ -13180,6 +13212,70 @@ async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A busy store is coded [`STORE_UNAVAILABLE`]; every other fault keeps
+    /// [`INTERNAL_ERROR`].
+    ///
+    /// The contention is REAL, not a hand-built error value: one connection
+    /// holds the write lock with `BEGIN IMMEDIATE` while a second, whose
+    /// `busy_timeout` is zero, tries to write. That is the only way to prove
+    /// the classifier reads the extended result code `SQLite` actually sets,
+    /// rather than a code a test author guessed.
+    ///
+    /// The `RowNotFound` half is the guard on the guard: if `store_error` ever
+    /// coded everything as unavailable, the TUI would degrade over genuine
+    /// faults and the shared thread would vanish with no explanation.
+    #[tokio::test]
+    async fn a_contended_store_is_coded_unavailable_and_other_faults_are_not() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let options = SqliteConnectOptions::new()
+            .filename(dir.path().join("busy.db"))
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            // Zero, so the loser fails immediately instead of waiting: this
+            // test must not be timing-sensitive.
+            .busy_timeout(std::time::Duration::from_millis(0));
+
+        let holder = SqlitePool::connect_with(options.clone()).await.expect("holder pool");
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            .execute(&holder)
+            .await
+            .expect("schema");
+        let mut held = holder.acquire().await.expect("hold a connection");
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *held)
+            .await
+            .expect("take the write lock");
+
+        let contender = SqlitePool::connect_with(options).await.expect("contender pool");
+        let busy = sqlx::query("INSERT INTO t (id) VALUES (1)")
+            .execute(&contender)
+            .await
+            .expect_err("the write lock is held, so this write must fail");
+
+        assert!(
+            ainb_hangar_store::repo::fleet::is_lock_contention(&busy),
+            "a held write lock must read as contention: {busy}"
+        );
+        let unavailable = store_error("read Interactive Codex thread", &busy);
+        assert_eq!(
+            unavailable.code, STORE_UNAVAILABLE,
+            "a busy store must not be indistinguishable from a real fault: {unavailable:?}"
+        );
+        assert!(
+            unavailable.message.contains("read Interactive Codex thread"),
+            "the log must still name the call: {}",
+            unavailable.message
+        );
+
+        let fault = store_error("read Interactive Codex thread", &sqlx::Error::RowNotFound);
+        assert_eq!(
+            fault.code, INTERNAL_ERROR,
+            "only contention may be coded unavailable: {fault:?}"
+        );
+    }
 
     #[test]
     fn codex_started_thread_claim_requires_fresh_tui_thread_in_exact_cwd() {

--- a/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/lib.rs
@@ -34,6 +34,18 @@ pub use ainb_hangar_core::channel::{Channel, ChannelSet};
 /// The JSON-RPC protocol version string carried by every envelope.
 pub const JSONRPC_VERSION: &str = "2.0";
 
+/// Application-defined error code for "the daemon's store could not be
+/// reached": the request was well-formed and would have succeeded, but `SQLite`
+/// reported lock contention, so nothing was read or written.
+///
+/// Lives here rather than in the daemon because a CLIENT branches on it. It is
+/// deliberately NOT the spec's `-32603` internal error: that code is the
+/// daemon's catch-all and also carries faults a caller must surface loudly, so
+/// a caller willing to degrade over a busy store needs a code that means only
+/// that. Callers must match the code, never the `SQLite` message text, which
+/// varies by platform and extended result code.
+pub const STORE_UNAVAILABLE: i32 = -32006;
+
 /// The default `jsonrpc` member value (`"2.0"`) for [`RpcRequest`] /
 /// [`RpcResponse`].
 ///

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -74,7 +74,14 @@ where
 /// 6 `SQLITE_LOCKED`, 261 `SQLITE_BUSY_RECOVERY`, 262 `SQLITE_LOCKED_SHAREDCACHE`,
 /// 517 `SQLITE_BUSY_SNAPSHOT`. Everything else (constraint violations, decode
 /// faults, corruption) must surface unchanged on the first attempt.
-fn is_lock_contention(error: &sqlx::Error) -> bool {
+///
+/// Public because the daemon classifies with it too: `codex/session_ensure`
+/// answers a contended store with its own wire code so a caller can tell "the
+/// store is busy" from "the request was wrong", and the one place the code list
+/// lives has to be this one. Duplicating it is how the two halves drift and a
+/// caller starts treating a real fault as transient.
+#[must_use]
+pub fn is_lock_contention(error: &sqlx::Error) -> bool {
     let Some(database) = error.as_database_error() else {
         return false;
     };


### PR DESCRIPTION
## What

A Codex session could not start while the Hangar daemon was **running but wedged**: its socket was bound, so nothing looked unreachable, but every write timed out on a held SQLite write lock and the RPC came back `database is locked`.

That error was classified as a hard failure, and the resulting failed-session cleanup deletes the worktree the remote-repo flow had cloned seconds earlier. #840 fixed the *stopped* daemon; this fixes the *sick* one.

## Why the launch should not fail at all

The daemon is load-bearing for the SHARED Codex thread and nothing else — the code has said so since #840:

> The daemon is load-bearing for the SHARED thread and nothing else, so this costs the session exactly the same one feature an ephemeral home does and degrades the same way.

`daemon_unreachable` only admitted `NoHome | Token | Connect`, so a daemon that *answered* with a store fault fell through to the hard-failure arm. A busy store costs the session exactly what an absent daemon costs it, so it now degrades the same way.

## Three layers

1. **store** — `is_lock_contention` (extended result codes `5 | 6 | 261 | 262 | 517`) is now `pub`, so the daemon classifies with the one list instead of a second copy.
2. **hangar** — `codex/session_ensure` answers contention with `STORE_UNAVAILABLE` (`-32006`) instead of collapsing into the `-32603` catch-all. The constant lives in `ainb-hangar-proto` because the TUI branches on it.
3. **core** — `daemon_store_unavailable` admits that one code and nothing else, and the warning names the cause and the consequence and offers **no retry** — the session is already running, and the retry is what reached the cleanup.

## Typed, not textual

Matching `"database is locked"` would have been wrong twice over: the same condition surfaces under result code **5** on one platform and **517** on another, and 517 (`SQLITE_BUSY_SNAPSHOT`) is a different bug class that must not degrade. The wire code survives a SQLite message reword; the string does not.

`-32603` is deliberately **excluded**. It also carries `"Ainb Codex remote control unavailable: still starting"`, which is genuinely worth retrying in a few seconds. `still_starting_stays_a_hard_failure` pins that a future widening cannot swallow it.

## Tests

Three added, each falsified (guard reverted, watched red, restored, watched green):

| test | falsified by | red |
|---|---|---|
| `a_wedged_store_launches_codex_without_a_remote_thread` | removing the degrade arm | `a wedged store must not fail the launch: Codex remote control unavailable. Check Hangar logs, then retry.` |
| `still_starting_stays_a_hard_failure` | widening the classifier to `-32603` | `a warming-up Codex transport must still fail the launch: None` |
| `a_contended_store_is_coded_unavailable_and_other_faults_are_not` | dropping the classification | `left: -32603  right: -32006` |

The first red is verbatim the message the user hit.

The daemon test drives **real** contention — one connection holds `BEGIN IMMEDIATE` while a second with `busy_timeout=0` writes — so it reads the code SQLite actually sets rather than one a test author guessed.

Suites: proto 111, store 323, daemon 654, core 2364 — **3,452 passed, 0 failed**. Both existing Codex degrade tripwires still green.

## No new tmux tripwire, deliberately

`tripwire_cli_run_codex_degraded.rs` states the constraint: the ephemeral home is *"the one cause that reaches the same `Ok(None)` WITHOUT spawning a daemon into a CI runner"*, and *"from the argv down, every degraded launch is this one"*. The wedged store converges on that same `Ok(None)`, so argv-down is already covered; driving it from tmux would need a real daemon plus a held lock on its store. The cause-specific classification is unit-tested at the `ensure_codex_remote_thread_with` seam, exactly as `Connect`/`NoHome`/`Token` are.

## Not fixed here

This makes the wedge **survivable**, not impossible. The daemon still holds its own write lock indefinitely — on the reporting machine, zero writes landed for ~50 minutes while a `BEGIN IMMEDIATE` probe waited 180s and never acquired. That is a separate defect and is not diagnosed to a line.

The `WorktreeOwner` / `WorktreeRollback` guards are untouched: they were correct, and are why the tree survived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sessions continue launching when shared remote control is unavailable due to temporary store contention, ephemeral homes, or unreachable daemons.
  - Clear notices explain when a session lacks shared remote control, identify the cause, and describe the resulting limitation.
  - Store lock contention now receives a distinct error classification, improving client handling and preserving meaningful failure messages.
  - Healthy and degraded launches are distinguished more reliably, while genuine failures remain failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->