### PR TITLE
fix: the hangar gate was calling every liveness probe a foreign-uid peer

### DIFF
--- a/ainb-tui/crates/ainb-core/src/components/daemons.rs
+++ b/ainb-tui/crates/ainb-core/src/components/daemons.rs
@@ -55,6 +55,21 @@ const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 /// connect and `sysinfo` process lookups — work that must NEVER run on the UI
 /// render thread (H-D2). A few seconds keeps the screen live while staying cheap.
 const COLLECT_INTERVAL: Duration = Duration::from_secs(2);
+/// How long the collector keeps polling after the screen last asked it for
+/// anything, before it parks itself.
+///
+/// It used to be forever. Opening the Daemons screen ONCE armed a thread that
+/// re-probed every daemon socket every two seconds for the rest of the
+/// process's life — including the hours after the operator navigated away and
+/// the whole time the TUI was suspended behind a tmux attach. On one real
+/// session that was ~25 connects a minute to `hangar.sock` for three hours from
+/// a single visit to the screen, none of which anything was going to read.
+///
+/// Comfortably longer than any render gap the screen can have while it is
+/// actually on view (the TUI redraws far faster than this), so parking cannot
+/// interrupt a screen someone is looking at; short enough that walking away
+/// stops the polling within one screenful of time.
+const COLLECT_IDLE_STOP_MS: i64 = 30_000;
 /// Evidence needs fresh process checks, unlike daemon rows. Avoid one `ps` per
 /// historical probe on every screen refresh.
 const EVIDENCE_INTERVAL_MS: i64 = 30_000;
@@ -92,6 +107,18 @@ pub struct Snapshot {
     /// one a switch would act on), or the meta will not parse. The mode toggle
     /// and the inline help are both hidden in that case rather than guessing.
     pub atc: Option<AtcModeView>,
+    /// When the UI thread last reached for this snapshot. The collector reads
+    /// it to decide whether anyone is still watching.
+    last_touch_ms: i64,
+    /// Set by the collector on its way out, cleared by whoever spawns the next
+    /// one. Lives inside the snapshot's mutex rather than in a separate atomic
+    /// so "is a collector running?" and "when was it last wanted?" are read and
+    /// written under ONE lock — that is what makes at-most-one-collector an
+    /// invariant instead of a race.
+    ///
+    /// Defaults to "not parked" so a test seam that installs a pre-seeded
+    /// snapshot (see `seeded_state`) still never spawns the real collector.
+    collector_parked: bool,
 }
 
 /// What the Daemons screen needs to know about the ATC supervisor beyond its
@@ -284,19 +311,49 @@ impl DaemonsState {
     ///
     /// The collector seeds an immediate first collect (so the screen is populated
     /// within one interval of opening), then re-collects every [`COLLECT_INTERVAL`]
-    /// for the lifetime of the process. It is intentionally a detached daemon
-    /// thread — the snapshot is the only shared state and it is best-effort, so
-    /// there is nothing to join on teardown.
+    /// for as long as the screen keeps asking. It is intentionally a detached
+    /// daemon thread — the snapshot is the only shared state and it is
+    /// best-effort, so there is nothing to join on teardown.
+    ///
+    /// Every call through here is the UI thread saying "I still want this",
+    /// which is what keeps the collector alive and what revives it after a park.
     fn shared(&mut self) -> Arc<Mutex<Snapshot>> {
         if let Some(shared) = &self.shared {
-            return Arc::clone(shared);
+            let shared = Arc::clone(shared);
+            if Self::touch(&shared, now_ms()) {
+                self.spawn_collector_for(&shared);
+            }
+            return shared;
         }
-        let shared = Arc::new(Mutex::new(Snapshot::default()));
-        let (wake, wake_rx) = std::sync::mpsc::channel();
-        spawn_collector(Arc::clone(&shared), wake_rx);
-        self.wake = Some(wake);
+        let shared = Arc::new(Mutex::new(Snapshot {
+            last_touch_ms: now_ms(),
+            ..Snapshot::default()
+        }));
+        self.spawn_collector_for(&shared);
         self.shared = Some(Arc::clone(&shared));
         shared
+    }
+
+    /// Record that the UI thread wants the snapshot, and claim the right to
+    /// spawn a collector if the last one parked. Returns `true` when the caller
+    /// must spawn.
+    ///
+    /// The claim and the timestamp are one critical section on purpose. Whoever
+    /// takes the lock first wins cleanly: if the UI wins, the collector reads a
+    /// fresh `last_touch_ms` and does not park; if the collector wins, it parks
+    /// and the UI sees `collector_parked` and revives it. `collector_parked` is
+    /// only ever set by a collector about to return and only ever cleared here,
+    /// so at most one collector can be live at a time.
+    fn touch(shared: &Mutex<Snapshot>, now: i64) -> bool {
+        let mut guard = shared.lock().unwrap_or_else(|p| p.into_inner());
+        guard.last_touch_ms = now;
+        std::mem::take(&mut guard.collector_parked)
+    }
+
+    fn spawn_collector_for(&mut self, shared: &Arc<Mutex<Snapshot>>) {
+        let (wake, wake_rx) = std::sync::mpsc::channel();
+        spawn_collector(Arc::clone(shared), wake_rx);
+        self.wake = Some(wake);
     }
 
     /// Ask the collector to re-collect now. The table free-runs anyway, so this
@@ -558,6 +615,8 @@ impl DaemonsState {
             evidence_census: guard.evidence_census,
             evidence_collected_at_ms: guard.evidence_collected_at_ms,
             atc: guard.atc.clone(),
+            last_touch_ms: guard.last_touch_ms,
+            collector_parked: guard.collector_parked,
         }
     }
 }
@@ -767,9 +826,16 @@ fn collect_atc_mode() -> Option<AtcModeView> {
     })
 }
 
+/// Has the screen stopped asking for snapshots long enough that the collector
+/// should stop producing them? Pure so the window is testable without threads.
+fn collector_should_park(last_touch_ms: i64, now_ms: i64) -> bool {
+    now_ms.saturating_sub(last_touch_ms) > COLLECT_IDLE_STOP_MS
+}
+
 /// Spawn the detached background collector: one immediate collect, then a collect
-/// every [`COLLECT_INTERVAL`] forever. Keeps ALL disk I/O / socket connects off
-/// the UI render thread (H-D2).
+/// every [`COLLECT_INTERVAL`] for as long as the screen keeps reaching for the
+/// snapshot. Keeps ALL disk I/O / socket connects off the UI render thread
+/// (H-D2).
 fn spawn_collector(shared: Arc<Mutex<Snapshot>>, wake: std::sync::mpsc::Receiver<()>) {
     std::thread::Builder::new()
         .name("ainb-daemons-collect".into())
@@ -785,6 +851,14 @@ fn spawn_collector(shared: Arc<Mutex<Snapshot>>, wake: std::sync::mpsc::Receiver
                     // The screen's state was dropped; nothing will read another
                     // snapshot.
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+                }
+                // Park when nobody has looked at the snapshot for a while. The
+                // flag is set under the same lock that publishes it, so the
+                // next `shared()` sees a parked collector and revives it.
+                let mut guard = shared.lock().unwrap_or_else(|p| p.into_inner());
+                if collector_should_park(guard.last_touch_ms, now_ms()) {
+                    guard.collector_parked = true;
+                    return;
                 }
             }
         })
@@ -1562,6 +1636,51 @@ mod tests {
         assert_eq!(daemon_version_label(&daemon).0, "999.0.0 newer");
     }
 
+    /// The collector used to run "for the lifetime of the process": one visit
+    /// to this screen armed a thread that re-probed every daemon socket every
+    /// two seconds until the TUI exited. A real session logged ~25 connects a
+    /// minute to the hangar daemon for three hours off a single navigation.
+    #[test]
+    fn a_screen_nobody_is_watching_stops_polling() {
+        let armed = 10_000;
+        assert!(
+            !collector_should_park(armed, armed + COLLECT_IDLE_STOP_MS),
+            "a screen still on view must keep collecting"
+        );
+        assert!(
+            collector_should_park(armed, armed + COLLECT_IDLE_STOP_MS + 1),
+            "past the idle window the collector must park"
+        );
+        assert!(
+            collector_should_park(armed, armed + 3 * 60 * 60 * 1_000),
+            "three hours after the last look, nothing should still be probing"
+        );
+    }
+
+    /// Parking is only useful if coming back works, and only SAFE if coming
+    /// back twice does not leave two collectors racing the same snapshot.
+    #[test]
+    fn a_parked_collector_is_revived_exactly_once() {
+        let shared = Mutex::new(Snapshot {
+            collector_parked: true,
+            ..Snapshot::default()
+        });
+        assert!(
+            DaemonsState::touch(&shared, 1_000),
+            "re-entering the screen must revive a parked collector"
+        );
+        assert!(
+            !DaemonsState::touch(&shared, 2_000),
+            "a live collector must not be spawned a second time"
+        );
+        let guard = shared.lock().unwrap();
+        assert_eq!(
+            guard.last_touch_ms, 2_000,
+            "every touch refreshes the clock"
+        );
+        assert!(!guard.collector_parked);
+    }
+
     /// A `DaemonsState` whose background collector is pre-empted: the shared
     /// snapshot is seeded with `rows` and the `shared` handle is installed, so
     /// `render`/`snapshot` read the seed and never spawn the real collector.
@@ -1574,6 +1693,8 @@ mod tests {
             hook_health: None,
             evidence_census: None,
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         }));
         DaemonsState {
             shared: Some(shared),
@@ -1599,6 +1720,8 @@ mod tests {
             hook_health: None,
             evidence_census: None,
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         }));
         DaemonsState {
             shared: Some(shared),
@@ -1616,6 +1739,8 @@ mod tests {
             hook_health: Some(hook_health()),
             evidence_census: None,
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         }));
         DaemonsState {
             shared: Some(shared),
@@ -1681,6 +1806,8 @@ mod tests {
             hook_health: None,
             evidence_census: None,
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         };
         assert_eq!(
             atc_help_lines(&snapshot, 0),
@@ -1700,6 +1827,8 @@ mod tests {
             hook_health: None,
             evidence_census: None,
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         };
         assert!(atc_help_lines(&snapshot, 0).is_empty(), "bridge row");
         assert!(!atc_help_lines(&snapshot, 1).is_empty(), "atc row");
@@ -1887,6 +2016,8 @@ mod tests {
             hook_health: Some(hook_health),
             evidence_census: Some(EvidenceCensus::from_counts(true, 1, 1)),
             evidence_collected_at_ms: 0,
+            last_touch_ms: now_ms(),
+            collector_parked: false,
         }));
         DaemonsState {
             shared: Some(shared),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/auth.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/auth.rs
@@ -213,10 +213,63 @@ pub fn write_token_file(path: &Path, plaintext: &str) -> std::io::Result<()> {
 ///
 /// # Errors
 ///
-/// Propagates the `getsockopt` failure (the caller treats it as a rejection).
+/// Propagates the `getsockopt` failure. Callers must go through
+/// [`PeerGate::classify`] rather than collapsing that error into `false`: a
+/// credential the daemon could not READ is a different fact from a credential
+/// that names someone else, and only one of them is worth an operator's
+/// attention.
 pub fn same_uid_peer(stream: &tokio::net::UnixStream) -> std::io::Result<bool> {
     let cred = stream.peer_cred()?;
     Ok(cred.uid() == nix::unistd::Uid::current().as_raw())
+}
+
+/// What the peer-credential gate concluded about one accepted connection.
+///
+/// Three outcomes, not two, because the gate has always had three and the
+/// missing one was being reported as the alarming one. `same_uid_peer(..)
+/// .unwrap_or(false)` folded a FAILED credential read into "foreign uid", so
+/// the daemon logged an intrusion-shaped warning for a case that carries no
+/// identity claim at all.
+///
+/// On macOS that case is not exotic, it is the norm. tokio's `peer_cred` reads
+/// `LOCAL_PEEREPID` first, and that `getsockopt` returns `ENOTCONN` the instant
+/// the peer disconnects — so every connect-and-drop liveness probe (the shape
+/// `socket_is_listening` uses to ask "is anyone accepting?") loses the race
+/// against the accepting task and is charged as a foreign-uid peer. A real
+/// mismatch then hides inside thousands of lines describing something that
+/// never happened.
+///
+/// All three outcomes still fail CLOSED: only [`Self::SameUid`] is served.
+/// This type changes what the daemon SAYS, never what it allows.
+#[derive(Debug)]
+pub enum PeerGate {
+    /// The kernel named this process's own uid. Serve the connection.
+    SameUid,
+    /// The kernel named a DIFFERENT uid. A genuine refusal, and the only
+    /// outcome that deserves a warning.
+    ForeignUid,
+    /// The credentials could not be read, so the peer's uid was never
+    /// established. Closed unverified — but not accused of anything.
+    Unreadable(std::io::Error),
+}
+
+impl PeerGate {
+    /// Map a [`same_uid_peer`] read onto the three outcomes. Split out from
+    /// [`classify_peer`] so the mapping is testable without a socket pair.
+    #[must_use]
+    pub fn classify(read: std::io::Result<bool>) -> Self {
+        match read {
+            Ok(true) => Self::SameUid,
+            Ok(false) => Self::ForeignUid,
+            Err(e) => Self::Unreadable(e),
+        }
+    }
+}
+
+/// Read one accepted connection's peer credentials and classify them.
+#[must_use]
+pub fn classify_peer(stream: &tokio::net::UnixStream) -> PeerGate {
+    PeerGate::classify(same_uid_peer(stream))
 }
 
 /// Validate a connection's first frame: it must be a well-formed `auth/hello`
@@ -288,6 +341,73 @@ fn unauthorized(id: RpcId, message: &str) -> RpcResponse {
 mod tests {
     use super::*;
     use ainb_hangar_store::Store;
+
+    /// The gate's three outcomes stay three. The regression this pins is the
+    /// old `same_uid_peer(..).unwrap_or(false)`, which collapsed a failed
+    /// credential READ onto the same branch as a uid that named someone else —
+    /// so the daemon warned about a foreign-uid peer for a connection that had
+    /// made no identity claim at all.
+    #[test]
+    fn a_credential_read_fault_is_not_a_foreign_uid() {
+        let fault = std::io::Error::from(std::io::ErrorKind::NotConnected);
+        assert!(
+            matches!(PeerGate::classify(Err(fault)), PeerGate::Unreadable(_)),
+            "an unreadable credential must not be reported as a foreign uid"
+        );
+    }
+
+    /// The real refusal still reads as a refusal — the fix must not soften the
+    /// one case an operator is meant to see.
+    #[test]
+    fn a_uid_mismatch_is_still_a_foreign_uid() {
+        assert!(matches!(
+            PeerGate::classify(Ok(false)),
+            PeerGate::ForeignUid
+        ));
+    }
+
+    /// Only our own uid is served.
+    #[test]
+    fn our_own_uid_is_served() {
+        assert!(matches!(PeerGate::classify(Ok(true)), PeerGate::SameUid));
+    }
+
+    /// macOS only, because this is a macOS kernel behaviour: tokio's
+    /// `peer_cred` reads `LOCAL_PEEREPID` before `getpeereid`, and that
+    /// `getsockopt` fails `ENOTCONN` once the peer has disconnected. Linux's
+    /// `SO_PEERCRED` latches the credentials and keeps answering, so there is
+    /// nothing to assert there.
+    ///
+    /// This is the live case: a probe from THIS uid that hangs up before the
+    /// accepting task reads its credentials. It must classify as unreadable,
+    /// never as a foreign uid.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn a_same_uid_peer_that_hung_up_first_is_unreadable_not_foreign() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gate.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        let client = tokio::net::UnixStream::connect(&path).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        // While the peer is still there its uid reads fine: this is us.
+        assert!(
+            matches!(classify_peer(&server), PeerGate::SameUid),
+            "a live same-uid peer must be served"
+        );
+
+        drop(client);
+        // The disconnect is what breaks the credential read; give the kernel a
+        // moment to tear the pair down before asking again.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        match classify_peer(&server) {
+            PeerGate::Unreadable(e) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::NotConnected, "{e}");
+            }
+            other => panic!("a same-uid peer that hung up was classified {other:?}"),
+        }
+    }
 
     /// `ensure_socket_token` mints once and is then stable across calls: the
     /// digest in the database matches the sha256 of the on-disk plaintext, the

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -341,10 +341,24 @@ async fn serve_conn(
     broker: EventBroker,
 ) -> std::io::Result<()> {
     // Gate 1 — kernel peer credentials: only this user's processes may talk to
-    // the control plane. Reject + close on mismatch (or on a cred-read fault).
-    if !auth::same_uid_peer(&stream).unwrap_or(false) {
-        tracing::warn!("hangar rpc: rejected connection from foreign-uid peer");
-        return Ok(());
+    // the control plane. All three outcomes close the connection; they differ
+    // only in what the daemon claims happened. A cred-read fault used to be
+    // logged as a foreign-uid peer, which on macOS meant every connect-and-drop
+    // liveness probe was filed as an intrusion attempt — 25 a minute of them,
+    // drowning the one line that would mean something.
+    match auth::classify_peer(&stream) {
+        auth::PeerGate::SameUid => {}
+        auth::PeerGate::ForeignUid => {
+            tracing::warn!("hangar rpc: rejected connection from foreign-uid peer");
+            return Ok(());
+        }
+        auth::PeerGate::Unreadable(e) => {
+            tracing::debug!(
+                error = %e,
+                "hangar rpc: closed a connection whose peer credentials could not be read"
+            );
+            return Ok(());
+        }
     }
 
     let (read_half, mut write_half) = stream.into_split();


### PR DESCRIPTION
## What was happening

A live hangar daemon was logging, continuously and for over a day:

```
WARN ainb_hangar_daemon::rpc: hangar rpc: rejected connection from foreign-uid peer
```

4,000+ of them, ~25/minute, every 2.03 seconds. Nothing was actually being refused, and no foreign uid was involved.

## Two independent defects

**1. The gate reported the wrong thing.** `rpc/mod.rs` read `same_uid_peer(&stream).unwrap_or(false)`, folding a FAILED credential read onto the same branch as a credential naming someone else. On macOS the failed read is the normal case, not an edge case: tokio's `peer_cred` calls `getsockopt(LOCAL_PEEREPID)` before `getpeereid`, and that `getsockopt` returns `ENOTCONN` as soon as the peer disconnects. So any client that connects and hangs up before the accepting task reads its credentials is charged as a foreign-uid peer, regardless of who it actually was.

Verified against the running daemon: 30 connections from this uid closed immediately produced exactly 30 `foreign-uid` lines; 30 held open produced none.

Fix: classify the read into three outcomes (`SameUid` / `ForeignUid` / `Unreadable`) instead of two. All three still fail closed and only a same-uid peer is served — the security posture is unchanged. What changes is that an unread credential is logged as one, at debug, with its errno, so a genuine mismatch is no longer buried under thousands of lines describing something that never happened.

**2. The client never stopped.** The dialer was the Daemons screen's background collector (`COLLECT_INTERVAL = 2s`), whose `socket_is_listening` connects and drops. Its documented lifetime was "for the lifetime of the process": one navigation into the screen armed a thread that kept probing every daemon socket every two seconds forever, long after the operator navigated away and while the TUI was suspended behind a tmux attach.

The TUI log pins it exactly — one `Navigating to Daemons` at `19:32:17.932Z`, first rejection at `19:32:18.121Z`, still going three hours later, and no second navigation in the whole life of the process.

Fix: the collector parks after 30s with no UI-thread interest; the next touch revives it. The park claim and the last-touch clock share the snapshot's existing mutex, so whichever side takes the lock first wins cleanly and at most one collector is ever live.

## What was NOT broken

Functionally, nothing. `connect()` succeeded, so the probe got its answer and the Daemons screen showed the hangar daemon as serving. The damage was to log integrity (a security signal that cried wolf 4,000 times), a 40 MB stderr log, and a thread plus four socket probes every two seconds for a screen nobody was looking at.

## Tests

Both guards falsified before being restored:

- restoring `Err(_) => ForeignUid`: `a_same_uid_peer_that_hung_up_was_classified ForeignUid` — 2 RED
- restoring the never-parking collector: `past the idle window the collector must park` — 1 RED

Green after: `ainb-hangar-daemon --lib` 657 passed / 0 failed, `ainb --lib` 2384 passed / 0 failed. `cargo fmt --check` clean.

The macOS socket-pair test is `#[cfg(target_os = "macos")]` on purpose: Linux's `SO_PEERCRED` latches credentials and keeps answering after the peer closes, so there is nothing to assert there.