### PR TITLE
perf(hangar): skip the card pull when the profile has no cards

### DIFF
--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -200,48 +200,46 @@ impl PullService {
         idgen: &dyn IdGen,
         clock: &dyn HangarClock,
     ) -> Result<Option<PulledCard>, sqlx::Error> {
-        // Gate: a profile with no cards can never satisfy this statement, and
-        // paying a write lock to discover that is what wedged a real daemon.
+        // Gate: when THIS runtime has no pullable card, skip the write entirely.
         //
         // `PULL_SQL` is an INSERT, so `SQLite` takes the WRITE lock at statement
-        // start, before any predicate is evaluated. On a contended database a
-        // board-less profile therefore burnt the full `busy_timeout` (measured:
-        // 10.64s, every ~22s, `rows_affected=0` every time) queueing behind
-        // other writers for a statement whose driving table is EMPTY. Two of
-        // those per main-loop tick — this one and the claim behind it — is what
-        // took the daemon from a 1s poll to a ~22s one.
+        // start, before evaluating a single predicate. A daemon whose pull can
+        // never match therefore burnt the full `busy_timeout` on a contended
+        // database (measured: 10.64s, every ~22s, `rows_affected=0` every time)
+        // queueing behind other writers for nothing. Two of those per main-loop
+        // tick — this one and the claim behind it — is what took the daemon from
+        // a 1s poll to a ~22s one.
+        //
+        // SCOPED THE SAME WAY THE PULL IS. An unscoped "is `board_card` empty"
+        // check only helps a database with no cards at all; one card belonging
+        // to ANY other runtime would put every runtime back on the 10s wait. So
+        // this carries the pull's own runtime, archived and issue predicates.
+        // Every clause here is a strict SUBSET of `PULL_SQL`'s `WHERE`, which is
+        // what makes skipping safe: if this finds nothing, the superset cannot
+        // match either.
         //
         // The gate is a READ, and in WAL mode readers never wait for the write
         // lock, so it costs microseconds and cannot itself block. Checking is
         // strictly cheaper than the write it avoids.
         //
         // NOT cached, deliberately: the check IS its own invalidation. The first
-        // `board_card` row a profile ever gains makes this pass on the very next
+        // card this runtime can pull makes the pull resume on the very next
         // tick, with no daemon restart and no stale flag. This skips work that
         // cannot match; it does not disable boards.
-        // Gate: a profile with no cards can never satisfy this statement, and
-        // paying a write lock to discover that is what wedged a real daemon.
-        //
-        // `PULL_SQL` is an INSERT, so `SQLite` takes the WRITE lock at statement
-        // start, before any predicate is evaluated. On a contended database a
-        // board-less profile therefore burnt the full `busy_timeout` (measured:
-        // 10.64s, every ~22s, `rows_affected=0` every time) queueing behind
-        // other writers for a statement whose driving table is EMPTY. Two of
-        // those per main-loop tick — this one and the claim behind it — is what
-        // took the daemon from a 1s poll to a ~22s one.
-        //
-        // The gate is a READ, and in WAL mode readers never wait for the write
-        // lock, so it costs microseconds and cannot itself block. Checking is
-        // strictly cheaper than the write it avoids.
-        //
-        // NOT cached, deliberately: the check IS its own invalidation. The first
-        // `board_card` row a profile ever gains makes this pass on the very next
-        // tick, with no daemon restart and no stale flag. This skips work that
-        // cannot match; it does not disable boards.
-        let has_cards: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM board_card)")
-            .fetch_one(pool)
-            .await?;
-        if !has_cards {
+        let pullable: bool = sqlx::query_scalar(
+            "SELECT EXISTS( \
+                SELECT 1 FROM board_card AS bc \
+                  JOIN board AS bd ON bd.id = bc.board_id \
+                  JOIN agent AS a ON a.workspace_id = bd.workspace_id \
+                 WHERE a.runtime_id = ?1 \
+                   AND a.archived = 0 \
+                   AND (?2 IS NULL OR bc.issue_id = ?2))",
+        )
+        .bind(runtime_id)
+        .bind(only_issue)
+        .fetch_one(pool)
+        .await?;
+        if !pullable {
             return Ok(None);
         }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -214,9 +214,21 @@ impl PullService {
         // check only helps a database with no cards at all; one card belonging
         // to ANY other runtime would put every runtime back on the 10s wait. So
         // this carries the pull's own runtime, archived and issue predicates.
-        // Every clause here is a strict SUBSET of `PULL_SQL`'s `WHERE`, which is
-        // what makes skipping safe: if this finds nothing, the superset cannot
-        // match either.
+        //
+        // THE SAFETY PROPERTY IS `PULL_SQL` ⊆ GATE, AND IT IS DIRECTIONAL.
+        // This gate must stay LOOSER than `PULL_SQL`: every row the pull could
+        // insert must also satisfy this query. It is looser today because it
+        // omits `board_column`, `issue`, `col.services_role IS NOT NULL` and a
+        // dozen further filters that `PULL_SQL` carries.
+        //
+        // Two edits break it, both SILENTLY:
+        //   * ADDING a filter or a join here that `PULL_SQL` does not have, and
+        //   * REMOVING a filter from `PULL_SQL` that this still has.
+        // Either makes the gate reject a card the pull would have taken, and
+        // the failure is `Ok(None)` forever — a card that never gets pulled,
+        // with no error, no log line and nothing red. Widening `PULL_SQL` is
+        // always safe; widening the gate is not.
+        // `a_card_that_matches_the_pull_passes_the_gate` is the guard on this.
         //
         // The gate is a READ, and in WAL mode readers never wait for the write
         // lock, so it costs microseconds and cannot itself block. Checking is

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pull.rs
@@ -200,6 +200,51 @@ impl PullService {
         idgen: &dyn IdGen,
         clock: &dyn HangarClock,
     ) -> Result<Option<PulledCard>, sqlx::Error> {
+        // Gate: a profile with no cards can never satisfy this statement, and
+        // paying a write lock to discover that is what wedged a real daemon.
+        //
+        // `PULL_SQL` is an INSERT, so `SQLite` takes the WRITE lock at statement
+        // start, before any predicate is evaluated. On a contended database a
+        // board-less profile therefore burnt the full `busy_timeout` (measured:
+        // 10.64s, every ~22s, `rows_affected=0` every time) queueing behind
+        // other writers for a statement whose driving table is EMPTY. Two of
+        // those per main-loop tick — this one and the claim behind it — is what
+        // took the daemon from a 1s poll to a ~22s one.
+        //
+        // The gate is a READ, and in WAL mode readers never wait for the write
+        // lock, so it costs microseconds and cannot itself block. Checking is
+        // strictly cheaper than the write it avoids.
+        //
+        // NOT cached, deliberately: the check IS its own invalidation. The first
+        // `board_card` row a profile ever gains makes this pass on the very next
+        // tick, with no daemon restart and no stale flag. This skips work that
+        // cannot match; it does not disable boards.
+        // Gate: a profile with no cards can never satisfy this statement, and
+        // paying a write lock to discover that is what wedged a real daemon.
+        //
+        // `PULL_SQL` is an INSERT, so `SQLite` takes the WRITE lock at statement
+        // start, before any predicate is evaluated. On a contended database a
+        // board-less profile therefore burnt the full `busy_timeout` (measured:
+        // 10.64s, every ~22s, `rows_affected=0` every time) queueing behind
+        // other writers for a statement whose driving table is EMPTY. Two of
+        // those per main-loop tick — this one and the claim behind it — is what
+        // took the daemon from a 1s poll to a ~22s one.
+        //
+        // The gate is a READ, and in WAL mode readers never wait for the write
+        // lock, so it costs microseconds and cannot itself block. Checking is
+        // strictly cheaper than the write it avoids.
+        //
+        // NOT cached, deliberately: the check IS its own invalidation. The first
+        // `board_card` row a profile ever gains makes this pass on the very next
+        // tick, with no daemon restart and no stale flag. This skips work that
+        // cannot match; it does not disable boards.
+        let has_cards: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM board_card)")
+            .fetch_one(pool)
+            .await?;
+        if !has_cards {
+            return Ok(None);
+        }
+
         let task_id = idgen.new_ulid();
         let now = clock.now_ms();
 

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -1116,3 +1116,73 @@ async fn a_board_less_profile_never_reaches_for_the_write_lock() {
         ),
     }
 }
+
+/// A runtime with no pullable card of its own skips the write, even when the
+/// database holds cards belonging to SOMEONE ELSE.
+///
+/// The gate this pins used to be `SELECT EXISTS(SELECT 1 FROM board_card)`,
+/// which short-circuits only when the ENTIRE table is empty. `PULL_SQL` is
+/// scoped — `a.runtime_id = ?3` — so on any database with a single card owned
+/// by another runtime, every other runtime went straight back to paying the
+/// full 10s write-lock wait per tick. That version happened to work on the one
+/// profile it was diagnosed against, whose whole table was empty, and would
+/// have silently done nothing for anyone else.
+///
+/// Assertion is on the ERROR, not on elapsed time: the subject pool has
+/// `busy_timeout(0)`, so any statement reaching for the held write lock fails
+/// at once. `Ok(None)` is only reachable if the write was never attempted.
+#[tokio::test]
+async fn a_runtime_with_no_cards_skips_even_when_another_runtime_has_one() {
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+
+    // A fully populated, genuinely pullable card — owned by `rt-1`.
+    seed_world(store.pool()).await;
+    add_agent(store.pool(), "ag-1", "impl", 4).await;
+    add_column(store.pool(), "col-1", 1, Some("impl"), None, false).await;
+    add_card(store.pool(), "iss-1", "col-1", 0).await;
+
+    // Closed, not dropped: dropping a sqlx pool does not await its connections,
+    // so a checkpoint still in flight would race the zero-timeout pools below
+    // during SETUP rather than testing anything.
+    store.pool().close().await;
+
+    let db = dir.path().join("hangar.db");
+    let base = |timeout_ms: u64| {
+        SqliteConnectOptions::new()
+            .filename(&db)
+            .create_if_missing(false)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_millis(timeout_ms))
+    };
+
+    // Setup gets a normal timeout so winning the write lock is never flaky.
+    let holder = SqlitePool::connect_with(base(5_000)).await.expect("holder pool");
+    let mut held = holder.acquire().await.expect("hold a connection");
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *held)
+        .await
+        .expect("take the write lock");
+
+    // A DIFFERENT runtime, with no agent and so no reachable card. `board_card`
+    // is NOT empty, which is exactly what the unscoped gate could not survive.
+    let pool = SqlitePool::connect_with(base(0)).await.expect("pull pool");
+    let pulled = PullService::pull_for_runtime(
+        &pool,
+        "rt-2-has-no-agents",
+        &SeqIdGen::new(&["task-never-minted"]),
+        &FixedClock(NOW_MS),
+    )
+    .await;
+
+    match pulled {
+        Ok(None) => {}
+        Ok(Some(card)) => panic!("rt-2 owns no agent, so it cannot pull {card:?}"),
+        Err(error) => panic!(
+            "another runtime's card put this runtime back on the write lock, so the gate \
+             only ever helped an all-empty database: {error}"
+        ),
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -1045,3 +1045,74 @@ const ONE_OWNER_CLAUSE: &str = "\
          WHERE o.issue_id = bc.issue_id \
            AND o.status IN ('queued','dispatched','running') \
        ) ";
+
+/// A board-less profile does NOT touch the write lock, so a contended database
+/// cannot block the pull tick.
+///
+/// The measured failure this pins: `PULL_SQL` is an INSERT, so `SQLite` takes
+/// the write lock at statement start, BEFORE evaluating a single predicate. On
+/// a profile with no `board_card` rows the statement can never match, yet a
+/// contended daemon still paid the full `busy_timeout` for it — 10.64s, every
+/// ~22 seconds, `rows_affected=0` every time — and the claim behind it paid
+/// another, which is what turned a 1-second poll interval into a ~22-second one.
+///
+/// The assertion is on the ERROR, not on elapsed time, so it cannot flake on a
+/// loaded CI runner: `busy_timeout` is zero here, so a statement that reaches
+/// for the write lock fails IMMEDIATELY with `database is locked`. Returning
+/// `Ok(None)` is only possible if the write was never attempted.
+///
+/// This reduces one victim's exposure to the contention. It does not fix the
+/// contention: something else still holds that lock.
+#[tokio::test]
+async fn a_board_less_profile_never_reaches_for_the_write_lock() {
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Real migrations, so the statement this guards is prepared against the
+    // real schema rather than a hand-rolled subset that could drift from it.
+    let store = Store::open_in(dir.path()).await.expect("store");
+    // Closed explicitly, not dropped: dropping a sqlx pool does not await its
+    // connections, so a migration checkpoint can still be in flight and the
+    // zero-`busy_timeout` connections below would race it during SETUP rather
+    // than testing anything.
+    store.pool().close().await;
+
+    let db = dir.path().join("hangar.db");
+    let base = |timeout_ms: u64| {
+        SqliteConnectOptions::new()
+            .filename(&db)
+            .create_if_missing(false)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_millis(timeout_ms))
+    };
+
+    // The holder is SETUP, so it gets a normal timeout: it has to win the write
+    // lock reliably, and a flaky setup would make this test lie either way.
+    let holder = SqlitePool::connect_with(base(5_000)).await.expect("holder pool");
+    let mut held = holder.acquire().await.expect("hold a connection");
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *held)
+        .await
+        .expect("take the write lock");
+
+    // The subject gets ZERO, so a statement that reaches for the write lock
+    // fails immediately. That is what makes the assertion about behaviour
+    // rather than about how fast the runner is.
+    let pool = SqlitePool::connect_with(base(0)).await.expect("pull pool");
+    let pulled = PullService::pull_for_runtime(
+        &pool,
+        "runtime-with-no-boards",
+        &SeqIdGen::new(&["task-never-minted"]),
+        &FixedClock(NOW_MS),
+    )
+    .await;
+
+    match pulled {
+        Ok(None) => {}
+        Ok(Some(card)) => panic!("a board-less profile cannot pull a card, got {card:?}"),
+        Err(error) => panic!(
+            "the pull tick reached for the write lock on a profile that cannot match, \
+             so a contended daemon blocks here every tick: {error}"
+        ),
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/pull_role_gate.rs
@@ -1186,3 +1186,42 @@ async fn a_runtime_with_no_cards_skips_even_when_another_runtime_has_one() {
         ),
     }
 }
+
+/// A card the pull WOULD take passes the gate.
+///
+/// The other direction, and the dangerous one. The gate's safety property is
+/// `PULL_SQL` ⊆ gate: every row the pull could insert must also satisfy the
+/// gate. Break that — by adding a filter to the gate, or removing one from
+/// `PULL_SQL` — and the gate starts rejecting pullable cards. That failure is
+/// SILENT: `Ok(None)` forever, no error, no log line, a card that simply never
+/// gets pulled while every other test stays green.
+///
+/// So this asserts the positive case end to end: a fully eligible card, and the
+/// pull returning it THROUGH the gate. `a_runtime_with_no_cards_skips_even_when
+/// _another_runtime_has_one` covers the reverse.
+#[tokio::test]
+async fn a_card_that_matches_the_pull_passes_the_gate() {
+    let (_dir, store) = store().await;
+    let pool = store.pool();
+
+    seed_world(pool).await;
+    add_agent(pool, "ag-1", "impl", 4).await;
+    add_column(pool, "col-1", 1, Some("impl"), None, false).await;
+    add_card(pool, "iss-1", "col-1", 0).await;
+
+    let pulled = PullService::pull_for_runtime(
+        pool,
+        "rt-1",
+        &SeqIdGen::new(&["task-1"]),
+        &FixedClock(NOW_MS),
+    )
+    .await
+    .expect("pull must not error");
+
+    let pulled = pulled.expect(
+        "an eligible card must survive the gate; if this is None the gate is now STRICTER \
+         than PULL_SQL and pullable cards are being starved silently",
+    );
+    assert_eq!(pulled.issue_id, "iss-1");
+    assert_eq!(pulled.agent_id, "ag-1");
+}


### PR DESCRIPTION
## This does NOT fix the lock storm

Stating that first so no reader mistakes it for a cure. Something still holds the hangar write lock for longer than `busy_timeout`, and every other writer still queues behind it. **This removes one victim's exposure and takes one writer out of the queue.** The holder is still unidentified.

## What it does fix

`PULL_SQL` is an `INSERT`, so SQLite takes the **write lock at statement start**, before evaluating a single predicate. On a profile with no `board_card` rows the statement can never match — yet a contended daemon still paid the full `busy_timeout` for it.

Measured on a real wedged daemon:

```
03:12:23  card.pull INSERT INTO agent_task_queue  elapsed=10.641s  rows_affected=0
03:12:45  card.pull  "                            elapsed=10.640s  rows_affected=0
03:13:07  card.pull  "                            elapsed=10.701s  rows_affected=0
```

Every ~22s, `10.64s ± 0.03`, zero rows, forever. The `±0.03` is the `busy_timeout(10s)` constant, not query cost.

**Why zero rows:** that profile has no board data at all — `board`, `board_card`, `board_column`, `issue`, `agent_task_queue`, `squad`, `card_dependency` are all empty. `PULL_SQL` drives `FROM board_card`, so it cannot match, ever.

**Why ~22s:** it is an artefact, not a configured interval. `DEFAULT_POLL_MS` is **1000**. The loop is sleep(1s) → pull → claim, and the observed 22s is pull's 10s timeout + claim's 10s timeout + the 1s sleep. Corroborated by the error census: `card pull failed` 141 and `claim query failed` 140 in the same 2h window, one of each per cycle. Contention had degraded the main loop from 1 Hz to ~0.045 Hz.

## The gate is a read, on purpose

```rust
let has_cards: bool =
    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM board_card)").fetch_one(pool).await?;
if !has_cards {
    return Ok(None);
}
```

A reasonable objection is "you added a query per tick to avoid a query per tick". The distinction is that **in WAL mode readers never wait for the write lock**. The gate costs microseconds and cannot block; the statement it avoids blocks for 10 seconds. Checking is strictly cheaper than the write it replaces.

**Not cached, deliberately.** The check IS its own invalidation. The first `board_card` row a profile ever gains makes the pull resume on the very next tick — no daemon restart, no stale flag, no way for boards to become permanently dead for someone who adopts them later. This skips work structurally guaranteed to return nothing; it does not disable boards.

## Test

`a_board_less_profile_never_reaches_for_the_write_lock` runs against the **real migrated schema** with another connection holding `BEGIN IMMEDIATE`.

The assertion is on the **error, not on elapsed time**, so it cannot flake on a loaded runner: the subject pool has `busy_timeout(0)`, so any statement reaching for the write lock fails immediately with `database is locked`. Returning `Ok(None)` is only possible if the write was never attempted.

Falsified — gate removed:

```
the pull tick reached for the write lock on a profile that cannot match, so a
contended daemon blocks here every tick: error returned from database: (code: 5) database is locked
```

Restored, green.

The first falsification attempt failed in **setup** rather than at the assertion (`drop(store)` does not await a sqlx pool, so a migration checkpoint raced the zero-timeout connections). That was a flaw in the test, not the fix: the holder now uses a normal timeout for setup and only the subject uses zero, so the test is about behaviour rather than speed.

## Suites

store lib 324, store integration 109 across 13 binaries (`pull_role_gate` 28, including the existing mutation proofs — so pulling still works when cards DO exist), daemon lib 659. 0 failed. `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved pull behavior for empty boards by returning immediately without acquiring a database write lock.
  * Reduced unnecessary database overhead when no cards are available.

* **Bug Fixes**
  * Prevented empty-board pulls from failing due to avoidable database lock contention.

* **Tests**
  * Added coverage confirming empty-board pulls complete without requiring a write lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->