### PR TITLE
feat(fleet): show an ACP session's live transcript in the notch

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/examples/fleet_fixture_daemon.rs
@@ -14,6 +14,9 @@ use ainb_hangar_daemon::events::EventBroker;
 use ainb_hangar_daemon::fleet::{self, HookObservation};
 use ainb_hangar_daemon::rpc::{self, DaemonHealth};
 use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::fleet_provider_event::{
+    FleetProviderEventRepo, NewFleetProviderEvent,
+};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -35,6 +38,27 @@ enum Command {
         #[serde(default)]
         observed_at: Option<i64>,
     },
+    /// Commit one ACP transcript chunk and wake the transcript forwarders.
+    ///
+    /// The transcript's only production writer is the ACP pool's store writer,
+    /// which needs a live adapter subprocess, so a fixture that stopped at
+    /// `apply_hook` could prove nothing about `fleet/transcript_subscribe`: a
+    /// client would have no way to make a chunk exist. This writes the SAME row
+    /// the pool writes (`source='acp'`, through the real repo) and rings the
+    /// SAME bell (`emit_transcript_order`); it does not emulate the RPC or the
+    /// forwarder, both of which stay the daemon's own code under test.
+    SeedTranscript {
+        event_id: String,
+        session_key: String,
+        #[serde(default = "default_transcript_event_type")]
+        event_type: String,
+        #[serde(default = "default_transcript_provider")]
+        provider: String,
+        #[serde(default)]
+        payload: Value,
+        #[serde(default)]
+        observed_at: Option<i64>,
+    },
     Shutdown,
 }
 
@@ -50,6 +74,19 @@ fn default_event_type() -> String {
 fn default_cwd() -> String {
     "/fixture".to_string()
 }
+fn default_transcript_event_type() -> String {
+    "acp.message".to_string()
+}
+fn default_transcript_provider() -> String {
+    "claude-agent-acp".to_string()
+}
+
+/// The `fleet_provider_event.source` the ACP pool writes transcript rows under.
+///
+/// Named rather than repeated as a literal: the prune path selects on it, so a
+/// fixture that drifted from the production writer would seed rows the daemon
+/// can read but never reclaim.
+const ACP_TRANSCRIPT_SOURCE: &str = "acp";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -123,6 +160,66 @@ async fn main() -> anyhow::Result<()> {
                                 "duplicate": result.duplicate,
                             })
                         ),
+                        Err(error) => println!(
+                            "{}",
+                            serde_json::json!({ "ok": false, "error": error.to_string() })
+                        ),
+                    }
+                    std::io::stdout().flush()?;
+                }
+                Command::SeedTranscript {
+                    event_id,
+                    session_key,
+                    event_type,
+                    provider,
+                    payload,
+                    observed_at,
+                } => {
+                    let observed_at = observed_at.unwrap_or_else(|| {
+                        next_observed_at += 1;
+                        next_observed_at
+                    });
+                    let row = FleetProviderEventRepo::append(
+                        store.pool(),
+                        &NewFleetProviderEvent {
+                            event_id: event_id.clone(),
+                            provider,
+                            // The source the ACP pool writes its transcript
+                            // rows under. NEITHER transcript read filters on
+                            // it (both select by `session_key` alone), so this
+                            // is about the row being the same shape the
+                            // production writer produces, not about being
+                            // visible: a fixture that seeded some other source
+                            // would be testing a row the daemon never writes.
+                            //
+                            // The prune path DOES filter `source = 'acp'`, so
+                            // a row written under another source would also be
+                            // unprunable, which is the second reason to match.
+                            source: ACP_TRANSCRIPT_SOURCE.to_string(),
+                            session_key: Some(session_key.clone()),
+                            provider_session_id: None,
+                            observed_at,
+                            received_at: observed_at,
+                            event_type,
+                            raw_payload: payload.to_string(),
+                        },
+                    )
+                    .await;
+                    match row {
+                        Ok(row) => {
+                            // AFTER the row is durable, never before: a
+                            // forwarder woken early reads the log and finds
+                            // nothing, which is the shape of a flake.
+                            sink.emit_transcript_order(&session_key, row.ingest_order);
+                            println!(
+                                "{}",
+                                serde_json::json!({
+                                    "ok": true,
+                                    "event_id": event_id,
+                                    "ingest_order": row.ingest_order,
+                                })
+                            );
+                        }
                         Err(error) => println!(
                             "{}",
                             serde_json::json!({ "ok": false, "error": error.to_string() })

--- a/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/rpc/mod.rs
@@ -2550,8 +2550,8 @@ async fn handle_fleet_transcript_list(
     req: &RpcRequest,
 ) -> Result<serde_json::Value, RpcError> {
     use ainb_hangar_proto::fleet::{
-        FLEET_CAPABILITY_TRANSCRIPT_READ, FLEET_TRANSCRIPT_LIST_MAX, FleetTranscriptListParams,
-        FleetTranscriptListResult,
+        FLEET_CAPABILITY_TRANSCRIPT_READ, FLEET_TRANSCRIPT_LIST_MAX,
+        FLEET_TRANSCRIPT_LIST_MAX_BYTES, FleetTranscriptListParams, FleetTranscriptListResult,
     };
     use ainb_hangar_store::repo::fleet_provider_event::FleetProviderEventRepo;
 
@@ -2561,22 +2561,55 @@ async fn handle_fleet_transcript_list(
     if params.session_key.trim().is_empty() {
         return Err(invalid_params("session_key must not be empty"));
     }
-    let after_order = params.after_order.unwrap_or(0);
-    if after_order < 0 {
+    if params.after_order.is_some_and(|order| order < 0) {
         return Err(invalid_params("after_order must be non-negative"));
     }
-    let rows = FleetProviderEventRepo::list_by_session_after(
-        pool,
-        &params.session_key,
-        after_order,
-        i64::from(params.limit.clamp(1, FLEET_TRANSCRIPT_LIST_MAX)),
-    )
-    .await
+    let limit = i64::from(params.limit.clamp(1, FLEET_TRANSCRIPT_LIST_MAX));
+    // A transcript read with NO cursor answers with the newest page, because
+    // that is what opening an execution view means. With a cursor it walks
+    // forward from that row exactly as before, so paging is untouched.
+    //
+    // The same split `fleet/message_list` takes, and here it is not merely
+    // nicer: `ingest_order` is ONE global AUTOINCREMENT sequence across every
+    // provider's rows, so a client cannot approximate this by naming a cursor
+    // of its own. Absent was previously collapsed into `unwrap_or(0)`, which is
+    // what made an uncursored read answer with the START of a session; the
+    // newest hundred ORDERS on a busy machine hold zero rows for the session
+    // being watched, so a client computing that window instead saw its pane
+    // empty while its agent was mid-turn. Neither is answerable client-side.
+    //
+    // The uncursored arm is the SAME read the board timeline uses, byte budget
+    // and truncation flag included. A tail is bounded twice because a chunk's
+    // payload has no ceiling of its own, and which bound bit is not inferable
+    // from the row count, so it rides the wire.
+    let (rows, truncated) = match params.after_order {
+        Some(after_order) => FleetProviderEventRepo::list_by_session_after(
+            pool,
+            &params.session_key,
+            after_order,
+            limit,
+        )
+        .await
+        // A cursored walk is bounded by rows alone and answers "what came after
+        // this row", so it has nothing to admit: `next_after_order` already
+        // tells the caller more may follow.
+        .map(|rows| (rows, false)),
+        None => {
+            FleetProviderEventRepo::list_by_session_tail(
+                pool,
+                &params.session_key,
+                limit,
+                FLEET_TRANSCRIPT_LIST_MAX_BYTES,
+            )
+            .await
+        }
+    }
     .map_err(|error| store_err(&error))?;
     let chunks: Vec<_> = rows.iter().map(transcript_chunk_wire).collect();
     to_value(&FleetTranscriptListResult {
         next_after_order: chunks.last().map(|chunk| chunk.ingest_order),
         chunks,
+        truncated,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_message_bus.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_message_bus.rs
@@ -1588,6 +1588,169 @@ async fn transcript_readers_answer_empty_and_the_forwarder_filters_its_session()
     assert_eq!(chunks[0]["chunk"]["session_key"], "acp:mine");
 }
 
+/// An UNCURSORED `fleet/transcript_list` answers with the end of the session's
+/// transcript, and a CURSORED one still walks forward from the named row.
+///
+/// The second session is what makes this test mean anything. `ingest_order` is
+/// one global AUTOINCREMENT sequence over every provider's rows, so the newest
+/// orders in the table are not the newest rows of a SESSION. A client that
+/// approximated the tail by naming `head - limit` as its cursor got a page that
+/// was mostly, and on a busy machine entirely, somebody else's rows: the pane
+/// went empty mid-turn. That approximation is what the uncursored arm replaces.
+#[tokio::test]
+async fn an_uncursored_transcript_read_answers_the_tail_of_its_own_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, _sink) = start_server(dir.path()).await;
+
+    // More rows than the page, then a noisy neighbour holding the newest
+    // global orders.
+    for index in 0..12 {
+        seed_transcript_row(&store, "acp:mine", &format!("mine-{index:02}")).await;
+    }
+    for index in 0..20 {
+        seed_transcript_row(&store, "acp:noisy", &format!("noise-{index:02}")).await;
+    }
+    let mut client = Client::authed(dir.path(), &socket).await;
+
+    let tail = client
+        .call(
+            methods::FLEET_TRANSCRIPT_LIST,
+            serde_json::json!({ "session_key": "acp:mine", "limit": 5 }),
+        )
+        .await;
+    let chunks = tail["result"]["chunks"].as_array().unwrap();
+    let ids: Vec<&str> = chunks.iter().map(|chunk| chunk["event_id"].as_str().unwrap()).collect();
+    assert_eq!(
+        ids,
+        ["mine-07", "mine-08", "mine-09", "mine-10", "mine-11"],
+        "an uncursored read answers the NEWEST page, oldest first"
+    );
+    assert!(
+        chunks.iter().all(|chunk| chunk["session_key"] == "acp:mine"),
+        "the neighbour's rows must never appear in this session's transcript"
+    );
+    assert_eq!(
+        tail["result"]["next_after_order"],
+        chunks.last().unwrap()["ingest_order"],
+        "the cursor to resume from is still the last row of the page"
+    );
+    assert_eq!(
+        tail["result"]["truncated"], true,
+        "seven older rows were left behind, and a full page cannot say so by itself"
+    );
+
+    // The cursored half is untouched by construction: named a row, it walks
+    // forward from it, exclusive, exactly as before.
+    let after_order = chunks[0]["ingest_order"].as_i64().unwrap();
+    let forward = client
+        .call(
+            methods::FLEET_TRANSCRIPT_LIST,
+            serde_json::json!({
+                "session_key": "acp:mine",
+                "after_order": after_order,
+                "limit": 3,
+            }),
+        )
+        .await;
+    let forward_ids: Vec<&str> = forward["result"]["chunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|chunk| chunk["event_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        forward_ids,
+        ["mine-08", "mine-09", "mine-10"],
+        "a cursor still means walk forward from this row, not re-read the tail"
+    );
+    assert_eq!(
+        forward["result"]["truncated"], false,
+        "a cursored walk has nothing to admit: next_after_order already says more follows"
+    );
+
+    // And a cursor of 0 is a real forward walk from the beginning, NOT the
+    // uncursored tail: absent and zero are different questions.
+    let from_start = client
+        .call(
+            methods::FLEET_TRANSCRIPT_LIST,
+            serde_json::json!({ "session_key": "acp:mine", "after_order": 0, "limit": 3 }),
+        )
+        .await;
+    let start_ids: Vec<&str> = from_start["result"]["chunks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|chunk| chunk["event_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        start_ids,
+        ["mine-00", "mine-01", "mine-02"],
+        "an explicit zero cursor still walks from the start of the log"
+    );
+
+    // A negative cursor stays refused rather than silently becoming a tail.
+    let refused = client
+        .call(
+            methods::FLEET_TRANSCRIPT_LIST,
+            serde_json::json!({ "session_key": "acp:mine", "after_order": -1, "limit": 3 }),
+        )
+        .await;
+    assert_eq!(refused["error"]["code"], -32602);
+}
+
+/// A CURSORED `fleet/transcript_subscribe` replays the gap, which is what a
+/// client reconnecting after an outage depends on.
+///
+/// The uncursored form starts the forwarder at the head, so everything
+/// committed while a client was disconnected is never pushed. Naming the last
+/// row the client holds is the only thing that asks for the rest, and the
+/// existing subscribe test covers only the uncursored form.
+#[tokio::test]
+async fn a_cursored_transcript_subscribe_replays_the_gap() {
+    use ainb_hangar_store::repo::fleet_provider_event::FleetProviderEventRepo;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (socket, store, _sink) = start_server(dir.path()).await;
+
+    // What the client saw before it dropped, then the outage's worth of rows,
+    // committed while nobody was subscribed.
+    seed_transcript_row(&store, "acp:mine", "seen").await;
+    let seen = FleetProviderEventRepo::head_order_for_session(store.pool(), "acp:mine")
+        .await
+        .unwrap()
+        .expect("the row it already holds");
+    for index in 0..3 {
+        seed_transcript_row(&store, "acp:mine", &format!("missed-{index}")).await;
+    }
+    // A neighbour's rows in the same window, which must not be replayed here.
+    seed_transcript_row(&store, "acp:other", "not-mine").await;
+
+    let mut client = Client::authed(dir.path(), &socket).await;
+    let ack = client
+        .call(
+            methods::FLEET_TRANSCRIPT_SUBSCRIBE,
+            serde_json::json!({ "session_key": "acp:mine", "after_order": seen }),
+        )
+        .await;
+    assert!(
+        ack["result"]["head_order"].as_i64().unwrap() > seen,
+        "the head has moved past the row the client holds"
+    );
+
+    let replayed = client
+        .drain_notifications("fleet/transcript_event", Duration::from_millis(800))
+        .await;
+    let ids: Vec<&str> = replayed
+        .iter()
+        .map(|chunk| chunk["chunk"]["event_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        ["missed-0", "missed-1", "missed-2"],
+        "the gap must replay in commit order, exclusive of the row the client already had"
+    );
+}
+
 /// An unbounded `targets` list is one request that writes an unbounded leg set
 /// and holds the daemon across a verified transport submit per recipient.
 #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/fleet.rs
@@ -1408,6 +1408,19 @@ pub const FLEET_MESSAGE_BODY_MAX: usize = 256 * 1024;
 /// Maximum chunks one `fleet/transcript_list` page may return.
 pub const FLEET_TRANSCRIPT_LIST_MAX: u32 = 100;
 
+/// Payload byte budget for ONE uncursored `fleet/transcript_list` page.
+///
+/// The row cap alone does not bound this read. A chunk's payload is
+/// adapter-authored JSON with no ceiling of its own, so `FLEET_TRANSCRIPT_LIST_MAX`
+/// rows of a tool call's verbatim update is an unbounded response materialised
+/// in the daemon before it is framed. WHICH cap binds depends on the run and
+/// neither dominates: a hundred short structural rows is a few KiB, while a
+/// hundred coalesced 4 KiB text chunks exhausts this budget first.
+///
+/// The read reports which one bit rather than pretending neither does, and that
+/// is why [`FleetTranscriptListResult::truncated`] exists.
+pub const FLEET_TRANSCRIPT_LIST_MAX_BYTES: usize = 512 * 1024;
+
 /// Chat message kind on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1666,6 +1679,25 @@ pub struct FleetTranscriptListResult {
     /// Cursor for the next page, or `null` when this page is empty.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_after_order: Option<i64>,
+    /// Whether older rows were left behind by the UNCURSORED read.
+    ///
+    /// Not inferable from `chunks.len()`, which is the whole reason it is on
+    /// the wire. The tail read is bounded twice, by rows and by payload bytes,
+    /// and which bound bit depends entirely on the run: a short page can mean
+    /// a short transcript or one 4 KiB chunk after another. A client that
+    /// assumed the first would render a partial run as a complete one, which is
+    /// the failure `FleetProviderEventRepo::list_by_session_tail` documents.
+    ///
+    /// Always `false` on a CURSORED read, which is bounded by rows alone and
+    /// answers "what came after this row" rather than "is this the whole
+    /// story": a caller walking forward already knows more may follow, because
+    /// `next_after_order` tells it so.
+    ///
+    /// `#[serde(default)]` so a client built against this reads a daemon built
+    /// before it as "nothing was left behind", which is what an older daemon's
+    /// unbounded page meant.
+    #[serde(default)]
+    pub truncated: bool,
 }
 
 /// Parameters for `fleet/transcript_subscribe`.
@@ -2699,7 +2731,14 @@ mod tests {
         round_trip(&FleetTranscriptListResult {
             chunks: vec![sample_chunk()],
             next_after_order: Some(41),
+            truncated: true,
         });
+        // And a daemon built before the flag decodes as "nothing left behind"
+        // rather than failing the page, which is what `#[serde(default)]` buys.
+        let legacy: FleetTranscriptListResult =
+            serde_json::from_str(r#"{"chunks":[],"next_after_order":null}"#)
+                .expect("a result without the flag still decodes");
+        assert!(!legacy.truncated);
         round_trip(&FleetTranscriptSubscribeParams {
             session_key: "acp:01J0KEY".to_string(),
             after_order: None,

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_provider_event.rs
@@ -430,6 +430,19 @@ impl FleetProviderEventRepo {
     /// The NEWEST rows of one session's transcript, returned oldest first, and
     /// whether older rows were left behind.
     ///
+    /// The read behind BOTH the board timeline and an UNCURSORED
+    /// `fleet/transcript_list`, which want the same thing for the same reason:
+    /// the end of a run, bounded in size as well as in rows, with an honest
+    /// admission when either bound bit.
+    ///
+    /// Its forward twin [`Self::list_by_session_after`] cannot answer this by
+    /// being handed a computed cursor. `ingest_order` is
+    /// `INTEGER PRIMARY KEY AUTOINCREMENT`, ONE global sequence shared by every
+    /// provider's rows in this table, so a window of the newest N ORDERS is not
+    /// a window of the newest N rows of a SESSION: on a machine running several
+    /// agents with hooks, the newest hundred orders can contain none of the
+    /// session being watched.
+    ///
     /// The tail read behind `hangar/board_card_timeline`: an execution view
     /// shows the END of a run, and a whole transcript is unbounded in both rows
     /// and bytes (a coalesced text chunk is a few KiB, a tool call's verbatim
@@ -977,6 +990,208 @@ mod tests {
             FleetProviderEventRepo::append(store.pool(), &event("source-1", "second")).await,
             Err(FleetProviderEventError::EventIdCollision { .. })
         ));
+    }
+
+    /// The uncursored read answers with the END of one session's transcript,
+    /// past its own limit, with ANOTHER session interleaved through it.
+    ///
+    /// The interleaving is the whole point rather than decoration. Because
+    /// `ingest_order` is one global AUTOINCREMENT sequence, a client that
+    /// approximated a tail by asking for the newest N ORDERS would get a page
+    /// that is mostly (here entirely) the other session's rows, and on a busy
+    /// machine an EMPTY page for the session it is watching. That approximation
+    /// is what this read exists to replace, so the test has to make the two
+    /// answers differ.
+    #[tokio::test]
+    async fn the_uncursored_tail_answers_one_session_s_newest_rows_not_the_newest_orders() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+
+        // 150 rows for the watched session, then 100 for a NOISY neighbour, so
+        // the newest 100 global orders contain none of the watched session.
+        let mut batch: Vec<_> =
+            (0..150).map(|i| acp_event(&format!("mine-{i:03}"), "acp:watched")).collect();
+        batch.extend((0..100).map(|i| acp_event(&format!("noise-{i:03}"), "acp:noisy")));
+        FleetProviderEventRepo::append_batch(store.pool(), &batch).await.unwrap();
+
+        let (tail, truncated) = FleetProviderEventRepo::list_by_session_tail(
+            store.pool(),
+            "acp:watched",
+            100,
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert_eq!(tail.len(), 100, "the tail fills its limit from one session");
+        assert!(
+            truncated,
+            "50 older rows were left behind and the caller cannot infer that from a full page"
+        );
+        assert_eq!(
+            tail.first().unwrap().event_id,
+            "mine-050",
+            "the tail starts where the newest 100 of THIS session start"
+        );
+        assert_eq!(
+            tail.last().unwrap().event_id,
+            "mine-149",
+            "and ends at the session's newest row"
+        );
+        assert!(
+            tail.iter().all(|row| row.session_key.as_deref() == Some("acp:watched")),
+            "the neighbour's rows must never appear in this session's transcript"
+        );
+
+        // Ascending, identical to the cursored walk: callers already rely on
+        // commit order and a reversed page would be a wire change in disguise.
+        let orders: Vec<i64> = tail.iter().map(|row| row.ingest_order).collect();
+        let mut sorted = orders.clone();
+        sorted.sort_unstable();
+        assert_eq!(orders, sorted, "the tail is returned oldest first");
+
+        // The global-order window the client used to compute, for contrast:
+        // it lands entirely inside the neighbour's rows.
+        let head = FleetProviderEventRepo::head_order_for_session(store.pool(), "acp:noisy")
+            .await
+            .unwrap()
+            .unwrap();
+        let windowed = FleetProviderEventRepo::list_by_session_after(
+            store.pool(),
+            "acp:watched",
+            head - 100,
+            100,
+        )
+        .await
+        .unwrap();
+        assert!(
+            windowed.is_empty(),
+            "the global-order window is empty for this session, which is the bug the tail fixes"
+        );
+
+        // And the cursored half is untouched: given a row, it still walks
+        // forward from it.
+        let after = FleetProviderEventRepo::list_by_session_after(
+            store.pool(),
+            "acp:watched",
+            tail.first().unwrap().ingest_order,
+            10,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            after.first().unwrap().event_id,
+            "mine-051",
+            "the cursor stays exclusive and forward"
+        );
+    }
+
+    /// A session with FEWER rows than the limit returns all of them, and an
+    /// unknown session returns nothing rather than somebody else's tail.
+    #[tokio::test]
+    async fn a_short_transcript_tails_whole_and_an_unknown_session_tails_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let batch: Vec<_> = (0..3).map(|i| acp_event(&format!("s-{i}"), "acp:short")).collect();
+        FleetProviderEventRepo::append_batch(store.pool(), &batch).await.unwrap();
+
+        let (whole, truncated) = FleetProviderEventRepo::list_by_session_tail(
+            store.pool(),
+            "acp:short",
+            100,
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !truncated,
+            "a transcript shorter than the limit is COMPLETE, not truncated"
+        );
+        assert_eq!(
+            whole.iter().map(|row| row.event_id.as_str()).collect::<Vec<_>>(),
+            ["s-0", "s-1", "s-2"],
+            "a transcript shorter than the limit is returned whole, oldest first"
+        );
+
+        let (none, _truncated) = FleetProviderEventRepo::list_by_session_tail(
+            store.pool(),
+            "acp:nobody",
+            100,
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert!(
+            none.is_empty(),
+            "an unknown session must not borrow another's rows"
+        );
+    }
+
+    /// The BYTE budget binds independently of the row cap, and says so.
+    ///
+    /// This is the half a caller cannot infer: the page comes back well short
+    /// of its row limit, which on a row-bounded read would mean "that is the
+    /// whole transcript". Here it means the opposite. A client that read
+    /// `rows.len()` as completeness would render a partial run as a whole one,
+    /// which is the failure the flag exists to prevent.
+    #[tokio::test]
+    async fn the_byte_budget_truncates_independently_of_the_row_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let fat = |id: &str| NewFleetProviderEvent {
+            raw_payload: format!("{{\"text\":\"{}\"}}", "x".repeat(4096)),
+            ..acp_event(id, "acp:fat")
+        };
+        let batch: Vec<_> = (0..20).map(|i| fat(&format!("fat-{i:02}"))).collect();
+        FleetProviderEventRepo::append_batch(store.pool(), &batch).await.unwrap();
+
+        // Room for roughly two payloads, against a row cap of twenty.
+        let (rows, truncated) =
+            FleetProviderEventRepo::list_by_session_tail(store.pool(), "acp:fat", 20, 9_000)
+                .await
+                .unwrap();
+
+        assert!(truncated, "the byte budget bit and the caller must be told");
+        assert!(
+            rows.len() < 20,
+            "the byte budget bound the page, not the row cap: {}",
+            rows.len()
+        );
+        assert_eq!(
+            rows.last().unwrap().event_id,
+            "fat-19",
+            "whichever bound bit, the page still ENDS at the newest row"
+        );
+    }
+
+    /// One payload larger than the whole budget is still shown.
+    ///
+    /// The alternative is an empty transcript for a session that has run, which
+    /// reads as "nothing happened" when the truth is "one thing happened and it
+    /// was big". Its own renderer caps the body.
+    #[tokio::test]
+    async fn a_single_oversized_payload_survives_the_byte_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        FleetProviderEventRepo::append(
+            store.pool(),
+            &NewFleetProviderEvent {
+                raw_payload: format!("{{\"text\":\"{}\"}}", "x".repeat(100_000)),
+                ..acp_event("huge", "acp:huge")
+            },
+        )
+        .await
+        .unwrap();
+
+        let (rows, _truncated) =
+            FleetProviderEventRepo::list_by_session_tail(store.pool(), "acp:huge", 10, 1_000)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            rows.len(),
+            1,
+            "a lone oversized row must never be swallowed into an empty transcript"
+        );
     }
 
     #[tokio::test]

--- a/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
+++ b/apps/ainb-fleet-macos/AINBFleet.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		A100000000000000000000111 /* FleetChatPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000110 /* FleetChatPresentation.swift */; };
 		A100000000000000000000113 /* FleetChatPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000112 /* FleetChatPaneView.swift */; };
 		A100000000000000000000115 /* FleetChatPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000114 /* FleetChatPresentationTests.swift */; };
+		A100000000000000000000131 /* FleetTranscriptPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000130 /* FleetTranscriptPresentation.swift */; };
+		A100000000000000000000133 /* FleetTranscriptPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000000000000000000132 /* FleetTranscriptPresentationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,6 +110,8 @@
 		A100000000000000000000110 /* FleetChatPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetChat/FleetChatPresentation.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000112 /* FleetChatPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetChat/FleetChatPaneView.swift; sourceTree = SOURCE_ROOT; };
 		A100000000000000000000114 /* FleetChatPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetChatPresentationTests.swift; sourceTree = "<group>"; };
+		A100000000000000000000130 /* FleetTranscriptPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/FleetChat/FleetTranscriptPresentation.swift; sourceTree = SOURCE_ROOT; };
+		A100000000000000000000132 /* FleetTranscriptPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetTranscriptPresentationTests.swift; sourceTree = "<group>"; };
 		A1000000000000000000004D /* FleetUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000031 /* AINBFleet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AINBFleet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000000000000000000032 /* FleetRPCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FleetRPCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -196,6 +200,7 @@
 			children = (
 				A100000000000000000000110 /* FleetChatPresentation.swift */,
 				A100000000000000000000112 /* FleetChatPaneView.swift */,
+				A100000000000000000000130 /* FleetTranscriptPresentation.swift */,
 			);
 			path = Sources/FleetChat;
 			sourceTree = SOURCE_ROOT;
@@ -227,6 +232,7 @@
 				A10000000000000000000098 /* FleetReceiptNoticeTests.swift */,
 				A1000000000000000000005B /* FleetFixtureDaemonFallbackTests.swift */,
 				A100000000000000000000114 /* FleetChatPresentationTests.swift */,
+				A100000000000000000000132 /* FleetTranscriptPresentationTests.swift */,
 			);
 			path = Tests/FleetRPCTests;
 			sourceTree = "<group>";
@@ -409,6 +415,7 @@
 				A100000000000000000000105 /* FleetProviderIcon.swift in Sources */,
 				A100000000000000000000111 /* FleetChatPresentation.swift in Sources */,
 				A100000000000000000000113 /* FleetChatPaneView.swift in Sources */,
+				A100000000000000000000131 /* FleetTranscriptPresentation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,6 +436,7 @@
 				A1000000000000000000005C /* FleetFixtureDaemon.swift in Sources */,
 				A1000000000000000000005A /* FleetFixtureDaemonFallbackTests.swift in Sources */,
 				A100000000000000000000115 /* FleetChatPresentationTests.swift in Sources */,
+				A100000000000000000000133 /* FleetTranscriptPresentationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -157,6 +157,21 @@ final class FleetStore: ObservableObject {
     /// its own result. Every fold is an upsert by id, so replaying an event the
     /// page already contains changes nothing.
     private var chatEventsDuringPage: [FleetChatEvent] = []
+    /// The transcript's OWN in-flight buffer, separate from the chat one.
+    ///
+    /// One shared FIFO was wrong the moment a fourth axis arrived. The three
+    /// chat frames and the transcript stream have completely different rates:
+    /// an agent mid-turn emits transcript chunks continuously while the
+    /// conversation is idle, so a single hundred-entry buffer is emptied of
+    /// chat messages by transcript traffic within one page. That would silently
+    /// undo the guarantee the buffer was added for, and it would do it exactly
+    /// when the pane is busiest.
+    ///
+    /// Bounded by the transcript page size for the same reason the chat buffer
+    /// is bounded by the message page size: the replay is onto a page that
+    /// already holds that many rows, so anything older is about to be dropped
+    /// by the surface's own ceiling anyway.
+    private var transcriptEventsDuringPage: [FleetChatEvent] = []
     /// How many pages are running. A count, not a flag: the poll loop and the
     /// send path both page, and they overlap. Buffering only while this is
     /// above zero is what keeps the buffer bounded by one page's duration
@@ -245,6 +260,22 @@ final class FleetStore: ObservableObject {
 
     var canAnswerConfirms: Bool {
         canWrite && negotiation?.capabilityIDs.contains("fleet.confirm.answer") == true && pendingIntentID == nil
+    }
+
+    /// Whether this daemon serves the ACP execution transcript.
+    ///
+    /// `fleet.transcript.read` is the id BOTH transcript arms check
+    /// (`handle_fleet_transcript_list`, `handle_fleet_transcript_subscribe`),
+    /// and it is gated SEPARATELY from `canReadChat` for the reason that gate
+    /// gives: a daemon built between phases serves the conversation while
+    /// answering -32601 for the transcript, and one combined gate would either
+    /// hide a working conversation or open a stream that errors.
+    ///
+    /// `fleet.transcript.prune` is deliberately NOT consulted. It is a separate
+    /// id naming the destructive verb, and nothing on this surface deletes a
+    /// transcript.
+    var canReadTranscript: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.transcript.read") == true
     }
 
     #if DEBUG
@@ -842,20 +873,181 @@ final class FleetStore: ObservableObject {
             canWrite: canWrite,
             mintedSessionKeyByScope: copilotSessionKeyByScope
         )
+        // An EARLY out on the same ticket, purely to stop a page the store has
+        // already disowned spending two more round trips on a transcript
+        // nobody will see. The check that actually gates the publish is the one
+        // below, after every read has finished.
+        guard copilotCacheGeneration == generation else { return nil }
+        var surface = paged
+        carryTranscriptForward(into: &surface)
+        await pageTranscript(using: connection, into: &surface)
         guard copilotCacheGeneration == generation else { return nil }
         if minted,
-           let scope = paged.scopeKey,
-           let sessionKey = paged.targetSessionKey {
+           let scope = surface.scopeKey,
+           let sessionKey = surface.targetSessionKey {
             copilotSessionKeyByScope[scope] = sessionKey
         }
         // Everything that arrived live while this page was reading, replayed
         // onto it. Without this the page silently rewinds the pane past any
-        // message committed after `fleet/message_list` answered.
-        var surface = paged
-        for event in chatEventsDuringPage {
+        // message committed after `fleet/message_list` answered, or any
+        // transcript chunk committed after `fleet/transcript_list` did.
+        // Both buffers replay, chat then transcript. The two touch disjoint
+        // parts of the surface, so their relative order does not matter; the
+        // order WITHIN each does, and appending preserves it.
+        for event in chatEventsDuringPage + transcriptEventsDuringPage {
             surface.apply(event)
         }
         return surface
+    }
+
+    /// Carry the transcript the operator is already reading onto a fresh page.
+    ///
+    /// A page builds its surface from an empty `FleetChatSurface` and the store
+    /// publishes it WHOLESALE, which is the invariant that stops a half-applied
+    /// refresh showing this page's cards beside the last one's timeline. For
+    /// the conversation that is harmless, because a page re-reads the whole
+    /// conversation. For the transcript it was destructive: nothing carried the
+    /// rows forward, so every safety-net page threw away every live row since
+    /// the last one. An agent mid-turn would emit three hundred rows, and at
+    /// thirty seconds the pane would drop to the empty state while it was still
+    /// running.
+    ///
+    /// The CLASSIFIER is carried for a reason of its own and it is the subtler
+    /// half: it holds the pending tool-title map, so discarding it mid-run
+    /// makes the next tool result render under the unnamed `tool` form. That is
+    /// the exact degradation the replay guard exists to prevent, arriving
+    /// through the page instead of through a replay.
+    ///
+    /// Only when the SESSION is unchanged. A re-minted copilot session is a
+    /// different transcript, and carrying rows across that boundary would paint
+    /// one agent's execution under another's name.
+    private func carryTranscriptForward(into surface: inout FleetChatSurface) {
+        guard let sessionKey = surface.targetSessionKey,
+              sessionKey == chat.targetSessionKey,
+              chat.transcriptState.cursor != nil else { return }
+        // ONE assignment, and that is the fix rather than a tidy-up. This was
+        // four hand-written copies, so what a new field did across a page
+        // depended on whether its author remembered to add a fifth. It is now
+        // decided at the declaration instead: inside `FleetTranscriptState` is
+        // carried, beside it is rebuilt. `transcriptDetail` is beside it, which
+        // is why a momentary refusal can no longer pin its banner forever.
+        surface.transcriptState = chat.transcriptState
+    }
+
+    /// Make sure this connection's transcript stream is open, and fill the tail
+    /// on the pages that need one.
+    ///
+    /// SUBSCRIBE FIRST, then page, which is the opposite order from the chat
+    /// half and not an inconsistency: the forwarder has to be armed before the
+    /// snapshot is taken, or a chunk committing between the two is delivered by
+    /// neither. The daemon registers the forwarder at the acked head and its
+    /// first act is to read everything past that cursor, so the two meet
+    /// exactly. Anything that lands in both is dropped by the surface's cursor.
+    ///
+    /// The page is UNCURSORED, and that is now a tail read rather than a
+    /// client-computed window. `ingest_order` is one global `AUTOINCREMENT`
+    /// sequence shared by every provider's rows, so the newest N orders are not
+    /// the newest N rows of a session: on a machine running several agents with
+    /// hooks, a window of the newest hundred orders can hold ZERO rows for the
+    /// session being watched. The daemon answers an absent cursor with that
+    /// session's own newest page, which is the only version of this read a
+    /// client can be correct with.
+    ///
+    /// A safety-net page costs ONE round trip once rows are on screen: the
+    /// subscribe that re-arms the stream, and no tail read, because the rows
+    /// are carried rather than re-fetched.
+    ///
+    /// TWO while the transcript is still empty, and that state is not rare: a
+    /// session that has not produced a turn leaves the cursor nil, so the tail
+    /// is read again on every page until something exists to read. That is the
+    /// state a pane most often opens in, so the cost is stated rather than
+    /// rounded down to nothing.
+    ///
+    /// Every failure degrades to an explained absence rather than failing the
+    /// page, exactly as the confirm and activity feeds do: a daemon that does
+    /// not serve transcripts must not cost the operator their conversation.
+    private func pageTranscript(
+        using connection: FleetConnection,
+        into surface: inout FleetChatSurface
+    ) async {
+        // Capability FIRST. A daemon that cannot serve transcripts and a scope
+        // with no session are two different absences, and the ORDER decides
+        // which one the operator is told about. Asking about the session first
+        // reported "no session attached" on a daemon that would have refused
+        // the read anyway, sending the reader off to look at the wrong thing.
+        guard canReadTranscript else {
+            surface.transcriptDetail = "This daemon does not serve ACP transcripts."
+            return
+        }
+        guard let sessionKey = surface.targetSessionKey,
+              !sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            surface.transcriptDetail = "No copilot session is attached, so there is no transcript to follow."
+            return
+        }
+        // SUBSCRIBE ON EVERY PAGE, with no guard in front of it.
+        //
+        // That is only safe because the subscribe now names a cursor: resuming
+        // from the row already shown can neither gap nor duplicate, so a
+        // repeat costs one round trip and nothing else. It buys the self-heal
+        // that the guard removed. `spawn_transcript_forwarder` exits on a
+        // single read error and leaves the socket alive with no forwarder
+        // behind it, and a transient sqlite lock is enough to do it; with a
+        // guard, that pane stayed silently dead until the session was
+        // re-minted. Re-arming every page is the cheapest way to notice.
+        //
+        // It also retires the bookkeeping this used to need. There is no
+        // remembered stream key to go stale, and therefore no question of
+        // whether a failed LIST should un-record a forwarder that is in fact
+        // registered.
+        let needsPage = surface.transcriptState.cursor == nil
+        do {
+            // RESUMING from the newest row already shown, not from the
+            // daemon's head. This is the lesson `openChatStream` records twenty
+            // lines below, and the transcript repeated it: a bare subscribe
+            // starts the forwarder at the head, so everything committed while
+            // this client was disconnected is never pushed. The tail page used
+            // to be the backstop and no longer is, because a carried cursor
+            // skips it: a five-second outage over a busy turn silently lost
+            // every row in the gap, with no seam to show it happened.
+            //
+            // Nil on a first page, which is the head, and the tail read that
+            // follows fills in behind it. No retry dance is needed here, unlike
+            // the message half: the daemon refuses only a NEGATIVE order, and
+            // an order it has never seen simply delivers nothing until the
+            // session commits past it.
+            //
+            // A long outage replays the whole gap, which is the same unbounded
+            // catch-up the chat stream accepts. The surface's own ceiling
+            // bounds what is kept.
+            _ = try await connection.transcriptSubscribe(
+                FleetTranscriptSubscribeParams(
+                    sessionKey: sessionKey,
+                    afterOrder: surface.transcriptState.cursor
+                )
+            )
+            guard needsPage else { return }
+            let page = try await connection.transcriptList(FleetTranscriptListParams(
+                sessionKey: sessionKey,
+                afterOrder: nil,
+                limit: fleetTranscriptListMax
+            ))
+            // The daemon's admission that it left rows behind, carried onto the
+            // surface rather than dropped. A short page is not the same fact as
+            // a short transcript: the tail is bounded by payload BYTES as well
+            // as rows, so a session of large chunks returns few of them, and a
+            // pane that read that as completeness would draw a partial run as a
+            // whole one.
+            surface.transcriptState.truncated = page.truncated
+            // Folded through the SAME door a live chunk takes, so the paged
+            // half and the live half of one transcript cannot disagree about a
+            // row, and the classifier the page leaves behind is the one the
+            // stream continues on.
+            for chunk in page.chunks {
+                surface.apply(.transcript(chunk))
+            }
+        } catch {
+            surface.transcriptDetail = String(describing: error)
+        }
     }
 
     /// Open the live chat stream, RESUMING from the newest row already shown.
@@ -916,6 +1108,7 @@ final class FleetStore: ObservableObject {
     private func beginChatPage() {
         if chatPagesInFlight == 0 {
             chatEventsDuringPage.removeAll()
+            transcriptEventsDuringPage.removeAll()
         }
         chatPagesInFlight += 1
     }
@@ -1169,6 +1362,12 @@ final class FleetStore: ObservableObject {
             }
         case let .activityEvent(params):
             fold(.activity(params.activity))
+        case let .transcriptEvent(params):
+            // The chunk goes in VERBATIM. Classifying here would bind it to
+            // whichever classifier was current when the frame arrived, and the
+            // one that has to read it is the surface's, which a page may be
+            // about to replace.
+            fold(.transcript(params.chunk))
         case .unknownNotification:
             break
         }
@@ -1181,9 +1380,11 @@ final class FleetStore: ObservableObject {
     /// moves NOW, and the event is remembered if a page is running so that
     /// page cannot overwrite it with a read that predates it.
     ///
-    /// The scope filter lives in `FleetChatSurface.apply`, where the scope key
-    /// is: the daemon's chat stream is fleet-wide, and every one of the three
-    /// event types carries the scope it was filed under.
+    /// The filter lives in `FleetChatSurface.apply`, where the keys are: the
+    /// daemon's streams are broader than this pane. Of the FOUR event types,
+    /// the three chat frames carry the scope they were filed under and the
+    /// transcript chunk carries no scope at all, so it is filtered by the
+    /// session that produced it instead.
     ///
     /// The write is guarded on a real change for the same reason the poll's is:
     /// an assignment to a `@Published` value redraws the pane whether or not
@@ -1194,24 +1395,58 @@ final class FleetStore: ObservableObject {
         // opens is what makes the surface current again, so the only thing lost
         // is liveness for a view nobody is looking at.
         guard chatPanesOpen > 0 else { return }
-        if chatPagesInFlight > 0, chat.scopeKey == nil || event.scopeKey == chat.scopeKey {
-            // Buffered by SCOPE at the door, not at replay. The stream is
-            // fleet-wide, so an unfiltered buffer collects every conversation's
+        if chatPagesInFlight > 0, event.belongsToPage(of: chat) {
+            // Buffered at the door, not at replay, and per AXIS: the chat
+            // frames are matched on scope and the transcript on session, which
+            // is what each stream is addressed by. The streams are broader than
+            // this pane, so an unfiltered buffer collects every conversation's
             // traffic, and a page whose RPC never answers holds the in-flight
             // count above zero for as long as that call hangs.
             //
-            // The nil case is not a hole in that filter, it is the FIRST page.
-            // Until one publishes there is no scope to compare against, and a
-            // filter that answered "no match" there would drop exactly what the
-            // buffer exists for: a message committed while the opening page was
-            // still reading its confirm and activity feeds. Replay applies the
-            // paged surface's own scope, so nothing foreign gets rendered, and
-            // the window lasts one page with the cap still in force.
-            chatEventsDuringPage.append(event)
-            if chatEventsDuringPage.count > Int(fleetMessageListMax) {
-                chatEventsDuringPage.removeFirst()
+            // The nil case on either axis is not a hole in that filter, it is
+            // the FIRST page. Until one publishes there is nothing to compare
+            // against, and a filter that answered "no match" there would drop
+            // exactly what the buffer exists for: a message committed while the
+            // opening page was still reading its confirm and activity feeds.
+            // Replay applies the paged surface's own scope and session, so
+            // nothing foreign gets rendered, and the window lasts one page with
+            // the cap still in force.
+            // Buffered per AXIS, not into one shared queue. An agent
+            // mid-turn emits transcript chunks continuously while the
+            // conversation sits idle, so a single FIFO would evict the chat
+            // messages this buffer was added to protect, and would do it
+            // exactly when the pane is busiest. Each axis is bounded by its own
+            // page size, which is the number of rows its replay target already
+            // holds.
+            switch event {
+            case .message, .confirm, .activity:
+                chatEventsDuringPage.append(event)
+                if chatEventsDuringPage.count > Int(fleetMessageListMax) {
+                    chatEventsDuringPage.removeFirst()
+                }
+            case .transcript:
+                transcriptEventsDuringPage.append(event)
+                if transcriptEventsDuringPage.count > Int(fleetTranscriptListMax) {
+                    transcriptEventsDuringPage.removeFirst()
+                }
             }
         }
+        // ponytail: this copies the surface and compares it whole, on the main
+        // actor, once per incoming event. With the transcript's ceiling that is
+        // up to 500 rows compared per chunk while an agent streams.
+        //
+        // Measured as cheap and left alone deliberately. `next` is a
+        // copy-on-write struct, so the copy is O(1) until `apply` mutates one
+        // array; the comparison then walks rows whose Strings are the SAME
+        // instances on both sides, which takes the identity fast path rather
+        // than comparing text. At ACP chunk rates (tens per second at the very
+        // most) it does not register.
+        //
+        // The obvious alternative, a dirty flag from `apply`, would trade that
+        // for a correctness hazard: this comparison is the ONLY thing stopping
+        // a no-op event writing `@Published` and redrawing the roster, the
+        // chips and the menu bar. Raise the ceiling a lot, or start folding
+        // something with genuinely expensive equality, and revisit it then.
         var next = chat
         next.apply(event)
         if next != chat { chat = next }

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
@@ -174,6 +174,7 @@ struct FleetChatPaneView: View {
             VStack(alignment: .leading, spacing: 14) {
                 confirmSection
                 activitySection
+                transcriptSection
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(16)
@@ -280,6 +281,81 @@ struct FleetChatPaneView: View {
                     .accessibilityIdentifier("fleet.chat.activity.\(row.seq)")
                 }
             }
+        }
+    }
+
+    /// The target session's ACP execution stream.
+    ///
+    /// LAST in the sidebar on purpose: the confirm cards above it are the only
+    /// thing here an operator has to act on, and a transcript that pushed them
+    /// below the fold would bury an approval under an agent's thinking.
+    ///
+    /// Gated on `canReadTranscript`, which is its own capability rather than
+    /// the pane's, so a daemon that serves the conversation but not the
+    /// transcript renders one and explains the other. Every empty state names
+    /// WHY it is empty: an idle session and an unreadable one are different
+    /// facts, and a section that showed silence for both would tell the
+    /// operator the agent has done nothing when the truth is that this build
+    /// cannot see what it did.
+    @ViewBuilder private var transcriptSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Execution transcript")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(FleetChatPalette.muted)
+            if let detail = store.chat.transcriptDetail {
+                Text("Transcript unavailable: \(detail)")
+                    .font(.caption)
+                    .foregroundStyle(FleetChatPalette.amber)
+                    .accessibilityIdentifier("fleet.chat.transcript.detail")
+            } else if store.chat.transcriptState.rows.isEmpty {
+                Text("Nothing yet. The session has not produced a turn.")
+                    .font(.callout)
+                    .foregroundStyle(FleetChatPalette.muted)
+                    .accessibilityIdentifier("fleet.chat.transcript.empty")
+            }
+            // The seam the daemon reported, above the rows it describes. A
+            // transcript that silently starts mid-run reads as a whole one,
+            // which is the failure the flag exists to prevent.
+            if store.chat.transcriptState.truncated, !store.chat.transcriptState.rows.isEmpty {
+                transcriptRow(fleetTranscriptTruncationRow)
+            }
+            ForEach(store.chat.transcriptState.rows) { row in
+                transcriptRow(row)
+            }
+        }
+    }
+
+    private func transcriptRow(_ row: FleetTranscriptRow) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(FleetTranscriptLabels.lane(row.lane))
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(laneColor(row.lane))
+            Text(row.body)
+                .font(.caption.monospaced())
+                // Bounded here as well as in the classifier: the cap upstream
+                // is a leak backstop at eight thousand characters, which is
+                // still far more than a sidebar row can show.
+                .lineLimit(4)
+                .textSelection(.enabled)
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+        // The lane is SPOKEN, not left to the colour. A VoiceOver user must be
+        // able to tell an error line from a tool result, and colour is the one
+        // signal that does not survive.
+        .accessibilityLabel("\(FleetTranscriptLabels.accessibilityLane(row.lane)): \(row.body)")
+        .accessibilityIdentifier("fleet.chat.transcript.\(row.id)")
+    }
+
+    /// Wildcard-free, so a sixth lane is a compile error here rather than a row
+    /// painted in whichever colour the last arm happened to name.
+    private func laneColor(_ lane: FleetTranscriptLane) -> Color {
+        switch lane {
+        case .agent: FleetChatPalette.mint
+        case .thinking: FleetChatPalette.violet
+        case .toolCall: FleetChatPalette.amber
+        case .toolResult: FleetChatPalette.muted
+        case .error: FleetChatPalette.coral
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
@@ -352,6 +352,36 @@ struct FleetChatSurface: Equatable {
     var messages: [FleetChatMessageRow] = []
     var confirms: [FleetChatConfirmCard] = []
     var activity: [FleetActivityRow] = []
+    /// Everything about the transcript that SURVIVES a page.
+    ///
+    /// One nested value, not four loose fields, and that is the whole point.
+    /// A page rebuilds its surface from an empty one, so every field here is
+    /// either carried across that boundary or rebuilt by it, and nothing about
+    /// a bare `var` says which. `carryTranscriptForward` used to answer with a
+    /// hand-written assignment per field, so a new field landed on whichever
+    /// side its author remembered and the compiler was happy either way.
+    ///
+    /// Two bugs came out of that one gap, and they were the same bug twice.
+    /// `transcriptDetail` was put on the carry side, so a momentary refusal
+    /// pinned its banner above a live transcript until the app restarted. The
+    /// cursor was carried but not USED on the resubscribe, so a reconnect
+    /// silently lost every row committed during the outage.
+    ///
+    /// Now the question is answered once, at the declaration: a field inside
+    /// this type is carried, a field beside it is rebuilt.
+    var transcriptState = FleetTranscriptState()
+    /// Why the transcript is empty, when it is empty for a REASON.
+    ///
+    /// The same distinction `confirmsDetail` draws: a daemon that does not
+    /// advertise `fleet.transcript.read`, or one that refused the page, is not
+    /// the same fact as a session that has not run a turn yet, and a pane that
+    /// rendered both as silence would tell the operator the agent is idle when
+    /// it simply cannot see.
+    ///
+    /// A PEER of `transcriptState`, never a member, and that placement is the
+    /// fix rather than a detail of it: this describes the page that set it, so
+    /// it must be rebuilt by the next page and cannot be carried by accident.
+    var transcriptDetail: String? = nil
     /// Why the confirm feed is empty, when it is empty for a REASON. A daemon
     /// built between phases answers -32601 here, and a pane that renders that
     /// as "no cards open" is telling the operator there is nothing to approve
@@ -365,25 +395,37 @@ struct FleetChatSurface: Equatable {
 
     /// Fold one live notification into this page.
     ///
-    /// The scope filter is HERE rather than at the call site because the
-    /// daemon's chat stream is fleet-wide: `fleet/message_event` carries every
+    /// The filter is HERE rather than at the call site because the daemon's
+    /// streams are broader than this pane: `fleet/message_event` carries every
     /// committed message on the socket, not this scope's. The surface is the
     /// only thing that knows which conversation is on screen, so it is the only
-    /// thing that can say an event is not this one's. An event for another
-    /// scope is dropped, never rendered.
+    /// thing that can say an event is not this one's. An event that does not
+    /// belong is dropped, never rendered.
     ///
-    /// Nothing is folded before a page has resolved a scope: `scopeKey` is nil
-    /// until then, and an event that cannot be proved to belong here does not
-    /// get the benefit of the doubt.
+    /// The three chat frames are filtered by SCOPE and the transcript frame by
+    /// SESSION, because that is what each one is addressed by: a chat message
+    /// is filed under a scope key, while a transcript chunk belongs to the ACP
+    /// session that produced it. Filtering the transcript on scope would match
+    /// nothing at all, and filtering it on nothing would paint another
+    /// session's execution into this pane.
+    ///
+    /// Nothing is folded before a page has resolved the axis it is filtered on:
+    /// an event that cannot be proved to belong here does not get the benefit
+    /// of the doubt.
     mutating func apply(_ event: FleetChatEvent) {
-        guard let scopeKey, scopeKey == event.scopeKey else { return }
         switch event {
         case let .message(message):
+            guard scopeKey != nil, scopeKey == message.scopeKey else { return }
             upsert(FleetChatMessageRow(message: message))
-        case let .confirm(card, _):
+        case let .confirm(card, cardScope):
+            guard scopeKey != nil, scopeKey == cardScope else { return }
             upsert(card)
         case let .activity(row):
+            guard scopeKey != nil, scopeKey == row.scopeKey else { return }
             upsert(row)
+        case let .transcript(chunk):
+            guard targetSessionKey != nil, targetSessionKey == chunk.sessionKey else { return }
+            append(chunk)
         }
     }
 
@@ -440,6 +482,27 @@ struct FleetChatSurface: Equatable {
             activity.removeFirst(activity.count - Int(fleetActivityListMax))
         }
     }
+
+    /// Classify one transcript chunk and append its rows, oldest first.
+    ///
+    /// APPEND, never upsert, and the guard in front of it is the cursor rather
+    /// than a row id. One chunk classifies into MANY rows, and the classifier
+    /// is stateful, so re-running a chunk is not idempotent: the second pass
+    /// finds the pending tool title already consumed and renders the result
+    /// under the unnamed `tool` form. The cursor stops the second pass ever
+    /// happening, which is both cheaper and the only version that is correct.
+    ///
+    /// Bounded like its neighbours, dropping the OLDEST rows, because this is
+    /// a tail view of a running session and the newest rows are the ones an
+    /// operator is reading.
+    private mutating func append(_ chunk: FleetTranscriptChunk) {
+        if let cursor = transcriptState.cursor, chunk.ingestOrder <= cursor { return }
+        transcriptState.cursor = chunk.ingestOrder
+        transcriptState.rows.append(contentsOf: transcriptState.classifier.rows(for: chunk))
+        if transcriptState.rows.count > fleetTranscriptRowMax {
+            transcriptState.rows.removeFirst(transcriptState.rows.count - fleetTranscriptRowMax)
+        }
+    }
 }
 
 /// One live chat notification, in the three shapes the chat surface folds.
@@ -456,18 +519,62 @@ struct FleetChatSurface: Equatable {
 /// tolerance would be the one shape of card the pane could not show. Its scope
 /// rides alongside because an unrecognised card has no readable fields to take
 /// it from.
+/// The transcript case carries the chunk VERBATIM rather than pre-classified
+/// rows, and that is the same reasoning once more: the taxonomy is stateful, so
+/// the rows a chunk produces depend on which classifier reads it, and the
+/// classifier that must read it is the one belonging to the surface the chunk
+/// is folded into. Classifying at the door would have bound every chunk to
+/// whichever classifier happened to be current when the frame arrived,
+/// including one owned by a page the store went on to disown.
 enum FleetChatEvent: Equatable, Sendable {
     case message(FleetMessage)
     case confirm(card: FleetChatConfirmCard, scopeKey: String)
     case activity(FleetActivityRow)
+    case transcript(FleetTranscriptChunk)
 
-    /// The scope this event was filed under. Every one of the three carries it,
-    /// which is what makes a fleet-wide stream safe to render in a scoped pane.
-    var scopeKey: String {
+    /// The scope this event was filed under, for the three chat frames that
+    /// have one. Nil for the transcript, which is addressed by session.
+    var scopeKey: String? {
         switch self {
         case let .message(message): message.scopeKey
         case let .confirm(_, scopeKey): scopeKey
         case let .activity(row): row.scopeKey
+        case .transcript: nil
+        }
+    }
+
+    /// The ACP session this event belongs to, for the transcript frame that has
+    /// one. Nil for the three chat frames, which are addressed by scope.
+    ///
+    /// Every event names exactly ONE of the two axes, and which one it names is
+    /// which stream it came off. A shape that named neither could not be
+    /// filtered at all.
+    var sessionKey: String? {
+        switch self {
+        case .message, .confirm, .activity: nil
+        case let .transcript(chunk): chunk.sessionKey
+        }
+    }
+
+    /// Whether a page that is still RUNNING should buffer this event to replay
+    /// onto its own result.
+    ///
+    /// Filtered at the door, per axis, for the reason the store's buffer
+    /// documents: the daemon's streams are broader than this pane, so an
+    /// unfiltered buffer collects every conversation's traffic while a page
+    /// whose RPC hangs holds the in-flight count open.
+    ///
+    /// The nil case on either axis is NOT a hole in that filter, it is the
+    /// FIRST page. Until one publishes there is nothing to compare against, and
+    /// a filter that answered "no match" there would drop exactly what the
+    /// buffer exists for. Replay applies the paged surface's own scope and
+    /// session, so nothing foreign gets rendered.
+    func belongsToPage(of surface: FleetChatSurface) -> Bool {
+        switch self {
+        case .message, .confirm, .activity:
+            return surface.scopeKey == nil || surface.scopeKey == scopeKey
+        case .transcript:
+            return surface.targetSessionKey == nil || surface.targetSessionKey == sessionKey
         }
     }
 }

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetTranscriptPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetTranscriptPresentation.swift
@@ -1,0 +1,684 @@
+import Foundation
+
+// The Swift half of the ACP transcript taxonomy, in pure display terms so the
+// tests can hold it without a window.
+//
+// This is a PORT of `AcpClassifier` in
+// `ainb-tui/crates/ainb-hangar-proto/src/transcript.rs`, arm for arm, and the
+// point of the port is that the notch and the terminal client read one
+// transcript the same way. An operator watching both surfaces must not have to
+// learn two vocabularies for one tool call, so every string this file emits is
+// the string the Rust side emits: the same double spaces, the same `[error]`
+// suffix, the same `· <subtype> · <duration>` run-status line, the same
+// `plan · <status> · <content>` checklist row.
+//
+// The deliberate divergences, all forced by the representation rather than
+// chosen, are named where they occur: object key ORDER in a compact JSON
+// rendering (a Swift dictionary has no insertion order), the codex and
+// stream-json arms (this client never reads a process executor's transcript),
+// and `acp_row_text` (its only caller is the daemon's PR-URL scanner).
+//
+// The caps are NOT among them. They count the same unit the Rust counts, down
+// to Unicode scalars rather than Swift `Character`s; see `truncateChars` for
+// why that distinction is the difference between a bound and no bound.
+//
+// Every `switch` below is exhaustive with NO `default`, per the rule
+// `FleetChatPresentation.swift` states: a new lane or a new JSON shape must
+// fail to COMPILE rather than fall through to whichever arm was written last.
+
+/// Clip a one-line summary / snippet to this many display chars (char-safe).
+///
+/// `SUMMARY_MAX` in the Rust.
+private let transcriptSummaryMax = 84
+
+/// Hard ceiling on a single classified body, in display CHARS not bytes.
+///
+/// `BODY_MAX` in the Rust, and generous for the same reason: this is a leak
+/// backstop, not a display width. An adapter is free to emit a megabyte of
+/// prose or a base64 blob in one chunk, and every classified body here is held
+/// in a `@Published` surface the whole notch observes, so an uncapped body is
+/// an unbounded allocation on the render path.
+///
+/// The UNIT is load-bearing and it is why `truncateChars` exists. Adapter prose
+/// carries non-ASCII routinely, so cutting at a byte index would split a code
+/// point; the Rust side pins exactly that
+/// (`the_body_cap_never_splits_a_multibyte_char`) and so does this one. The
+/// unit is Unicode SCALARS, matching the Rust's `chars()`, because a Swift
+/// `Character` is a grapheme cluster of unbounded length and a cap counted in
+/// those would not bound anything at all.
+private let transcriptBodyMax = 8192
+
+/// Ceiling on the rows ONE chunk may classify into.
+///
+/// `ENTRIES_PER_LINE_MAX` in the Rust. A single chunk carrying a multi-line
+/// text block yields one row per line, so the per-body cap above bounds each
+/// row without bounding their count.
+private let transcriptEntriesPerChunkMax = 512
+
+/// Most tool calls remembered while awaiting their update.
+///
+/// `MAX_PENDING_TOOLS` in the Rust, and the same backstop rather than a working
+/// limit: an adapter issues a handful per turn.
+private let transcriptPendingToolsMax = 256
+
+/// How many classified rows the surface keeps.
+///
+/// A CLIENT display choice, not a daemon constant, which is why it does not
+/// live beside `fleetTranscriptListMax` in the wire file. One page is up to
+/// `fleetTranscriptListMax` chunks and one chunk can classify into
+/// `transcriptEntriesPerChunkMax` rows, so a page alone has a worst case of
+/// fifty thousand rows before a single live chunk arrives. This is the ceiling
+/// that makes the pane's cost a function of the ceiling instead of a function
+/// of how chatty the adapter is.
+///
+/// The OLDEST rows go, which is what a fresh page of a busier transcript would
+/// have shown anyway: this is a tail view of a running session.
+let fleetTranscriptRowMax = 500
+
+/// The five-lane transcript taxonomy, mirroring the Rust `MessageKind`.
+///
+/// NOT a wire enum: the daemon sends chunks, this client derives the lane, so
+/// there is no token to be tolerant about and no `unknown` arm to add. A chunk
+/// type the taxonomy does not carry yields NO row rather than an unknown one.
+enum FleetTranscriptLane: String, Equatable, CaseIterable, Sendable {
+    /// Adapter prose.
+    case agent
+    /// Adapter reasoning.
+    case thinking
+    /// A tool invocation.
+    case toolCall
+    /// A tool's result.
+    case toolResult
+    /// An error line.
+    case error
+}
+
+/// One classified line, before it is anchored to the chunk it came from.
+///
+/// A named struct rather than the Rust's `(MessageKind, String)` tuple, because
+/// a tuple has no key paths and the tests read these by lane and by body.
+struct FleetTranscriptEntry: Equatable, Sendable {
+    let lane: FleetTranscriptLane
+    let body: String
+}
+
+/// One classified transcript row, ready to paint.
+struct FleetTranscriptRow: Equatable, Identifiable, Sendable {
+    /// `<ingest order>.<row index within the chunk>`.
+    ///
+    /// Derived rather than the chunk's `event_id`, because one chunk classifies
+    /// into MANY rows and `ForEach` needs each of them to be distinct. Anchored
+    /// to the commit cursor rather than to a UUID so the same chunk classified
+    /// twice produces the same ids, which is what makes a replayed chunk a
+    /// no-op instead of a duplicated tool call.
+    let id: String
+    /// The commit-ordered cursor of the chunk this row came from.
+    let ingestOrder: Int64
+    let lane: FleetTranscriptLane
+    let body: String
+}
+
+/// The transcript state that SURVIVES a safety-net page.
+///
+/// Grouped so that "is this field carried across a page, or rebuilt by it" is
+/// answered by which type a field is declared in, rather than by remembering to
+/// edit a copy function. See `FleetChatSurface.transcriptState`.
+///
+/// The classifier belongs in here rather than beside it: it holds the pending
+/// tool-title map, so a page that kept the rows but dropped the classifier
+/// would re-render the next tool result under the unnamed `tool` form. Rows and
+/// the state that produced them travel together or not at all.
+struct FleetTranscriptState: Equatable, Sendable {
+    /// The classified rows on screen, oldest first.
+    var rows: [FleetTranscriptRow] = []
+    /// The highest `ingest_order` folded, and the transcript's dedup key.
+    ///
+    /// A CURSOR rather than a set of ids because the classifier is stateful:
+    /// re-classifying a chunk already held would consume the pending tool title
+    /// its first pass consumed, and re-render the result under the unnamed
+    /// form. A chunk at or below this is dropped BEFORE the taxonomy sees it,
+    /// the same "strictly after" rule the daemon's forwarder pages by.
+    ///
+    /// Also what a reconnect resumes the live stream FROM, so the rows
+    /// committed during an outage are replayed rather than skipped.
+    var cursor: Int64?
+    /// The taxonomy state that produced `rows`, carried so the live fold
+    /// continues where the page left off.
+    var classifier = AcpTranscriptClassifier()
+    /// Whether the daemon's tail read left older rows behind.
+    ///
+    /// A SEAM, not an error, which is why it is not `transcriptDetail`: the
+    /// rows shown are real as far as they go, and the pane says where they
+    /// start rather than claiming the run began there. Carried, because it
+    /// describes the rows it is carried with.
+    var truncated = false
+}
+
+/// Display mappings for the transcript lanes, in ONE place.
+///
+/// Same reasoning as `FleetChatLabels`: a mapping written twice is a mapping
+/// that can disagree with itself.
+enum FleetTranscriptLabels {
+    /// The lane's on-screen tag. The terminal client paints a glyph per lane
+    /// (`▌ * → ← !`); a menu-bar pane has room for the word, and the word is
+    /// what survives VoiceOver.
+    static func lane(_ lane: FleetTranscriptLane) -> String {
+        switch lane {
+        case .agent: "REPLY"
+        case .thinking: "THINKING"
+        case .toolCall: "TOOL"
+        case .toolResult: "RESULT"
+        case .error: "ERROR"
+        }
+    }
+
+    /// Spoken lane, so a VoiceOver user gets the distinction a sighted one gets
+    /// from the colour.
+    static func accessibilityLane(_ lane: FleetTranscriptLane) -> String {
+        switch lane {
+        case .agent: "Agent reply"
+        case .thinking: "Agent thinking"
+        case .toolCall: "Tool call"
+        case .toolResult: "Tool result"
+        case .error: "Error"
+        }
+    }
+
+    /// Whether the lane is drawn with the loud styling. Errors only: a
+    /// transcript that shouted at every tool call would not distinguish the one
+    /// line an operator has to act on.
+    static func laneIsLoud(_ lane: FleetTranscriptLane) -> Bool {
+        switch lane {
+        case .error: true
+        case .agent, .thinking, .toolCall, .toolResult: false
+        }
+    }
+}
+
+/// The running classification state for ONE ACP session's transcript.
+///
+/// Stateful across chunks for exactly one reason, the same one the Rust states:
+/// a `tool_call_update` carries only the `toolCallId`, so it can name its tool
+/// only because the earlier `tool_call` chunk's `title` was remembered.
+/// Everything else about a chunk is self-describing.
+///
+/// A VALUE type, unlike the Rust's `&mut self` classifier, and that is what
+/// makes it safe to hang off `FleetChatSurface`: a page builds a fresh
+/// classifier, runs its own chunks through it, and the live fold continues on
+/// the copy that page published. A page the store DISOWNS takes its classifier
+/// with it instead of leaving the live stream reading half-consumed tool
+/// titles, which is what a shared reference-type classifier would have done.
+///
+/// `Equatable` includes the pending titles on purpose: two surfaces with
+/// identical rows but different pending tool calls will classify the NEXT chunk
+/// differently, so they are not the same state and must not compare equal.
+struct AcpTranscriptClassifier: Equatable, Sendable {
+    /// `toolCallId` → the tool's human title, so a later update can name it.
+    private var toolTitles: [String: String] = [:]
+
+    init() {}
+
+    /// Classify one chunk into zero or more rows, in commit order.
+    ///
+    /// Total: a chunk type this taxonomy does not carry, and a known type with
+    /// missing fields, both yield what they can (usually nothing) rather than
+    /// failing. Feed one session's chunks through one classifier, oldest first.
+    mutating func rows(for chunk: FleetTranscriptChunk) -> [FleetTranscriptRow] {
+        classify(eventType: chunk.eventType, payload: chunk.payload)
+            .enumerated()
+            .map { index, entry in
+                FleetTranscriptRow(
+                    id: "\(chunk.ingestOrder).\(index)",
+                    ingestOrder: chunk.ingestOrder,
+                    lane: entry.lane,
+                    body: entry.body
+                )
+            }
+    }
+
+    /// The Rust `AcpClassifier::classify_value`, arm for arm.
+    ///
+    /// Deliberately silent on the chunk types the Rust is silent on, and for
+    /// the reason it gives: `acp.usage` is the run's token accounting and
+    /// belongs on a status line, `acp.user_message` is the adapter echoing back
+    /// a prompt that is the task's brief rather than its output, and
+    /// `acp.turn_started` / `acp.context_rebuilt` are session bookkeeping.
+    mutating func classify(
+        eventType: String,
+        payload: JSONValue
+    ) -> [FleetTranscriptEntry] {
+        var out: [FleetTranscriptEntry] = []
+        switch eventType {
+        case "acp.message":
+            Self.foldText(payload, lane: .agent, into: &out)
+        case "acp.thought":
+            Self.foldText(payload, lane: .thinking, into: &out)
+        case "acp.tool_call":
+            foldTool(payload, into: &out)
+        case "acp.plan":
+            Self.foldPlan(payload, into: &out)
+        case "acp.permission":
+            Self.foldPermission(payload, into: &out)
+        case "acp.transcript_truncated":
+            Self.foldTruncated(payload, into: &out)
+        case "acp.turn_completed", "acp.turn_failed", "acp.turn_interrupted":
+            Self.foldTurnEnd(eventType: eventType, payload: payload, into: &out)
+        // KEPT, and it is not the `default` this codebase bans: that rule is
+        // about switches over a WIRE ENUM this build owns, where a new variant
+        // must fail to compile. `event_type` is an open string the daemon and
+        // its adapters choose, so an unknown one is a taxonomy this build does
+        // not carry, and the contract is to skip it rather than mis-render it.
+        default:
+            break
+        }
+        return Self.capped(out)
+    }
+
+    /// A `tool_call` / `tool_call_update` chunk.
+    ///
+    /// The initial call is the tool-call lane (`<title>  <compact rawInput>`);
+    /// an update that carries output or reached a terminal status is the
+    /// result lane, and the ERROR lane when it failed. An update that only
+    /// moves `pending → in_progress` is not a transcript row at all: every
+    /// adapter emits one per call and it says nothing an operator can use.
+    private mutating func foldTool(
+        _ payload: JSONValue,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        let id = payload.value("toolCallId")?.stringValue ?? ""
+        let title = payload.value("title")?.stringValue
+        let status = payload.value("status")?.stringValue ?? ""
+        let isCall = payload.value("sessionUpdate")?.stringValue == "tool_call"
+
+        if isCall {
+            let name = title ?? "tool"
+            let summary = Self.compactInput(payload.value("rawInput"))
+            out.append(FleetTranscriptEntry(lane: .toolCall, body: summary.isEmpty ? name : "\(name)  \(summary)"))
+            if !id.isEmpty {
+                // The Rust's backstop, kept verbatim: past this many calls
+                // awaiting an update, forget them ALL rather than track age. A
+                // cancelled turn would otherwise pin its entry forever in a
+                // classifier that lives as long as the pane. Raise the cap
+                // before reaching for an LRU.
+                if toolTitles.count >= transcriptPendingToolsMax {
+                    toolTitles.removeAll()
+                }
+                toolTitles[id] = name
+            }
+        }
+
+        let snippet = Self.toolOutputText(payload)
+            .map { truncateChars(oneLine($0), transcriptSummaryMax) } ?? ""
+        let terminal = status == "completed" || status == "failed"
+        if snippet.isEmpty, !terminal { return }
+        // An initial `tool_call` that ALREADY carries its output names itself;
+        // a later update resolves the name from the call it belongs to, and
+        // degrades to the unnamed form when that call fell outside the page.
+        let name = title ?? toolTitles[id] ?? "tool"
+        if status == "failed" {
+            toolTitles.removeValue(forKey: id)
+            out.append(FleetTranscriptEntry(lane: .error, body: snippet.isEmpty ? "\(name)  [error]" : "\(name)  \(snippet)  [error]"))
+            return
+        }
+        if terminal {
+            toolTitles.removeValue(forKey: id)
+        }
+        out.append(FleetTranscriptEntry(lane: .toolResult, body: snippet.isEmpty ? "\(name)  (\(status))" : "\(name)  \(snippet)"))
+    }
+
+    /// A coalesced text chunk (`{kind, text, coalescedDeltas}`), one row per
+    /// line so a multi-line reply never overflows a render row.
+    ///
+    /// The same `event_type` also carries the reducer's NON-text shape (an
+    /// image, audio, or embedded resource block, `text` empty and the verbatim
+    /// update under `block`). That one has no text to show, so it is NAMED
+    /// rather than dropped: a transcript that silently omits a row reads as a
+    /// complete one.
+    private static func foldText(
+        _ payload: JSONValue,
+        lane: FleetTranscriptLane,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        let text = payload.value("text")?.stringValue ?? ""
+        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            pushLines(out: &out, lane: lane, text: text)
+            return
+        }
+        if let block = payload.value("block") {
+            let contentType = block.value("content")?.value("type")?.stringValue ?? "non-text"
+            out.append(FleetTranscriptEntry(lane: lane, body: "· \(contentType) content"))
+        }
+    }
+
+    /// A `plan` update: one tool-call row per entry, so the agent's plan reads
+    /// as the checklist it is rather than as a JSON blob on one row.
+    private static func foldPlan(
+        _ payload: JSONValue,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        guard let entries = payload.value("entries")?.arrayValue else { return }
+        for entry in entries {
+            let status = entry.value("status")?.stringValue ?? "pending"
+            let content = entry.value("content")?.stringValue ?? ""
+            out.append(FleetTranscriptEntry(
+                lane: .toolCall,
+                body: truncateChars(oneLine("plan · \(status) · \(content)"), transcriptSummaryMax)
+            ))
+        }
+    }
+
+    /// A parked permission ask, named for the tool it is gating.
+    ///
+    /// The payload is the daemon's own approval envelope (`acp_pool`'s
+    /// `raise_permission`), not an adapter update, so the tool sits under
+    /// `toolCall`.
+    ///
+    /// NOT a guardrail confirm card, and the two must never be merged in this
+    /// pane: a confirm card is answered through `fleet/confirm_answer`, while
+    /// this is an ACP permission answered as an attention row through
+    /// `fleet/action`. This row is a READOUT of one, never a control.
+    private static func foldPermission(
+        _ payload: JSONValue,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        let call = payload.value("toolCall")
+        let name = call?.value("title")?.stringValue
+            ?? call?.value("toolCallId")?.stringValue
+            ?? "tool"
+        out.append(FleetTranscriptEntry(lane: .toolCall, body: "[approval] \(name)"))
+    }
+
+    /// The writer's own "I threw rows away" marker, in the error lane.
+    ///
+    /// The one row the transcript MUST show: a silently short transcript reads
+    /// as a complete one, which is the whole reason the store writer mints this
+    /// instead of just dropping.
+    private static func foldTruncated(
+        _ payload: JSONValue,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        let dropped = payload.value("droppedRows")?.int64Value ?? 0
+        out.append(FleetTranscriptEntry(lane: .error, body: "· transcript truncated · \(dropped) rows dropped"))
+    }
+
+    /// A turn's closing marker as the run-status line the process executor's
+    /// `result` line renders (`· <subtype> · <duration>`), so both executors
+    /// close the same way.
+    private static func foldTurnEnd(
+        eventType: String,
+        payload: JSONValue,
+        into out: inout [FleetTranscriptEntry]
+    ) {
+        let subtype = eventType.hasPrefix("acp.") ? String(eventType.dropFirst("acp.".count)) : eventType
+        var status = "· \(subtype)"
+        if let ms = payload.value("durationMs")?.int64Value {
+            status += " · \(formatDuration(ms))"
+        }
+        if let cause = payload.value("cause")?.stringValue {
+            status += " · \(cause)"
+        }
+        out.append(FleetTranscriptEntry(
+            lane: eventType == "acp.turn_completed" ? .toolResult : .error,
+            body: status
+        ))
+    }
+
+    /// The displayable output of a tool-call update: its `content` blocks'
+    /// text, else its `rawOutput`.
+    ///
+    /// `content` is an array of `{type:"content"|"diff"|"terminal", …}` where
+    /// the `content` flavour wraps a `{type:"text",text:…}` block. Only TEXT is
+    /// pulled out: a diff or an embedded terminal contributes NOTHING rather
+    /// than a JSON blob rendered as if it were the tool's output. The bare
+    /// `{type:"text",…}` fallback is for an adapter that skips the wrapper, and
+    /// the fallback fires only when the wrapped path is ABSENT, never when it
+    /// is present but not a string.
+    ///
+    /// Blocks join on a NEWLINE, not a space, matching the Rust: the display
+    /// path re-flattens to one line anyway, but the separator is what stops a
+    /// whole-line-anchored scanner losing a URL an adapter split across two
+    /// blocks.
+    private static func toolOutputText(_ payload: JSONValue) -> String? {
+        if let blocks = payload.value("content")?.arrayValue {
+            let joined = blocks.compactMap { block -> String? in
+                let wrapped = block.value("content")?.value("text")
+                return (wrapped ?? block.value("text"))?.stringValue
+            }.joined(separator: "\n")
+            if !joined.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return joined
+            }
+        }
+        return payload.value("rawOutput").flatMap(valueText)
+    }
+
+    /// The ONE gate every classified row passes through.
+    ///
+    /// It lives here rather than at the dozen append sites because a tool
+    /// `name`, a `subtype` and a tool `title` are adapter strings too, and
+    /// capping only the prose in `pushLines` left those uncapped.
+    private static func capped(
+        _ out: [FleetTranscriptEntry]
+    ) -> [FleetTranscriptEntry] {
+        var out = out
+        if out.count > transcriptEntriesPerChunkMax {
+            // Say so rather than dropping silently, the way the body cap
+            // appends its ellipsis: a six-hundred-line block otherwise loses
+            // eighty-eight lines with no sign at all. The COUNT is the part an
+            // off-by-one ships silently, so the Rust pins it and so does this.
+            let kept = transcriptEntriesPerChunkMax - 1
+            let dropped = out.count - kept
+            out.removeLast(dropped)
+            out.append(FleetTranscriptEntry(lane: .toolResult, body: "… \(dropped) more lines"))
+        }
+        return out.map { entry in
+            entry.body.unicodeScalars.count > transcriptBodyMax
+                ? FleetTranscriptEntry(lane: entry.lane, body: truncateChars(entry.body, transcriptBodyMax))
+                : entry
+        }
+    }
+
+    /// Split `text` into non-empty trimmed lines and append one row per line,
+    /// so a multi-line block never overflows a single render row.
+    ///
+    /// Rust's `str::lines()` semantics, not Swift's `components(separatedBy:)`:
+    /// a single trailing newline yields no extra line, and a trailing carriage
+    /// return is stripped.
+    private static func pushLines(
+        out: inout [FleetTranscriptEntry],
+        lane: FleetTranscriptLane,
+        text: String
+    ) {
+        for line in rustLines(text) {
+            let trimmed = trimTrailingWhitespace(line)
+            if trimmed.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { continue }
+            out.append(FleetTranscriptEntry(lane: lane, body: trimmed))
+        }
+    }
+
+    /// A compact one-line summary of a tool call's `rawInput`: the most telling
+    /// field for the common tools (a shell command, a file path, a query), else
+    /// a truncated flat rendering, so a tool call reads at a glance without its
+    /// full JSON payload.
+    private static func compactInput(_ input: JSONValue?) -> String {
+        guard let object = input?.objectValue else {
+            return input.map(compactValue) ?? ""
+        }
+        for key in ["command", "file_path", "path", "pattern", "query", "url", "prompt"] {
+            if let text = object[key].flatMap(valueText) {
+                return truncateChars(oneLine(text), transcriptSummaryMax)
+            }
+        }
+        // No telling field: a flat, truncated key=val rendering. Sorted, which
+        // is what walking a `serde_json::Map` gives too, since that map is a
+        // `BTreeMap` unless `preserve_order` is on and it is not. Neither side
+        // renders the adapter's own order; a Swift dictionary does not keep one.
+        let flat = object.keys.sorted()
+            .map { "\($0)=\(oneLine(compactValue(object[$0] ?? .null)))" }
+            .joined(separator: " ")
+        return truncateChars(flat, transcriptSummaryMax)
+    }
+
+    /// Read a JSON value as display text: a string as-is, else its compact
+    /// JSON. A tool result's `content` is often an array of
+    /// `{type:"text", text:…}` blocks, so their text is joined.
+    private static func valueText(_ value: JSONValue) -> String? {
+        switch value {
+        case let .string(text):
+            return text
+        case let .array(items):
+            let joined = items.compactMap { item -> String? in
+                item.value("text")?.stringValue ?? item.stringValue
+            }.joined(separator: " ")
+            return joined.isEmpty ? nil : joined
+        case .null:
+            return nil
+        case .bool, .number, .object:
+            return compactJSON(value)
+        }
+    }
+
+    /// A short flat rendering of any JSON value for a compact input summary.
+    private static func compactValue(_ value: JSONValue) -> String {
+        switch value {
+        case let .string(text): text
+        case .null, .bool, .number, .array, .object: compactJSON(value)
+        }
+    }
+}
+
+// MARK: - Rendering primitives
+//
+// Free functions rather than methods because none of them touch classifier
+// state, and every one has a Rust twin whose behaviour is pinned by a test on
+// both sides.
+
+/// Collapse every whitespace run (newlines included) to single spaces, trimmed.
+/// Keeps a summary on one render row.
+private func oneLine(_ text: String) -> String {
+    text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+}
+
+/// Format a duration in milliseconds as `Nms` / `N.Ns` / `NmNs`.
+///
+/// A negative delta (clock skew between two chunks) reads `0ms` rather than a
+/// nonsense value.
+private func formatDuration(_ milliseconds: Int64) -> String {
+    let ms = max(0, milliseconds)
+    if ms < 1000 { return "\(ms)ms" }
+    if ms < 60_000 { return String(format: "%.1fs", Double(ms) / 1000.0) }
+    return "\(ms / 60_000)m\((ms % 60_000) / 1000)s"
+}
+
+/// Truncate to `max` Unicode SCALARS with a trailing ellipsis on overflow.
+///
+/// Scalars, matching the Rust's `chars()`, and NOT Swift `Character`s. The two
+/// are not interchangeable and picking the wrong one defeats the cap: a
+/// grapheme cluster has no length limit, so one combining sequence of a million
+/// scalars counts as a single `Character` and would sail through a
+/// grapheme-counted cap untouched. That is the opposite of what a leak backstop
+/// is for, and it is reachable by any adapter that emits combining marks.
+///
+/// Slicing scalars is still safe in the way byte slicing is not: a scalar
+/// boundary always exists, so this cannot panic or split a code point the way
+/// the UTF-8 truncation trap does.
+private func truncateChars(_ text: String, _ max: Int) -> String {
+    let scalars = text.unicodeScalars
+    guard scalars.count > max else { return text }
+    return String(String.UnicodeScalarView(scalars.prefix(Swift.max(0, max - 1)))) + "…"
+}
+
+/// The wording the daemon's own board timeline uses for the same seam, so an
+/// operator reading both surfaces reads one sentence.
+///
+/// Deliberately the ERROR lane and deliberately FIRST: it describes where the
+/// rows below it begin, and a marker under them would read as the end of the
+/// run rather than the start of what was kept.
+let fleetTranscriptTruncationRow = FleetTranscriptRow(
+    id: "truncated",
+    ingestOrder: 0,
+    lane: .error,
+    body: "· transcript truncated · older lines not shown"
+)
+
+/// `str::lines()` semantics: split on newline, drop the ONE empty piece a
+/// trailing newline produces, strip a trailing carriage return from each line.
+private func rustLines(_ text: String) -> [String] {
+    var parts = text.components(separatedBy: "\n")
+    if parts.last == "" { parts.removeLast() }
+    return parts.map { $0.hasSuffix("\r") ? String($0.dropLast()) : $0 }
+}
+
+/// Rust's `str::trim_end`, which trims trailing whitespace only.
+private func trimTrailingWhitespace(_ text: String) -> String {
+    var text = text
+    while let last = text.last, last.isWhitespace { text.removeLast() }
+    return text
+}
+
+/// Compact JSON for one value, the way `serde_json`'s `to_string` renders it.
+///
+/// Written here rather than routed through `JSONEncoder` for two reasons: a
+/// `Decimal` must render as the adapter wrote it rather than through a float
+/// formatter, and a top-level fragment must be encodable at all.
+///
+/// The ONE divergence from the Rust is object key ORDER, which is sorted here.
+/// It is not a choice: `JSONValue.object` is a Swift dictionary, so the
+/// adapter's order is already gone by the time this function is reached. Sorted
+/// is the only rendering that is at least stable across runs.
+private func compactJSON(_ value: JSONValue) -> String {
+    switch value {
+    case .null:
+        return "null"
+    case let .bool(flag):
+        return flag ? "true" : "false"
+    case let .number(number):
+        return number.description
+    case let .string(text):
+        return jsonQuoted(text)
+    case let .array(items):
+        return "[" + items.map(compactJSON).joined(separator: ",") + "]"
+    case let .object(fields):
+        let body = fields.keys.sorted()
+            .map { "\(jsonQuoted($0)):\(compactJSON(fields[$0] ?? .null))" }
+            .joined(separator: ",")
+        return "{" + body + "}"
+    }
+}
+
+/// One JSON string literal, escaped to `serde_json`'s rules.
+private func jsonQuoted(_ text: String) -> String {
+    var out = "\""
+    for scalar in text.unicodeScalars {
+        switch scalar {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if scalar.value < 0x20 {
+                out += String(format: "\\u%04x", scalar.value)
+            } else {
+                out.unicodeScalars.append(scalar)
+            }
+        }
+    }
+    return out + "\""
+}
+
+extension JSONValue {
+    /// The value as a whole number, the way `serde_json`'s `as_i64` reads one.
+    ///
+    /// A FRACTIONAL number is not a whole one and answers nil, matching the
+    /// Rust rather than silently rounding: `durationMs: 1.5` is an adapter bug
+    /// and a transcript that rendered it as `1ms` would hide it.
+    var int64Value: Int64? {
+        guard case let .number(number) = self else { return nil }
+        var source = number
+        var whole = Decimal()
+        NSDecimalRound(&whole, &source, 0, .down)
+        guard whole == number else { return nil }
+        guard whole >= Decimal(Int64.min), whole <= Decimal(Int64.max) else { return nil }
+        return NSDecimalNumber(decimal: whole).int64Value
+    }
+}

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -30,9 +30,10 @@ struct FleetResyncRequired: Decodable, Equatable, Sendable {
 /// Everything the daemon pushes at us on a socket we already own.
 ///
 /// The three chat cases arrive only after `fleet/message_subscribe` is
-/// acknowledged on THIS connection, and they ride the same socket as
+/// acknowledged on THIS connection, and the transcript case only after
+/// `fleet/transcript_subscribe`. They all ride the same socket as
 /// `fleet/event`: the daemon runs them as independent forwarders over one
-/// writer, so a client needs one connection, not two.
+/// writer, so a client needs one connection, not four.
 enum FleetIncoming: Equatable, Sendable {
     case event(FleetEvent)
     case resyncRequired(FleetResyncRequired)
@@ -41,6 +42,11 @@ enum FleetIncoming: Equatable, Sendable {
     /// pane as an unanswerable one instead of being dropped.
     case confirmEvent(FleetConfirmEventRawParams)
     case activityEvent(FleetActivityEventParams)
+    /// One ACP transcript chunk, after `fleet/transcript_subscribe` is
+    /// acknowledged on THIS connection. Unlike the three above it is addressed
+    /// by SESSION, so the daemon runs exactly one transcript forwarder per
+    /// socket and a second subscribe REPLACES the first.
+    case transcriptEvent(FleetTranscriptEventParams)
     /// A notification this connection did not turn into one of the above:
     /// either a method this build has never heard of, or a chat frame whose
     /// params did not decode. Both are named and dropped, never fatal.
@@ -250,6 +256,39 @@ actor FleetConnection {
         return try await request("fleet/activity_list", params: params, result: FleetActivityListResult.self)
     }
 
+    /// Page one ACP session's transcript by `ingest_order`.
+    ///
+    /// Gated by `fleet.transcript.read`, which is the id
+    /// `handle_fleet_transcript_list` itself checks, NOT the `fleet.chat.read`
+    /// its confirm and activity neighbours use: the transcript is a different
+    /// log with a different capability, and the daemon can advertise one
+    /// without the other. `fleet.transcript.prune` is a SEPARATE id naming the
+    /// destructive verb, and nothing on this surface asks for it.
+    func transcriptList(_ params: FleetTranscriptListParams) async throws -> FleetTranscriptListResult {
+        try requireReadCapability("fleet.transcript.read")
+        return try await request("fleet/transcript_list", params: params, result: FleetTranscriptListResult.self)
+    }
+
+    /// Open the live transcript stream for ONE session on this connection.
+    ///
+    /// Gated by the same `fleet.transcript.read`, because
+    /// `handle_fleet_transcript_subscribe` checks the same id: the ack is a
+    /// read of that session's transcript head and the daemon gates it as one.
+    ///
+    /// The daemon answers with the head order and THEN registers a per-session
+    /// forwarder on this socket, aborting whichever one it was already running.
+    /// So a second call for a different session MOVES the stream rather than
+    /// adding one, and `fleet/transcript_event` arrives on `incoming()`
+    /// alongside `fleet/event` and the chat frames.
+    func transcriptSubscribe(_ params: FleetTranscriptSubscribeParams) async throws -> FleetTranscriptSubscribeResult {
+        try requireReadCapability("fleet.transcript.read")
+        return try await request(
+            "fleet/transcript_subscribe",
+            params: params,
+            result: FleetTranscriptSubscribeResult.self
+        )
+    }
+
     func incoming() -> AsyncStream<FleetIncoming> {
         AsyncStream { continuation in
             let id = UUID()
@@ -407,6 +446,13 @@ actor FleetConnection {
                 yield(decoded(FleetConfirmEventRawParams.self, from: envelope, as: FleetIncoming.confirmEvent, method: method))
             case "fleet/activity_event":
                 yield(decoded(FleetActivityEventParams.self, from: envelope, as: FleetIncoming.activityEvent, method: method))
+            // The transcript frame takes the SAME degrade-and-name answer as
+            // the three chat frames, for the same reason and one more: its
+            // payload is arbitrary adapter-authored JSON, so it is the frame
+            // most likely to carry a shape this build has never seen. Throwing
+            // here would let an adapter's output close the operator's roster.
+            case "fleet/transcript_event":
+                yield(decoded(FleetTranscriptEventParams.self, from: envelope, as: FleetIncoming.transcriptEvent, method: method))
             // KEPT, and it is not the `default` this codebase bans: that rule is
             // about switches over a WIRE ENUM this build owns, where a new
             // variant must fail to compile. This switches over an open string

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -1330,6 +1330,156 @@ struct FleetActivityEventParams: Codable, Equatable {
     let activity: FleetActivityRow
 }
 
+// MARK: - fleet/transcript_* (the ACP execution stream)
+//
+// Addressed by SESSION, not by scope, which is the one structural difference
+// from the three chat frames above: a transcript belongs to the ACP session
+// that produced it, and `fleet/transcript_subscribe` names that session. The
+// gate on all of it is `fleet.transcript.read`, which is what BOTH daemon arms
+// check (`handle_fleet_transcript_list`, `handle_fleet_transcript_subscribe`).
+
+/// One ACP transcript chunk: a `fleet_provider_event` row with `source='acp'`.
+///
+/// `payload` is arbitrary adapter-authored JSON, decoded as `JSONValue` rather
+/// than as a typed shape, because the taxonomy that reads it
+/// (`AcpTranscriptClassifier`) is deliberately total: a row type this build
+/// does not carry yields nothing rather than failing the page it arrived on.
+struct FleetTranscriptChunk: Codable, Equatable, Sendable {
+    /// Commit-ordered transcript cursor (`ingest_order`).
+    let ingestOrder: Int64
+    /// Replay-safe chunk identity.
+    let eventID: String
+    /// The owning Fleet session.
+    let sessionKey: String
+    /// Normalized discriminator, `acp.<kind>`.
+    let eventType: String
+    /// Normalized chunk body.
+    let payload: JSONValue
+    /// Observation time in epoch milliseconds.
+    let observedAt: Int64
+
+    private enum CodingKeys: String, CodingKey {
+        case payload
+        case ingestOrder = "ingest_order"
+        case eventID = "event_id"
+        case sessionKey = "session_key"
+        case eventType = "event_type"
+        case observedAt = "observed_at"
+    }
+}
+
+/// Maximum chunks one `fleet/transcript_list` page may return
+/// (`FLEET_TRANSCRIPT_LIST_MAX`). The daemon clamps, so asking for more is not
+/// an error, but asking for the wrong number silently pages differently from
+/// the CLI reading the same transcript.
+let fleetTranscriptListMax: UInt32 = 100
+
+/// Params for `fleet/transcript_list`.
+///
+/// `after_order` is OMITTED when nil rather than sent as `null`, matching the
+/// daemon's `skip_serializing_if`, for the same reason `FleetMessageListParams`
+/// omits its cursor.
+struct FleetTranscriptListParams: Encodable, Equatable {
+    let sessionKey: String
+    let afterOrder: Int64?
+    let limit: UInt32
+
+    private enum CodingKeys: String, CodingKey {
+        case limit
+        case sessionKey = "session_key"
+        case afterOrder = "after_order"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionKey, forKey: .sessionKey)
+        try container.encodeIfPresent(afterOrder, forKey: .afterOrder)
+        try container.encode(limit, forKey: .limit)
+    }
+}
+
+/// Result for `fleet/transcript_list`: chunks in ascending `ingest_order`.
+///
+/// The page walks FORWARD from `after_order`, so a page taken from the start of
+/// a long transcript is its OLDEST hundred chunks. A tail view has to name a
+/// window that ends at the head, which is why the store subscribes first and
+/// pages from the head the ack publishes.
+struct FleetTranscriptListResult: Codable, Equatable {
+    let chunks: [FleetTranscriptChunk]
+    let nextAfterOrder: Int64?
+    /// Whether the daemon left older rows behind.
+    ///
+    /// NOT inferable from `chunks.count`, which is the whole reason it is on
+    /// the wire. The uncursored read is bounded twice, by rows and by payload
+    /// bytes, and which bound bit depends on the run: a short page can mean a
+    /// short transcript or one 4 KiB chunk after another. A pane that read a
+    /// short page as completeness would render a partial run as a whole one.
+    ///
+    /// Defaulted rather than required, so a daemon built before the flag reads
+    /// as "nothing was left behind", which is what its unbounded page meant.
+    let truncated: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case chunks, truncated
+        case nextAfterOrder = "next_after_order"
+    }
+
+    init(chunks: [FleetTranscriptChunk], nextAfterOrder: Int64?, truncated: Bool = false) {
+        self.chunks = chunks
+        self.nextAfterOrder = nextAfterOrder
+        self.truncated = truncated
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            chunks: try container.decode([FleetTranscriptChunk].self, forKey: .chunks),
+            nextAfterOrder: try container.decodeIfPresent(Int64.self, forKey: .nextAfterOrder),
+            truncated: try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+        )
+    }
+}
+
+/// Params for `fleet/transcript_subscribe`.
+///
+/// An absent `after_order` starts the forwarder at the head the ack publishes;
+/// a named one asks the daemon to replay from that cursor. The daemon refuses a
+/// NEGATIVE order outright, so nothing here may send one.
+struct FleetTranscriptSubscribeParams: Encodable, Equatable {
+    let sessionKey: String
+    let afterOrder: Int64?
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionKey = "session_key"
+        case afterOrder = "after_order"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionKey, forKey: .sessionKey)
+        try container.encodeIfPresent(afterOrder, forKey: .afterOrder)
+    }
+}
+
+/// Result for `fleet/transcript_subscribe`: the newest committed
+/// `ingest_order` for the session, or nil on an empty transcript.
+///
+/// The ack is not the point of the call; the `fleet/transcript_event`
+/// notifications that follow it on the SAME socket are. The daemon registers
+/// the forwarder at this head AFTER the response is queued, and the forwarder
+/// reads everything past its cursor before it waits, so a client that pages up
+/// to this head cannot miss a chunk between the two.
+struct FleetTranscriptSubscribeResult: Codable, Equatable {
+    let headOrder: Int64?
+
+    private enum CodingKeys: String, CodingKey { case headOrder = "head_order" }
+}
+
+/// Payload of the `fleet/transcript_event` notification.
+struct FleetTranscriptEventParams: Codable, Equatable, Sendable {
+    let chunk: FleetTranscriptChunk
+}
+
 enum FleetWire {
     static func decoder() -> JSONDecoder { JSONDecoder() }
     static func encoder() -> JSONEncoder {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
@@ -739,17 +739,200 @@ final class FleetChatPresentationTests: XCTestCase {
         XCTAssertEqual(surface.activity.first?.tool, "kill_session")
     }
 
-    /// Every event type reports the scope it was filed under, which is what
-    /// makes a fleet-wide stream safe to render in a scoped pane. Exhaustive
-    /// over the enum on purpose: a fourth event shape must fail here.
-    func testEveryLiveEventNamesItsScope() throws {
-        let events: [FleetChatEvent] = [
+    /// Every event type names EXACTLY ONE addressing axis, and which one it
+    /// names is which daemon stream it came off.
+    ///
+    /// This is what makes broad streams safe to render in a narrow pane: the
+    /// three chat frames are filed under a scope and the transcript chunk
+    /// belongs to a session, so each is filtered on the axis it carries. A
+    /// shape naming NEITHER could not be filtered at all, and one naming BOTH
+    /// would have two answers to which pane it belongs in. Exhaustive over the
+    /// enum on purpose: a fifth event shape must fail here.
+    func testEveryLiveEventNamesExactlyOneAddressingAxis() throws {
+        let scoped: [FleetChatEvent] = [
             .message(try Self.liveMessage(id: "01J0B", body: "b")),
             Self.liveConfirm(id: "01J0CARD", state: "open"),
             .activity(try Self.liveActivity(seq: 9)),
         ]
+        let sessioned: [FleetChatEvent] = [.transcript(try Self.liveChunk(order: 9))]
 
-        XCTAssertEqual(events.map(\.scopeKey), Array(repeating: "channel:copilot", count: events.count))
+        XCTAssertEqual(scoped.map(\.scopeKey), Array(repeating: "channel:copilot", count: scoped.count))
+        XCTAssertEqual(scoped.compactMap(\.sessionKey), [], "a chat frame must not claim a session")
+        XCTAssertEqual(sessioned.map(\.sessionKey), ["acp:1"])
+        XCTAssertEqual(sessioned.compactMap(\.scopeKey), [], "a transcript chunk must not claim a scope")
+    }
+
+    // MARK: - The transcript section of the surface
+
+    /// A chunk for the session on screen is classified and appended, and the
+    /// surface's cursor moves with it.
+    func testALiveTranscriptChunkForTheShownSessionAppends() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(order: 7, text: "on it")))
+
+        XCTAssertEqual(surface.transcriptState.rows.map(\.body), ["on it"])
+        XCTAssertEqual(surface.transcriptState.rows.map(\.lane), [.agent])
+        XCTAssertEqual(surface.transcriptState.cursor, 7)
+    }
+
+    /// A chunk from ANOTHER session is dropped, never rendered.
+    ///
+    /// The transcript's version of the scope filter, and it matters more: a
+    /// foreign chat message is at least visibly somebody else's conversation,
+    /// while a foreign transcript row reads as this agent's own execution.
+    func testATranscriptChunkForAnotherSessionIsDropped() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(order: 7, sessionKey: "acp:elsewhere")))
+
+        XCTAssertEqual(surface.transcriptState.rows, [])
+        XCTAssertNil(surface.transcriptState.cursor, "a foreign chunk must not move this session's cursor")
+    }
+
+    /// Nothing is folded before a page has resolved a session, exactly as
+    /// nothing is folded before one has resolved a scope.
+    func testATranscriptChunkArrivingBeforeASessionIsResolvedIsDropped() throws {
+        var surface = FleetChatSurface()
+        surface.apply(.transcript(try Self.liveChunk(order: 1)))
+
+        XCTAssertEqual(surface.transcriptState.rows, [])
+    }
+
+    /// A chunk at or below the cursor is dropped BEFORE the taxonomy sees it.
+    ///
+    /// Not merely a de-duplication: the classifier is stateful, so a second
+    /// pass over a tool call's update would find the pending title already
+    /// consumed and re-render the result under the unnamed `tool` form. The
+    /// guard is what stops a replayed chunk REWRITING a row that was correct.
+    func testAReplayedChunkIsDroppedBeforeItCanDegradeTheRowItAlreadyProduced() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(
+            order: 5,
+            eventType: "acp.tool_call",
+            payload: ["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"]
+        )))
+        surface.apply(.transcript(try Self.liveChunk(
+            order: 6,
+            eventType: "acp.tool_call",
+            payload: ["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed"]
+        )))
+        XCTAssertEqual(surface.transcriptState.rows.map(\.body), ["Bash", "Bash  (completed)"])
+
+        // The same chunk again, as a page window overlapping the stream.
+        surface.apply(.transcript(try Self.liveChunk(
+            order: 6,
+            eventType: "acp.tool_call",
+            payload: ["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed"]
+        )))
+        XCTAssertEqual(
+            surface.transcriptState.rows.map(\.body), ["Bash", "Bash  (completed)"],
+            "a replayed chunk must neither duplicate its rows nor degrade them to the unnamed form"
+        )
+        XCTAssertEqual(surface.transcriptState.cursor, 6)
+    }
+
+    /// The classifier CARRIES across chunks, which is the only reason a tool
+    /// result can name the tool it belongs to.
+    func testTheSurfaceCarriesTheClassifierAcrossChunks() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(
+            order: 1,
+            eventType: "acp.tool_call",
+            payload: ["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Read"]
+        )))
+        surface.apply(.transcript(try Self.liveChunk(
+            order: 2,
+            eventType: "acp.tool_call",
+            payload: [
+                "sessionUpdate": "tool_call_update", "toolCallId": "t1",
+                "status": "completed", "rawOutput": "hello",
+            ]
+        )))
+
+        XCTAssertEqual(
+            surface.transcriptState.rows.last?.body, "Read  hello",
+            "the result lost the title the call left behind, so the fold is not carrying the classifier"
+        )
+    }
+
+    /// One chunk classifying into many rows still yields one row per line, each
+    /// addressed by the chunk's cursor.
+    func testOneChunkClassifiesIntoManyAddressableRows() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(order: 3, text: "alpha\nbeta")))
+
+        XCTAssertEqual(surface.transcriptState.rows.map(\.id), ["3.0", "3.1"])
+        XCTAssertEqual(surface.transcriptState.rows.map(\.body), ["alpha", "beta"])
+    }
+
+    /// The transcript stays inside its display ceiling, dropping the OLDEST
+    /// rows, because it is a tail view of a running session.
+    func testTheTranscriptStaysBoundedByItsDisplayCeiling() throws {
+        var surface = try Self.shownSurface()
+        for order in 1...(fleetTranscriptRowMax + 10) {
+            surface.apply(.transcript(try Self.liveChunk(order: Int64(order), text: "row \(order)")))
+        }
+
+        XCTAssertEqual(surface.transcriptState.rows.count, fleetTranscriptRowMax)
+        XCTAssertEqual(surface.transcriptState.rows.first?.body, "row 11", "the ceiling drops the oldest row")
+        XCTAssertEqual(surface.transcriptState.rows.last?.body, "row \(fleetTranscriptRowMax + 10)")
+    }
+
+    /// A chunk this taxonomy does not carry moves the cursor and adds no row.
+    ///
+    /// Both halves matter. Skipping the row is the taxonomy's contract, and
+    /// moving the cursor is what stops a session that only emits bookkeeping
+    /// from re-reading the same chunk on every page.
+    func testASilentChunkMovesTheCursorWithoutAddingARow() throws {
+        var surface = try Self.shownSurface()
+        surface.apply(.transcript(try Self.liveChunk(order: 4, eventType: "acp.usage", payload: [:])))
+
+        XCTAssertEqual(surface.transcriptState.rows, [])
+        XCTAssertEqual(surface.transcriptState.cursor, 4)
+    }
+
+    /// A page's chunks and a live chunk go through ONE door, so a surface built
+    /// by replaying a page is identical to one built live.
+    func testAPagedFoldAndALiveFoldProduceTheSameSurface() throws {
+        let chunks = [
+            try Self.liveChunk(order: 1, eventType: "acp.tool_call", payload: [
+                "sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash",
+            ]),
+            try Self.liveChunk(order: 2, text: "done"),
+        ]
+        var paged = try Self.shownSurface()
+        var live = try Self.shownSurface()
+        for chunk in chunks { paged.apply(.transcript(chunk)) }
+        for chunk in chunks { live.apply(.transcript(chunk)) }
+
+        XCTAssertEqual(paged, live)
+        XCTAssertEqual(paged.transcriptState.rows.map(\.body), ["Bash", "done"])
+    }
+
+    /// The buffer door matches on the axis the event carries, and the FIRST
+    /// page's unresolved axis is admitted rather than filtered out.
+    ///
+    /// The store's in-flight buffer reads this. Getting it wrong on the
+    /// transcript axis would drop exactly what the buffer exists for: a chunk
+    /// committed while the opening page was still reading.
+    func testTheBufferDoorMatchesOnTheAxisTheEventCarries() throws {
+        let resolved = try Self.shownSurface()
+        let opening = FleetChatSurface()
+
+        XCTAssertTrue(FleetChatEvent.transcript(try Self.liveChunk(order: 1)).belongsToPage(of: resolved))
+        XCTAssertFalse(
+            FleetChatEvent.transcript(try Self.liveChunk(order: 1, sessionKey: "acp:other")).belongsToPage(of: resolved),
+            "another session's chunk must not be buffered against this page"
+        )
+        XCTAssertTrue(
+            FleetChatEvent.transcript(try Self.liveChunk(order: 1)).belongsToPage(of: opening),
+            "the first page has no session yet, and dropping here loses the chunk entirely"
+        )
+        // And the chat axis is unchanged by any of it.
+        XCTAssertTrue(FleetChatEvent.activity(try Self.liveActivity(seq: 1)).belongsToPage(of: resolved))
+        XCTAssertFalse(
+            FleetChatEvent.activity(try Self.liveActivity(seq: 1, scope: "channel:other"))
+                .belongsToPage(of: resolved)
+        )
     }
 
     // MARK: - The chat route's way back
@@ -846,6 +1029,32 @@ final class FleetChatPresentationTests: XCTestCase {
         {"confirm_id":"\(id)","scope_key":"\(scope)","tool":"\(tool)","arguments":{},
          "state":"\(state)","created_at":1,"expires_at":2}
         """.utf8))) ?? .null
+    }
+
+    /// One transcript chunk, built through the REAL decoder so a renamed wire
+    /// key fails here rather than being renamed on both sides.
+    ///
+    /// THROWING, not `try?` with a hand-built fallback. A fallback defeats the
+    /// only guarantee this helper offers: a renamed key would decode to nothing,
+    /// the fallback would supply a chunk anyway, and the test would pass while
+    /// the wire and this build disagreed. Every caller is already `throws`.
+    private static func liveChunk(
+        order: Int64,
+        sessionKey: String = "acp:1",
+        eventType: String = "acp.message",
+        text: String = "hello",
+        payload: [String: Any]? = nil
+    ) throws -> FleetTranscriptChunk {
+        let frame: [String: Any] = [
+            "ingest_order": order,
+            "event_id": "evt-\(order)",
+            "session_key": sessionKey,
+            "event_type": eventType,
+            "payload": payload ?? ["text": text],
+            "observed_at": 1_700_000_000_000,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: frame)
+        return try FleetWire.decoder().decode(FleetTranscriptChunk.self, from: data)
     }
 
     private static func liveActivity(seq: Int64, tool: String = "list_sessions", scope: String = "channel:copilot") throws -> FleetActivityRow {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -1132,16 +1132,675 @@ final class FleetConnectionTests: XCTestCase {
         }
     }
 
+    // MARK: - The ACP transcript stream (PR C)
+
+    /// The store opens the transcript stream for the session the page just
+    /// resolved, then reads that session's tail with NO cursor.
+    ///
+    /// The absent cursor is the assertion. `ingest_order` is one global
+    /// AUTOINCREMENT sequence over every provider's rows, so a client cannot
+    /// name a window of its own that means "the newest rows of THIS session":
+    /// the newest hundred orders on a busy machine can hold none of them. An
+    /// uncursored read is the daemon's tail arm, and it is the only version of
+    /// this read a client can be correct with.
+    func testTheStoreSubscribesFirstThenReadsTheSessionTailWithNoCursor() async throws {
+        let counts = ChatServerCounts(
+            transcriptHeadOrder: 500,
+            transcriptChunks: [Self.transcriptChunkObject(order: 500, text: "reading the code")]
+        )
+        try await withChatStore(counts: counts) { store, _ in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            let subscribes = counts.transcriptSubscribes
+            XCTAssertEqual(subscribes.count, 1, "the stream must be opened exactly once per page")
+            let subscribeParams = subscribes[0]["params"] as? [String: Any]
+            XCTAssertEqual(
+                subscribeParams?["session_key"] as? String, "acp:1",
+                "the stream must follow the session the page minted, not the channel"
+            )
+            XCTAssertNil(
+                subscribeParams?["after_order"],
+                "an absent cursor is what asks the daemon to start at the head; a null is not the same frame"
+            )
+
+            let lists = counts.transcriptLists
+            XCTAssertEqual(lists.count, 1)
+            let listParams = lists[0]["params"] as? [String: Any]
+            XCTAssertEqual(listParams?["session_key"] as? String, "acp:1")
+            XCTAssertNil(
+                listParams?["after_order"],
+                "a client-computed window over GLOBAL orders is the bug; the tail read takes no cursor"
+            )
+            XCTAssertEqual((listParams?["limit"] as? NSNumber)?.uint32Value, fleetTranscriptListMax)
+
+            await MainActor.run {
+                XCTAssertEqual(store.chat.transcriptState.rows.map(\.body), ["reading the code"])
+                XCTAssertEqual(store.chat.transcriptState.cursor, 500)
+                XCTAssertNil(store.chat.transcriptDetail, "a page that worked must not explain an absence")
+            }
+        }
+    }
+
+    /// An EMPTY transcript opens the stream, reads its tail, and shows nothing
+    /// without claiming the transcript is unreadable.
+    ///
+    /// The tail read is issued regardless: an empty answer and an unreadable
+    /// one are different facts, and only the daemon can tell them apart. The
+    /// stream is open, so the session's first chunk still arrives live.
+    func testAnEmptyTranscriptOpensTheStreamAndShowsNothing() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(counts: counts) { store, _ in
+            await store.refreshChatOnce()
+
+            XCTAssertEqual(counts.transcriptSubscribes.count, 1)
+            XCTAssertEqual(counts.transcriptLists.count, 1, "an empty transcript is still read, not assumed")
+            await MainActor.run {
+                XCTAssertEqual(store.chat.transcriptState.rows, [])
+                XCTAssertNil(store.chat.transcriptDetail, "empty is not the same fact as unreadable")
+            }
+        }
+    }
+
+    /// THE CRITICAL. A safety-net page must not throw away the transcript the
+    /// operator is reading.
+    ///
+    /// The page rebuilds its surface from an empty one and the store publishes
+    /// it wholesale, so without an explicit carry the rows accumulated live
+    /// since the last page are discarded every thirty seconds. The concrete
+    /// failure it caused: an agent runs a long turn, hundreds of rows arrive on
+    /// the stream, and the pane drops to "Nothing yet" mid-turn.
+    ///
+    /// The scripted daemon answers with an empty transcript throughout, so this
+    /// fails unless the rows are genuinely carried rather than re-read. That is
+    /// also the live shape: a tail read can legitimately return nothing the
+    /// client did not already have.
+    func testASafetyNetPageKeepsTheTranscriptTheOperatorIsReading() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            // A turn's worth of live rows, none of which any page will return.
+            for order in 1...3 {
+                try Self.writeNotification(
+                    to: server,
+                    method: "fleet/transcript_event",
+                    params: ["chunk": Self.transcriptChunkObject(order: Int64(order), text: "row \(order)")]
+                )
+            }
+            let arrived = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.rows.count == 3 }
+            }
+            XCTAssertTrue(arrived, "the live rows never landed, so the page cannot be what drops them")
+
+            // The safety net fires.
+            await store.refreshChatOnce()
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.transcriptState.rows.map(\.body), ["row 1", "row 2", "row 3"],
+                    "the page wiped a transcript the operator was reading mid-turn"
+                )
+                XCTAssertEqual(store.chat.transcriptState.cursor, 3, "and the cursor went with it")
+            }
+        }
+    }
+
+    /// The CLASSIFIER is carried too, which is the subtler half of the same
+    /// fix.
+    ///
+    /// It holds the pending tool-title map, so a page that dropped it would
+    /// leave the next tool result rendering under the unnamed `tool` form. That
+    /// is the exact degradation the replay guard exists to prevent, arriving
+    /// through the page instead of through a replay, and no row-count assertion
+    /// would notice it.
+    func testASafetyNetPageKeepsThePendingToolTitles() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            // A tool call, whose title only the classifier now remembers.
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(
+                    order: 1,
+                    eventType: "acp.tool_call",
+                    payload: ["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"]
+                )]
+            )
+            let called = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.rows.map(\.body) == ["Bash"] }
+            }
+            XCTAssertTrue(called, "the tool call never landed")
+
+            // The safety net fires BETWEEN the call and its result.
+            await store.refreshChatOnce()
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(
+                    order: 2,
+                    eventType: "acp.tool_call",
+                    payload: [
+                        "sessionUpdate": "tool_call_update", "toolCallId": "t1",
+                        "status": "completed", "rawOutput": "ok",
+                    ]
+                )]
+            )
+            let resolved = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.rows.count == 2 }
+            }
+            XCTAssertTrue(resolved, "the tool result never landed")
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.transcriptState.rows.last?.body, "Bash  ok",
+                    "the page dropped the pending tool title, so the result lost the tool it belongs to"
+                )
+            }
+        }
+    }
+
+    /// A page whose transcript was carried forward is never RE-READ.
+    ///
+    /// The subscribe repeats once per page, deliberately: naming the cursor
+    /// makes a repeat neither gap nor duplicate, and repeating it is what
+    /// re-arms a forwarder the daemon dropped on a transient error. The tail
+    /// read is the half that must not repeat, because the rows are already on
+    /// screen. This is also the guard against the carry-forward being
+    /// implemented as a re-read that happens to produce the same rows.
+    func testACarriedTranscriptIsNotReReadFromTheDaemon() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            XCTAssertEqual(counts.transcriptSubscribes.count, 1, "the first page opens the stream")
+            XCTAssertEqual(counts.transcriptLists.count, 1, "and reads the tail once")
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(order: 1, text: "live")]
+            )
+            let landed = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.cursor == 1 }
+            }
+            XCTAssertTrue(landed, "the live row never landed")
+
+            await store.refreshChatOnce()
+            await store.refreshChatOnce()
+
+            // The SUBSCRIBE repeats deliberately, once per page: it names a
+            // cursor, so it can neither gap nor duplicate, and re-arming is
+            // what notices a forwarder the daemon has silently dropped.
+            XCTAssertEqual(
+                counts.transcriptSubscribes.count, 3,
+                "every page must re-arm the stream, or a dead forwarder is never noticed"
+            )
+            // The tail READ is the expensive half, and it must not repeat.
+            XCTAssertEqual(
+                counts.transcriptLists.count, 1,
+                "a carried transcript must not be re-read from the daemon"
+            )
+            for subscribe in counts.transcriptSubscribes.dropFirst() {
+                let params = subscribe["params"] as? [String: Any]
+                XCTAssertEqual(
+                    (params?["after_order"] as? NSNumber)?.int64Value, 1,
+                    "a repeat subscribe must resume from the cursor, or it re-delivers the whole tail"
+                )
+            }
+        }
+    }
+
+    /// A committed chunk reaches an open pane with no page behind it, and one
+    /// for ANOTHER session never appears.
+    ///
+    /// Ordered rather than timed, like its message sibling: both frames go down
+    /// one socket in order, so when the second has landed the first has already
+    /// been through the fold. Waiting a fixed interval to prove an absence is
+    /// how a suite gets a flake that only fires on a loaded machine.
+    func testALiveTranscriptChunkReachesTheOpenPaneWithoutAPage() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            await MainActor.run { XCTAssertEqual(store.chat.targetSessionKey, "acp:1") }
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(
+                    order: 8, sessionKey: "acp:elsewhere", text: "another agent"
+                )]
+            )
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(order: 9, text: "on it")]
+            )
+
+            let landed = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.rows.map(\.body) == ["on it"] }
+            }
+            XCTAssertTrue(
+                landed,
+                "a committed chunk must reach the pane on the stream, and only this session's"
+            )
+        }
+    }
+
+    /// A chunk that arrives while a page is READING must survive that page.
+    ///
+    /// The page replaces the surface wholesale and its `fleet/transcript_list`
+    /// answered before this chunk was committed, so folding it into the live
+    /// surface alone is not enough: the page lands afterwards and rewinds the
+    /// pane past it. Driven by holding the daemon inside the page rather than
+    /// by hoping the interleaving happens, so it fails deterministically
+    /// without the replay.
+    func testALiveTranscriptChunkIsNotLostByAPageAlreadyInFlight() async throws {
+        let gate = ChatServerGate()
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(gate: gate, counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            gate.arm()
+            let paging = Task { await store.refreshChatOnce() }
+            let stopped = await Self.waitUntil { gate.hasReached }
+            XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(order: 11, text: "mid-page")]
+            )
+            let folded = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.rows.map(\.body) == ["mid-page"] }
+            }
+            XCTAssertTrue(folded, "the chunk never reached the surface, so the page cannot be what dropped it")
+
+            gate.letGo()
+            await paging.value
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.transcriptState.rows.map(\.body), ["mid-page"],
+                    "the page overwrote a chunk that was committed while it was reading"
+                )
+            }
+        }
+    }
+
+    /// A transcript BURST during a page must not evict the chat message that
+    /// page's buffer exists to protect.
+    ///
+    /// The buffers are per axis for exactly this. An agent mid-turn emits
+    /// transcript chunks continuously while the conversation sits idle, so one
+    /// shared hundred-entry FIFO is emptied of chat messages by transcript
+    /// traffic inside a single page. That would silently undo the guarantee the
+    /// previous PR added, and it would do it precisely when the pane is
+    /// busiest.
+    ///
+    /// The message goes in FIRST and the burst after it, so a shared FIFO
+    /// evicts the message and this fails.
+    func testATranscriptBurstDoesNotEvictTheBufferedChatMessage() async throws {
+        let gate = ChatServerGate()
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(gate: gate, counts: counts) { store, server in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            gate.arm()
+            let paging = Task { await store.refreshChatOnce() }
+            let stopped = await Self.waitUntil { gate.hasReached }
+            XCTAssertTrue(stopped, "the daemon never reached the point the page is held at")
+
+            try Self.writeNotification(
+                to: server,
+                method: "fleet/message_event",
+                params: ["message": Self.messageObject(id: "01J0KEEP", scope: "channel:c1")]
+            )
+            // Well past the shared buffer's old hundred-entry ceiling.
+            for order in 1...150 {
+                try Self.writeNotification(
+                    to: server,
+                    method: "fleet/transcript_event",
+                    params: ["chunk": Self.transcriptChunkObject(order: Int64(order), text: "burst \(order)")]
+                )
+            }
+            let burstLanded = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.cursor == 150 }
+            }
+            XCTAssertTrue(burstLanded, "the burst never landed, so nothing was under pressure")
+
+            gate.letGo()
+            await paging.value
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.chat.messages.map(\.id), ["01J0KEEP"],
+                    "the transcript burst evicted the chat message the buffer was added to protect"
+                )
+            }
+        }
+    }
+
+    /// The daemon's truncation flag reaches the surface, and survives the
+    /// carry-forward.
+    ///
+    /// A short page is not the same fact as a short transcript: the tail is
+    /// bounded by payload BYTES as well as rows, so a session of large chunks
+    /// returns few of them. A pane that read that as completeness would draw a
+    /// partial run as a whole one. The second page is the other half: the
+    /// marker describes rows that are still on screen, so dropping it thirty
+    /// seconds later would quietly turn a partial run into a complete-looking
+    /// one.
+    func testTheTruncationFlagReachesTheSurfaceAndSurvivesTheCarryForward() async throws {
+        let counts = ChatServerCounts(
+            transcriptHeadOrder: 9,
+            transcriptChunks: [Self.transcriptChunkObject(order: 9, text: "the tail")],
+            transcriptTruncated: true
+        )
+        try await withChatStore(counts: counts) { store, _ in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertTrue(
+                    store.chat.transcriptState.truncated,
+                    "the daemon said it left rows behind and the pane must say so too"
+                )
+                XCTAssertNil(store.chat.transcriptDetail, "a seam is not an error")
+            }
+
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertTrue(
+                    store.chat.transcriptState.truncated,
+                    "the seam marker was dropped by the page that kept the rows it describes"
+                )
+            }
+        }
+    }
+
+    /// A daemon that cannot serve transcripts says SO, even when there is also
+    /// no session to follow.
+    ///
+    /// Two absences, and the order of the guards decides which one the operator
+    /// is told about. Reporting the missing session first sent the reader off
+    /// to look at a session that would have been refused the read anyway.
+    func testAMissingCapabilityIsReportedAheadOfAMissingSession() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: nil)
+        try await withChatStore(serveTranscript: false, refuseAcpSessionCreate: true, counts: counts) { store, _ in
+            await store.refreshChatOnce()
+
+            await MainActor.run {
+                XCTAssertNil(store.chat.targetSessionKey, "the fixture refused the mint, so there is no session")
+                XCTAssertEqual(
+                    store.chat.transcriptDetail, "This daemon does not serve ACP transcripts.",
+                    "the capability is the real reason and must be the one reported"
+                )
+            }
+        }
+    }
+
+    /// MAJOR 1. A MOMENTARY refusal must not pin the banner forever.
+    ///
+    /// The detail describes what happened on the page that set it. Carrying it
+    /// forward made a single hiccup permanent: it rode onto every later
+    /// surface, the steady-state page returned before anything could clear it,
+    /// and the pane rendered "Transcript unavailable" above a live, updating
+    /// transcript until the session was re-minted or the app restarted. Before
+    /// the carry-forward existed this self-healed on the next page, so the
+    /// regression arrived with the fix for something else.
+    ///
+    /// It takes a RECONNECT to reach, and the first version of this test did
+    /// not: a refusal on the opening page leaves no cursor, so the carry never
+    /// runs and the assertion passes against the bug. The failure needs an
+    /// opening subscribe that SUCCEEDS, so a cursor exists to be carried, and a
+    /// later one that does not. Five older assertions touch `transcriptDetail`
+    /// and none watches it CLEAR, which is how this could land unnoticed.
+    func testATransientTranscriptRefusalClearsOnceItStopsHolding() async throws {
+        // The subscribe on the SECOND connection is refused; the opening one
+        // and the retry after it are not.
+        let counts = ChatServerCounts(
+            transcriptHeadOrder: 5,
+            transcriptChunks: [Self.transcriptChunkObject(order: 5, text: "still running")],
+            refusedTranscriptSubscribes: [2]
+        )
+        try await withReconnectingChatStore(counts: counts) { store, firstServer, factory in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertEqual(store.chat.transcriptState.cursor, 5, "the opening page must leave a cursor to carry")
+                XCTAssertNil(store.chat.transcriptDetail)
+            }
+
+            Darwin.shutdown(firstServer, SHUT_RDWR)
+            let reconnected = await Self.waitUntil { factory.count == 2 }
+            XCTAssertTrue(reconnected, "the store never reconnected")
+            _ = await Self.waitUntil { await MainActor.run { store.connectionState.isLive } }
+
+            // The page whose subscribe is refused, with a cursor carried.
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertNotNil(
+                    store.chat.transcriptDetail,
+                    "a refused subscribe must be explained while it is still the truth"
+                )
+                XCTAssertEqual(
+                    store.chat.transcriptState.cursor, 5,
+                    "and the rows already read must survive the refusal"
+                )
+            }
+
+            // The daemon is well again. Nothing else changed.
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertNil(
+                    store.chat.transcriptDetail,
+                    "the banner outlived the refusal and now sits above a working transcript"
+                )
+            }
+        }
+    }
+
+    /// MAJOR 2. A reconnect resumes the stream from the rows already on screen,
+    /// not from the daemon's head.
+    ///
+    /// A bare subscribe starts the forwarder at the head, so everything
+    /// committed while this client was disconnected is never pushed. The tail
+    /// page used to be the backstop and no longer is, because a carried cursor
+    /// skips it: a five-second outage over a busy turn silently lost every row
+    /// in the gap, with no seam to show it happened. `openChatStream` records
+    /// this lesson for the chat half; the transcript half repeated it.
+    ///
+    /// Two connections, because the failure only exists across a reconnect: the
+    /// assertion is on the SECOND subscribe's cursor.
+    func testAReconnectResumesTheTranscriptStreamFromTheRowsAlreadyShown() async throws {
+        let counts = ChatServerCounts(
+            transcriptHeadOrder: 5,
+            transcriptChunks: [Self.transcriptChunkObject(order: 5, text: "before the drop")]
+        )
+        try await withReconnectingChatStore(counts: counts) { store, firstServer, factory in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            // One row past the page, so the cursor is somewhere only the live
+            // stream could have put it.
+            try Self.writeNotification(
+                to: firstServer,
+                method: "fleet/transcript_event",
+                params: ["chunk": Self.transcriptChunkObject(order: 6, text: "live before the drop")]
+            )
+            let atSix = await Self.waitUntil {
+                await MainActor.run { store.chat.transcriptState.cursor == 6 }
+            }
+            XCTAssertTrue(atSix, "the live row never landed, so there is no cursor to resume from")
+
+            // The outage.
+            Darwin.shutdown(firstServer, SHUT_RDWR)
+            let reconnected = await Self.waitUntil { factory.count == 2 }
+            XCTAssertTrue(reconnected, "the store never reconnected")
+            let relive = await Self.waitUntil {
+                await MainActor.run { store.connectionState.isLive }
+            }
+            XCTAssertTrue(relive, "the second connection never came up")
+
+            // The first page on the new socket, which is where the stream reopens.
+            await store.refreshChatOnce()
+
+            let subscribes = counts.transcriptSubscribes
+            XCTAssertEqual(subscribes.count, 2, "the new connection must re-open the stream")
+            let resumed = subscribes[1]["params"] as? [String: Any]
+            XCTAssertEqual(
+                (resumed?["after_order"] as? NSNumber)?.int64Value, 6,
+                "the reconnect subscribed at the daemon's head, so every row committed during the outage is lost"
+            )
+        }
+    }
+
+    /// Bring a store up against TWO scripted chat connections, so a test can
+    /// drop the first and watch what the second asks for.
+    ///
+    /// Both legs are served by the same `serveChatConnection`, and both share
+    /// one `counts`, which is what lets a test compare the frames the two
+    /// connections sent. A second copy of the bootstrap is how the two legs of
+    /// a reconnect test start disagreeing about the wire.
+    private func withReconnectingChatStore(
+        counts: ChatServerCounts,
+        _ body: (FleetStore, Int32, TestConnectionFactory) async throws -> Void
+    ) async throws {
+        var first = [Int32](repeating: 0, count: 2)
+        var second = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &first), 0)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &second), 0)
+        let firstServer = first[1]
+        let secondServer = second[1]
+        defer {
+            Darwin.close(firstServer)
+            Darwin.close(secondServer)
+        }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let factory = TestConnectionFactory(descriptors: [first[0], second[0]], location: location)
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: factory.make,
+                reconnectDelayNanoseconds: { _ in 0 }
+            )
+        }
+
+        let serversDone = expectation(description: "both chat servers finished")
+        serversDone.expectedFulfillmentCount = 2
+        let serverResult = SocketServerResult()
+        for descriptor in [firstServer, secondServer] {
+            DispatchQueue.global().async {
+                defer { serversDone.fulfill() }
+                do {
+                    try Self.serveChatConnection(descriptor: descriptor, counts: counts)
+                } catch StoreServerError.closed {
+                    // The client hung up. Expected on both legs.
+                } catch {
+                    serverResult.record(error)
+                }
+            }
+        }
+
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run { store.connectionState.isLive && store.canWrite }
+        }
+        XCTAssertTrue(live, "the fixture never reached a live connection")
+
+        try await body(store, firstServer, factory)
+
+        await MainActor.run { store.stop() }
+        await fulfillment(of: [serversDone], timeout: 5)
+        try serverResult.throwIfRecorded()
+    }
+
+    /// Bootstrap one scripted chat connection and serve it until it closes.
+    ///
+    /// Extracted so a test with TWO connections drives both the same way
+    /// `withChatStore` drives one; a second copy of the bootstrap is how the
+    /// two legs of a reconnect test start disagreeing about the wire.
+    private static func serveChatConnection(descriptor: Int32, counts: ChatServerCounts) throws {
+        try serveStoreBootstrap(
+            descriptor: descriptor,
+            subscriptionSnapshot: try snapshotObject(head: 1, sessions: []),
+            eventBeforeSubscriptionResponse: false,
+            snapshotAfterEvent: try snapshotObject(head: 1, sessions: []),
+            capabilityIDs: [
+                "fleet.chat.read", "fleet.chat.write",
+                "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
+                "fleet.transcript.read",
+            ]
+        )
+        while true {
+            try answerChatRequest(try readRequest(from: descriptor), to: descriptor, counts: counts)
+        }
+    }
+
+    /// A daemon that does not advertise `fleet.transcript.read` costs the pane
+    /// its transcript and NOTHING else, with the absence explained.
+    ///
+    /// Gated separately from the conversation for exactly this: a daemon built
+    /// between phases serves the chat while answering -32601 here, and a
+    /// combined gate would either hide a working conversation or open a stream
+    /// that errors on every page.
+    func testADaemonWithoutTheTranscriptCapabilityExplainsTheAbsence() async throws {
+        let counts = ChatServerCounts(transcriptHeadOrder: 5)
+        try await withChatStore(serveTranscript: false, counts: counts) { store, _ in
+            await store.refreshChatOnce()
+
+            await MainActor.run {
+                XCTAssertFalse(store.canReadTranscript)
+                XCTAssertTrue(store.canReadChat, "the conversation must survive a missing transcript capability")
+                XCTAssertEqual(store.chat.scopeKey, "channel:c1", "and the page still published")
+                XCTAssertNotNil(store.chat.transcriptDetail, "an unreadable transcript must say so")
+                XCTAssertEqual(store.chat.transcriptState.rows, [])
+            }
+            XCTAssertEqual(counts.transcriptSubscribes.count, 0, "a capability this daemon lacks must not be called")
+            XCTAssertEqual(counts.transcriptLists.count, 0)
+        }
+    }
+
+    /// One transcript chunk in the shape the daemon frames it.
+    private static func transcriptChunkObject(
+        order: Int64,
+        sessionKey: String = "acp:1",
+        eventType: String = "acp.message",
+        text: String = "hello",
+        payload: [String: Any]? = nil
+    ) -> [String: Any] {
+        [
+            "ingest_order": order,
+            "event_id": "evt-\(order)",
+            "session_key": sessionKey,
+            "event_type": eventType,
+            "payload": payload ?? ["text": text],
+            "observed_at": 1_700_000_000_000,
+        ]
+    }
+
     /// Bring a store up against the scripted chat daemon and hand both it and
     /// the SERVER end of the socket to `body`.
     ///
     /// Handing over the raw descriptor is what lets a test push a notification.
     /// It is safe because the server thread is blocked reading (or held at the
     /// gate) whenever `body` runs, so there is never a second writer.
+    /// `counts` is passed IN rather than handed back, so a test that needs to
+    /// assert on what the wire was asked for holds the same object the
+    /// scripted daemon is writing to.
     private func withChatStore(
         refuseMessageSubscribe: Bool = false,
         gate: ChatServerGate? = nil,
         pagesReturnMarkerRows: Bool = false,
+        serveTranscript: Bool = true,
+        refuseAcpSessionCreate: Bool = false,
+        counts providedCounts: ChatServerCounts? = nil,
         _ body: (FleetStore, Int32) async throws -> Void
     ) async throws {
         var descriptors = [Int32](repeating: 0, count: 2)
@@ -1152,7 +1811,7 @@ final class FleetConnectionTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: location.home) }
         let serverDone = expectation(description: "chat server finished")
         let serverResult = SocketServerResult()
-        let counts = ChatServerCounts(pagesReturnMarkerRows: pagesReturnMarkerRows)
+        let counts = providedCounts ?? ChatServerCounts(pagesReturnMarkerRows: pagesReturnMarkerRows)
 
         DispatchQueue.global().async {
             defer { serverDone.fulfill() }
@@ -1165,7 +1824,7 @@ final class FleetConnectionTests: XCTestCase {
                     capabilityIDs: [
                         "fleet.chat.read", "fleet.chat.write",
                         "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
-                    ],
+                    ] + (serveTranscript ? ["fleet.transcript.read"] : []),
                     refuseMessageSubscribe: refuseMessageSubscribe
                 )
                 while true {
@@ -1173,7 +1832,8 @@ final class FleetConnectionTests: XCTestCase {
                         try Self.readRequest(from: serverDescriptor),
                         to: serverDescriptor,
                         counts: counts,
-                        gate: gate
+                        gate: gate,
+                        refuseAcpSessionCreate: refuseAcpSessionCreate
                     )
                 }
             } catch StoreServerError.closed {
@@ -1223,7 +1883,8 @@ final class FleetConnectionTests: XCTestCase {
         _ request: [String: Any],
         to descriptor: Int32,
         counts: ChatServerCounts,
-        gate: ChatServerGate? = nil
+        gate: ChatServerGate? = nil,
+        refuseAcpSessionCreate: Bool = false
     ) throws {
         switch request["method"] as? String {
         case "fleet/channel_list":
@@ -1237,6 +1898,12 @@ final class FleetConnectionTests: XCTestCase {
             ]]])
         case "fleet/acp_session_create":
             counts.recordAcpCreate()
+            // A refused mint leaves the surface with no target at all, because
+            // a copilot channel carries no recipient list to fall back on.
+            if refuseAcpSessionCreate {
+                try writeError(to: descriptor, request: request)
+                return
+            }
             try writeResponse(to: descriptor, request: request, result: [
                 "session_key": "acp:1",
                 "scope_key": "channel:c1",
@@ -1258,6 +1925,28 @@ final class FleetConnectionTests: XCTestCase {
             try writeResponse(to: descriptor, request: request, result: ["confirms": []])
         case "fleet/activity_list":
             try writeResponse(to: descriptor, request: request, result: ["activities": []])
+        case "fleet/transcript_subscribe":
+            // The head the page's window is measured back from, and the
+            // session it was asked for, both recorded: the ack is the only
+            // place the wire says WHICH session's stream the store opened.
+            if counts.recordTranscriptSubscribe(request) {
+                try writeError(to: descriptor, request: request)
+                return
+            }
+            try writeResponse(
+                to: descriptor,
+                request: request,
+                result: ["head_order": counts.transcriptHeadOrder as Any]
+            )
+        case "fleet/transcript_list":
+            counts.recordTranscriptList(request)
+            try writeResponse(to: descriptor, request: request, result: [
+                "chunks": counts.transcriptChunks,
+                "next_after_order": counts.transcriptChunks.isEmpty
+                    ? NSNull()
+                    : counts.transcriptHeadOrder as Any,
+                "truncated": counts.transcriptTruncated,
+            ])
         case "fleet/message_send":
             try writeResponse(to: descriptor, request: request, result: [
                 "message_id": "01J0MSG",
@@ -1652,9 +2341,63 @@ private final class ChatServerCounts: @unchecked Sendable {
     /// which page's surface reached the screen.
     let pagesReturnMarkerRows: Bool
 
-    init(rejectionDetail: String = "target_not_running", pagesReturnMarkerRows: Bool = false) {
+    /// The head order this fixture's transcript reports, or nil for an empty
+    /// one. The store measures its page window back from this.
+    let transcriptHeadOrder: Int64?
+    /// The chunks `fleet/transcript_list` answers with.
+    let transcriptChunks: [[String: Any]]
+    /// Whether the scripted tail read says it left older rows behind.
+    let transcriptTruncated: Bool
+    /// Which `fleet/transcript_subscribe` calls are refused, counted from one.
+    ///
+    /// By INDEX rather than "the first N", because the failure that pinned the
+    /// banner needs an opening subscribe that SUCCEEDS (so a cursor exists to
+    /// be carried) and a later one that does not.
+    private var transcriptSubscribeRequests: [[String: Any]] = []
+    private var transcriptListRequests: [[String: Any]] = []
+
+    init(
+        rejectionDetail: String = "target_not_running",
+        pagesReturnMarkerRows: Bool = false,
+        transcriptHeadOrder: Int64? = nil,
+        transcriptChunks: [[String: Any]] = [],
+        transcriptTruncated: Bool = false,
+        refusedTranscriptSubscribes: Set<Int> = []
+    ) {
+        self.refusedTranscriptSubscribes = refusedTranscriptSubscribes
         self.rejectionDetail = rejectionDetail
         self.pagesReturnMarkerRows = pagesReturnMarkerRows
+        self.transcriptHeadOrder = transcriptHeadOrder
+        self.transcriptChunks = transcriptChunks
+        self.transcriptTruncated = transcriptTruncated
+    }
+
+    let refusedTranscriptSubscribes: Set<Int>
+
+    /// Record the call and say whether this one is refused.
+    func recordTranscriptSubscribe(_ request: [String: Any]) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        transcriptSubscribeRequests.append(request)
+        return refusedTranscriptSubscribes.contains(transcriptSubscribeRequests.count)
+    }
+
+    func recordTranscriptList(_ request: [String: Any]) {
+        lock.lock()
+        transcriptListRequests.append(request)
+        lock.unlock()
+    }
+
+    var transcriptSubscribes: [[String: Any]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return transcriptSubscribeRequests
+    }
+
+    var transcriptLists: [[String: Any]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return transcriptListRequests
     }
 
     /// Count this page's timeline read and answer with its ordinal.

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
@@ -561,6 +561,184 @@ final class FleetDaemonContractTests: XCTestCase {
         XCTAssertEqual(roster.eventID, "both-2")
     }
 
+    // MARK: - The ACP transcript stream (PR C)
+
+    /// `fleet.transcript.read` is advertised, which is what a UI gating on the
+    /// catalogue depends on.
+    ///
+    /// The client-side half of the daemon's own advertisement test: gating a
+    /// surface on the catalogue is only safe if the catalogue never names a
+    /// method that answers -32601, and never omits one that works.
+    /// `fleet.transcript.prune` is asserted too, and separately, because the
+    /// destructive verb having its own id is the reason this pane can read a
+    /// transcript without being able to delete one.
+    func testRealDaemonAdvertisesTheTranscriptCapabilities() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedConnection()
+        defer { Task { await connection.close() } }
+
+        let result = try await connection.negotiate()
+        XCTAssertTrue(
+            result.capabilityIDs.contains("fleet.transcript.read"),
+            "the transcript arms exist but are not advertised, so a UI gating on the catalogue stays dark"
+        )
+        XCTAssertTrue(
+            result.capabilityIDs.contains("fleet.transcript.prune"),
+            "the destructive verb must be its own id, or a read surface cannot be granted without a delete"
+        )
+    }
+
+    /// The whole point of PR C, against a real daemon: a transcript chunk
+    /// committed by somebody else reaches this connection as a notification,
+    /// with nothing polled in between.
+    ///
+    /// The ack alone is deliberately not the assertion. `head_order` says the
+    /// daemon parsed the frame; only the event says it registered the forwarder
+    /// that makes the pane live, and that registration happens in `serve_conn`
+    /// AFTER the response is queued, i.e. in code the ack cannot reach.
+    ///
+    /// The chunk is committed by the FIXTURE rather than by this client because
+    /// there is no client-facing write for a transcript row: the production
+    /// writer is the ACP pool, driven by a real adapter subprocess. The fixture
+    /// writes the same `source='acp'` row through the same repo and rings the
+    /// same bell; the RPC, the head read and the forwarder are all the daemon's
+    /// own code under test.
+    func testRealDaemonPushesACommittedTranscriptChunkToASubscribedConnection() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let reader = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await reader.close() } }
+
+        let stream = await reader.incoming()
+        let acknowledgement = try await reader.transcriptSubscribe(
+            FleetTranscriptSubscribeParams(sessionKey: "acp:contract", afterOrder: nil)
+        )
+        XCTAssertNil(acknowledgement.headOrder, "an empty transcript has no head")
+
+        async let incoming = Self.nextTranscriptEvent(from: stream)
+        let order = try fixture.seedTranscript(
+            eventID: "chunk-1",
+            sessionKey: "acp:contract",
+            payload: ["text": "reading the code"]
+        )
+        let event = try await incoming
+
+        XCTAssertEqual(event.chunk.ingestOrder, order)
+        XCTAssertEqual(event.chunk.eventID, "chunk-1")
+        XCTAssertEqual(event.chunk.sessionKey, "acp:contract")
+        XCTAssertEqual(event.chunk.eventType, "acp.message")
+        XCTAssertEqual(event.chunk.payload.value("text")?.stringValue, "reading the code")
+
+        // And the SURFACE reaches the operator, not just the frame: the same
+        // fold the store runs, through the same taxonomy, on a chunk that came
+        // off a real socket rather than out of a literal.
+        var surface = FleetChatSurface()
+        surface.targetSessionKey = "acp:contract"
+        surface.apply(.transcript(event.chunk))
+        XCTAssertEqual(surface.transcriptState.rows.map(\.body), ["reading the code"])
+        XCTAssertEqual(surface.transcriptState.rows.map(\.lane), [.agent])
+    }
+
+    /// The paged half, against the real daemon: an UNCURSORED read answers the
+    /// tail of this session, a cursored one still walks forward, and both are
+    /// ascending. This is the fact the store's bootstrap is built on.
+    ///
+    /// The second session is what makes it mean anything. `ingest_order` is one
+    /// global AUTOINCREMENT sequence, so the newest orders in the table are not
+    /// the newest rows of a session; a client approximating a tail by naming
+    /// `head - limit` gets the neighbour's rows, or none. That approximation is
+    /// what the uncursored arm replaces, and only a real daemon proves the arm
+    /// is wired to the read it claims.
+    func testRealDaemonAnswersAnUncursoredTranscriptReadWithTheSessionTail() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        var orders: [Int64] = []
+        for index in 0..<5 {
+            orders.append(try fixture.seedTranscript(
+                eventID: "page-\(index)",
+                sessionKey: "acp:paged",
+                payload: ["text": "line \(index)"]
+            ))
+        }
+        // A NOISIER neighbour committed afterwards, so it owns every one of the
+        // newest global orders.
+        for index in 0..<8 {
+            _ = try fixture.seedTranscript(
+                eventID: "other-\(index)",
+                sessionKey: "acp:elsewhere",
+                payload: ["text": "not mine"]
+            )
+        }
+
+        let tail = try await connection.transcriptList(FleetTranscriptListParams(
+            sessionKey: "acp:paged",
+            afterOrder: nil,
+            limit: 2
+        ))
+        XCTAssertEqual(
+            tail.chunks.map(\.eventID), ["page-3", "page-4"],
+            "an uncursored read must answer the NEWEST page of this session, oldest first"
+        )
+        XCTAssertEqual(tail.nextAfterOrder, orders.last)
+        XCTAssertTrue(
+            tail.chunks.allSatisfy { $0.sessionKey == "acp:paged" },
+            "the neighbour's rows must never appear in this session's transcript"
+        )
+
+        let forward = try await connection.transcriptList(FleetTranscriptListParams(
+            sessionKey: "acp:paged",
+            afterOrder: orders[0],
+            limit: fleetTranscriptListMax
+        ))
+        XCTAssertEqual(
+            forward.chunks.map(\.eventID), ["page-1", "page-2", "page-3", "page-4"],
+            "the cursor is exclusive and forward, so a client resuming from a row it holds does not re-read it"
+        )
+
+        // The head the subscribe publishes is this session's own last order,
+        // not the table's, which is what makes the stream and the tail meet.
+        let acknowledgement = try await connection.transcriptSubscribe(
+            FleetTranscriptSubscribeParams(sessionKey: "acp:paged", afterOrder: nil)
+        )
+        XCTAssertEqual(acknowledgement.headOrder, orders.last)
+    }
+
+    /// The next `fleet/transcript_event`, or a FAILURE within `timeout`.
+    ///
+    /// Bounded for the reason its message sibling is: the failure under test is
+    /// one where the notification simply never comes, and an unbounded await
+    /// turns that into a suite that hangs instead of a test that fails.
+    private static func nextTranscriptEvent(
+        from stream: AsyncStream<FleetIncoming>,
+        timeout: Duration = .seconds(5)
+    ) async throws -> FleetTranscriptEventParams {
+        try await withThrowingTaskGroup(of: FleetTranscriptEventParams?.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                while let incoming = await iterator.next() {
+                    if case let .transcriptEvent(event) = incoming {
+                        return event
+                    }
+                }
+                return nil
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                return nil
+            }
+            let first = try await group.next() ?? nil
+            group.cancelAll()
+            guard let event = first else {
+                throw MissingChatNotification()
+            }
+            return event
+        }
+    }
+
     /// The next `fleet/message_event`, or a FAILURE within `timeout`.
     ///
     /// Bounded, unlike its `nextFleetEvent` sibling, because the thing it waits
@@ -723,6 +901,31 @@ private final class FixtureDaemon {
             throw FixtureError.invalidResponse
         }
         return revision.int64Value
+    }
+
+    /// Commit one ACP transcript chunk, returning its `ingest_order`.
+    ///
+    /// The fixture writes the row the ACP pool writes (`source='acp'`, through
+    /// the real repo) and then rings the daemon's own transcript bell. It does
+    /// NOT emulate the RPC, the head read, or the forwarder, which are exactly
+    /// what the tests above are about.
+    func seedTranscript(
+        eventID: String,
+        sessionKey: String,
+        eventType: String = "acp.message",
+        payload: [String: Any]
+    ) throws -> Int64 {
+        let response = try send([
+            "command": "seed_transcript",
+            "event_id": eventID,
+            "session_key": sessionKey,
+            "event_type": eventType,
+            "payload": payload,
+        ])
+        guard response["ok"] as? Bool == true, let order = response["ingest_order"] as? NSNumber else {
+            throw FixtureError.invalidResponse
+        }
+        return order.int64Value
     }
 
     private func send(_ command: [String: Any]) throws -> [String: Any] {

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetTranscriptPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetTranscriptPresentationTests.swift
@@ -1,0 +1,642 @@
+import Foundation
+import XCTest
+@testable import AINBFleet
+
+/// The Swift half of the ACP transcript taxonomy, held against the Rust it was
+/// ported from (`ainb-tui/crates/ainb-hangar-proto/src/transcript.rs`).
+///
+/// These assert on the EXACT strings, double spaces included, because that is
+/// the whole contract: the notch and the terminal client render one transcript,
+/// and an operator watching both must not have to learn two vocabularies for
+/// one tool call. A test that only checked "the row mentions the tool" would
+/// pass while the two surfaces drifted apart.
+final class FleetTranscriptPresentationTests: XCTestCase {
+    // MARK: - The taxonomy, arm by arm
+
+    /// `acp.message` and `acp.thought` fold their text, one row per line, into
+    /// their own lanes.
+    func testProseAndThinkingFoldIntoTheirOwnLanes() {
+        var classifier = AcpTranscriptClassifier()
+
+        let prose = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": "first line\nsecond line"])
+        )
+        XCTAssertEqual(prose.map(\.lane), [.agent, .agent])
+        XCTAssertEqual(prose.map(\.body), ["first line", "second line"])
+
+        let thought = classifier.classify(
+            eventType: "acp.thought",
+            payload: Self.json(["text": "weighing it up"])
+        )
+        XCTAssertEqual(thought.map(\.lane), [.thinking])
+        XCTAssertEqual(thought.map(\.body), ["weighing it up"])
+    }
+
+    /// A blank line inside a block yields no row, so a reply padded with
+    /// newlines does not paint empty rows.
+    func testBlankLinesInsideABlockYieldNoRows() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": "one\n\n   \ntwo\n"])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["one", "two"])
+    }
+
+    /// A chunk with no text but a NON-TEXT block is named rather than dropped.
+    ///
+    /// The Rust's reason, kept: a transcript that silently omits a row reads as
+    /// a complete one, so an image the agent produced has to leave a mark.
+    func testANonTextBlockIsNamedRatherThanDropped() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": "", "block": ["content": ["type": "image"]]])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["· image content"])
+        XCTAssertEqual(rows.map(\.lane), [.agent])
+    }
+
+    /// A block whose content type this build cannot read still leaves a row,
+    /// under the taxonomy's own placeholder rather than the adapter's.
+    func testANonTextBlockWithNoTypeStillLeavesARow() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": "  ", "block": ["content": ["nothing": 1]]])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["· non-text content"])
+    }
+
+    /// A chunk with neither text nor a block yields nothing at all.
+    func testAnEmptyTextChunkYieldsNothing() {
+        var classifier = AcpTranscriptClassifier()
+
+        XCTAssertTrue(classifier.classify(eventType: "acp.message", payload: Self.json(["text": ""])).isEmpty)
+    }
+
+    /// A `tool_call` renders its title and a compact rawInput summary, picking
+    /// the most telling field rather than dumping the JSON.
+    func testAToolCallRendersItsTitleAndACompactInput() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "title": "Bash",
+                "status": "pending",
+                "rawInput": ["command": "cargo test", "description": "run the suite"],
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.lane), [.toolCall])
+        XCTAssertEqual(rows.map(\.body), ["Bash  cargo test"], "two spaces, and the command not the description")
+    }
+
+    /// With no telling field the summary is a flat key=value rendering.
+    func testAToolCallWithNoTellingFieldRendersFlatPairs() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "title": "Weird",
+                "rawInput": ["beta": 2, "alpha": "one"],
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["Weird  alpha=one beta=2"])
+    }
+
+    /// A call with no rawInput at all is just its name, with no trailing gap.
+    func testAToolCallWithNoInputIsJustItsName() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["Bash"])
+    }
+
+    /// A LATER update names its tool only because the call's title was
+    /// remembered. This is the one reason the classifier is stateful at all.
+    func testAnUpdateResolvesItsToolNameFromTheEarlierCall() {
+        var classifier = AcpTranscriptClassifier()
+        _ = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash", "status": "pending",
+            ])
+        )
+        let update = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "content": [["type": "content", "content": ["type": "text", "text": "6 passed"]]],
+            ])
+        )
+
+        XCTAssertEqual(update.map(\.lane), [.toolResult])
+        XCTAssertEqual(update.map(\.body), ["Bash  6 passed"])
+    }
+
+    /// An update whose call fell outside the page degrades to the UNNAMED
+    /// form, never to a guess and never to nothing.
+    func testAnUpdateWithNoRememberedCallDegradesToTheUnnamedForm() {
+        var classifier = AcpTranscriptClassifier()
+        let update = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update", "toolCallId": "gone", "status": "completed",
+            ])
+        )
+
+        XCTAssertEqual(update.map(\.body), ["tool  (completed)"])
+    }
+
+    /// A terminal update CONSUMES the remembered title, so a re-delivered
+    /// update for the same id degrades exactly as an unknown one does.
+    func testATerminalUpdateConsumesTheRememberedTitle() {
+        var classifier = AcpTranscriptClassifier()
+        _ = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Read"])
+        )
+        let first = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed"])
+        )
+        let repeated = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed"])
+        )
+
+        XCTAssertEqual(first.map(\.body), ["Read  (completed)"])
+        XCTAssertEqual(repeated.map(\.body), ["tool  (completed)"], "the resolved id must be evicted")
+    }
+
+    /// A FAILED update is the error lane, carries `[error]`, and FORGETS the
+    /// title. The Rust arm does all three and so must this one.
+    func testAFailedUpdateIsAnErrorRowAndForgetsTheTitle() {
+        var classifier = AcpTranscriptClassifier()
+        _ = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"])
+        )
+        let failed = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "failed",
+                "rawOutput": "exit 1",
+            ])
+        )
+        let afterwards = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed"])
+        )
+
+        XCTAssertEqual(failed.map(\.lane), [.error])
+        XCTAssertEqual(failed.map(\.body), ["Bash  exit 1  [error]"])
+        XCTAssertEqual(afterwards.map(\.body), ["tool  (completed)"], "a failed call must not keep its title")
+    }
+
+    /// A failure with no output still says which tool failed.
+    func testAFailedUpdateWithNoOutputStillNamesItsTool() {
+        var classifier = AcpTranscriptClassifier()
+        _ = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"])
+        )
+        let failed = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "failed"])
+        )
+
+        XCTAssertEqual(failed.map(\.body), ["Bash  [error]"])
+    }
+
+    /// `pending → in_progress` with no output is NOT a transcript row.
+    ///
+    /// Every adapter emits one per call, so rendering it would double the row
+    /// count of every transcript for no information at all.
+    func testAnInProgressUpdateWithNoOutputIsNotARow() {
+        var classifier = AcpTranscriptClassifier()
+        _ = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"])
+        )
+        let moved = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "in_progress",
+            ])
+        )
+
+        XCTAssertEqual(moved.count, 0)
+    }
+
+    /// An initial call that ALREADY carries its output emits both rows and
+    /// names itself on the second without consulting the map.
+    func testACallCarryingItsOwnOutputEmitsBothRows() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "title": "Read",
+                "status": "completed",
+                "rawInput": ["file_path": "/tmp/x"],
+                "content": [["type": "content", "content": ["type": "text", "text": "hello"]]],
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.lane), [.toolCall, .toolResult])
+        XCTAssertEqual(rows.map(\.body), ["Read  /tmp/x", "Read  hello"])
+    }
+
+    /// A diff or an embedded terminal contributes NOTHING to the summary, so a
+    /// JSON blob is never rendered as if it were the tool's output.
+    func testOnlyTextBlocksReachTheResultSummary() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "content": [
+                    ["type": "diff", "oldText": "a", "newText": "b"],
+                    ["type": "content", "content": ["type": "text", "text": "one line"]],
+                ],
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["tool  one line"])
+    }
+
+    /// With no readable content the summary falls back to `rawOutput`.
+    func testTheResultSummaryFallsBackToRawOutput() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "content": [["type": "diff", "oldText": "a"]],
+                "rawOutput": "fell back",
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["tool  fell back"])
+    }
+
+    /// A multi-line tool output is FLATTENED to one row and clipped to the
+    /// summary width, so a result never takes over the pane.
+    func testAToolResultSummaryIsOneClippedLine() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "rawOutput": String(repeating: "abc\n", count: 200),
+            ])
+        )
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(
+            rows[0].body.unicodeScalars.count, "tool  ".unicodeScalars.count + 84,
+            "the snippet is clipped to the summary width"
+        )
+        XCTAssertTrue(rows[0].body.hasSuffix("…"))
+        XCTAssertFalse(rows[0].body.contains("\n"), "a result summary is one row")
+    }
+
+    /// Past the pending-call backstop the map is cleared wholesale rather than
+    /// growing forever behind a cancelled turn.
+    func testPendingToolTitlesAreCappedRatherThanLeaked() {
+        var classifier = AcpTranscriptClassifier()
+        for index in 0..<600 {
+            _ = classifier.classify(
+                eventType: "acp.tool_call",
+                payload: Self.json([
+                    "sessionUpdate": "tool_call", "toolCallId": "t\(index)", "title": "Read",
+                ])
+            )
+        }
+        // The clear is wholesale, so an id from before the last flush is gone
+        // and its update degrades rather than naming a tool at random.
+        let stale = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call_update", "toolCallId": "t0", "status": "completed"])
+        )
+
+        XCTAssertEqual(stale.map(\.body), ["tool  (completed)"])
+    }
+
+    /// A plan folds one row per entry, so it reads as the checklist it is.
+    func testAPlanFoldsOneRowPerEntry() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.plan",
+            payload: Self.json(["entries": [
+                ["status": "completed", "content": "read the code"],
+                ["status": "in_progress", "content": "write the port"],
+                ["content": "run the suite"],
+            ]])
+        )
+
+        XCTAssertEqual(rows.map(\.lane), [.toolCall, .toolCall, .toolCall])
+        XCTAssertEqual(rows.map(\.body), [
+            "plan · completed · read the code",
+            "plan · in_progress · write the port",
+            "plan · pending · run the suite",
+        ])
+    }
+
+    /// A permission ask is named for the tool it gates, falling back to the
+    /// call id when the envelope carries no title.
+    func testAPermissionAskIsNamedForTheToolItGates() {
+        var classifier = AcpTranscriptClassifier()
+
+        let titled = classifier.classify(
+            eventType: "acp.permission",
+            payload: Self.json(["toolCall": ["title": "Bash", "toolCallId": "t1"]])
+        )
+        XCTAssertEqual(titled.map(\.lane), [.toolCall])
+        XCTAssertEqual(titled.map(\.body), ["[approval] Bash"])
+
+        let untitled = classifier.classify(
+            eventType: "acp.permission",
+            payload: Self.json(["toolCall": ["toolCallId": "t2"]])
+        )
+        XCTAssertEqual(untitled.map(\.body), ["[approval] t2"])
+
+        let bare = classifier.classify(eventType: "acp.permission", payload: Self.json([:]))
+        XCTAssertEqual(bare.map(\.body), ["[approval] tool"])
+    }
+
+    /// The truncation marker is the one row the transcript MUST show, in the
+    /// error lane, because a silently short transcript reads as a complete one.
+    func testTheTruncationMarkerIsLoudRatherThanSilent() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.transcript_truncated",
+            payload: Self.json(["droppedRows": 1200])
+        )
+
+        XCTAssertEqual(rows.map(\.lane), [.error])
+        XCTAssertEqual(rows.map(\.body), ["· transcript truncated · 1200 rows dropped"])
+    }
+
+    /// The three turn-end kinds close the run the way the process executor's
+    /// own result line does, and only a completed turn is the calm lane.
+    func testEveryTurnEndKindClosesTheRun() {
+        var classifier = AcpTranscriptClassifier()
+
+        let completed = classifier.classify(
+            eventType: "acp.turn_completed",
+            payload: Self.json(["durationMs": 1500])
+        )
+        XCTAssertEqual(completed.map(\.lane), [.toolResult])
+        XCTAssertEqual(completed.map(\.body), ["· turn_completed · 1.5s"])
+
+        let failed = classifier.classify(
+            eventType: "acp.turn_failed",
+            payload: Self.json(["durationMs": 61_000, "cause": "adapter exited"])
+        )
+        XCTAssertEqual(failed.map(\.lane), [.error])
+        XCTAssertEqual(failed.map(\.body), ["· turn_failed · 1m1s · adapter exited"])
+
+        let interrupted = classifier.classify(eventType: "acp.turn_interrupted", payload: Self.json([:]))
+        XCTAssertEqual(interrupted.map(\.lane), [.error])
+        XCTAssertEqual(interrupted.map(\.body), ["· turn_interrupted"])
+    }
+
+    /// A duration under a second reads in milliseconds, and a NEGATIVE one
+    /// (clock skew between two chunks) reads as zero rather than as nonsense.
+    func testDurationsRenderCompactlyAndNeverNegative() {
+        var classifier = AcpTranscriptClassifier()
+
+        XCTAssertEqual(
+            classifier.classify(eventType: "acp.turn_completed", payload: Self.json(["durationMs": 250])).map(\.body),
+            ["· turn_completed · 250ms"]
+        )
+        XCTAssertEqual(
+            classifier.classify(eventType: "acp.turn_completed", payload: Self.json(["durationMs": -5])).map(\.body),
+            ["· turn_completed · 0ms"]
+        )
+    }
+
+    /// A FRACTIONAL duration is not a whole number of milliseconds and is
+    /// omitted rather than rounded, so an adapter bug stays visible.
+    func testAFractionalDurationIsOmittedRatherThanRounded() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.turn_completed",
+            payload: try! FleetWire.decoder().decode(JSONValue.self, from: Data(#"{"durationMs":1.5}"#.utf8))
+        )
+
+        XCTAssertEqual(rows.map(\.body), ["· turn_completed"])
+    }
+
+    /// The chunk types the Rust is deliberately silent on stay silent here, and
+    /// so does a type this build has never heard of.
+    func testTheSilentAndUnknownChunkTypesYieldNothing() {
+        var classifier = AcpTranscriptClassifier()
+        for eventType in [
+            "acp.usage", "acp.user_message", "acp.turn_started", "acp.context_rebuilt",
+            "acp.some_future_kind", "", "message",
+        ] {
+            XCTAssertEqual(
+                classifier.classify(eventType: eventType, payload: Self.json(["text": "ignored"])).count, 0,
+                "\(eventType) must not render"
+            )
+        }
+    }
+
+    // MARK: - The caps, which are the reason a transcript cannot cost the pane
+
+    /// The body cap counts CHARACTERS, not bytes.
+    ///
+    /// The Rust pins exactly this (`the_body_cap_never_splits_a_multibyte_char`)
+    /// because adapter prose carries non-ASCII routinely and a byte-index cut
+    /// would land mid-scalar. Three bytes per character here, so a byte cap
+    /// would be caught by the count.
+    func testTheBodyCapCountsCharactersNotBytes() {
+        var classifier = AcpTranscriptClassifier()
+        let huge = String(repeating: "日", count: 8192 * 2)
+        let rows = classifier.classify(eventType: "acp.message", payload: Self.json(["text": huge]))
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].body.unicodeScalars.count, 8192, "capped by scalars")
+        XCTAssertGreaterThan(rows[0].body.utf8.count, 8192, "and the byte length is larger, which is the point")
+        XCTAssertTrue(rows[0].body.hasSuffix("…"), "the elision marker survives intact")
+    }
+
+    /// The cap counts SCALARS, not Swift `Character`s, and this is the test
+    /// that tells the two apart.
+    ///
+    /// A grapheme cluster has no length limit: one base letter followed by a
+    /// hundred thousand combining marks is a SINGLE `Character`. A cap counted
+    /// in characters would see a length of one and let the whole thing through,
+    /// which is not a loose bound but no bound at all, and it is reachable by
+    /// any adapter that emits combining marks. Counting scalars, as the Rust
+    /// does, is what makes the backstop a backstop.
+    func testTheBodyCapIsNotDefeatedByOneEnormousGraphemeCluster() {
+        var classifier = AcpTranscriptClassifier()
+        // One base scalar plus 40,000 combining acute accents: 40,001 scalars
+        // and, to Swift, exactly one Character.
+        let oneHugeCluster = "e" + String(repeating: "\u{0301}", count: 40_000)
+        XCTAssertEqual(oneHugeCluster.count, 1, "Swift really does read this as a single Character")
+
+        let rows = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": oneHugeCluster])
+        )
+
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(
+            rows[0].body.unicodeScalars.count, 8192,
+            "a Character-counted cap would have passed all 40,001 scalars through untouched"
+        )
+    }
+
+    /// An arbitrarily large block is capped rather than carried whole: every
+    /// classified body sits in a `@Published` surface the whole notch observes.
+    func testAHugeTextBlockIsCapped() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.message",
+            payload: Self.json(["text": String(repeating: "x", count: 100_000)])
+        )
+
+        XCTAssertEqual(rows.count, 1, "one block, one body")
+        XCTAssertEqual(rows[0].body.unicodeScalars.count, 8192)
+    }
+
+    /// A tool NAME is an adapter string too, and it does not pass through the
+    /// line splitter. Capping only the prose left exactly this uncapped, which
+    /// is the bug the Rust's `a_huge_tool_name_is_capped_too` records.
+    func testAHugeToolTitleIsCappedToo() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json([
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "title": String(repeating: "N", count: 50_000),
+            ])
+        )
+
+        XCTAssertEqual(rows.map(\.lane), [.toolCall])
+        XCTAssertEqual(rows[0].body.unicodeScalars.count, 8192)
+    }
+
+    /// One chunk cannot classify into unbounded rows, and the count of what was
+    /// dropped is REPORTED rather than lost.
+    ///
+    /// The Rust asserts the exact dropped count for the reason it gives: an
+    /// off-by-one here ships silently in both halves.
+    func testOneChunkCannotClassifyIntoUnboundedRows() {
+        var classifier = AcpTranscriptClassifier()
+        let block = String(repeating: "line\n", count: 512 * 3)
+        let rows = classifier.classify(eventType: "acp.message", payload: Self.json(["text": block]))
+
+        XCTAssertEqual(rows.count, 512)
+        XCTAssertEqual(rows.last?.body, "… \(512 * 3 - 511) more lines")
+        XCTAssertEqual(rows.last?.lane, .toolResult)
+    }
+
+    // MARK: - Rows, ids and the lane labels
+
+    /// A chunk's rows are addressed by its COMMIT CURSOR plus their index, so
+    /// the same chunk classified twice produces the same ids.
+    func testRowIDsAreAnchoredToTheCommitCursor() {
+        var classifier = AcpTranscriptClassifier()
+        let rows = classifier.rows(for: Self.chunk(
+            order: 42,
+            eventType: "acp.message",
+            payload: ["text": "one\ntwo"]
+        ))
+
+        XCTAssertEqual(rows.map(\.id), ["42.0", "42.1"])
+        XCTAssertEqual(rows.map(\.ingestOrder), [42, 42])
+    }
+
+    /// A chunk that classifies into nothing produces no rows at all, rather
+    /// than an empty placeholder row.
+    func testASilentChunkProducesNoRows() {
+        var classifier = AcpTranscriptClassifier()
+
+        XCTAssertEqual(classifier.rows(for: Self.chunk(order: 1, eventType: "acp.usage", payload: [:])), [])
+    }
+
+    /// Every lane renders a label and a spoken label, and only the error lane
+    /// is loud. Exhaustive over the enum, so a sixth lane fails here.
+    func testEveryLaneRendersADistinctLabel() {
+        let labels = FleetTranscriptLane.allCases.map(FleetTranscriptLabels.lane)
+        let spoken = FleetTranscriptLane.allCases.map(FleetTranscriptLabels.accessibilityLane)
+
+        XCTAssertEqual(Set(labels).count, FleetTranscriptLane.allCases.count, "two lanes read the same")
+        XCTAssertEqual(Set(spoken).count, FleetTranscriptLane.allCases.count, "two lanes SOUND the same")
+        XCTAssertTrue(labels.allSatisfy { !$0.isEmpty })
+        XCTAssertEqual(
+            FleetTranscriptLane.allCases.filter(FleetTranscriptLabels.laneIsLoud), [.error],
+            "a transcript that shouted at every tool call would not mark the line to act on"
+        )
+    }
+
+    /// The classifier's EQUALITY includes its pending calls, because two
+    /// surfaces with identical rows and different pending titles will classify
+    /// the next chunk differently.
+    func testClassifierEqualityIncludesThePendingCalls() {
+        var withPending = AcpTranscriptClassifier()
+        _ = withPending.classify(
+            eventType: "acp.tool_call",
+            payload: Self.json(["sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Bash"])
+        )
+
+        XCTAssertNotEqual(withPending, AcpTranscriptClassifier())
+    }
+
+    // MARK: - Fixtures
+
+    /// One transcript chunk in the shape the daemon frames it.
+    static func chunk(
+        order: Int64,
+        sessionKey: String = "acp:1",
+        eventType: String,
+        payload: [String: Any]
+    ) -> FleetTranscriptChunk {
+        FleetTranscriptChunk(
+            ingestOrder: order,
+            eventID: "evt-\(order)",
+            sessionKey: sessionKey,
+            eventType: eventType,
+            payload: json(payload),
+            observedAt: 1_700_000_000_000
+        )
+    }
+
+    /// A `JSONValue` built through the REAL decoder, so a payload here is one
+    /// the wire could actually deliver.
+    static func json(_ object: [String: Any]) -> JSONValue {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return try! FleetWire.decoder().decode(JSONValue.self, from: data)
+    }
+}


### PR DESCRIPTION
## What this adds

The notch's chat pane now shows an ACP session's live execution transcript: the agent's messages and thinking, its tool calls paired with their results, plans, permissions and turn ends. Nothing rendered any of this before.

## An uncursored transcript read returned the oldest rows

The same collapse the message list had, one line: an absent `after_order` became zero, so a read with no cursor returned the *start* of a run, which is the half an operator opening a pane least wants.

Fixed as a dispatch rather than a new method, matching the message fix exactly. Absent tails, present walks forward, an explicit zero still starts at the beginning because absent and zero are different questions, and a negative is refused. The tail routes through the existing `list_by_session_tail`, so this pane and the board timeline read through one function.

That brings its byte budget, which is why `truncated` now rides the wire: a caller cannot infer truncation from the row count, and one that assumes otherwise renders a partial run as a complete one.

Two callers improve and neither breaks, since neither loops from an absent cursor. The CLI with no `--after` printed the oldest chunks and now prints the newest. The reprime path handed an agent a long session's first rows when it wanted the recent ones.

## The safety-net page used to destroy the live transcript

Each page rebuilt the surface from scratch and refilled the transcript from a bounded window. Because `ingest_order` is one global sequence shared by every provider's rows, and agent hooks write to the same table, that window can hold nothing for this session at all.

The failure: operator opens the pane, the agent runs a long turn, hundreds of rows arrive live, the page fires and returns nothing, and the pane drops to zero rows and announces the session has produced no turn while the agent is mid-turn.

The carried state is now one type instead of four hand-written assignments. That is the fix rather than a tidy-up: what a new field did across a page depended on whether its author remembered a fifth assignment, and two separate defects came from answering that question wrongly.

## Two defects that carrying state introduced, both fixed

- A transient subscribe failure pinned its banner permanently above a working transcript, because the detail was carried and never cleared. It is now a peer field and cannot be carried at all.
- A reconnect resubscribed at the daemon's head and skipped the page, so rows committed during the outage were delivered by neither path. The subscribe now names the cursor. That also made repeating it harmless, which retired the once-per-connection guard entirely, so every page re-arms a forwarder the daemon dropped on a transient error.

## Truncation counted a unit that bounds nothing

The classifier capped bodies by `Character` count. A grapheme cluster has no length limit, so one base letter followed by a hundred thousand combining marks is a single `Character` and passed an 8192 cap untouched. Both the guard and the truncation now count scalars, matching the Rust. Pinned by a test building a single 40,001-scalar cluster.

## Classifier fidelity

A faithful port of `AcpClassifier`: the same nine event arms, the same four caps, tool calls paired by id behind a pending-title map with a clear-all backstop, and a failed tool emitting an error row and forgetting its title. Reviewed byte for byte against the Rust, including emitted format strings and their double spaces. One seam row is byte-identical to the daemon's own.

## Tests

| Suite | Result |
|---|---|
| `FleetRPCTests` | 247 passed |
| `cargo test -p ainb-hangar-proto --lib` | 111 passed |
| `cargo test -p ainb-hangar-store --lib repo::fleet_provider_event` | 29 passed |
| `cargo test -p ainb-hangar-daemon --test rpc_message_bus` | 28 passed |

Reproduced independently of the author. Three contract tests run against the fixture daemon rebuilt from the changed Rust.

Every significant fix was falsified. One falsification found a defect in its own test: the first stale-banner test passed against the reintroduced bug, because a refusal on the opening page leaves no cursor, so the carry path was never reached. It was rewritten on a two-connection harness and now fails with "the banner outlived the refusal and now sits above a working transcript".

## Not verified

The pane has never been rendered in a window. XCTest is wedged on the development machine, so the transcript section and the truncation row have no visual proof, and no accessibility identifier here is referenced by a test. The CLI behaviour change is verified by reading the call site rather than running the command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added execution transcript support to Fleet chat.
  - View messages, thoughts, tool activity, plans, permissions, and turn outcomes in a dedicated transcript section.
  - Added live transcript updates with reliable replay and recovery when reconnecting or paging.
  - Added session-scoped transcript browsing with cursor-based navigation.
  - Added transcript availability, empty, and access-restricted states.
  - Added indicators when older transcript content is omitted due to page limits.
  - Added accessible labels, lane styling, and concise formatting for transcript entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->