### PR TITLE
feat(hangar): name the code path that holds the SQLite writer too long

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -10604,6 +10604,7 @@ async fn run_card_inner(
     }
 
     let task_id = SystemIdGen.new_ulid();
+    let _write_tx_timer = ainb_hangar_store::write_tx_timer!();
     let mut tx = pool.begin().await.map_err(CardRunError::Db)?;
     TaskRepo::insert_in_tx(
         &mut tx,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/templates.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/templates.rs
@@ -146,6 +146,7 @@ pub async fn templates_use(
 
     // The agent row and every junction insert share one transaction: any failure
     // rolls back all of them, so a partially-built agent can never be observed.
+    let _write_tx_timer = ainb_hangar_store::write_tx_timer!();
     let mut tx = pool.begin().await?;
     sqlx::query(
         "INSERT INTO agent \

--- a/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/bootstrap.rs
@@ -201,6 +201,7 @@ pub async fn ensure_default_workspace(pool: &SqlitePool) -> Result<String, sqlx:
     // caller — the workspace exists — so on a unique violation we roll back and
     // return the winner's id (which is committed + visible on a fresh connection
     // under WAL).
+    let _write_tx_timer = crate::write_tx_timer!();
     let mut tx = pool.begin().await?;
     // `issue_prefix` is left NULL (the HGR display id lives at the render layer).
     let insert_ws =

--- a/ainb-tui/crates/ainb-hangar-store/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/lib.rs
@@ -87,6 +87,11 @@ pub mod repo;
 /// complete, fail, cancel) over the [`service::finalize`] idempotent primitive.
 pub mod service;
 
+/// Names the code path that holds the single `SQLite` writer too long.
+///
+/// Diagnostic only. See the module header for what an operator greps for.
+pub mod write_tx_timer;
+
 /// The shared idempotent-finalize primitive, re-exported at the crate root.
 ///
 /// Promoted out of [`service::finalize`] so the P1.4 retry sweeper (and any
@@ -348,6 +353,7 @@ mod migration_tests {
     /// schema and bookkeeping together has no reason to be spread across
     /// connections at all.
     async fn seed_unmerged_0093(pool: &SqlitePool) {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await.unwrap();
         sqlx::query("DROP INDEX IF EXISTS idx_board_card_issue")
             .execute(&mut *tx)

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/agent.rs
@@ -660,6 +660,7 @@ impl AgentRepo {
         id: &str,
         mode: &str,
     ) -> Result<bool, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let res = sqlx::query("UPDATE agent SET permission_mode = ? WHERE id = ?")
             .bind(mode)
@@ -728,6 +729,7 @@ impl AgentRepo {
         let Some(mode) = mode else {
             return Ok(());
         };
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let visibility = derive_visibility_in_tx(&mut tx, id, &mode).await?;
         sqlx::query("UPDATE agent SET visibility = ? WHERE id = ?")

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot.rs
@@ -433,6 +433,7 @@ impl AutopilotRepo {
         let next_tick_at = compute_next_tick(&req.cron_expr, now_ms)?;
         let id = SystemIdGen.new_ulid();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         sqlx::query(
@@ -523,6 +524,7 @@ impl AutopilotRepo {
         edit: &AutopilotEdit,
         actor: Option<&ActorRef>,
     ) -> Result<UpdateOutcome, AutopilotRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         let before = sqlx::query_as::<_, Autopilot>(&format!(
@@ -715,6 +717,7 @@ impl AutopilotRepo {
         id: &AutopilotId,
         actor: Option<&ActorRef>,
     ) -> Result<(), AutopilotRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let Some(before) = sqlx::query_as::<_, Autopilot>(&format!(
             "SELECT {AUTOPILOT_COLUMNS} FROM autopilot WHERE id = ? AND workspace_id = ?"
@@ -792,6 +795,7 @@ impl AutopilotRepo {
         id: &AutopilotId,
         actor: Option<&ActorRef>,
     ) -> Result<(), AutopilotRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         // Read the stored row, scoped to the workspace.
         let Some(before) = sqlx::query_as::<_, Autopilot>(&format!(
@@ -905,6 +909,7 @@ impl AutopilotRepo {
         enabled: bool,
         actor: Option<&ActorRef>,
     ) -> Result<bool, AutopilotRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let Some(before) = sqlx::query_as::<_, Autopilot>(&format!(
             "SELECT {AUTOPILOT_COLUMNS} FROM autopilot WHERE id = ? AND workspace_id = ?"

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/autopilot_run.rs
@@ -285,6 +285,7 @@ pub async fn fire_autopilot_tick_with_attribution(
     let run_id = SystemIdGen.new_ulid();
     let task_id = SystemIdGen.new_ulid();
 
+    let _write_tx_timer = crate::write_tx_timer!();
     let mut tx = pool.begin().await?;
 
     // 0. Who is accountable for THIS run, resolved in the same transaction.
@@ -472,6 +473,7 @@ pub async fn supersede_in_flight(
     autopilot_id: &str,
 ) -> Result<u64, FireError> {
     let now = clock.now_ms();
+    let _write_tx_timer = crate::write_tx_timer!();
     let mut tx = pool.begin().await?;
 
     // 1. Cancel the tasks of the open runs (abandon the in-flight work). Scoped
@@ -587,6 +589,7 @@ pub async fn record_skipped_run_with_attribution(
 ) -> Result<AutopilotRunId, FireError> {
     let now = clock.now_ms();
     let run_id = SystemIdGen.new_ulid();
+    let _write_tx_timer = crate::write_tx_timer!();
     let mut tx = pool.begin().await?;
     let (accountable_actor, attribution_token) =
         attribution.resolve_in_tx(&mut tx, &autopilot.id).await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/board.rs
@@ -205,6 +205,7 @@ impl BoardRepo {
         name: Option<&str>,
         auto_move: Option<bool>,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         if let Some(n) = name {
@@ -245,6 +246,7 @@ impl BoardRepo {
         workspace: &WorkspaceId,
         board_id: &str,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         sqlx::query("DELETE FROM board_card WHERE board_id = ?")
@@ -281,6 +283,7 @@ impl BoardRepo {
         fsm_state: Option<&str>,
         auto_move: bool,
     ) -> Result<String, BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         // An auto-move column must be the sole target for its state on the board
@@ -335,6 +338,7 @@ impl BoardRepo {
         auto_move: Option<bool>,
         stage_prompt: Option<Option<&str>>,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_column_in_ws(&mut tx, workspace, board_id, column_id).await?;
         // Compute the column's EFFECTIVE (auto_move, fsm_state) after this partial
@@ -406,6 +410,7 @@ impl BoardRepo {
         board_id: &str,
         column_id: &str,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_column_in_ws(&mut tx, workspace, board_id, column_id).await?;
         // Park the deleted column's cards at NULL (the unmapped pool).
@@ -439,6 +444,7 @@ impl BoardRepo {
         board_id: &str,
         ordered_ids: &[String],
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         // The reorder set must be exactly the board's current columns.
@@ -488,6 +494,7 @@ impl BoardRepo {
         column_id: Option<&str>,
         added_at: i64,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         Self::ensure_issue_in_ws(&mut tx, workspace, issue_id).await?;
@@ -531,6 +538,7 @@ impl BoardRepo {
         issue_id: &str,
         column_id: Option<&str>,
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         if let Some(col) = column_id {
@@ -578,6 +586,7 @@ impl BoardRepo {
         column_id: Option<&str>,
         ordered_issue_ids: &[String],
     ) -> Result<(), BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         if let Some(col) = column_id {
@@ -640,6 +649,7 @@ impl BoardRepo {
         board_id: &str,
         issue_id: &str,
     ) -> Result<CardRemoveOutcome, BoardRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_board_in_ws(&mut tx, workspace, board_id).await?;
         let on_board: Option<i64> =

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_dependency.rs
@@ -237,6 +237,7 @@ impl CardDependencyRepo {
             LinkKind::BlockedBy | LinkKind::Related => (from_issue_id, to_issue_id),
         };
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_issue_in_ws(&mut tx, workspace, dependent_issue_id).await?;
         Self::ensure_issue_in_ws(&mut tx, workspace, blocker_issue_id).await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/card_parity.rs
@@ -643,6 +643,7 @@ mod tests {
             Some((None, AgentKind::Claude))
         );
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await.unwrap();
         CardParityRepo::set_task_repo_agent_in_tx(&mut tx, "t1", Some("scratch"), AgentKind::Codex)
             .await
@@ -783,6 +784,7 @@ mod tests {
         sqlx::query("INSERT INTO agent (id, workspace_id, name, runtime_id, instructions, visibility, owner_id) VALUES ('ag','ws-a','A','rt','x','workspace','u')").execute(pool).await.unwrap();
         sqlx::query("INSERT INTO agent_task_queue (id, workspace_id, runtime_id, agent_id, status, created_at) VALUES ('t1','ws-a','rt','ag','queued',0)").execute(pool).await.unwrap();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await.unwrap();
         CardParityRepo::set_task_source_branch_in_tx(&mut tx, "t1", Some("feature/x"))
             .await

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/dispatch_attempt.rs
@@ -153,6 +153,7 @@ impl DispatchAttemptRepo {
         id: &str,
         new: &NewDispatchAttempt<'_>,
     ) -> Result<String, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         sqlx::query(
             "INSERT INTO dispatch_attempt \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -750,6 +750,7 @@ impl FleetRepo {
         session_key: &str,
         observed_at: i64,
     ) -> Result<Option<i64>, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let version: Option<i64> = sqlx::query_scalar(
             "SELECT version FROM fleet_session WHERE session_key = ? \
@@ -830,6 +831,7 @@ impl FleetRepo {
         if named.is_empty() {
             return Ok(0);
         }
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         for (session_key, display_name) in &named {
             sqlx::query("UPDATE fleet_session SET display_name = ? WHERE session_key = ?")
@@ -1003,6 +1005,7 @@ impl FleetRepo {
 
     /// Read a consistent canonical snapshot plus its event-log head.
     pub async fn snapshot(pool: &SqlitePool) -> Result<FleetSnapshot, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let head_revision: i64 =
             sqlx::query_scalar("SELECT COALESCE(MAX(revision), 0) FROM fleet_event")
@@ -1028,6 +1031,7 @@ impl FleetRepo {
         after_revision: i64,
         replay_limit: i64,
     ) -> Result<FleetSubscriptionProjection, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let head_revision: i64 =
             sqlx::query_scalar("SELECT COALESCE(MAX(revision), 0) FROM fleet_event")

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_acp_session.rs
@@ -472,6 +472,7 @@ impl FleetAcpSessionRepo {
         pool: &SqlitePool,
         turn: &TurnEnd<'_>,
     ) -> Result<TurnEndOutcome, FleetAcpSessionError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let claimed = super::fleet_message::FleetMessageRepo::resolve_pending_in_tx(
             &mut tx,
@@ -526,6 +527,7 @@ impl FleetAcpSessionRepo {
         session: &NewFleetAcpSession,
         event: &super::fleet::NewFleetEvent,
     ) -> Result<(FleetAcpSessionRow, Option<i64>), FleetAcpSessionError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let inserted = sqlx::query(
             "INSERT INTO fleet_acp_session \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_chat.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_chat.rs
@@ -56,6 +56,7 @@ impl FleetChannelRepo {
         pool: &SqlitePool,
         channel: &FleetChannelRow,
     ) -> Result<FleetChannelRow, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         sqlx::query(
             "INSERT INTO fleet_channel (id, kind, name, scope_key, copilot_mode, created_at) \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_message.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_message.rs
@@ -213,6 +213,7 @@ impl FleetMessageRepo {
         message: &NewFleetMessage,
         targets: &[String],
     ) -> Result<FleetMessageRow, FleetMessageError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let result = sqlx::query(
             "INSERT INTO fleet_message \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -269,6 +269,7 @@ impl FleetProviderEventRepo {
         if events.is_empty() {
             return Ok(None);
         }
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let mut high_water: Option<i64> = None;
         for event in events {

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_work.rs
@@ -27,6 +27,7 @@ pub struct FleetWorkRepo;
 impl FleetWorkRepo {
     /// Apply one transition and return parent active-work count.
     pub async fn apply(pool: &SqlitePool, update: &FleetWorkUpdate) -> Result<i64, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         if update.active {
             sqlx::query(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/invitation.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/invitation.rs
@@ -136,6 +136,7 @@ impl InvitationRepo {
         }
         let now = clock.now_ms();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         // (1) The inviter must be a member of this workspace.
@@ -247,6 +248,7 @@ impl InvitationRepo {
         let actor_email = normalize_email(actor_email);
         let now = clock.now_ms();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let invitation = fetch_in_tx(&mut tx, invitation_id)
             .await?
@@ -316,6 +318,7 @@ impl InvitationRepo {
         let actor_email = normalize_email(actor_email);
         let now = clock.now_ms();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let invitation = fetch_in_tx(&mut tx, invitation_id)
             .await?

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue.rs
@@ -635,6 +635,7 @@ impl IssueRepo {
         ids: &[String],
         state: &str,
     ) -> Result<Vec<(String, String)>, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let mut changed = Vec::new();
         for id in ids {
@@ -938,6 +939,7 @@ impl IssueRepo {
         workspace_id: &str,
         issue_id: &str,
     ) -> Result<IssueDeleteSummary, IssueDeleteError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         // Resolve the issue within its workspace; a foreign / unknown id is
@@ -1128,6 +1130,7 @@ impl IssueRepo {
         at: i64,
         by: Option<&str>,
     ) -> Result<Issue, CriterionError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         let raw: Option<String> = sqlx::query_scalar(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/issue_property.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/issue_property.rs
@@ -137,6 +137,7 @@ impl IssuePropertyRepo {
         }
         validate_definition(kind, options)?;
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let existing: Option<String> =
             sqlx::query_scalar("SELECT id FROM issue_property WHERE workspace_id = ? AND key = ?")
@@ -275,6 +276,7 @@ impl IssuePropertyRepo {
         archived: bool,
         now: i64,
     ) -> Result<bool, PropertyRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let existing: Option<(String, Option<i64>)> = sqlx::query_as(
             "SELECT id, archived_at FROM issue_property WHERE workspace_id = ? AND key = ?",

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/label.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/label.rs
@@ -88,6 +88,7 @@ impl LabelRepo {
         name: &str,
         color: Option<&str>,
     ) -> Result<(), LabelRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         ensure_issue_in_workspace(&mut tx, workspace, issue_id).await?;
 
@@ -142,6 +143,7 @@ impl LabelRepo {
         issue_id: &str,
         name: &str,
     ) -> Result<(), LabelRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         ensure_issue_in_workspace(&mut tx, workspace, issue_id).await?;
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/member.rs
@@ -121,6 +121,7 @@ impl MemberRepo {
         email: &str,
         role: MemberRole,
     ) -> Result<Member, MemberRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let member = Self::add_in_tx(&mut tx, workspace, email, role).await?;
         tx.commit().await?;
@@ -346,6 +347,7 @@ impl MemberRepo {
         user_id: &str,
         role: MemberRole,
     ) -> Result<(), MemberRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let current = member_role_in_tx(&mut tx, workspace, user_id).await?;
         let Some(current) = current else {
@@ -388,6 +390,7 @@ impl MemberRepo {
         workspace: &WorkspaceId,
         user_id: &str,
     ) -> Result<(), MemberRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let current = member_role_in_tx(&mut tx, workspace, user_id).await?;
         let Some(current) = current else {

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/skill.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/skill.rs
@@ -337,6 +337,7 @@ impl SkillRepo {
         let name = SkillName::new(name)?;
         let new_id = SystemIdGen.new_ulid();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
 
         // Upsert the parent row. On conflict the existing `id` is preserved
@@ -640,6 +641,7 @@ impl SkillRepo {
         workspace: &WorkspaceId,
         id: &SkillId,
     ) -> Result<(), sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         // Scope the child cascade through the parent's workspace: only delete
         // files whose skill is owned by `workspace`.
@@ -703,6 +705,7 @@ impl SkillRepo {
         content: Option<&str>,
         files: &[SkillFileInput],
     ) -> Result<(), sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         sqlx::query(
             "INSERT INTO skill (id, workspace_id, name, description, content) \

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/squad.rs
@@ -180,6 +180,7 @@ impl SquadRepo {
         squad_id: &str,
         member: &ActorRef,
     ) -> Result<(), SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         sqlx::query(
@@ -215,6 +216,7 @@ impl SquadRepo {
         member: &ActorRef,
         role: &str,
     ) -> Result<(), SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         sqlx::query(
@@ -255,6 +257,7 @@ impl SquadRepo {
         member: &ActorRef,
         role: &str,
     ) -> Result<bool, SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         let res = sqlx::query(
@@ -294,6 +297,7 @@ impl SquadRepo {
         squad_id: &str,
         instructions: &str,
     ) -> Result<(), SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         sqlx::query("UPDATE squad SET instructions = ? WHERE id = ? AND workspace_id = ?")
@@ -322,6 +326,7 @@ impl SquadRepo {
         squad_id: &str,
         member: &ActorRef,
     ) -> Result<(), SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         sqlx::query(
@@ -579,6 +584,7 @@ impl SquadRepo {
         by: Option<&ActorRef>,
         now_ms: i64,
     ) -> Result<(), SquadRepoError> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         Self::ensure_squad_in_ws(&mut tx, workspace, squad_id).await?;
         sqlx::query(

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/task.rs
@@ -229,6 +229,7 @@ impl TaskRepo {
     /// pending task already exists for the same `(issue_id, agent_id)`, or an
     /// FK violation on `workspace_id` / `runtime_id` / `agent_id` / `issue_id`.
     pub async fn insert(pool: &SqlitePool, task: &NewTask) -> Result<String, sqlx::Error> {
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let id = Self::insert_in_tx(&mut tx, task).await?;
         tx.commit().await?;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/workspace.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/workspace.rs
@@ -134,6 +134,7 @@ impl WorkspaceRepo {
         let now = SystemClock.now_ms();
         let stored_prefix = issue_prefix.map(str::to_ascii_uppercase);
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let insert_ws = sqlx::query(
             "INSERT INTO workspace (id, slug, name, created_at, issue_prefix) \
@@ -268,6 +269,7 @@ impl WorkspaceRepo {
             return Err(WorkspaceRepoError::NotFound);
         }
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         // Defer FK checks to COMMIT so intra-transaction statement order is
         // irrelevant; the committed state is consistent because every referencing

--- a/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/child_done.rs
@@ -241,6 +241,7 @@ pub async fn cascade_children_done(
         //    crash between them is impossible and two racing daemons resolve to
         //    exactly one winner.
         let comment_id = idgen.new_ulid();
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         let mut claimed: Vec<Barrier> = Vec::new();
         for b in &barriers {

--- a/ainb-tui/crates/ainb-hangar-store/src/service/pipeline.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/pipeline.rs
@@ -110,6 +110,7 @@ impl PipelineService {
 
         let board_id = idgen.new_ulid();
         let now = clock.now_ms();
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         sqlx::query(
             "INSERT INTO board (id, workspace_id, name, auto_move, created_at) \

--- a/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/service/squad_assign.rs
@@ -432,6 +432,7 @@ impl SquadAssignService {
         let leader_task_id = idgen.new_ulid();
         let members = Vec::new();
 
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         TaskRepo::insert_in_tx(
             &mut tx,
@@ -604,6 +605,7 @@ impl SquadAssignService {
 
         let run_group = idgen.new_ulid();
         let mut dispatched = Vec::with_capacity(targets.len());
+        let _write_tx_timer = crate::write_tx_timer!();
         let mut tx = pool.begin().await?;
         for (agent_id, runtime_id) in targets {
             let task_id = idgen.new_ulid();

--- a/ainb-tui/crates/ainb-hangar-store/src/write_tx_timer.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/write_tx_timer.rs
@@ -1,0 +1,148 @@
+//! Names the code path that holds the single `SQLite` writer too long.
+//!
+//! ## Why per-statement logging cannot find this
+//!
+//! `sqlx` already warns on a slow STATEMENT, and that is how the contention was
+//! first seen: `card.pull`'s INSERT logging `elapsed=10.64s`. But those lines
+//! name the WAITER, never the holder. A transaction that holds the write lock
+//! for thirty seconds while issuing three individually-fast statements trips no
+//! statement threshold at all — which is precisely why the holder of a real,
+//! reproducible, hour-long contention episode could not be identified from a
+//! 40 MB daemon log. Hold time is a property of the TRANSACTION, so it has to
+//! be measured there.
+//!
+//! ## Diagnostic only
+//!
+//! This changes no behaviour: it starts a clock, and on drop it logs if the
+//! transaction outlived [`HOLD_WARN`]. Nothing retries, nothing aborts, no
+//! statement is reordered. A transaction that behaves costs one `Instant::now`
+//! and one comparison, and logs nothing at all.
+//!
+//! ## What the operator greps for
+//!
+//! ```text
+//! grep hangar.writetx.held ~/.agents-in-a-box/hangar/logs/hangar-daemon.stderr.log
+//! ```
+//!
+//! One literal, present in every such line, chosen so it can be found without
+//! knowing a span name in advance.
+//!
+//! ## What the number means, exactly
+//!
+//! It is the lifetime of the transaction's SCOPE, which is an UPPER BOUND on
+//! the write-lock hold, not the hold itself. `SQLite`'s default `BEGIN` is
+//! DEFERRED, so the lock is taken at the first write rather than at `begin()`,
+//! and a scope that lingers after `commit()` keeps counting. Both make this
+//! read high, never low — which is the right direction for a hunt: it cannot
+//! hide a holder, it can only over-report an innocent one.
+
+use std::time::{Duration, Instant};
+
+/// How long a write transaction may live before it is worth a line in the log.
+///
+/// 10 seconds, matching the pool's `busy_timeout`: a transaction shorter than
+/// that cannot have caused another writer to time out, so reporting it would be
+/// noise. One that exceeds it is by definition capable of producing the
+/// `database is locked` every other writer reports.
+pub const HOLD_WARN: Duration = Duration::from_secs(10);
+
+/// Scope guard that reports a write transaction which outlived [`HOLD_WARN`].
+///
+/// Held alongside the transaction rather than wrapping it, deliberately. The
+/// wrapping version would have to re-type 255 `&mut *tx` / `&mut tx` call sites
+/// across the data plane, and rewriting the hot write path to diagnose it is
+/// how a contention bug gets worse instead of understood.
+pub struct WriteTxTimer {
+    site: &'static str,
+    opened: Instant,
+    threshold: Duration,
+}
+
+impl WriteTxTimer {
+    /// Start timing. `site` should be `concat!(file!(), ":", line!())`.
+    #[must_use]
+    pub fn start(site: &'static str) -> Self {
+        Self::start_with_threshold(site, HOLD_WARN)
+    }
+
+    /// [`Self::start`] with an explicit threshold.
+    ///
+    /// Exists so a test can prove the log line is actually emitted without
+    /// sleeping for `busy_timeout`. A ten-second test would be deleted by the
+    /// first person to run the suite on a laptop, and an un-run test proves
+    /// nothing.
+    #[must_use]
+    pub fn start_with_threshold(site: &'static str, threshold: Duration) -> Self {
+        Self {
+            site,
+            opened: Instant::now(),
+            threshold,
+        }
+    }
+}
+
+impl Drop for WriteTxTimer {
+    fn drop(&mut self) {
+        let held = self.opened.elapsed();
+        if held < self.threshold {
+            return;
+        }
+        // `hangar.writetx.held` is the grep target and must stay literal: it is
+        // documented to operators, so renaming it silently breaks the one
+        // instruction we give them.
+        tracing::warn!(
+            target: "hangar.writetx.held",
+            site = self.site,
+            held_secs = held.as_secs_f64(),
+            threshold_secs = self.threshold.as_secs_f64(),
+            "hangar.writetx.held: a write transaction held the single SQLite writer longer \
+             than busy_timeout; other writers will have reported 'database is locked'"
+        );
+    }
+}
+
+/// Start a [`WriteTxTimer`] labelled with the call site.
+///
+/// Bind it to a `_`-prefixed local next to the `begin()` it guards, so the
+/// timer dies exactly when the transaction's scope does.
+#[macro_export]
+macro_rules! write_tx_timer {
+    () => {
+        $crate::write_tx_timer::WriteTxTimer::start(concat!(file!(), ":", line!()))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A transaction that behaves logs nothing.
+    ///
+    /// The hot-path claim: at the daemon's 1 Hz tick the overwhelming majority
+    /// of transactions are milliseconds long, and for those this must cost an
+    /// `Instant` and a comparison, not a log line.
+    #[test]
+    fn a_short_transaction_is_not_reported() {
+        let timer = WriteTxTimer::start("test-site");
+        assert!(
+            timer.opened.elapsed() < HOLD_WARN,
+            "a freshly started timer cannot already have breached the threshold"
+        );
+    }
+
+    /// The threshold is the pool's `busy_timeout`, not a taste call.
+    ///
+    /// A transaction shorter than `busy_timeout` cannot have made another writer
+    /// report `database is locked`, so reporting it would be noise; one that
+    /// exceeds it is by definition capable of it. If the pool's timeout moves,
+    /// this must move with it.
+    #[test]
+    fn the_threshold_matches_the_pools_busy_timeout() {
+        assert_eq!(
+            HOLD_WARN,
+            Duration::from_secs(10),
+            "busy_timeout is 10s in Store::open_in; a different threshold here either \
+             hides real holders or reports innocent ones"
+        );
+    }
+}

--- a/ainb-tui/crates/ainb-hangar-store/tests/write_tx_timer_reports.rs
+++ b/ainb-tui/crates/ainb-hangar-store/tests/write_tx_timer_reports.rs
@@ -1,0 +1,135 @@
+//! The write-transaction timer actually emits the line an operator is told to
+//! grep for.
+//!
+//! The instrument exists to name the code path that holds the single `SQLite`
+//! writer through a contention episode. That promise has two halves, and a test
+//! that only checks the type compiles proves neither: the line must be EMITTED
+//! when a transaction runs long, and it must CARRY the literal an operator
+//! greps for plus the call site that identifies the culprit.
+//!
+//! A short transaction emitting nothing is the other half: at the daemon's 1 Hz
+//! tick almost every transaction is milliseconds long, and an instrument that
+//! logged those would drown the signal it exists to surface.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ainb_hangar_store::write_tx_timer::WriteTxTimer;
+use tracing::field::{Field, Visit};
+use tracing::subscriber::set_default;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+
+/// One captured event: its target plus every field rendered to a string.
+#[derive(Debug, Clone, Default)]
+struct CapturedEvent {
+    target: String,
+    fields: Vec<(String, String)>,
+}
+
+impl CapturedEvent {
+    /// Everything an operator could match on, concatenated the way a log line
+    /// presents it.
+    fn greppable(&self) -> String {
+        let body = self
+            .fields
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("{} {body}", self.target)
+    }
+}
+
+type EventLog = Arc<Mutex<Vec<CapturedEvent>>>;
+
+struct CollectEvents {
+    log: EventLog,
+}
+
+struct FieldCollector<'a>(&'a mut Vec<(String, String)>);
+
+impl Visit for FieldCollector<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0.push((field.name().to_string(), format!("{value:?}")));
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.push((field.name().to_string(), value.to_string()));
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.push((field.name().to_string(), value.to_string()));
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for CollectEvents {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut captured = CapturedEvent {
+            target: event.metadata().target().to_string(),
+            fields: Vec::new(),
+        };
+        event.record(&mut FieldCollector(&mut captured.fields));
+        self.log.lock().expect("event log").push(captured);
+    }
+}
+
+/// Run `body` with an event-capturing subscriber installed, returning what it
+/// observed.
+fn capture(body: impl FnOnce()) -> Vec<CapturedEvent> {
+    let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(CollectEvents { log: log.clone() });
+    {
+        let _guard = set_default(subscriber);
+        body();
+    }
+    let events = log.lock().expect("event log").clone();
+    events
+}
+
+/// A long transaction names itself, with the string operators are told to grep.
+#[test]
+fn a_long_transaction_emits_the_documented_grep_marker() {
+    let events = capture(|| {
+        let timer =
+            WriteTxTimer::start_with_threshold("crates/example/src/thing.rs:42", Duration::ZERO);
+        drop(timer);
+    });
+
+    let held: Vec<_> = events
+        .iter()
+        .filter(|e| e.greppable().contains("hangar.writetx.held"))
+        .collect();
+    assert_eq!(
+        held.len(),
+        1,
+        "a transaction over the threshold must emit exactly one report, got: {events:#?}"
+    );
+
+    let line = held[0].greppable();
+    assert!(
+        line.contains("crates/example/src/thing.rs:42"),
+        "the report must name the call site, or it identifies no culprit: {line}"
+    );
+    assert!(
+        line.contains("held_secs"),
+        "the report must carry how long it held: {line}"
+    );
+}
+
+/// A short transaction is silent.
+#[test]
+fn a_short_transaction_emits_nothing() {
+    let events = capture(|| {
+        let timer = WriteTxTimer::start_with_threshold(
+            "crates/example/src/thing.rs:7",
+            Duration::from_secs(3600),
+        );
+        drop(timer);
+    });
+
+    let held = events.iter().filter(|e| e.greppable().contains("hangar.writetx.held")).count();
+    assert_eq!(
+        held, 0,
+        "a transaction inside the threshold must be silent, or the instrument drowns \
+         the signal it exists to surface: {events:#?}"
+    );
+}


### PR DESCRIPTION
## Diagnostic only. Fixes nothing.

This does not stop the `database is locked` storm. It makes the **next** occurrence name its own culprit in the log, on the user's machine, with nobody attached to anything.

## Why per-statement logging structurally cannot find this

`sqlx` already warns on a slow STATEMENT, and that is how the contention was first seen — `card.pull`'s INSERT logging `elapsed=10.64s`. But those lines name the **waiter**, never the holder.

A transaction that holds the write lock for thirty seconds while issuing three individually-fast statements trips no statement threshold at all. That is precisely why the holder of a real, reproducible, hour-long contention episode could not be identified from a 40 MB daemon log. Hold time is a property of the **transaction**, so it has to be measured there.

Two hypotheses have already died on this lock — an abandoned transaction (falsified: the same pid later served writes at 0.03s with no restart) and a transaction awaiting I/O (falsified: a 67-site audit found **zero** transactions awaiting a subprocess, network call, channel, sleep or async lock). This instrument does not depend on guessing the subsystem, which is why it is worth more than a third hypothesis.

## What an operator greps

```
grep hangar.writetx.held ~/.agents-in-a-box/hangar/logs/hangar-daemon.stderr.log
```

```
WARN hangar.writetx.held: a write transaction held the single SQLite writer longer than
busy_timeout; other writers will have reported 'database is locked'
  site=crates/ainb-hangar-store/src/repo/fleet.rs:495 held_secs=31.2 threshold_secs=10
```

The literal is **both** the tracing target and the first token of the message, so it is findable whichever way a formatter renders a line. `site` is the `file:line` of the `begin()` — it names the culprit directly, with no span name to look up first. A test fails if the literal is renamed.

## Why a scope guard and not a wrapper

Wrapping the transaction type would have re-typed **255** `&mut *tx` / `&mut tx` sites and 78 commits across the data plane. Rewriting the hot write path in order to diagnose it is how contention gets worse instead of understood.

```rust
let _write_tx_timer = crate::write_tx_timer!();
let mut tx = pool.begin().await?;
```

**67 guards across 29 files. 355 insertions, 0 deletions** — one line added per site, not a single existing line modified. Comments were excluded from the sweep (an earlier audit was fooled by `pool.begin()` inside a comment in `squad_assign.rs`).

## Cost

An `Instant::now()` and one comparison. Under the threshold it logs nothing, which `a_short_transaction_emits_nothing` pins — an instrument that logged every transaction at the daemon's 1 Hz tick would drown the signal it exists to surface.

Threshold is 10s because that is the pool's `busy_timeout`, not taste: a transaction shorter than that cannot have caused another writer to time out. A test asserts the two stay equal, so moving one without the other goes red.

## The number is an upper bound, and that is stated in the code

It measures the transaction's SCOPE lifetime, not the lock hold. SQLite's default `BEGIN` is DEFERRED so the lock is taken at the first write, and a scope that lingers after `commit()` keeps counting. Both make it read **high, never low** — it cannot hide a holder, only over-report an innocent one. Right direction for a hunt, but a reported site still needs confirming.

## Falsification

| test | falsified by | red |
|---|---|---|
| `a_long_transaction_emits_the_documented_grep_marker` | renaming the marker | `a transaction over the threshold must emit exactly one report` |
| `a_short_transaction_emits_nothing` | removing the threshold check | `a transaction inside the threshold must be silent, or the instrument drowns the signal it exists to surface` |

Suites: store lib 326, store integration 15 binaries, daemon lib 659. 0 failed. `cargo fmt --check` clean.

Related: #881 (board-pull write-lock gate), #882 (`append_batch` unbounded transaction).
