### PR TITLE
feat(fleet): carry the notch chat pane on live push, and give it a way in

### DIFF
--- a/.github/workflows/fleet-macos-contract.yml
+++ b/.github/workflows/fleet-macos-contract.yml
@@ -69,23 +69,5 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-contract" \
             CODE_SIGNING_ALLOWED=NO
-      # The shell journeys, which the AINBFleet scheme above does NOT run: its
-      # TestAction lists FleetRPCTests alone, so every UI test in this repo was
-      # invisible to CI. That gap is not theoretical. The chat pane's host view
-      # stopped being instantiated on 2026-08-07 and the pane itself landed
-      # three days later, so it shipped unreachable and stayed that way for a
-      # month with a green pipeline the whole time, because nothing in CI ever
-      # opened a window.
-      #
-      # No CODE_SIGNING_ALLOWED=NO here, unlike the step above: a UI test runs
-      # through a generated runner app, and that runner has to be signed, even
-      # if only ad hoc, before the system will let it drive another process.
-      - name: Run Fleet UI journeys
-        run: |
-          xcodebuild test \
-            -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
-            -scheme FleetUITests \
-            -destination 'platform=macOS' \
-            -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-journeys"
       - name: Build Release Fleet app
         run: bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh "$RUNNER_TEMP/ainb-fleet-macos-release"

--- a/.github/workflows/fleet-macos-contract.yml
+++ b/.github/workflows/fleet-macos-contract.yml
@@ -69,5 +69,23 @@ jobs:
             -destination 'platform=macOS' \
             -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-contract" \
             CODE_SIGNING_ALLOWED=NO
+      # The shell journeys, which the AINBFleet scheme above does NOT run: its
+      # TestAction lists FleetRPCTests alone, so every UI test in this repo was
+      # invisible to CI. That gap is not theoretical. The chat pane's host view
+      # stopped being instantiated on 2026-08-07 and the pane itself landed
+      # three days later, so it shipped unreachable and stayed that way for a
+      # month with a green pipeline the whole time, because nothing in CI ever
+      # opened a window.
+      #
+      # No CODE_SIGNING_ALLOWED=NO here, unlike the step above: a UI test runs
+      # through a generated runner app, and that runner has to be signed, even
+      # if only ad hoc, before the system will let it drive another process.
+      - name: Run Fleet UI journeys
+        run: |
+          xcodebuild test \
+            -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
+            -scheme FleetUITests \
+            -destination 'platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/ainb-fleet-macos-journeys"
       - name: Build Release Fleet app
         run: bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh "$RUNNER_TEMP/ainb-fleet-macos-release"

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -1747,11 +1747,19 @@ fn require_fleet_capability(id: &str) -> Result<(), RpcError> {
 /// An id that resolves to no row is `invalid_params`, never start-of-log: a
 /// client paging with a stale or fabricated cursor must hear about it instead
 /// of silently receiving the whole log again.
-async fn message_cursor_for(pool: &SqlitePool, after_id: Option<&str>) -> Result<i64, RpcError> {
+async fn message_cursor_for(
+    pool: &SqlitePool,
+    after_id: Option<&str>,
+) -> Result<Option<i64>, RpcError> {
     use ainb_hangar_store::repo::fleet_message::FleetMessageRepo;
 
+    // `None`, not `Some(0)`. An ABSENT cursor and a cursor that happens to
+    // resolve to the start of the log are different questions: the first asks
+    // for the newest page of a conversation, the second walks forward from a
+    // row the caller already has. Collapsing them into 0 is what made every
+    // uncursored read answer with the beginning of the thread.
     let Some(after_id) = after_id else {
-        return Ok(0);
+        return Ok(None);
     };
     if after_id.trim().is_empty() {
         return Err(invalid_params("after_id must not be empty"));
@@ -1759,6 +1767,7 @@ async fn message_cursor_for(pool: &SqlitePool, after_id: Option<&str>) -> Result
     FleetMessageRepo::seq_for_id(pool, after_id)
         .await
         .map_err(|error| store_err(&error))?
+        .map(Some)
         .ok_or_else(|| invalid_params(&format!("after_id {after_id} is not a known message")))
 }
 
@@ -2480,12 +2489,16 @@ async fn handle_fleet_message_list(
         // The both-set case is rejected above, so this arm only ever sees a
         // thread filter on its own.
         (Some(origin_id), _) => {
-            FleetMessageRepo::list_by_origin(pool, origin_id, after_seq, limit).await
+            FleetMessageRepo::list_by_origin(pool, origin_id, after_seq.unwrap_or(0), limit).await
         }
-        (None, Some(scope_key)) => {
-            FleetMessageRepo::list_by_scope(pool, scope_key, after_seq, limit).await
-        }
-        (None, None) => FleetMessageRepo::list_all(pool, after_seq, limit).await,
+        // A scope read with NO cursor answers with the newest page, because
+        // that is what opening a conversation means. With a cursor it walks
+        // forward from that row exactly as before, so paging is untouched.
+        (None, Some(scope_key)) => match after_seq {
+            Some(seq) => FleetMessageRepo::list_by_scope(pool, scope_key, seq, limit).await,
+            None => FleetMessageRepo::tail_by_scope(pool, scope_key, limit).await,
+        },
+        (None, None) => FleetMessageRepo::list_all(pool, after_seq.unwrap_or(0), limit).await,
     }
     .map_err(|error| store_err(&error))?;
     let messages: Vec<_> = rows.iter().map(message_wire).collect();

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_message_bus.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_message_bus.rs
@@ -906,6 +906,74 @@ async fn oversized_limit_is_clamped() {
     );
 }
 
+/// An uncursored scope read answers the END of the conversation, and a
+/// cursored one still walks forward.
+///
+/// A chat client opening a pane holds no cursor. Answering it with the first
+/// page means every message past the limit is unreachable by paging at all, and
+/// a client that also takes live pushes watches each new message arrive and
+/// then be wiped by its own next page. Both this app's clients read exactly
+/// this way, so both were blind past their limit.
+#[tokio::test]
+async fn an_uncursored_scope_page_answers_the_live_tail() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, _sink) = start_server(dir.path()).await;
+    let scope = "session:seeded";
+    for index in 0..(ainb_hangar_proto::fleet::FLEET_MESSAGE_LIST_MAX + 20) {
+        FleetMessageRepo::insert_message(store.pool(), &message(&format!("m-{index:04}")))
+            .await
+            .unwrap();
+    }
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let page = client
+        .call(
+            methods::FLEET_MESSAGE_LIST,
+            serde_json::json!({ "scope_key": scope, "limit": 10 }),
+        )
+        .await;
+    let messages = page["result"]["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 10, "{page}");
+    assert_eq!(
+        messages[9]["id"], "m-0119",
+        "an uncursored page must end at the newest message: {page}"
+    );
+    assert_eq!(
+        messages[0]["id"], "m-0110",
+        "and start one page back from it, not at the head of the log: {page}"
+    );
+    // Ascending commit order, the same as every cursored page. A tail read that
+    // answered newest-first would be a wire change wearing a bug fix's clothes.
+    let ordered: Vec<&str> = messages.iter().map(|row| row["id"].as_str().unwrap()).collect();
+    let mut ascending = ordered.clone();
+    ascending.sort_unstable();
+    assert_eq!(ordered, ascending, "the tail page is not in commit order");
+    assert_eq!(
+        page["result"]["next_after_id"], "m-0119",
+        "the cursor handed back is the newest row, so the next page is what follows it"
+    );
+
+    // The cursored walk is untouched: from a row near the start, the next page
+    // is still the rows immediately after it.
+    let walked = client
+        .call(
+            methods::FLEET_MESSAGE_LIST,
+            serde_json::json!({ "scope_key": scope, "after_id": "m-0000", "limit": 3 }),
+        )
+        .await;
+    let walked_ids: Vec<&str> = walked["result"]["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        walked_ids,
+        vec!["m-0001", "m-0002", "m-0003"],
+        "a cursored page must still walk forward: {walked}"
+    );
+}
+
 /// Scope and thread filters page the same commit-ordered log.
 #[tokio::test]
 async fn list_filters_by_scope_and_by_thread_origin() {

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_message.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_message.rs
@@ -317,7 +317,13 @@ impl FleetMessageRepo {
         .transpose()
     }
 
-    /// Page one scope's messages after a `seq` cursor, oldest first.
+    /// Walk one scope's messages FORWARD from a `seq` cursor, oldest first.
+    ///
+    /// This is the cursored half of scope paging, for a caller that already
+    /// holds a row and wants what came after it. A caller that holds NOTHING
+    /// wants [`Self::tail_by_scope`] instead: starting this walk at 0 answers
+    /// with the beginning of the conversation, which for any scope longer than
+    /// one page is not what a chat surface is asking for.
     pub async fn list_by_scope(
         pool: &SqlitePool,
         scope_key: &str,
@@ -334,6 +340,39 @@ impl FleetMessageRepo {
         .fetch_all(pool)
         .await?;
         rows.iter().map(message_from).collect()
+    }
+
+    /// The NEWEST page of one scope, returned oldest first.
+    ///
+    /// What an uncursored read of a conversation means. A client opening a chat
+    /// pane holds no cursor and wants the end of the thread, the way every chat
+    /// surface ever built opens on the latest message; walking forward from 0
+    /// hands it the first hundred messages instead, and past that hundred the
+    /// live tail is unreachable by paging at all. Both the notch and the
+    /// terminal client read this way, and both were blind past their limit.
+    ///
+    /// Selected `seq DESC` so the index does the work and only `limit` rows are
+    /// read, then REVERSED so the response ordering is identical to the
+    /// cursored walk. Callers already rely on ascending commit order, and a
+    /// read that returned the same rows backwards would be a wire change
+    /// wearing the clothes of a bug fix.
+    pub async fn tail_by_scope(
+        pool: &SqlitePool,
+        scope_key: &str,
+        limit: i64,
+    ) -> Result<Vec<FleetMessageRow>, sqlx::Error> {
+        let rows = sqlx::query(&format!(
+            "SELECT {MESSAGE_COLUMNS} FROM fleet_message \
+             WHERE scope_key = ? ORDER BY seq DESC LIMIT ?"
+        ))
+        .bind(scope_key)
+        .bind(limit.max(0))
+        .fetch_all(pool)
+        .await?;
+        let mut messages: Vec<FleetMessageRow> =
+            rows.iter().map(message_from).collect::<Result<_, _>>()?;
+        messages.reverse();
+        Ok(messages)
     }
 
     /// Page every message after a `seq` cursor, oldest first (the digest view
@@ -661,6 +700,57 @@ mod tests {
         assert_eq!(second.id, "msg-2");
     }
 
+    /// A scope LONGER than one page answers an uncursored read with its END,
+    /// and a cursored read still walks forward from where the caller is.
+    ///
+    /// The bug this pins is silent and total: an uncursored read that walks
+    /// forward from 0 hands a chat client the first page of the conversation
+    /// forever, so every message past the limit is unreachable, and a client
+    /// that also receives live pushes watches each new message appear and then
+    /// be wiped by its own next page.
+    #[tokio::test]
+    async fn an_uncursored_scope_read_answers_the_newest_page() {
+        let (_dir, store) = store().await;
+        for index in 1..=5 {
+            FleetMessageRepo::insert_message(
+                store.pool(),
+                &message(&format!("msg-{index}"), "session:s-1"),
+            )
+            .await
+            .unwrap();
+        }
+
+        let tail = FleetMessageRepo::tail_by_scope(store.pool(), "session:s-1", 2).await.unwrap();
+        assert_eq!(
+            tail.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["msg-4", "msg-5"],
+            "an uncursored read must answer the END of the conversation, ascending"
+        );
+
+        // And the forward walk is untouched: from the tail's own last row, the
+        // next page is empty, and from the start it is still the beginning.
+        let after_tail = FleetMessageRepo::list_by_scope(store.pool(), "session:s-1", 5, 2)
+            .await
+            .unwrap();
+        assert!(after_tail.is_empty(), "nothing is committed after the head");
+        let from_start = FleetMessageRepo::list_by_scope(store.pool(), "session:s-1", 0, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            from_start.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["msg-1", "msg-2"],
+            "a cursored walk from the start still pages forward"
+        );
+        let next = FleetMessageRepo::list_by_scope(store.pool(), "session:s-1", 2, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            next.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["msg-3", "msg-4"],
+            "and continues from the cursor it was given"
+        );
+    }
+
     #[tokio::test]
     async fn lists_page_by_seq_and_scope() {
         let (_dir, store) = store().await;
@@ -694,6 +784,13 @@ mod tests {
             .unwrap();
         assert_eq!(after.len(), 1, "the cursor pages by seq, not by id");
         assert_eq!(after[0].id, "msg-3");
+
+        let tail = FleetMessageRepo::tail_by_scope(store.pool(), "session:s-1", 10).await.unwrap();
+        assert_eq!(
+            tail.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["msg-1", "msg-3"],
+            "a scope shorter than the limit answers the same rows either way"
+        );
 
         assert_eq!(
             FleetMessageRepo::seq_for_id(store.pool(), "msg-3").await.unwrap(),

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */; };
 		A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */; };
 		A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */; };
+		A10000000000000000000120 /* ChatPaneJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000122 /* ChatPaneJourneyTests.swift */; };
+		A10000000000000000000121 /* FleetChatClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000123 /* FleetChatClient.swift */; };
 		A1000000000000000000005D /* FleetNotificationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000100 /* FleetNotificationPolicy.swift */; };
 		A1000000000000000000005E /* FleetNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000101 /* FleetNotificationCenter.swift */; };
 		A100000000000000000000103 /* FleetDesktopController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000104 /* FleetDesktopController.swift */; };
@@ -94,6 +96,8 @@
 		A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/MenuBarRosterJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/OfflineAndReconnectJourneyTests.swift; sourceTree = SOURCE_ROOT; };
 		A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ProtocolCompatibilityJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000122 /* ChatPaneJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/ShellJourneys/ChatPaneJourneyTests.swift; sourceTree = SOURCE_ROOT; };
+		A10000000000000000000123 /* FleetChatClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests/Support/FleetChatClient.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000100 /* FleetNotificationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationPolicy.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000101 /* FleetNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/Notifications/FleetNotificationCenter.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000104 /* FleetDesktopController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDesktopController.swift; sourceTree = "<group>"; };
@@ -245,6 +249,8 @@
 				A1000000000000000000004B /* MenuBarRosterJourneyTests.swift */,
 				A10000000000000000000050 /* OfflineAndReconnectJourneyTests.swift */,
 				A10000000000000000000059 /* ProtocolCompatibilityJourneyTests.swift */,
+				A10000000000000000000122 /* ChatPaneJourneyTests.swift */,
+				A10000000000000000000123 /* FleetChatClient.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -435,6 +441,8 @@
 				A10000000000000000000047 /* MenuBarRosterJourneyTests.swift in Sources */,
 				A1000000000000000000004F /* OfflineAndReconnectJourneyTests.swift in Sources */,
 				A10000000000000000000058 /* ProtocolCompatibilityJourneyTests.swift in Sources */,
+				A10000000000000000000120 /* ChatPaneJourneyTests.swift in Sources */,
+				A10000000000000000000121 /* FleetChatClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -23,7 +23,7 @@ final class FleetPresentationStore: ObservableObject {
 /// Interviews destination -- a tab that only re-showed the roster was a dead end
 /// in a nav that is meant to be the single one.
 enum FleetNotchRoute: String, CaseIterable, Identifiable {
-    case sessions, needsYou, usage, settings
+    case sessions, needsYou, chat, usage, settings
 
     var id: Self { self }
 
@@ -31,6 +31,7 @@ enum FleetNotchRoute: String, CaseIterable, Identifiable {
         switch self {
         case .sessions: "Sessions"
         case .needsYou: "Needs you"
+        case .chat: "Chat"
         case .usage: "Usage"
         case .settings: "Settings"
         }
@@ -40,7 +41,27 @@ enum FleetNotchRoute: String, CaseIterable, Identifiable {
 @MainActor
 final class FleetNotchNavigation: ObservableObject {
     @Published var isExpanded = false
-    @Published var route: FleetNotchRoute = .sessions
+    @Published var route: FleetNotchRoute = .sessions {
+        didSet { rememberRouteBeforeChat(oldValue) }
+    }
+
+    /// Where closing the chat pane puts the operator back.
+    ///
+    /// The pane is a route rather than a presentation, so its Close has to
+    /// choose a destination, and the only defensible one is where the operator
+    /// came from. Sending them to Sessions unconditionally silently discards a
+    /// filter or a route they had set up before they went to read the
+    /// conversation.
+    private(set) var routeBeforeChat: FleetNotchRoute = .sessions
+
+    /// Record the route being LEFT, unless it is the chat route itself.
+    ///
+    /// Leaving chat must not overwrite the answer with chat, or Close would
+    /// return to the pane it just closed.
+    private func rememberRouteBeforeChat(_ leaving: FleetNotchRoute) {
+        guard leaving != .chat else { return }
+        routeBeforeChat = leaving
+    }
 }
 
 @MainActor
@@ -63,7 +84,16 @@ final class FleetDesktopController: NSObject {
             let size = NSSize(width: 320, height: 38)
             let panel: NSWindow
             if FleetAppConfiguration.isUITest {
-                panel = NSWindow(
+                // A KEY-CAPABLE borderless window, not a plain one.
+                // `NSWindow.canBecomeKey` is false for a borderless window, so
+                // the plain one this branch used could never take keyboard
+                // focus: every text field in the notch was unfocusable under
+                // XCUITest, and typing into one failed with "Neither element
+                // nor any descendant has keyboard focus". The shipping panel
+                // does not have that problem, because `FleetNotchPanel`
+                // overrides the same property, so the harness was refusing an
+                // interaction the real app allows.
+                panel = FleetKeyableWindow(
                     contentRect: NSRect(origin: .zero, size: size),
                     styleMask: [.borderless],
                     backing: .buffered,
@@ -286,6 +316,17 @@ private struct FleetNotchView: View {
             switch navigation.route {
             case .sessions, .needsYou:
                 rosterContent
+            case .chat:
+                // A ROUTE, not a sheet. The notch is the only surface this app
+                // has, and its idiom for a large secondary view is already a
+                // route: Usage and Settings arrive the same way. A sheet would
+                // present from a borderless panel and, at the pane's 760 by 520
+                // minimum against a 920 by 720 notch, would cover its own host.
+                //
+                // Closing returns the operator to the route they came from,
+                // because there is no presentation to dismiss here and no
+                // reason to discard the view they had set up.
+                FleetChatPaneView(store: store, close: { navigation.route = navigation.routeBeforeChat })
             case .usage:
                 FleetUsageView(store: store, period: $usagePeriod)
             case .settings:
@@ -381,6 +422,16 @@ private struct FleetNotchView: View {
 }
 
 private final class FleetNotchPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+/// The UI-test stand-in for `FleetNotchPanel`, key-capable for the same reason.
+///
+/// A plain `NSWindow` is used under test rather than the panel because a
+/// non-activating panel does not receive synthesized events reliably, but the
+/// substitution has to keep the one behaviour a journey depends on: a window
+/// the composer can take focus in.
+private final class FleetKeyableWindow: NSWindow {
     override var canBecomeKey: Bool { true }
 }
 

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -142,8 +142,11 @@ final class FleetStore: ObservableObject {
     ///
     /// ponytail: per connection, not per session lifetime. A session evicted by
     /// the pool while this app sits idle is only noticed at the next send, and
-    /// that send is the one that reports REJECTED. Live `fleet/message_event`
-    /// (PR B) is where a torn-down session becomes visible without a send.
+    /// that send is the one that reports REJECTED. The live chat stream does
+    /// NOT close that gap, contrary to what this note said when it was written:
+    /// `fleet/message_event` carries a committed message and nothing about its
+    /// delivery legs, so a torn-down session is still invisible until something
+    /// is addressed to it.
     private var copilotSessionKeyByScope: [String: String] = [:]
     /// Bumped by every invalidation, so a page that was already in flight when
     /// one happened cannot put the forgotten key back.
@@ -155,6 +158,40 @@ final class FleetStore: ObservableObject {
     /// operator's next message went to the same dead session. That is the exact
     /// failure the invalidation exists to prevent, arriving one poll later.
     private var copilotCacheGeneration: UInt = 0
+    /// Live chat events that landed while a page was in flight.
+    ///
+    /// A page is four round trips and it REPLACES the surface wholesale, which
+    /// is the invariant that stops a half-applied refresh showing this page's
+    /// cards next to the last one's timeline. That same wholesale replacement
+    /// is what would drop a message committed after `fleet/message_list` read
+    /// the log and before the page finished: folded into the live surface, then
+    /// overwritten by a page that never saw it, and gone until the safety net
+    /// pages again half a minute later.
+    ///
+    /// So the fold does both: it applies the event to what is on screen now,
+    /// and, if a page is running, remembers it so that page can replay it onto
+    /// its own result. Every fold is an upsert by id, so replaying an event the
+    /// page already contains changes nothing.
+    private var chatEventsDuringPage: [FleetChatEvent] = []
+    /// How many pages are running. A count, not a flag: the poll loop and the
+    /// send path both page, and they overlap. Buffering only while this is
+    /// above zero is what keeps the buffer bounded by one page's duration
+    /// rather than by how long the pane stays open.
+    private var chatPagesInFlight = 0
+    /// How many chat panes are on screen.
+    ///
+    /// The fold is gated on this, and the gate is not an optimisation. `chat`
+    /// is `@Published` on the store the WHOLE notch observes, so every folded
+    /// event re-evaluates the roster, the chips and the menu-bar summary. A
+    /// scope filter alone does not stop that: once a pane has been opened once,
+    /// `chat.scopeKey` stays set for the life of the connection, so a busy
+    /// copilot would invalidate the roster several times a second while the
+    /// operator is looking at Sessions and no chat surface exists at all.
+    ///
+    /// A count rather than a flag, because SwiftUI can have the outgoing and
+    /// incoming instances of a view alive at once during a transition, and a
+    /// flag cleared by the outgoing one would silence the incoming one.
+    private var chatPanesOpen = 0
     private let maximumReconnectAttempts = 3
     private let reconnectResetInterval: TimeInterval = 30
 
@@ -671,24 +708,32 @@ final class FleetStore: ObservableObject {
 
     /// One page, awaited.
     ///
-    /// The poll loop awaits THIS rather than firing `refreshChat()` on a timer:
-    /// a page that takes longer than the interval would otherwise stack, and
-    /// five overlapping RPC sets racing each other means whichever finishes
+    /// The safety-net loop awaits THIS rather than firing `refreshChat()` on a
+    /// timer: a page that takes longer than the interval would otherwise stack,
+    /// and five overlapping RPC sets racing each other means whichever finishes
     /// last wins and the pane can go backwards in time.
+    ///
+    /// This is the BOOTSTRAP for a pane that has just opened and the repair for
+    /// one whose stream dropped a frame. The conversation itself arrives on
+    /// `fleet/message_subscribe` between these calls.
     func refreshChatOnce() async {
         guard canReadChat, let connection else {
-            // Assigned only on a real change: this runs once a second and a
-            // @Published write redraws the pane whether or not the value moved.
+            // Assigned only on a real change: a @Published write redraws the
+            // pane whether or not the value moved, and this shares `chat` with
+            // a live event stream that can write it several times a second.
             let unavailable = FleetChatSurface(sessionDetail: "Chat is unavailable for this daemon.")
             if chat != unavailable { chat = unavailable }
             return
         }
         do {
             // Same guard as the unavailable branch above, for the same reason:
-            // this runs once a second and an unconditional @Published write
-            // re-evaluates the whole window subtree even when nothing moved.
-            // `FleetChatSurface` is Equatable, so the comparison is free.
-            let paged = try await pagedChat(using: connection)
+            // an unconditional @Published write re-evaluates the whole window
+            // subtree even when nothing moved, and `FleetChatSurface` is
+            // Equatable, so the comparison is free.
+            // A nil page is a page whose read was invalidated while it ran.
+            // Publishing it would put back state the store already knows is
+            // dead, so it is dropped and the next page asks again.
+            guard let paged = try await pagedChat(using: connection) else { return }
             if chat != paged { chat = paged }
         } catch {
             controlNotice = "Chat refresh refused: \(String(describing: error))"
@@ -743,7 +788,7 @@ final class FleetStore: ObservableObject {
                 self.controlNotice = "Chat send refused: \(String(describing: error))"
                 return
             }
-            self.chat = (try? await self.pagedChat(using: connection)) ?? self.chat
+            self.publish(try? await self.pagedChat(using: connection))
         }
     }
 
@@ -776,7 +821,7 @@ final class FleetStore: ObservableObject {
             } catch {
                 self.controlNotice = "Confirm answer refused: \(String(describing: error))"
             }
-            self.chat = (try? await self.pagedChat(using: connection)) ?? self.chat
+            self.publish(try? await self.pagedChat(using: connection))
         }
     }
 
@@ -927,20 +972,109 @@ final class FleetStore: ObservableObject {
     /// and a page that finished afterwards must not restore what it read at the
     /// start. It still renders its own result; only the remembering is dropped,
     /// so the next page asks the daemon again.
-    private func pagedChat(using connection: FleetConnection) async throws -> FleetChatSurface {
+    /// Returns nil when the page is STALE, meaning the cache was invalidated
+    /// while it was reading.
+    ///
+    /// Dropping the write-back is not enough, and that was the gap: the page
+    /// still returned a surface, and every caller published it. A send whose
+    /// leg came back `target_not_running` forgets the dead session, re-pages,
+    /// mints a live one and publishes it; an older page that read the dead key
+    /// then lands and puts it back on screen, and the composer aims at a
+    /// session nobody is listening on. At a one-second poll that healed itself
+    /// in a second. At `fleetChatSafetyNetInterval` it lasts half a minute,
+    /// which is the whole of an operator's next message.
+    ///
+    /// So the generation is a TICKET, not just a guard on the cache: a page
+    /// that cannot prove it read current state does not get to render.
+    private func pagedChat(using connection: FleetConnection) async throws -> FleetChatSurface? {
         let generation = copilotCacheGeneration
-        let (surface, minted) = try await Self.pageChat(
+        beginChatPage()
+        defer { endChatPage() }
+        let (paged, minted) = try await Self.pageChat(
             using: connection,
             canWrite: canWrite,
             mintedSessionKeyByScope: copilotSessionKeyByScope
         )
+        guard copilotCacheGeneration == generation else { return nil }
         if minted,
-           copilotCacheGeneration == generation,
-           let scope = surface.scopeKey,
-           let sessionKey = surface.targetSessionKey {
+           let scope = paged.scopeKey,
+           let sessionKey = paged.targetSessionKey {
             copilotSessionKeyByScope[scope] = sessionKey
         }
+        // Everything that arrived live while this page was reading, replayed
+        // onto it. Without this the page silently rewinds the pane past any
+        // message committed after `fleet/message_list` answered.
+        var surface = paged
+        for event in chatEventsDuringPage {
+            surface.apply(event)
+        }
         return surface
+    }
+
+    /// Open the live chat stream, RESUMING from the newest row already shown.
+    ///
+    /// A bare subscribe starts at the daemon's head, so everything committed
+    /// while this client was disconnected is never pushed. The page behind it
+    /// used to be the backstop, and no longer is: a page reads one bounded
+    /// window, so an outage longer than that window loses the middle for good.
+    /// Naming the last row this surface holds asks the daemon to replay the gap.
+    ///
+    /// The retry is the honest half. A remembered id the daemon has never heard
+    /// of, which is what a restarted or pruned daemon answers, is refused as
+    /// invalid params, and a swallowed refusal there would leave the connection
+    /// with NO stream at all: silently poll-only, looking identical to working.
+    /// So the refusal costs the resume, not the subscription.
+    private func openChatStream(on connection: FleetConnection) async {
+        guard let resume = chat.messages.last?.id else {
+            _ = try? await connection.messageSubscribe()
+            return
+        }
+        do {
+            _ = try await connection.messageSubscribe(afterID: resume)
+        } catch FleetConnectionError.rpc(let refusal) where refusal.code == -32602 {
+            _ = try? await connection.messageSubscribe()
+        } catch {
+            // Anything else is the connection itself failing, and the bootstrap
+            // that follows will report it.
+        }
+    }
+
+    /// The chat pane appeared. Live events are folded from here.
+    func chatPaneAppeared() {
+        chatPanesOpen += 1
+    }
+
+    /// The chat pane went away. Floored at zero so a stray unbalanced call
+    /// cannot drive the count negative and silence the fold permanently.
+    func chatPaneDisappeared() {
+        chatPanesOpen = max(0, chatPanesOpen - 1)
+    }
+
+    /// Show a page, unless it has nothing to show.
+    ///
+    /// Two different nils arrive here and both mean "keep what is on screen":
+    /// a page that threw, and a page the store disowned because its read went
+    /// stale mid-flight. Neither is a reason to blank a pane the operator is
+    /// reading.
+    private func publish(_ surface: FleetChatSurface??) {
+        guard let surface = surface ?? nil else { return }
+        if chat != surface { chat = surface }
+    }
+
+    /// Start counting live events against a page that is about to run.
+    ///
+    /// The buffer is cleared by the FIRST page only: a second page starting
+    /// while one is still running must not throw away what the first one still
+    /// has to replay.
+    private func beginChatPage() {
+        if chatPagesInFlight == 0 {
+            chatEventsDuringPage.removeAll()
+        }
+        chatPagesInFlight += 1
+    }
+
+    private func endChatPage() {
+        chatPagesInFlight -= 1
     }
 
     /// Get-or-create the copilot session for `scopeKey`, naming as little as
@@ -1078,6 +1212,28 @@ final class FleetStore: ObservableObject {
                 return
             }
             apply(bootstrapped)
+            // The live chat stream, on this same socket.
+            //
+            // Opened with the CONNECTION, not with the pane: the daemon runs
+            // one message forwarder per socket, so a subscription opened per
+            // appearance of the sheet would be a second stream writing the same
+            // surface, and closing the sheet would have to decide which one to
+            // keep. It costs nothing while no pane is open, because the fold
+            // is gated on one being on screen.
+            //
+            // Opened BEFORE any page, so the window between the two is covered
+            // from the page's side: the daemon starts the forwarder at the head
+            // it just acked, and the page that follows reads everything up to
+            // it. The other order would leave messages committed in between
+            // visible to neither.
+            //
+            // A refusal is not fatal and is not reported. A daemon built before
+            // this method answers -32601, and the honest consequence is that
+            // the pane is carried by `fleetChatSafetyNetInterval` alone: later
+            // than live, but never wrong, and the same surface either way.
+            if result.capabilityIDs.contains("fleet.message.read") {
+                await openChatStream(on: newConnection)
+            }
             if result.capabilityIDs.contains("fleet.receipt.read") {
                 do {
                     receipts = try await newConnection.receiptList(FleetReceiptListParams(limit: 50)).receipts
@@ -1176,10 +1332,66 @@ final class FleetStore: ObservableObject {
                 generation: generation
             )
             return false
+        case let .messageEvent(params):
+            fold(.message(params.message))
+        case let .confirmEvent(params):
+            // Decoded the way the PAGE decodes a card, tolerantly, so a row
+            // this build cannot fully read renders as unanswerable instead of
+            // vanishing. Its scope is taken from the raw frame, and a card that
+            // cannot even say which conversation it belongs to is dropped:
+            // rendering it would put another scope's approval in front of this
+            // operator.
+            if let scope = params.confirm.value("scope_key")?.stringValue {
+                fold(.confirm(card: FleetChatConfirmCard.decode(params.confirm), scopeKey: scope))
+            }
+        case let .activityEvent(params):
+            fold(.activity(params.activity))
         case .unknownNotification:
             break
         }
         return true
+    }
+
+    /// Fold one live chat notification into the surface on screen.
+    ///
+    /// Two things, and both are needed. The surface is updated so the pane
+    /// moves NOW, and the event is remembered if a page is running so that
+    /// page cannot overwrite it with a read that predates it.
+    ///
+    /// The scope filter lives in `FleetChatSurface.apply`, where the scope key
+    /// is: the daemon's chat stream is fleet-wide, and every one of the three
+    /// event types carries the scope it was filed under.
+    ///
+    /// The write is guarded on a real change for the same reason the poll's is:
+    /// an assignment to a `@Published` value redraws the pane whether or not
+    /// anything moved, and a busy copilot emits activity rows faster than a
+    /// human reads.
+    private func fold(_ event: FleetChatEvent) {
+        // Nothing is folded with no pane on screen. The page that runs when one
+        // opens is what makes the surface current again, so the only thing lost
+        // is liveness for a view nobody is looking at.
+        guard chatPanesOpen > 0 else { return }
+        if chatPagesInFlight > 0, chat.scopeKey == nil || event.scopeKey == chat.scopeKey {
+            // Buffered by SCOPE at the door, not at replay. The stream is
+            // fleet-wide, so an unfiltered buffer collects every conversation's
+            // traffic, and a page whose RPC never answers holds the in-flight
+            // count above zero for as long as that call hangs.
+            //
+            // The nil case is not a hole in that filter, it is the FIRST page.
+            // Until one publishes there is no scope to compare against, and a
+            // filter that answered "no match" there would drop exactly what the
+            // buffer exists for: a message committed while the opening page was
+            // still reading its confirm and activity feeds. Replay applies the
+            // paged surface's own scope, so nothing foreign gets rendered, and
+            // the window lasts one page with the cap still in force.
+            chatEventsDuringPage.append(event)
+            if chatEventsDuringPage.count > Int(fleetMessageListMax) {
+                chatEventsDuringPage.removeFirst()
+            }
+        }
+        var next = chat
+        next.apply(event)
+        if next != chat { chat = next }
     }
 
     private func apply(_ next: FleetProjection) {

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
@@ -11,7 +11,15 @@ import SwiftUI
 /// that always reads, and the rest make it glanceable.
 struct FleetChatPaneView: View {
     @ObservedObject var store: FleetStore
-    @Environment(\.dismiss) private var dismiss
+    /// How this host dismisses the pane.
+    ///
+    /// Injected rather than taken from `@Environment(\.dismiss)` because the
+    /// pane has two hosts with nothing in common: a sheet, where dismiss is the
+    /// right verb, and a ROUTE inside the notch panel, where there is no
+    /// presentation to dismiss and the close has to move the navigation back.
+    /// An environment dismiss in the second host is not an error, it is a
+    /// button that silently does nothing, which is the worse failure.
+    let close: () -> Void
     @State private var composer = ""
     @State private var editingCard: FleetChatConfirmCard?
     @State private var editedArguments = ""
@@ -31,12 +39,33 @@ struct FleetChatPaneView: View {
         }
         .frame(minWidth: 760, minHeight: 520)
         .background(FleetChatPalette.canvas)
+        // The bootstrap page, then a slow safety net.
+        //
+        // The conversation itself arrives on the store's live subscription,
+        // which belongs to the CONNECTION and is opened once when it comes up.
+        // This view opens nothing: a subscription per appearance would mean a
+        // second stream every time the sheet is reopened, all of them writing
+        // the same surface.
+        //
         // Bound to the pane's lifetime: the loop is cancelled when the sheet
-        // closes, so a closed chat costs the daemon nothing.
+        // closes, so a closed chat costs the daemon nothing. The sleep is where
+        // that cancellation is observed, and it RETURNS rather than falling
+        // through, so a sheet closed during the wait cannot spend one more page
+        // on a pane nobody is looking at.
         .task {
+            // The pane announces itself, and the store folds live events only
+            // while at least one is on screen. `chat` is observed by the whole
+            // notch, so an event folded with no pane open redraws the roster
+            // for nothing.
+            store.chatPaneAppeared()
+            defer { store.chatPaneDisappeared() }
             while !Task.isCancelled {
                 await store.refreshChatOnce()
-                try? await Task.sleep(for: fleetChatPollInterval)
+                do {
+                    try await Task.sleep(for: fleetChatSafetyNetInterval)
+                } catch {
+                    return
+                }
             }
         }
         .sheet(item: $editingCard) { card in
@@ -58,9 +87,9 @@ struct FleetChatPaneView: View {
             Button("Refresh") { store.refreshChat() }
                 .disabled(!store.canReadChat)
                 .accessibilityIdentifier("fleet.chat.refresh")
-            // Explicit, not Esc-only: the composer holds focus, and a sheet
+            // Explicit, not Esc-only: the composer holds focus, and a surface
             // whose only exit is a key the focused control might eat is a trap.
-            Button("Close") { dismiss() }
+            Button("Close", action: close)
                 .accessibilityIdentifier("fleet.chat.close")
         }
         .padding(.horizontal, 18)
@@ -343,6 +372,10 @@ private struct FleetChatMessageView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(row.actor.accessibilityLabel): \(row.body)")
+        // Addressable by the id the daemon minted, the way a confirm card is.
+        // A journey that has just filed a message knows that id and can assert
+        // on THE row rather than on a body string that could appear anywhere.
+        .accessibilityIdentifier("fleet.chat.message.\(row.id)")
     }
 
     private var attributionColor: Color {
@@ -359,9 +392,15 @@ private struct FleetChatMessageView: View {
     }
 }
 
-/// Local palette. `FleetPalette` is file-private to `FleetWindowView.swift`;
-/// these values match it rather than importing, and the chat-only accent
-/// (`violet`, the copilot's colour in the TUI too) lives here.
+/// The chat module's own palette. Owned here, borrowed from nowhere.
+///
+/// These are the Fleet surface colours, declared rather than imported, plus the
+/// chat-only accent (`violet`, the copilot's colour in the terminal client
+/// too). Copies of a palette are usually a smell, and this one is deliberate:
+/// the values also appear in the roster's file-private palette, and a shared
+/// one would have to live somewhere both can see, which is a module this app
+/// does not have. Owning them keeps this pane compiling no matter what happens
+/// to any other view.
 private enum FleetChatPalette {
     static let canvas = Color(red: 0.055, green: 0.071, blue: 0.086)
     static let sidebar = Color(red: 0.043, green: 0.057, blue: 0.071)

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
@@ -362,15 +362,133 @@ struct FleetChatSurface: Equatable {
     /// gets, and it is usually "this scope is already held by a session whose
     /// cwd is X, not Y".
     var sessionDetail: String? = nil
+
+    /// Fold one live notification into this page.
+    ///
+    /// The scope filter is HERE rather than at the call site because the
+    /// daemon's chat stream is fleet-wide: `fleet/message_event` carries every
+    /// committed message on the socket, not this scope's. The surface is the
+    /// only thing that knows which conversation is on screen, so it is the only
+    /// thing that can say an event is not this one's. An event for another
+    /// scope is dropped, never rendered.
+    ///
+    /// Nothing is folded before a page has resolved a scope: `scopeKey` is nil
+    /// until then, and an event that cannot be proved to belong here does not
+    /// get the benefit of the doubt.
+    mutating func apply(_ event: FleetChatEvent) {
+        guard let scopeKey, scopeKey == event.scopeKey else { return }
+        switch event {
+        case let .message(message):
+            upsert(FleetChatMessageRow(message: message))
+        case let .confirm(card, _):
+            upsert(card)
+        case let .activity(row):
+            upsert(row)
+        }
+    }
+
+    /// Replace the row with this id, or append it.
+    ///
+    /// Append, because `fleet/message_list` returns ascending commit order and
+    /// a committed message is newer than everything already paged. Replace in
+    /// place on a repeat, because the daemon replays from a cursor and a
+    /// boundary row can arrive live AND in the page: appending it twice would
+    /// show the operator their own message twice with no way to tell which is
+    /// real.
+    private mutating func upsert(_ row: FleetChatMessageRow) {
+        if let index = messages.firstIndex(where: { $0.id == row.id }) {
+            messages[index] = row
+            return
+        }
+        messages.append(row)
+        // The same ceiling the page asks for, so a pane left open for a day
+        // does not grow without bound. The oldest goes, matching what a fresh
+        // page of a longer conversation would show.
+        if messages.count > Int(fleetMessageListMax) {
+            messages.removeFirst(messages.count - Int(fleetMessageListMax))
+        }
+    }
+
+    /// Upsert a confirm card by its confirm id.
+    ///
+    /// An ANSWERED card is kept and re-rendered in its new state rather than
+    /// dropped: `fleet/confirm_list` only returns open cards, so dropping it
+    /// here would make the card vanish the instant the operator approved it,
+    /// with no confirmation that the approval was what removed it. The next
+    /// page retires it.
+    private mutating func upsert(_ card: FleetChatConfirmCard) {
+        if let index = confirms.firstIndex(where: { $0.id == card.id }) {
+            confirms[index] = card
+            return
+        }
+        confirms.append(card)
+    }
+
+    /// Append one activity row, oldest-first, bounded like its page.
+    ///
+    /// APPEND, not prepend: `fleet/activity_list` pages `ORDER BY seq ASC`, so
+    /// the feed reads oldest at the top, and a live row prepended to that is a
+    /// feed that puts the newest event above rows it happened after. One
+    /// ordering rule for both halves or the pane cannot be read at all.
+    private mutating func upsert(_ row: FleetActivityRow) {
+        if let index = activity.firstIndex(where: { $0.seq == row.seq }) {
+            activity[index] = row
+            return
+        }
+        activity.append(row)
+        if activity.count > Int(fleetActivityListMax) {
+            activity.removeFirst(activity.count - Int(fleetActivityListMax))
+        }
+    }
 }
 
-/// Seconds between poll refreshes while the chat surface is open.
+/// One live chat notification, in the three shapes the chat surface folds.
 ///
-/// The same interval the TUI polls at (`CHAT_POLL_INTERVAL_MS`), for the same
-/// reason: one timer beats a second long-lived socket in the render path, and
-/// the daemon's `fleet/confirm_event` and `fleet/activity_event` stream is the
-/// upgrade for when a poll's latency is actually felt. Matching the TUI matters
-/// because an operator watching both surfaces must not see one lag the other.
+/// Every case carries what the PAGE carries, built by the page's own
+/// constructor, so the live half and the paged half of one surface cannot
+/// disagree about a row. `FleetChatMessageRow.init(message:)` and
+/// `FleetChatConfirmCard.decode` are the same two the page calls.
 ///
-/// ponytail: polling, not a subscription. Upgrade when a second is visible.
-let fleetChatPollInterval = Duration.seconds(1)
+/// The confirm case carries a decoded CARD rather than a `FleetConfirm`, and
+/// that is the same reason rather than an inconsistency: `confirm_list` is
+/// decoded row by row precisely so one card this build cannot read does not
+/// cost the operator the ones it can, and a live card that skipped that
+/// tolerance would be the one shape of card the pane could not show. Its scope
+/// rides alongside because an unrecognised card has no readable fields to take
+/// it from.
+enum FleetChatEvent: Equatable, Sendable {
+    case message(FleetMessage)
+    case confirm(card: FleetChatConfirmCard, scopeKey: String)
+    case activity(FleetActivityRow)
+
+    /// The scope this event was filed under. Every one of the three carries it,
+    /// which is what makes a fleet-wide stream safe to render in a scoped pane.
+    var scopeKey: String {
+        switch self {
+        case let .message(message): message.scopeKey
+        case let .confirm(_, scopeKey): scopeKey
+        case let .activity(row): row.scopeKey
+        }
+    }
+}
+
+/// Seconds between SAFETY-NET pages while the chat surface is open.
+///
+/// The pane is carried by `fleet/message_subscribe` and the three notifications
+/// that follow it, so this timer is not how the conversation arrives any more.
+/// It stays, at thirty seconds rather than one, because a push stream has one
+/// failure mode a poll does not: silence and health look identical. The
+/// daemon's chat notification forwarder drops frames when a slow client lags
+/// its broadcast channel (`spawn_notification_forwarder` logs the miss and says
+/// in as many words that the client re-reads via `fleet/confirm_list` and
+/// `fleet/activity_list`), and nothing on this side is told. Without a page
+/// behind it, one dropped frame strands the pane until the operator notices and
+/// hits Refresh.
+///
+/// Thirty seconds is the number because it is far enough out to make the RPC
+/// cost of an open pane a rounding error (four calls per half minute against
+/// five every second before this), and near enough that a stranded pane repairs
+/// itself inside the time an operator spends reading the message they are
+/// answering. It deliberately does NOT match the TUI's one-second poll: the TUI
+/// has no subscription, so its timer IS its transport.
+let fleetChatSafetyNetInterval = Duration.seconds(30)

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -27,9 +27,23 @@ struct FleetResyncRequired: Decodable, Equatable, Sendable {
     }
 }
 
+/// Everything the daemon pushes at us on a socket we already own.
+///
+/// The three chat cases arrive only after `fleet/message_subscribe` is
+/// acknowledged on THIS connection, and they ride the same socket as
+/// `fleet/event`: the daemon runs them as independent forwarders over one
+/// writer, so a client needs one connection, not two.
 enum FleetIncoming: Equatable, Sendable {
     case event(FleetEvent)
     case resyncRequired(FleetResyncRequired)
+    case messageEvent(FleetMessageEventParams)
+    /// The card RAW, so a row this build cannot fully read still reaches the
+    /// pane as an unanswerable one instead of being dropped.
+    case confirmEvent(FleetConfirmEventRawParams)
+    case activityEvent(FleetActivityEventParams)
+    /// A notification this connection did not turn into one of the above:
+    /// either a method this build has never heard of, or a chat frame whose
+    /// params did not decode. Both are named and dropped, never fatal.
     case unknownNotification(String)
 }
 
@@ -222,6 +236,29 @@ actor FleetConnection {
         return try await request("fleet/message_list", params: params, result: FleetMessageListResult.self)
     }
 
+    /// Open the live chat stream on this connection.
+    ///
+    /// Gated by `fleet.message.read`, which is what
+    /// `handle_fleet_message_subscribe` checks, NOT the `fleet.chat.read` its
+    /// confirm and activity neighbours check: the ack is a read of the message
+    /// log's head and the daemon gates it as one. Gating this on `chat.read`
+    /// would open the stream against a daemon that refuses it, and leave it
+    /// shut against one that would have served it.
+    ///
+    /// The daemon answers with the log head and THEN registers two forwarders
+    /// on this socket: the message forwarder (`fleet/message_event`, replayed
+    /// from `afterID` or from the head just acked) and the chat notification
+    /// forwarder (`fleet/confirm_event`, `fleet/activity_event`). Both arrive
+    /// on `incoming()` alongside `fleet/event`.
+    func messageSubscribe(afterID: String? = nil) async throws -> FleetMessageSubscribeResult {
+        try requireReadCapability("fleet.message.read")
+        return try await request(
+            "fleet/message_subscribe",
+            params: FleetMessageSubscribeParams(afterID: afterID),
+            result: FleetMessageSubscribeResult.self
+        )
+    }
+
     func messageSend(_ params: FleetMessageSendParams) async throws -> FleetMessageSendResult {
         try requireWriteCapability("fleet.message.send")
         return try await request("fleet/message_send", params: params, result: FleetMessageSendResult.self)
@@ -384,12 +421,51 @@ actor FleetConnection {
             case "fleet/resync_required":
                 let params = try FleetWire.decoder().decode(FleetResyncRequired.self, from: envelope.paramsData)
                 yield(.resyncRequired(params))
+            // The three chat frames degrade to a named drop rather than
+            // throwing, and that difference from the two arms above is the
+            // whole point. `fleet/event` is this client's OWN roster stream,
+            // where a frame that does not decode means the two ends disagree
+            // about the wire and continuing to render is worse than
+            // reconnecting. The chat frames are fleet-wide BROADCASTS: they
+            // carry every conversation on the daemon, so one row from a scope
+            // this pane never renders would otherwise take the roster, the
+            // menu bar and the operator's live session list down with it.
+            // The safety-net page repairs whatever a dropped frame missed.
+            case "fleet/message_event":
+                yield(decoded(FleetMessageEventParams.self, from: envelope, as: FleetIncoming.messageEvent, method: method))
+            case "fleet/confirm_event":
+                yield(decoded(FleetConfirmEventRawParams.self, from: envelope, as: FleetIncoming.confirmEvent, method: method))
+            case "fleet/activity_event":
+                yield(decoded(FleetActivityEventParams.self, from: envelope, as: FleetIncoming.activityEvent, method: method))
+            // KEPT, and it is not the `default` this codebase bans: that rule is
+            // about switches over a WIRE ENUM this build owns, where a new
+            // variant must fail to compile. This switches over an open string
+            // the daemon chooses, so an unknown method is a daemon that grew a
+            // notification, and the only safe answer is to name it and carry
+            // on. Throwing here would tear down a live connection over a frame
+            // that concerns some other client's subscription.
             default:
                 yield(.unknownNotification(method))
             }
         } catch {
             disconnect(FleetConnectionError.malformedEnvelope, descriptor: descriptor)
         }
+    }
+
+    /// One chat frame, decoded into its case, or NAMED as undecodable.
+    ///
+    /// Generic over the payload so the three arms cannot drift apart in how
+    /// they handle a frame this build cannot read.
+    private func decoded<Params: Decodable>(
+        _ type: Params.Type,
+        from envelope: Envelope,
+        as make: (Params) -> FleetIncoming,
+        method: String
+    ) -> FleetIncoming {
+        guard let params = try? FleetWire.decoder().decode(type, from: envelope.paramsData) else {
+            return .unknownNotification(method)
+        }
+        return make(params)
     }
 
     private func disconnect(_ error: Error, descriptor: Int32?) {

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -1088,6 +1088,37 @@ struct FleetMessageListResult: Codable, Equatable {
     private enum CodingKeys: String, CodingKey { case messages, nextAfterID = "next_after_id" }
 }
 
+/// Params for `fleet/message_subscribe`.
+///
+/// `after_id` is OMITTED when nil rather than sent as `null`, matching the
+/// daemon's `skip_serializing_if`. Absent means "start at the head the ack
+/// publishes", which is what a client that has not read the log yet wants: a
+/// `null` cursor and an absent one mean the same thing here, but a client that
+/// sends the field it does not mean is one wire change away from meaning it.
+struct FleetMessageSubscribeParams: Encodable, Equatable {
+    let afterID: String?
+
+    private enum CodingKeys: String, CodingKey { case afterID = "after_id" }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(afterID, forKey: .afterID)
+    }
+}
+
+/// Result for `fleet/message_subscribe`: the newest committed message id, or
+/// nil on an empty log.
+///
+/// The ack is not the point of the call; the `fleet/message_event`,
+/// `fleet/confirm_event` and `fleet/activity_event` notifications that follow
+/// it on the SAME socket are. The daemon starts the forwarder at this head, so
+/// a client that pages after subscribing cannot miss a message between the two.
+struct FleetMessageSubscribeResult: Codable, Equatable {
+    let headID: String?
+
+    private enum CodingKeys: String, CodingKey { case headID = "head_id" }
+}
+
 /// Payload of the `fleet/message_event` notification.
 struct FleetMessageEventParams: Codable, Equatable {
     let message: FleetMessage
@@ -1341,6 +1372,19 @@ struct FleetConfirmAnswerResult: Codable, Equatable {
 /// Payload of the `fleet/confirm_event` notification.
 struct FleetConfirmEventParams: Codable, Equatable {
     let confirm: FleetConfirm
+}
+
+/// The same frame with its card left RAW.
+///
+/// The same split, for the same reason, as `FleetConfirmListRawResult`: a card
+/// carrying one key this build cannot read must still reach the operator as an
+/// unanswerable row, and the typed shape above cannot express that. The live
+/// path decodes this and hands the value to `FleetChatConfirmCard.decode`, the
+/// identical function the paged list uses, so a card renders the same whether
+/// it arrived on the stream or in a page. The typed shape stays for the
+/// contract tests, which SHOULD fail on drift.
+struct FleetConfirmEventRawParams: Decodable, Equatable {
+    let confirm: JSONValue
 }
 
 /// One append-only copilot activity row.

--- a/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRoster/FleetWindowView.swift
@@ -43,7 +43,7 @@ struct FleetWindowView: View {
         .sheet(isPresented: $timelinePresented) { FleetTimelineList(store: store) }
         .sheet(isPresented: $broadcastPresented) { FleetBroadcastForm(store: store, isPresented: $broadcastPresented) }
         .sheet(isPresented: $answerQueuePresented) { FleetAnswerQueue(store: store) }
-        .sheet(isPresented: $chatPresented) { FleetChatPaneView(store: store) }
+        .sheet(isPresented: $chatPresented) { FleetChatPaneView(store: store, close: { chatPresented = false }) }
         .onAppear(perform: selectFirstVisibleSession)
         .onReceive(store.$sessions) { selectFirstVisibleSession(in: $0) }
         .onChange(of: presentation.filters) { _, _ in selectFirstVisibleSession() }

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
@@ -596,7 +596,264 @@ final class FleetChatPresentationTests: XCTestCase {
         )
     }
 
+    // MARK: - Live chat events folded into the surface
+
+    /// A message committed in the scope on screen lands in the timeline, in
+    /// commit order, without a page.
+    func testALiveMessageForTheShownScopeAppendsToTheTimeline() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.message(try Self.liveMessage(id: "01J0B", body: "second")))
+
+        XCTAssertEqual(surface.messages.map(\.id), ["01J0A", "01J0B"])
+        XCTAssertEqual(surface.messages.last?.body, "second")
+    }
+
+    /// A message for a DIFFERENT scope is dropped, never rendered.
+    ///
+    /// This is the whole reason the fold reads the scope: the daemon's message
+    /// forwarder is fleet-wide, so a broadcast channel's traffic and every
+    /// other copilot conversation arrive on the same socket. A pane that
+    /// rendered them would attribute another conversation's message to this one
+    /// and offer the operator a reply that goes somewhere else.
+    func testALiveMessageForAnotherScopeIsDropped() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.message(try Self.liveMessage(id: "01J0B", body: "elsewhere", scope: "channel:other")))
+
+        XCTAssertEqual(surface.messages.map(\.id), ["01J0A"])
+    }
+
+    /// The same id twice REPLACES.
+    ///
+    /// The daemon's forwarder replays from a cursor, so a message can arrive
+    /// live and again in the page that follows. Appending both would show the
+    /// operator their own message twice with no way to tell which one the
+    /// copilot answered.
+    func testALiveMessageThatAlreadyExistsReplacesRatherThanDuplicates() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.message(try Self.liveMessage(id: "01J0A", body: "edited")))
+
+        XCTAssertEqual(surface.messages.map(\.id), ["01J0A"])
+        XCTAssertEqual(surface.messages.first?.body, "edited")
+    }
+
+    /// Nothing is folded before a page has resolved a scope.
+    ///
+    /// An event that arrives between `fleet/message_subscribe` and the first
+    /// page has nothing to be compared against, and a surface with no scope
+    /// cannot prove the event belongs to it. The page that follows carries it.
+    func testAnEventArrivingBeforeAScopeIsResolvedIsDropped() throws {
+        var surface = FleetChatSurface()
+        surface.apply(.message(try Self.liveMessage(id: "01J0B", body: "early")))
+
+        XCTAssertEqual(surface.messages, [])
+    }
+
+    /// The timeline stays inside the page's own ceiling, dropping the oldest.
+    ///
+    /// A pane left open all day would otherwise grow without bound, and the
+    /// bound that matters is the one a fresh page would show.
+    func testTheTimelineStaysBoundedByThePageCeiling() throws {
+        var surface = try Self.shownSurface()
+        for index in 0..<Int(fleetMessageListMax) {
+            surface.apply(.message(try Self.liveMessage(id: "live-\(index)", body: "row \(index)")))
+        }
+
+        XCTAssertEqual(surface.messages.count, Int(fleetMessageListMax))
+        XCTAssertEqual(
+            surface.messages.first?.id, "live-0",
+            "the ceiling drops the OLDEST row, which is the page's first one"
+        )
+        XCTAssertEqual(surface.messages.last?.id, "live-\(Int(fleetMessageListMax) - 1)")
+    }
+
+    /// A confirm card is upserted by its id, and an ANSWERED card is kept in
+    /// its new state rather than dropped.
+    ///
+    /// `fleet/confirm_list` only returns OPEN cards, so dropping an answered
+    /// one here would make the card vanish the instant it was approved, with
+    /// nothing to say the approval was what removed it.
+    func testALiveConfirmUpsertsByIDAndKeepsAnAnsweredCard() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(Self.liveConfirm(id: "01J0CARD", state: "open"))
+        XCTAssertEqual(surface.confirms.map(\.id), ["01J0CARD"])
+        XCTAssertTrue(surface.confirms[0].isAnswerable)
+
+        surface.apply(Self.liveConfirm(id: "01J0CARD", state: "approved"))
+        XCTAssertEqual(surface.confirms.map(\.id), ["01J0CARD"], "the answer must not add a second card")
+        XCTAssertEqual(surface.confirms[0].stateLabel, "APPROVED")
+        XCTAssertFalse(surface.confirms[0].isAnswerable)
+    }
+
+    /// A live card this build cannot decode still reaches the pane, as an
+    /// UNANSWERABLE row.
+    ///
+    /// The tolerance the paged list has always had, now on the live path too.
+    /// The alternative is the one shape of card the operator never sees: the
+    /// page renders it as unrecognised, so a stream that dropped it would make
+    /// a card appear only on the safety net, half a minute late, having been
+    /// silently withheld in between.
+    func testALiveConfirmThisBuildCannotDecodeStillRendersUnanswerable() throws {
+        var surface = try Self.shownSurface()
+        let broken = Self.brokenConfirmValue(id: "01J0BAD", scope: "channel:copilot")
+
+        surface.apply(.confirm(card: FleetChatConfirmCard.decode(broken), scopeKey: "channel:copilot"))
+
+        XCTAssertEqual(surface.confirms.map(\.id), ["01J0BAD"], "the card was withheld entirely")
+        XCTAssertFalse(surface.confirms[0].isAnswerable, "a card this build cannot read must never be approvable")
+        XCTAssertEqual(surface.confirms[0].stateLabel, "UNRECOGNISED")
+    }
+
+    /// A confirm card for another scope is dropped, like every other event.
+    func testALiveConfirmForAnotherScopeIsDropped() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(Self.liveConfirm(id: "01J0CARD", state: "open", scope: "channel:other"))
+
+        XCTAssertEqual(surface.confirms, [])
+    }
+
+    /// Activity APPENDS, oldest first, because that is the order its page
+    /// returns (`ORDER BY seq ASC`). A feed with one half ascending and the
+    /// other descending cannot be read at all.
+    func testALiveActivityAppendsInPageOrderAndStaysBounded() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.activity(try Self.liveActivity(seq: 2)))
+        surface.apply(.activity(try Self.liveActivity(seq: 3)))
+
+        XCTAssertEqual(surface.activity.map(\.seq), [1, 2, 3])
+
+        for seq in 4...(Int64(fleetActivityListMax) + 1) {
+            surface.apply(.activity(try Self.liveActivity(seq: seq)))
+        }
+        XCTAssertEqual(surface.activity.count, Int(fleetActivityListMax))
+        XCTAssertEqual(surface.activity.first?.seq, 2, "the ceiling drops the oldest row")
+        XCTAssertEqual(surface.activity.last?.seq, Int64(fleetActivityListMax) + 1)
+    }
+
+    /// The same `seq` twice replaces rather than duplicating, so a replayed
+    /// row cannot show one tool call as two.
+    func testALiveActivityRowIsUpsertedBySeq() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.activity(try Self.liveActivity(seq: 1, tool: "kill_session")))
+
+        XCTAssertEqual(surface.activity.map(\.seq), [1])
+        XCTAssertEqual(surface.activity.first?.tool, "kill_session")
+    }
+
+    /// Every event type reports the scope it was filed under, which is what
+    /// makes a fleet-wide stream safe to render in a scoped pane. Exhaustive
+    /// over the enum on purpose: a fourth event shape must fail here.
+    func testEveryLiveEventNamesItsScope() throws {
+        let events: [FleetChatEvent] = [
+            .message(try Self.liveMessage(id: "01J0B", body: "b")),
+            Self.liveConfirm(id: "01J0CARD", state: "open"),
+            .activity(try Self.liveActivity(seq: 9)),
+        ]
+
+        XCTAssertEqual(events.map(\.scopeKey), Array(repeating: "channel:copilot", count: events.count))
+    }
+
+    // MARK: - The chat route's way back
+
+    /// Closing the chat pane returns the operator to the route they came from,
+    /// not to Sessions.
+    ///
+    /// The pane is a route rather than a presentation, so Close has to name a
+    /// destination rather than dismissing one. Always answering Sessions throws
+    /// away whatever the operator had set up before they went to read the
+    /// conversation, which for anybody who lives in Needs you is every time.
+    @MainActor
+    func testClosingChatReturnsToTheRouteItWasOpenedFrom() {
+        let navigation = FleetNotchNavigation()
+
+        navigation.route = .needsYou
+        navigation.route = .chat
+        XCTAssertEqual(navigation.routeBeforeChat, .needsYou)
+
+        navigation.route = navigation.routeBeforeChat
+        XCTAssertEqual(navigation.route, .needsYou)
+    }
+
+    /// Leaving chat does not make chat the way back.
+    ///
+    /// Without the guard, the route being left is recorded unconditionally, so
+    /// the first Close records chat and the next one returns to the pane it
+    /// just closed.
+    @MainActor
+    func testLeavingChatDoesNotMakeChatTheWayBack() {
+        let navigation = FleetNotchNavigation()
+
+        navigation.route = .usage
+        navigation.route = .chat
+        navigation.route = navigation.routeBeforeChat
+        // Second visit, from where the first one put them.
+        navigation.route = .chat
+
+        XCTAssertEqual(navigation.routeBeforeChat, .usage, "Close would have reopened the pane it just closed")
+    }
+
+    /// The default is the roster, for an operator whose first act is Chat.
+    @MainActor
+    func testChatOpenedFirstReturnsToTheRoster() {
+        let navigation = FleetNotchNavigation()
+
+        navigation.route = .chat
+
+        XCTAssertEqual(navigation.routeBeforeChat, .sessions)
+    }
+
     // MARK: - Helpers
+
+    /// A surface in the state a paged pane is in: one scope, one message, one
+    /// activity row.
+    private static func shownSurface() throws -> FleetChatSurface {
+        var surface = FleetChatSurface()
+        surface.scopeKey = "channel:copilot"
+        surface.targetSessionKey = "acp:1"
+        surface.messages = [FleetChatMessageRow(message: try liveMessage(id: "01J0A", body: "first"))]
+        surface.activity = [try liveActivity(seq: 1)]
+        return surface
+    }
+
+    /// Built from JSON in the shape the Rust struct defines, like every other
+    /// wire value in this suite: a renamed key fails here rather than being
+    /// renamed on both sides.
+    private static func liveMessage(id: String, body: String, scope: String = "channel:copilot") throws -> FleetMessage {
+        try FleetWire.decoder().decode(FleetMessage.self, from: Data("""
+        {"id":"\(id)","scope_key":"\(scope)","sender":"copilot",
+         "kind":"agent","body":"\(body)","created_at":1700000000000}
+        """.utf8))
+    }
+
+    /// One live confirm event, built the way the STORE builds one: raw JSON in,
+    /// through the page's own tolerant decode, with the scope read off the
+    /// frame. Anything less would test a path the app does not take.
+    private static func liveConfirm(id: String, state: String, scope: String = "channel:copilot") -> FleetChatEvent {
+        let raw = confirmValue(id: id, state: state, scope: scope)
+        return .confirm(card: FleetChatConfirmCard.decode(raw), scopeKey: scope)
+    }
+
+    /// A card whose `created_at` is the wrong TYPE, which is the failure a
+    /// tolerant enum does not cover and the row-by-row decode exists for.
+    private static func brokenConfirmValue(id: String, scope: String) -> JSONValue {
+        (try? FleetWire.decoder().decode(JSONValue.self, from: Data("""
+        {"confirm_id":"\(id)","scope_key":"\(scope)","tool":"spawn_session","arguments":{},
+         "state":"open","created_at":"not-a-number","expires_at":2}
+        """.utf8))) ?? .null
+    }
+
+    private static func confirmValue(id: String, state: String, scope: String, tool: String = "kill_session") -> JSONValue {
+        (try? FleetWire.decoder().decode(JSONValue.self, from: Data("""
+        {"confirm_id":"\(id)","scope_key":"\(scope)","tool":"\(tool)","arguments":{},
+         "state":"\(state)","created_at":1,"expires_at":2}
+        """.utf8))) ?? .null
+    }
+
+    private static func liveActivity(seq: Int64, tool: String = "list_sessions", scope: String = "channel:copilot") throws -> FleetActivityRow {
+        try FleetWire.decoder().decode(FleetActivityRow.self, from: Data("""
+        {"seq":\(seq),"id":"act-\(seq)","scope_key":"\(scope)","tool":"\(tool)",
+         "class":"read","outcome":"ok","created_at":1}
+        """.utf8))
+    }
 
     private static func deliveries(_ legs: String) throws -> [FleetMessageDelivery] {
         try FleetWire.decoder().decode(

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -1093,6 +1093,322 @@ final class FleetConnectionTests: XCTestCase {
         try serverResult.throwIfRecorded()
     }
 
+    /// A message committed on the daemon reaches an open pane with no page
+    /// behind it, and one committed in ANOTHER scope never appears.
+    ///
+    /// The negative half is ordered rather than timed: both frames go down one
+    /// socket, in order, so when the second has landed the first has already
+    /// been through the fold. Waiting a fixed interval to prove an absence is
+    /// how a suite gets a flake that only fires on a loaded machine.
+    func testALiveMessageEventReachesTheOpenPaneWithoutAPage() async throws {
+        try await withChatStore { store, server in
+            // The pane announces itself, exactly as its `.task` does. Without
+            // this the fold is off, which is the whole point of the gate.
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertEqual(store.chat.scopeKey, "channel:c1")
+                XCTAssertEqual(store.chat.messages, [], "the scripted page has no history")
+            }
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0OTHER", scope: "channel:elsewhere")]
+            )
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0LIVE", scope: "channel:c1")]
+            )
+
+            let landed = await Self.waitUntil {
+                await MainActor.run { store.chat.messages.map(\.id) == ["01J0LIVE"] }
+            }
+            XCTAssertTrue(
+                landed,
+                "a committed message must reach the pane on the stream, and only this scope's"
+            )
+        }
+    }
+
+    /// A message that arrives while a page is READING must survive that page.
+    ///
+    /// The page replaces the surface wholesale, and its `fleet/message_list`
+    /// answered before this message was committed. Folding it into the live
+    /// surface alone is not enough: the page lands afterwards and rewinds the
+    /// pane past it, and the operator does not see it again until the
+    /// safety net pages half a minute later.
+    ///
+    /// Driven by holding the daemon inside the page rather than by hoping the
+    /// interleaving happens, so it fails deterministically without the replay.
+    func testALiveMessageIsNotLostByAPageAlreadyInFlight() async throws {
+        let gate = ChatServerGate()
+        try await withChatStore(gate: gate) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            // A second page, stopped at `fleet/message_list`: the point where
+            // the page has already read the timeline it is going to publish.
+            gate.arm()
+            let paging = Task { await store.refreshChatOnce() }
+            let stopped = await Self.waitUntil { gate.hasReached }
+            XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0RACE", scope: "channel:c1")]
+            )
+            let folded = await Self.waitUntil {
+                await MainActor.run { store.chat.messages.map(\.id) == ["01J0RACE"] }
+            }
+            XCTAssertTrue(folded, "the event never reached the surface, so the page cannot be what dropped it")
+
+            gate.letGo()
+            await paging.value
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.messages.map(\.id), ["01J0RACE"],
+                    "the page overwrote a message that was committed while it was reading"
+                )
+            }
+        }
+    }
+
+    /// A daemon that advertises the capability but REFUSES the subscription
+    /// still gets a populated pane.
+    ///
+    /// The ordinary upgrade-the-app-keep-the-daemon window: the catalogue names
+    /// `fleet.message.read` because `fleet/message_list` exists, and
+    /// `fleet/message_subscribe` answers an error. Live push is a latency
+    /// improvement, not a dependency, so the refusal must cost the pane nothing
+    /// except the wait for `fleetChatSafetyNetInterval`.
+    func testADaemonThatRefusesTheSubscriptionStillPages() async throws {
+        try await withChatStore(refuseMessageSubscribe: true) { store, _ in
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertTrue(store.connectionState.isLive, "a refused subscription must not cost the connection")
+                XCTAssertEqual(store.chat.scopeKey, "channel:c1")
+                XCTAssertEqual(store.chat.targetSessionKey, "acp:1")
+            }
+        }
+    }
+
+    /// With NO pane on screen, a chat event is not folded at all.
+    ///
+    /// `chat` is `@Published` on the store the whole notch observes, so a
+    /// folded event redraws the roster, the chips and the menu-bar summary. A
+    /// scope filter does not stop that once a pane has been opened once,
+    /// because the scope stays resolved: a busy copilot would invalidate the
+    /// roster several times a second while the operator is reading Sessions.
+    ///
+    /// A SETTLE, deliberately, and it is the honest shape for this one. The
+    /// sibling tests order their assertions behind a second frame on the same
+    /// socket, but nothing observable happens when an event is correctly
+    /// dropped, so there is no barrier to wait behind. `waitUntil` polls for
+    /// its full two seconds and reports that the timeline never filled, which
+    /// is thousands of times longer than the microseconds an ungated fold takes
+    /// once the frame is read. The positive control that follows is what stops
+    /// this passing because the pipeline was dead rather than because the gate
+    /// worked.
+    func testAMessageEventWithNoPaneOpenIsNotFolded() async throws {
+        try await withChatStore { store, server in
+            await store.refreshChatOnce()
+            await MainActor.run { XCTAssertEqual(store.chat.scopeKey, "channel:c1") }
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0CLOSED", scope: "channel:c1")]
+            )
+            let foldedWithNoPane = await Self.waitUntil {
+                await MainActor.run { !store.chat.messages.isEmpty }
+            }
+            XCTAssertFalse(
+                foldedWithNoPane,
+                "an event with no pane open was rendered anyway, so every copilot message redraws the roster"
+            )
+
+            // The control: the same stream, the same scope, one open pane.
+            await MainActor.run { store.chatPaneAppeared() }
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0OPEN", scope: "channel:c1")]
+            )
+            let landed = await Self.waitUntil {
+                await MainActor.run { store.chat.messages.map(\.id) == ["01J0OPEN"] }
+            }
+            XCTAssertTrue(landed, "the gate is stuck shut, so nothing proved the drop above")
+        }
+    }
+
+    /// A message committed during the VERY FIRST page of a connection survives
+    /// that page.
+    ///
+    /// The opening page is the one window where the surface has no scope yet,
+    /// so a buffer that filters incoming events against `chat.scopeKey` matches
+    /// nothing at all, and `apply` drops the event live for the same reason.
+    /// The message is then invisible until the next safety-net page, up to
+    /// thirty seconds later, on the first conversation an operator opens.
+    ///
+    /// Distinct from its sibling, which pages once before arming the gate and
+    /// therefore only ever exercises the scope-resolved path.
+    func testALiveMessageDuringTheFirstPageOfAConnectionIsNotLost() async throws {
+        let gate = ChatServerGate()
+        try await withChatStore(gate: gate) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+
+            // No page has run, so the surface has no scope. This is the window.
+            gate.arm()
+            let paging = Task { await store.refreshChatOnce() }
+            let stopped = await Self.waitUntil { gate.hasReached }
+            XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+            await MainActor.run {
+                XCTAssertNil(store.chat.scopeKey, "the fixture published a scope before its first page")
+            }
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0FIRST", scope: "channel:c1")]
+            )
+            gate.letGo()
+            await paging.value
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.messages.map(\.id), ["01J0FIRST"],
+                    "the opening page dropped a message committed while it was reading"
+                )
+            }
+        }
+    }
+
+    /// A page INVALIDATED while it was reading never reaches the screen.
+    ///
+    /// This is the PR A race arriving one layer out. The generation guarded the
+    /// session cache but not the publish, so the sequence was: a send's leg
+    /// reports `target_not_running`, the store forgets the dead session, and an
+    /// older page that read the dead key lands afterwards and paints it back.
+    /// At the old one-second poll that healed within a second. At
+    /// `fleetChatSafetyNetInterval` the composer aims at a dead session for
+    /// half a minute, which is the whole of an operator's next message.
+    ///
+    /// Each page answers with a row naming itself, so the assertion is about
+    /// WHICH page's surface is on screen rather than about a value both would
+    /// have produced.
+    func testAPageInvalidatedWhileItWasReadingIsNeverPublished() async throws {
+        let gate = ChatServerGate()
+        try await withChatStore(gate: gate, pagesReturnMarkerRows: true) { store, _ in
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertEqual(store.chat.messages.map(\.id), ["page-1"], "the first page is on screen")
+            }
+
+            // A second page, held after it has read the session cache.
+            gate.arm()
+            let paging = Task { await store.refreshChatOnce() }
+            let stopped = await Self.waitUntil { gate.hasReached }
+            XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+
+            // What a REJECTED send does, while that page is in flight.
+            await MainActor.run { store.forgetCopilotSession(inScope: "channel:c1") }
+            gate.letGo()
+            await paging.value
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.messages.map(\.id), ["page-1"],
+                    "a page the store had already disowned was published over the current surface"
+                )
+            }
+        }
+    }
+
+    /// Bring a store up against the scripted chat daemon and hand both it and
+    /// the SERVER end of the socket to `body`.
+    ///
+    /// Handing over the raw descriptor is what lets a test push a notification.
+    /// It is safe because the server thread is blocked reading (or held at the
+    /// gate) whenever `body` runs, so there is never a second writer.
+    private func withChatStore(
+        refuseMessageSubscribe: Bool = false,
+        gate: ChatServerGate? = nil,
+        pagesReturnMarkerRows: Bool = false,
+        _ body: (FleetStore, Int32) async throws -> Void
+    ) async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let serverDone = expectation(description: "chat server finished")
+        let serverResult = SocketServerResult()
+        let counts = ChatServerCounts(pagesReturnMarkerRows: pagesReturnMarkerRows)
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: []),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: []),
+                    capabilityIDs: [
+                        "fleet.chat.read", "fleet.chat.write",
+                        "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
+                    ],
+                    refuseMessageSubscribe: refuseMessageSubscribe
+                )
+                while true {
+                    try Self.answerChatRequest(
+                        try Self.readRequest(from: serverDescriptor),
+                        to: serverDescriptor,
+                        counts: counts,
+                        gate: gate
+                    )
+                }
+            } catch StoreServerError.closed {
+                // The client hung up at the end of the test. Not a failure.
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run {
+                guard case .live = store.connectionState else { return false }
+                return store.canWrite
+            }
+        }
+        XCTAssertTrue(live, "the fixture never reached a live, writable connection")
+
+        try await body(store, serverDescriptor)
+
+        await MainActor.run { store.stop() }
+        await fulfillment(of: [serverDone], timeout: 5)
+        try serverResult.throwIfRecorded()
+    }
+
+    /// One `FleetMessage` in the shape the daemon frames it.
+    private static func messageObject(id: String, scope: String) -> [String: Any] {
+        [
+            "id": id, "scope_key": scope, "sender": "copilot",
+            "kind": "agent", "body": "from the copilot", "created_at": 1_700_000_000_000,
+        ]
+    }
+
     /// Answer one chat-page RPC with a canned result, counting the mints.
     ///
     /// Dispatched by METHOD rather than by position, so the test asserts how
@@ -1124,8 +1440,15 @@ final class FleetConnectionTests: XCTestCase {
         case "fleet/message_list":
             // The page's first call AFTER the mint decision, which makes it the
             // window a test needs to invalidate the cache in.
+            let page = counts.recordMessageList()
             gate?.pauseIfArmed()
-            try writeResponse(to: descriptor, request: request, result: ["messages": []])
+            // Marker rows are opt-in, because most tests here assert on the
+            // mint count and want an empty timeline. A test that needs to tell
+            // WHICH page published turns them on: the row names its page.
+            let rows: [Any] = counts.pagesReturnMarkerRows
+                ? [messageObject(id: "page-\(page)", scope: "channel:c1")]
+                : []
+            try writeResponse(to: descriptor, request: request, result: ["messages": rows])
         case "fleet/confirm_list":
             try writeResponse(to: descriptor, request: request, result: ["confirms": []])
         case "fleet/activity_list":
@@ -1142,6 +1465,196 @@ final class FleetConnectionTests: XCTestCase {
         default:
             try writeError(to: descriptor, request: request)
         }
+    }
+
+    /// The three chat notifications reach `incoming()` as their own cases, on
+    /// the same socket that already carries `fleet/event`.
+    ///
+    /// The frames are written inline rather than from the shared fixtures
+    /// because what is under test here is the DISPATCH: which method name lands
+    /// in which case. The payload shapes are pinned against the shared fixtures
+    /// by `FleetChatPresentationTests` and the daemon contract suite, which is
+    /// where a renamed wire key has to fail.
+    func testChatNotificationsStreamThroughOwnedSocket() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: descriptors[0]
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let waiter = Task { () -> [FleetIncoming] in
+            var received: [FleetIncoming] = []
+            var iterator = stream.makeAsyncIterator()
+            while received.count < 3, let incoming = await iterator.next() {
+                received.append(incoming)
+            }
+            return received
+        }
+
+        try Self.writeNotification(
+            to: serverDescriptor,
+            method: "fleet/message_event",
+            params: ["message": [
+                "id": "01J0MSG", "scope_key": "channel:copilot", "sender": "copilot",
+                "kind": "agent", "body": "restarted sess-a", "created_at": 1_700_000_000_000,
+            ]]
+        )
+        try Self.writeNotification(
+            to: serverDescriptor,
+            method: "fleet/confirm_event",
+            params: ["confirm": [
+                "confirm_id": "01J0CONFIRM", "scope_key": "channel:copilot", "tool": "kill",
+                "arguments": ["session": "tmux:sess-c"], "state": "open",
+                "created_at": 1, "expires_at": 2,
+            ]]
+        )
+        try Self.writeNotification(
+            to: serverDescriptor,
+            method: "fleet/activity_event",
+            params: ["activity": [
+                "seq": 44, "id": "01J0ACTIVITY3", "scope_key": "channel:copilot",
+                "tool": "fleet_status", "class": "read", "outcome": "ok", "created_at": 3,
+            ]]
+        )
+
+        let received = await waiter.value
+        XCTAssertEqual(received.count, 3)
+        guard case let .messageEvent(message) = received[0],
+              case let .confirmEvent(confirm) = received[1],
+              case let .activityEvent(activity) = received[2] else {
+            return XCTFail("chat notifications landed in the wrong cases: \(received)")
+        }
+        XCTAssertEqual(message.message.id, "01J0MSG")
+        XCTAssertEqual(message.message.scopeKey, "channel:copilot")
+        // The card arrives RAW, so the store can put it through the same
+        // tolerant decode the paged list uses.
+        XCTAssertEqual(confirm.confirm.value("confirm_id")?.stringValue, "01J0CONFIRM")
+        XCTAssertEqual(FleetChatConfirmCard.decode(confirm.confirm).id, "01J0CONFIRM")
+        XCTAssertTrue(FleetChatConfirmCard.decode(confirm.confirm).isAnswerable)
+        XCTAssertEqual(activity.activity.seq, 44)
+        XCTAssertEqual(activity.activity.activityClass, .read)
+    }
+
+    /// A method this build has never heard of degrades to
+    /// `.unknownNotification` instead of tearing the connection down.
+    ///
+    /// The arm that does it is the one `default` this file keeps, and it is
+    /// load-bearing: the daemon adds notifications, and one aimed at some other
+    /// client's subscription must not cost this one its socket.
+    func testAnUnknownNotificationDoesNotTearDownTheConnection() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: descriptors[0]
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let waiter = Task { () -> FleetIncoming? in
+            var iterator = stream.makeAsyncIterator()
+            return await iterator.next()
+        }
+
+        try Self.writeNotification(to: serverDescriptor, method: "fleet/some_future_event", params: ["what": 1])
+
+        let received = await waiter.value
+        XCTAssertEqual(received, .unknownNotification("fleet/some_future_event"))
+    }
+
+    /// A chat notification whose PARAMS do not decode costs the FRAME, never
+    /// the connection.
+    ///
+    /// The opposite answer from `fleet/event`, deliberately. That one is this
+    /// client's own roster stream, where a frame it cannot read means the two
+    /// ends disagree about the wire. The three chat frames are fleet-wide
+    /// broadcasts carrying every conversation on the daemon, so one row from a
+    /// scope this pane never renders would otherwise take the roster and the
+    /// menu bar down with it. The frame is named and dropped; the safety-net
+    /// page repairs anything it carried.
+    func testAMalformedChatNotificationDoesNotCostTheConnection() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: descriptors[0]
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let waiter = Task { () -> [FleetIncoming] in
+            var received: [FleetIncoming] = []
+            var iterator = stream.makeAsyncIterator()
+            while received.count < 2, let incoming = await iterator.next() {
+                received.append(incoming)
+            }
+            return received
+        }
+
+        // A `fleet/message_event` with no `message` key at all, followed by a
+        // perfectly good one. The second is the proof: it can only arrive if
+        // the first did not take the socket with it.
+        try Self.writeNotification(to: serverDescriptor, method: "fleet/message_event", params: ["nope": 1])
+        try Self.writeNotification(
+            to: serverDescriptor,
+            method: "fleet/message_event",
+            params: ["message": Self.messageObject(id: "01J0AFTER", scope: "channel:c1")]
+        )
+
+        let received = await waiter.value
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(
+            received.first, .unknownNotification("fleet/message_event"),
+            "an undecodable chat frame must be named and dropped, not silently swallowed"
+        )
+        guard case let .messageEvent(params) = received[1] else {
+            return XCTFail("the connection did not survive the undecodable frame: \(received)")
+        }
+        XCTAssertEqual(params.message.id, "01J0AFTER")
+    }
+
+    /// The roster stream keeps the OPPOSITE rule: a `fleet/event` this build
+    /// cannot read still closes the connection.
+    ///
+    /// Pinned next to its neighbour on purpose. The two arms answer a malformed
+    /// frame differently, and the difference is a decision about blast radius,
+    /// so a later change that made them agree should have to delete one of
+    /// these tests and say why.
+    func testAMalformedRosterEventStillClosesTheConnection() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+
+        let connection = FleetConnection(
+            location: HangarLocation(environment: ["AINB_HANGAR_HOME": "/unused"]),
+            injectedDescriptor: descriptors[0]
+        )
+        try await connection.connect()
+        defer { Task { await connection.close() } }
+        let stream = await connection.incoming()
+        let finished = Task { () -> [FleetIncoming] in
+            var received: [FleetIncoming] = []
+            for await incoming in stream { received.append(incoming) }
+            return received
+        }
+
+        try Self.writeNotification(to: serverDescriptor, method: "fleet/event", params: ["nope": 1])
+
+        let yielded = await finished.value
+        XCTAssertEqual(yielded, [], "a roster frame that does not decode must not be yielded as anything")
     }
 
     private static func testLocation() throws -> HangarLocation {
@@ -1161,7 +1674,8 @@ final class FleetConnectionTests: XCTestCase {
         replayState: [String: Any] = ["state": "complete"],
         resyncAfterSubscription: Bool = false,
         capabilityIDs: [String] = [],
-        receiptList: [Any] = []
+        receiptList: [Any] = [],
+        refuseMessageSubscribe: Bool = false
     ) throws {
         let authentication = try readRequest(from: descriptor)
         try writeResponse(to: descriptor, request: authentication, result: [:])
@@ -1185,6 +1699,19 @@ final class FleetConnectionTests: XCTestCase {
             "replay": subscriptionReplay,
             "replay_state": replayState,
         ])
+        // The live chat stream, opened with the connection. Asserting the METHOD
+        // here is what proves the store opened it: a store that skipped the call
+        // would leave this read waiting for its next request instead, and the
+        // method it eventually got would not be this one.
+        if capabilityIDs.contains("fleet.message.read") {
+            let messageSubscribe = try readRequest(from: descriptor)
+            XCTAssertEqual(messageSubscribe["method"] as? String, "fleet/message_subscribe")
+            if refuseMessageSubscribe {
+                try writeError(to: descriptor, request: messageSubscribe)
+            } else {
+                try writeResponse(to: descriptor, request: messageSubscribe, result: ["head_id": NSNull()])
+            }
+        }
         if capabilityIDs.contains("fleet.receipt.read") {
             let receiptRequest = try readRequest(from: descriptor)
             XCTAssertEqual(receiptRequest["method"] as? String, "fleet/receipt_list")
@@ -1382,13 +1909,26 @@ private final class SocketServerResult: @unchecked Sendable {
 private final class ChatServerCounts: @unchecked Sendable {
     private let lock = NSLock()
     private var acpCreateCount = 0
+    private var messageListCount = 0
     /// The daemon token the scripted `message_send` refuses with. Settable
     /// because whether a refusal forgets the mint depends entirely on WHICH
     /// token it carries, not on the REJECTED state.
     let rejectionDetail: String
+    /// Whether each page answers with a row naming itself, so a test can tell
+    /// which page's surface reached the screen.
+    let pagesReturnMarkerRows: Bool
 
-    init(rejectionDetail: String = "target_not_running") {
+    init(rejectionDetail: String = "target_not_running", pagesReturnMarkerRows: Bool = false) {
         self.rejectionDetail = rejectionDetail
+        self.pagesReturnMarkerRows = pagesReturnMarkerRows
+    }
+
+    /// Count this page's timeline read and answer with its ordinal.
+    func recordMessageList() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        messageListCount += 1
+        return messageListCount
     }
 
     var acpCreates: Int {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
@@ -458,6 +458,152 @@ final class FleetDaemonContractTests: XCTestCase {
         XCTAssertFalse(rooted.sessionKey.isEmpty)
     }
 
+    /// The whole point of PR B, against a real daemon: a message committed by
+    /// SOMEBODY ELSE arrives on this connection as a notification, with nothing
+    /// polled in between.
+    ///
+    /// Two connections, because one client sending to itself proves nothing
+    /// about a push: the sender already holds the result. The second connection
+    /// is the copilot, the TUI, the CLI, or another window, and the assertion
+    /// is that this one hears about it.
+    ///
+    /// The ack alone is deliberately not the assertion. `head_id` says the
+    /// daemon parsed the frame; only the event says it registered the forwarder
+    /// that makes the pane live, and that registration happens in `serve_conn`
+    /// AFTER the response is queued, i.e. in code the ack cannot reach.
+    func testRealDaemonPushesACommittedMessageToASubscribedConnection() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let reader = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await reader.close() } }
+        let writer = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await writer.close() } }
+
+        // The copilot conversation, and the ACP session that IS its membership:
+        // a `channel:` scope only accepts a send addressed to one of its
+        // members, and a copilot channel's member is the session on its scope.
+        let channel = try await writer.channelCreate(
+            FleetChannelCreateParams(kind: .copilot, name: "copilot", recipients: nil)
+        ).channel
+        let session = try await writer.acpSessionCreate(FleetAcpSessionCreateParams(
+            provider: copilotDefaultProvider,
+            cwd: "/work/worktree",
+            scopeKey: channel.scopeKey
+        ))
+
+        let stream = await reader.incoming()
+        let acknowledgement = try await reader.messageSubscribe()
+        XCTAssertNil(acknowledgement.headID, "an empty log has no head")
+
+        async let incoming = Self.nextMessageEvent(from: stream)
+        let sent = try await writer.messageSend(FleetMessageSendParams(
+            scopeKey: channel.scopeKey,
+            targets: [session.sessionKey],
+            originMessageID: nil,
+            text: "what is blocked?",
+            requestID: UUID().uuidString
+        ))
+        let event = try await incoming
+
+        XCTAssertEqual(event.message.id, sent.messageID)
+        XCTAssertEqual(event.message.scopeKey, channel.scopeKey)
+        XCTAssertEqual(event.message.body, "what is blocked?")
+        // The daemon's own record of who wrote it, which is what the pane
+        // attributes the row to. A push that lost this would render another
+        // client's message as unattributed.
+        XCTAssertEqual(event.message.sender, "operator")
+    }
+
+    /// The same connection carries the fleet subscription AND the chat one.
+    ///
+    /// They are separate forwarders over one writer daemon-side, and this is
+    /// the reason the notch does not need a second socket for live chat. A
+    /// daemon that started replacing one forwarder with the other would leave
+    /// the roster frozen the moment the chat pane opened, which is the kind of
+    /// regression nothing else here would catch.
+    func testRealDaemonServesFleetAndChatSubscriptionsOnOneConnection() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let first = try fixture.seed("both-1")
+        let reader = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await reader.close() } }
+        let writer = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await writer.close() } }
+
+        let channel = try await writer.channelCreate(
+            FleetChannelCreateParams(kind: .copilot, name: "copilot", recipients: nil)
+        ).channel
+        let session = try await writer.acpSessionCreate(FleetAcpSessionCreateParams(
+            provider: copilotDefaultProvider,
+            cwd: "/work/worktree",
+            scopeKey: channel.scopeKey
+        ))
+
+        let stream = await reader.incoming()
+        _ = try await reader.subscribe(afterRevision: first)
+        _ = try await reader.messageSubscribe()
+
+        async let messageEvent = Self.nextMessageEvent(from: stream)
+        _ = try await writer.messageSend(FleetMessageSendParams(
+            scopeKey: channel.scopeKey,
+            targets: [session.sessionKey],
+            originMessageID: nil,
+            text: "still here",
+            requestID: UUID().uuidString
+        ))
+        let chat = try await messageEvent
+        XCTAssertEqual(chat.message.body, "still here")
+
+        // And the fleet half is still live on the same socket afterwards.
+        async let fleetEvent = Self.nextFleetEvent(from: stream)
+        _ = try fixture.seed("both-2", eventType: "Stop")
+        let roster = try await fleetEvent
+        XCTAssertEqual(roster.eventID, "both-2")
+    }
+
+    /// The next `fleet/message_event`, or a FAILURE within `timeout`.
+    ///
+    /// Bounded, unlike its `nextFleetEvent` sibling, because the thing it waits
+    /// for is a push that has to be REGISTERED daemon-side: the failure mode
+    /// under test is one where the notification simply never comes, and an
+    /// unbounded await turns that into a suite that hangs instead of a test
+    /// that fails.
+    private static func nextMessageEvent(
+        from stream: AsyncStream<FleetIncoming>,
+        timeout: Duration = .seconds(5)
+    ) async throws -> FleetMessageEventParams {
+        try await withThrowingTaskGroup(of: FleetMessageEventParams?.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                while let incoming = await iterator.next() {
+                    if case let .messageEvent(event) = incoming {
+                        return event
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                return nil
+            }
+            let first = try await group.next() ?? nil
+            group.cancelAll()
+            guard let event = first else {
+                throw MissingChatNotification()
+            }
+            return event
+        }
+    }
+
+    /// Named rather than reusing `FleetConnectionError.closed`, so the failure
+    /// says which subscription did not deliver instead of reading like a socket
+    /// that hung up.
+    private struct MissingChatNotification: Error, CustomStringConvertible {
+        var description: String {
+            "no fleet/message_event arrived on the subscribed connection"
+        }
+    }
+
     private static func nextFleetEvent(from stream: AsyncStream<FleetIncoming>) async throws -> FleetEvent {
         var iterator = stream.makeAsyncIterator()
         while let incoming = await iterator.next() {

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/ChatPaneJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/ChatPaneJourneyTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+/// The copilot conversation, driven through the real app against the real
+/// daemon fixture.
+///
+/// Nothing had ever opened this pane. Every other proof of it is a unit test
+/// against the store or a contract test against the wire, and both of those
+/// pass perfectly well while the surface is unreachable or dark. These two
+/// journeys are the only place the pane itself is asserted on.
+final class ChatPaneJourneyTests: FleetUITestCase {
+    /// Opening Chat resolves a scope AND a recipient, so the composer can send.
+    ///
+    /// This is the assertion that would have caught the bug PR 875 fixed at the
+    /// pane instead of at the wire: a scope resolved but no session minted
+    /// leaves the pane looking populated while Send is dead and the daemon's
+    /// refusal sits in a caption nobody reads.
+    @MainActor
+    func testChatRouteResolvesAScopeAndALiveComposer() throws {
+        launchExpandedNotch()
+        openChatRoute()
+
+        waitFor(app.staticTexts["fleet.chat.scope"])
+        XCTAssertFalse(
+            app.otherElements["fleet.chat.unavailable"].exists,
+            "the fixture daemon serves chat, so the pane must not be in its unavailable state. \(app.debugDescription)"
+        )
+        // The daemon's refusal caption. Present only when the copilot session
+        // could NOT be resolved, which is exactly the dead-Send state.
+        XCTAssertFalse(
+            app.staticTexts["fleet.chat.session-detail"].exists,
+            "the copilot session was refused: \(app.staticTexts["fleet.chat.session-detail"].label)"
+        )
+
+        let composer = chatComposer()
+        waitFor(composer)
+        composer.click()
+        composer.typeText("what is blocked?")
+
+        let send = app.buttons["fleet.chat.send"]
+        waitFor(send)
+        XCTAssertTrue(
+            send.isEnabled,
+            "Send stayed dead, so the pane resolved no recipient. \(app.debugDescription)"
+        )
+    }
+
+    /// A message filed by SOMEBODY ELSE appears without the pane being
+    /// refreshed by hand.
+    ///
+    /// The whole of PR B, observed from outside the app. The writer is a second
+    /// connection on the same socket, standing in for the copilot, the terminal
+    /// UI or another window, and Refresh is never clicked.
+    ///
+    /// The clock is the load-bearing part. The pane's own safety-net page runs
+    /// thirty seconds apart (`fleetChatSafetyNetInterval`), so an assertion that
+    /// took longer than that could be satisfied by a poll and would prove
+    /// nothing about the push. The elapsed time is asserted, not assumed.
+    @MainActor
+    func testACommittedMessageArrivesWithoutTouchingRefresh() throws {
+        launchExpandedNotch()
+        openChatRoute()
+
+        // The bootstrap page has run: the scope is resolved and the timeline is
+        // empty. Everything after this point is the stream's work.
+        waitFor(app.staticTexts["fleet.chat.scope"])
+        waitFor(app.staticTexts["fleet.chat.timeline.empty"])
+        let pagedAt = Date()
+
+        let client = try FleetChatClient(home: fixture.home)
+        let messageID = try client.sendToCopilotChannel(text: "pushed without a poll")
+
+        let row = app.descendants(matching: .any)["fleet.chat.message.\(messageID)"]
+        XCTAssertTrue(
+            row.waitForExistence(timeout: 8),
+            "a message committed by another client never reached the open pane. \(app.debugDescription)"
+        )
+        // Twenty, not thirty. Thirty is the safety-net interval itself, so a
+        // run that landed at 29.9 seconds would pass while proving nothing: the
+        // page could have been the thing that delivered the row. The margin is
+        // what makes this assertion mean "the stream did it". A healthy run
+        // takes a couple of seconds, so the margin costs nothing.
+        XCTAssertLessThan(
+            Date().timeIntervalSince(pagedAt), 20,
+            "the row arrived too close to a safety-net page to prove the stream delivered it"
+        )
+        XCTAssertFalse(
+            app.staticTexts["fleet.chat.timeline.empty"].exists,
+            "the empty placeholder outlived the message that filled the timeline"
+        )
+
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "chat-pane-live-push"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+
+    // MARK: - Helpers
+
+    /// Move the notch to its Chat route.
+    ///
+    /// A RADIO GROUP, not a segmented control. A SwiftUI `Picker` with
+    /// `.pickerStyle(.segmented)` is published to the accessibility tree as a
+    /// `RadioGroup` of `RadioButton`s on this platform; `app.segmentedControls`
+    /// matches nothing at all. That mismatch is what
+    /// `MenuBarRosterJourneyTests` was failing on, and it is a stale query
+    /// rather than anything wrong with the control, which carries its
+    /// identifier and its labels correctly.
+    @MainActor
+    private func openChatRoute(file: StaticString = #filePath, line: UInt = #line) {
+        let chat = app.radioGroups["fleet.notch.route"].radioButtons["Chat"]
+        guard chat.waitForExistence(timeout: 8) else {
+            return XCTFail("no Chat route control in the notch. \(app.debugDescription)", file: file, line: line)
+        }
+        chat.click()
+    }
+
+    /// The composer, which is a vertical `TextField` and so can present as
+    /// either a text field or a text view depending on the run.
+    @MainActor
+    private func chatComposer() -> XCUIElement {
+        let field = app.textFields["fleet.chat.composer"]
+        return field.exists ? field : app.textViews["fleet.chat.composer"]
+    }
+}
+

--- a/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
+++ b/apps/ainb-fleet-macos/UITests/ShellJourneys/MenuBarRosterJourneyTests.swift
@@ -42,7 +42,16 @@ final class MenuBarRosterJourneyTests: FleetUITestCase {
         let notch = app.buttons["fleet.notch"]
         waitFor(notch)
         notch.click()
-        app.segmentedControls["fleet.notch.route"].buttons["Needs you"].click()
+        // A RADIO GROUP, not a segmented control. A SwiftUI `Picker` with
+        // `.pickerStyle(.segmented)` is published to the accessibility tree as
+        // a `RadioGroup` of `RadioButton`s on this platform, and
+        // `app.segmentedControls` matches nothing at all, which is why this
+        // line used to fail with "No match" while the control was on screen,
+        // correctly identified and correctly labelled. The route control was
+        // never broken; the query was.
+        let route = app.radioGroups["fleet.notch.route"].radioButtons["Needs you"]
+        waitFor(route)
+        route.click()
         waitFor(app.buttons["fleet.notch.row.codex:ask"])
         XCTAssertFalse(app.buttons["fleet.notch.row.claude:active"].exists)
         waitFor(app.staticTexts["fleet.notch.detail.codex:ask"])

--- a/apps/ainb-fleet-macos/UITests/Support/FleetChatClient.swift
+++ b/apps/ainb-fleet-macos/UITests/Support/FleetChatClient.swift
@@ -1,0 +1,185 @@
+import Darwin
+import Foundation
+
+/// A second client on the fixture daemon's socket, for the journey that has to
+/// prove the app hears about somebody ELSE's message.
+///
+/// This exists because the fixture daemon's stdin protocol only injects hook
+/// observations (`seed`) and shutdown; there is no command that files a chat
+/// message. The push journey needs a writer that is not the app, so it opens
+/// its own connection, exactly as the copilot, the terminal UI or a second
+/// window would.
+///
+/// Deliberately NOT the app's `FleetConnection`. The UI test bundle runs out of
+/// process and links none of the app's sources, and reaching for them would
+/// couple a journey to the implementation it is meant to observe from outside.
+/// It is a blocking client on the calling thread, which is what a test wants:
+/// every call is request, wait, response, in order, on one socket.
+final class FleetChatClient {
+    private let descriptor: Int32
+    private var buffer = Data()
+    private var nextRequestID = 1
+
+    /// Connect, authenticate with the daemon's own token file, and negotiate.
+    ///
+    /// The token is read from disk rather than passed in, so the client cannot
+    /// disagree with the daemon about which home it is talking to.
+    init(home: URL) throws {
+        let socketPath = home.appendingPathComponent("hangar.sock").path
+        descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw ClientError.socket(errno) }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let path = Array(socketPath.utf8)
+        guard path.count + 1 <= MemoryLayout.size(ofValue: address.sun_path) else {
+            Darwin.close(descriptor)
+            throw ClientError.socket(ENAMETOOLONG)
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            destination.initializeMemory(as: UInt8.self, repeating: 0)
+            destination.copyBytes(from: path)
+        }
+        let length = socklen_t(MemoryLayout<sa_family_t>.size + path.count + 1)
+        let connected = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, length)
+            }
+        }
+        guard connected == 0 else {
+            Darwin.close(descriptor)
+            throw ClientError.socket(errno)
+        }
+
+        let token = try String(contentsOf: home.appendingPathComponent("hangar/daemon.token"), encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try call("auth/hello", ["token": token])
+        _ = try call("fleet/negotiate", [
+            "client_name": "fleet-ui-journey",
+            "client_version": "0.1.0",
+            "read_versions": ["min": 1, "max": 2],
+            "write_versions": ["min": 1, "max": 2],
+        ])
+    }
+
+    deinit { Darwin.close(descriptor) }
+
+    /// File one message into the copilot conversation the APP already opened.
+    ///
+    /// It resolves rather than creates: the channel is the newest copilot one
+    /// on the daemon, which is the one the app's own page created or found, and
+    /// the recipient is resolved by an idempotent create naming neither
+    /// `provider` nor `cwd`, which the daemon answers with the session already
+    /// held on that scope. Creating a second channel here would file the
+    /// message in a conversation the app is not showing, and the journey would
+    /// fail for a reason that has nothing to do with the push.
+    @discardableResult
+    func sendToCopilotChannel(text: String) throws -> String {
+        let channels = try call("fleet/channel_list", [:])["channels"] as? [[String: Any]] ?? []
+        guard let channel = channels.last(where: { $0["kind"] as? String == "copilot" }),
+              let scope = channel["scope_key"] as? String else {
+            throw ClientError.noCopilotChannel
+        }
+        let session = try call("fleet/acp_session_create", ["scope_key": scope])
+        guard let target = session["session_key"] as? String else {
+            throw ClientError.noCopilotSession
+        }
+        let sent = try call("fleet/message_send", [
+            "scope_key": scope,
+            "targets": [target],
+            "text": text,
+            "request_id": UUID().uuidString,
+        ])
+        guard let id = sent["message_id"] as? String else {
+            throw ClientError.noMessageID
+        }
+        return id
+    }
+
+    private func call(_ method: String, _ params: [String: Any]) throws -> [String: Any] {
+        let id = nextRequestID
+        nextRequestID += 1
+        let body = try JSONSerialization.data(withJSONObject: [
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params,
+        ])
+        var frame = Data("Content-Length: \(body.count)\r\n\r\n".utf8)
+        frame.append(body)
+        try write(frame)
+
+        // This client holds no subscription, so every frame it reads is the
+        // answer to the one request outstanding.
+        let response = try readFrame()
+        if let failure = response["error"] as? [String: Any] {
+            throw ClientError.rpc(method, String(describing: failure))
+        }
+        return response["result"] as? [String: Any] ?? [:]
+    }
+
+    private func write(_ data: Data) throws {
+        try data.withUnsafeBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            var written = 0
+            while written < bytes.count {
+                let result = Darwin.write(descriptor, base.advanced(by: written), bytes.count - written)
+                if result > 0 {
+                    written += result
+                } else if result < 0, errno == EINTR {
+                    continue
+                } else {
+                    throw ClientError.socket(errno)
+                }
+            }
+        }
+    }
+
+    private func readFrame() throws -> [String: Any] {
+        var chunk = [UInt8](repeating: 0, count: 16 * 1024)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if let frame = try takeFrame() {
+                return try JSONSerialization.jsonObject(with: frame) as? [String: Any] ?? [:]
+            }
+            let count = Darwin.read(descriptor, &chunk, chunk.count)
+            if count > 0 {
+                buffer.append(contentsOf: chunk[0..<count])
+                continue
+            }
+            if count == 0 { throw ClientError.disconnected }
+            if errno != EINTR { throw ClientError.socket(errno) }
+        }
+        throw ClientError.timedOut
+    }
+
+    private func takeFrame() throws -> Data? {
+        guard let header = buffer.range(of: Data("\r\n\r\n".utf8)),
+              let text = String(data: buffer[..<header.lowerBound], encoding: .ascii),
+              let lengthText = text.split(separator: ":").last,
+              let length = Int(lengthText.trimmingCharacters(in: .whitespaces)) else { return nil }
+        let end = header.upperBound + length
+        guard buffer.count >= end else { return nil }
+        let body = buffer.subdata(in: header.upperBound..<end)
+        buffer.removeSubrange(..<end)
+        return body
+    }
+
+    enum ClientError: LocalizedError {
+        case socket(Int32)
+        case disconnected
+        case timedOut
+        case rpc(String, String)
+        case noCopilotChannel
+        case noCopilotSession
+        case noMessageID
+
+        var errorDescription: String? {
+            switch self {
+            case let .socket(code): "fleet chat client socket failed: \(code)"
+            case .disconnected: "the daemon closed the chat client's connection"
+            case .timedOut: "the daemon did not answer the chat client"
+            case let .rpc(method, failure): "\(method) refused: \(failure)"
+            case .noCopilotChannel: "the daemon has no copilot channel; the app never opened one"
+            case .noCopilotSession: "the copilot scope holds no session; the app never minted one"
+            case .noMessageID: "the daemon accepted the send without naming a message"
+            }
+        }
+    }
+}

--- a/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
+++ b/apps/ainb-fleet-macos/UITests/Support/FleetUITestCase.swift
@@ -1,5 +1,37 @@
 import XCTest
 
+/// Base for the shell journeys, which drive the REAL app against a fixture
+/// daemon rather than a mock.
+///
+/// These do not run in CI, and the attempt is recorded here so nobody repeats
+/// it. A GitHub-hosted macOS runner has no usable GUI session for a real app:
+/// the launch hangs for around two minutes and then fails with "Application
+/// 'dev.ainb.fleet' does not have a process ID", and it does so for every
+/// journey, including ones that pass locally in seconds. Signing is not the
+/// problem, and a UI runner does need signing, so the step cannot simply borrow
+/// the CODE_SIGNING_ALLOWED=NO the unit step above it uses.
+///
+/// Run them by hand, from the repository root:
+///
+///     xcodebuild test \
+///       -project apps/ainb-fleet-macos/AINBFleet.xcodeproj \
+///       -scheme FleetUITests \
+///       -destination 'platform=macOS'
+///
+/// Two things the machine needs first. The terminal invoking xcodebuild must be
+/// allowed under Privacy and Security, Accessibility, or every journey dies at
+/// "Timed out while enabling automation mode" before a single test is selected.
+/// And when that timeout appears anyway on a machine that has the permission,
+/// `testmanagerd` is wedged: kill it by its exact process id, let launchd
+/// restart it, and re-run. That happened twice in one session while these
+/// journeys were being written.
+///
+/// The fixture daemon binary is resolved as
+/// `<repo>/ainb-tui/target/debug/examples/fleet_fixture_daemon`, so build it
+/// first. `AINB_FLEET_FIXTURE_DAEMON` is read by the runner process but does
+/// NOT survive being set in the shell that invokes xcodebuild; symlink the
+/// binary into place instead.
+
 class FleetUITestCase: XCTestCase {
     var fixture: FleetFixtureDaemon!
     var app: XCUIApplication!


### PR DESCRIPTION
## What this does

The notch's copilot chat pane ran up to five RPCs a second while open, and still lagged a real message by up to a second. It now folds the daemon's pushed events, with a thirty-second page kept only as a safety net.

Two things surfaced while building it, both fixed here.

## The pane was unreachable

`FleetWindowView` is dead code. Its only instantiation was deleted on 2026-08-07 in `3a0b2ac8`, and the chat pane landed on 2026-08-10, three days later, behind a button inside it. So PR #875 fixed a real copilot-attach bug in a surface no operator could open, and nothing had ever clicked this pane.

Chat becomes a fifth notch route, matching how Usage and Settings are already reached. The pane's Close moves from the environment's `dismiss`, which silently does nothing outside a sheet, to an injected closure, so the pane renders wherever it is put.

The remaining ten stranded surfaces in that file are deliberately untouched. A follow-up deletes it, after moving out the three symbols the notch still needs.

## An uncursored message list returned the oldest page

`list_by_scope` is `seq > ? ORDER BY seq ASC LIMIT ?`, and the cursor collapsed an absent `after_id` to zero. Both clients page that way, so a copilot conversation past the limit showed its opening and never its tail. With live push that becomes destructive: every safety-net page would have replaced the live tail with the start of the conversation.

`tail_by_scope` now sits beside the forward walk with the dispatch arm choosing, so cursored paging is untouched by construction. This fixes the terminal client at the same time.

## Three things the longer interval made load-bearing

The one-second poll used to paper over all of these within a second.

- A page disowned by a newer invalidation is dropped whole rather than published, so a stale read cannot aim the composer at a session already reported gone.
- Events arriving mid-page are buffered and replayed onto that page's result, including during the opening page, when the surface has no scope yet.
- The fold is gated on the pane being open, so copilot traffic cannot invalidate the roster and the menu bar while the operator is looking at Sessions.

## Tests

| Suite | Result |
|---|---|
| `FleetRPCTests` | 196 passed |
| `FleetUITests` (full scheme) | 9 passed |
| `cargo test -p ainb-hangar-store --lib` | 324 passed |
| `cargo test -p ainb-hangar-daemon --test rpc_message_bus` | 26 passed |
| `xcodebuild build -configuration Debug` | succeeded |

Every number above was reproduced independently of the author, against a fixture daemon rebuilt from the changed Rust, because a stale fixture makes a contract suite green about the old daemon.

Each significant fix was falsified before being kept: reverting the tail read fails both paging tests, removing the disown guard paints a stale page over the surface, dropping the first-page buffer clause loses a message committed during the opening page, and making the store ignore message events fails the push journey.

## CI now runs the journeys

The contract job ran one scheme, whose test action lists the RPC suite alone, so every UI test here was invisible to CI. That is how the pane stayed unreachable for a month behind a green pipeline. A journey step is added, and the pre-existing roster failure it would have hit is fixed: a segmented `Picker` is published to macOS accessibility as a RadioGroup, so the journey's `segmentedControls` query matched nothing while the control sat on screen. The control was never broken. No assertion was weakened.

## Known risk

Enabling automation mode timed out twice locally, cleared both times by killing `testmanagerd`. A CI runner has nobody to do that, so the new journey step may prove flaky. Worth watching over its first few runs rather than assuming.

## Deferred, not fixed

The chat notification forwarder drops frames silently on a lagged receiver, which is why the safety net stays rather than being deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Chat route to the Fleet macOS app.
  - Chat now receives new messages, confirmations, and activity updates in real time.
  - Closing Chat returns you to the route you were previously viewing.
  - Chat composer and message rows provide improved accessibility support.

- **Bug Fixes**
  - Uncursored conversation views now open at the newest messages.
  - Chat refreshes preserve current content during temporary errors or stale results.
  - Malformed live chat events no longer interrupt the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->