### PR TITLE
fix(notices): a failure you can read, dismiss, and still find afterwards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,14 @@ jobs:
           cargo test -p ainb --test tripwire_sessions_answer_outcome_per_question
           --no-fail-fast
         working-directory: ${{ env.WORKING_DIR }}
+      - name: Tripwire — a notice is readable, dismissable, and kept in the log
+        if: >-
+          !cancelled() && (github.event_name != 'pull_request' ||
+          needs.changes.outputs.relevant != 'false')
+        run: >-
+          cargo test -p ainb --test tripwire_notice_dismiss_and_expiry
+          --no-fail-fast
+        working-directory: ${{ env.WORKING_DIR }}
       - name: Sandbox script safety guards (rm -rf belts)
         if: >-
           !cancelled() && (github.event_name != 'pull_request' ||

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -136,6 +136,11 @@ pub enum AppEvent {
     PickRepoPaste(String), // Append bracketed-paste text to the repo-picker filter (Cmd+V)
     // Notification events
     ShowNotification(String), // Display a notification message to the user
+    /// Retire every notice currently on screen (`Ctrl+X`).
+    ///
+    /// Only ever raised when something is showing. The messages are not lost:
+    /// each was written to the app log when it was raised.
+    DismissNotifications,
     // File finder events for @ symbol trigger
     FileFinderNavigateUp,
     FileFinderNavigateDown,
@@ -1870,6 +1875,32 @@ impl EventHandler {
             // Global help toggle: `?` or `Shift+H` from any non-text view.
             if matches!(key_event.code, KeyCode::Char('?' | 'H')) {
                 return Some(AppEvent::ToggleHelp);
+            }
+
+            // Global notice dismiss: `Ctrl+X` from any non-text view.
+            //
+            // A Ctrl-chord rather than a bare letter, and not by preference: a
+            // notice can be up on ANY screen, so the dismiss key has to be
+            // global, and every printable letter is already claimed by some
+            // screen's own handler further down. A chord is the mechanism this
+            // block's own contract points at for exactly that reason.
+            //
+            // Claimed ONLY while a notice is actually showing, so an empty
+            // corner leaves the chord exactly where it was. The one behaviour
+            // it does take, and only for as long as a notice is up: the
+            // session list matches a bare `KeyCode::Char('x')` without looking
+            // at modifiers, so `Ctrl+X` there used to fall into Cleanup
+            // Orphaned. Plain `x` is that action's documented key and is
+            // untouched.
+            //
+            // Sits inside the `!host_globals_suppressed` guard so an attached
+            // terminal or any text field still receives its own `Ctrl+X` —
+            // that chord means something in nano and emacs.
+            if matches!(key_event.code, KeyCode::Char('x' | 'X'))
+                && key_event.modifiers.contains(KeyModifiers::CONTROL)
+                && state.has_visible_notifications()
+            {
+                return Some(AppEvent::DismissNotifications);
             }
 
             // Global `W`: wire Claude Code statusline. Active from any
@@ -4111,6 +4142,10 @@ impl EventHandler {
             AppEvent::ShowNotification(message) => {
                 tracing::info!("Event: ShowNotification - {}", message);
                 state.add_warning_notification(message);
+            }
+            AppEvent::DismissNotifications => {
+                let dismissed = state.dismiss_notifications();
+                tracing::debug!("Event: DismissNotifications - cleared={dismissed}");
             }
             AppEvent::AttachSession => {
                 if let Some(session_id) = state.get_selected_session_id() {
@@ -8580,6 +8615,56 @@ mod session_list_key_tests {
         let mut state = AppState::default();
         state.current_screen = ids::SESSION_LIST.to_string();
         state
+    }
+
+    fn ctrl_x(state: &mut AppState) -> Option<AppEvent> {
+        EventHandler::handle_key_event(
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            state,
+        )
+    }
+
+    /// The chord is claimed only while a notice is showing; an empty corner
+    /// leaves it doing whatever the screen already did with it.
+    ///
+    /// On the session list that is Cleanup Orphaned, because the branch there
+    /// matches a bare `Char('x')` without looking at modifiers. Asserted
+    /// rather than glossed over: it is the one behaviour the dismiss chord
+    /// takes, and only for as long as there is something to dismiss.
+    #[test]
+    fn ctrl_x_dismisses_only_while_a_notice_is_showing() {
+        let mut state = session_list_state();
+        assert!(
+            matches!(ctrl_x(&mut state), Some(AppEvent::CleanupOrphaned)),
+            "an empty corner must leave the chord where the screen had it"
+        );
+
+        state.add_error_notification("a failure worth reading".to_string());
+        assert!(matches!(
+            ctrl_x(&mut state),
+            Some(AppEvent::DismissNotifications)
+        ));
+
+        EventHandler::process_event(AppEvent::DismissNotifications, &mut state);
+        assert!(
+            !state.has_visible_notifications(),
+            "the notice is gone from the screen"
+        );
+        assert!(
+            matches!(ctrl_x(&mut state), Some(AppEvent::CleanupOrphaned)),
+            "and the chord goes straight back to the screen"
+        );
+    }
+
+    /// The plain key keeps its old meaning whether or not a notice is up.
+    #[test]
+    fn a_notice_on_screen_does_not_steal_the_plain_x_key() {
+        let mut state = session_list_state();
+        state.add_error_notification("a failure worth reading".to_string());
+        assert!(matches!(
+            key(&mut state, 'x'),
+            Some(AppEvent::CleanupOrphaned)
+        ));
     }
 
     /// Locks the attach-key pairing: 'a' = full-screen, Shift+A = in-pane

--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -4233,7 +4233,15 @@ impl EventHandler {
                         state.selected_workspace_index,
                         state.selected_session_index
                     );
-                    state.add_error_notification("No session selected to attach".to_string());
+                    // Says what to do, not just what failed. A notice that
+                    // lives for a minute and can be dismissed has room for
+                    // the remedy; the five-second box did not.
+                    state.add_error_notification(
+                        "No session selected to attach. Pick a session row with ↑/↓ (or 1-9) \
+                         and press a again; press n to start one, or f to refresh the list if \
+                         you expected a session here."
+                            .to_string(),
+                    );
                 }
             }
             AppEvent::DetachSession => {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -400,45 +400,81 @@ pub struct Notification {
     pub duration: Duration,
 }
 
+/// Notices kept in memory at once.
+///
+/// Only [`MAX_VISIBLE_NOTIFICATIONS`] of them are drawn; the rest exist so the
+/// "+N more" count is honest. A bound is needed at all because a minute-long
+/// notice plus a producer that fails every refresh tick is otherwise an
+/// unbounded `Vec`.
+pub const MAX_STORED_NOTIFICATIONS: usize = 12;
+
+/// How long a success receipt stays up.
+///
+/// A `const` where the other three levels are `[ui]` tunables, and
+/// deliberately: a success notice confirms something the operator just did and
+/// is already watching for. It is the one level with nothing to read.
+const SUCCESS_NOTICE_SECS: u64 = 3;
+
+/// Lifetime for `level`, from `[ui]`.
+///
+/// Read per notice rather than cached, so an edit in the config screen applies
+/// to the next failure instead of the next launch.
+fn notice_lifetime(level: &NotificationType) -> Duration {
+    let ui = &crate::config::tunables::snapshot().ui;
+    let secs = match level {
+        NotificationType::Success => SUCCESS_NOTICE_SECS,
+        NotificationType::Error => ui.notice_error_secs,
+        NotificationType::Warning => ui.notice_warning_secs,
+        NotificationType::Info => ui.notice_info_secs,
+    };
+    Duration::from_secs(secs.max(1))
+}
+
+/// Does a repeat of this level fold into the notice already showing?
+///
+/// Failures do: the same message arriving every refresh tick is one fact, and
+/// stacking it would bury the other failures. Announcements do not, for the
+/// reason spelled out on [`AppState::add_notification`].
+fn coalesces(level: &NotificationType) -> bool {
+    matches!(level, NotificationType::Error | NotificationType::Warning)
+}
+
 impl Notification {
-    pub fn success(message: String) -> Self {
+    /// A notice of `level` that starts its clock now.
+    pub fn new(message: String, notification_type: NotificationType) -> Self {
+        let duration = notice_lifetime(&notification_type);
         Self {
             message,
-            notification_type: NotificationType::Success,
+            notification_type,
             created_at: Instant::now(),
-            duration: Duration::from_secs(3),
+            duration,
         }
+    }
+
+    pub fn success(message: String) -> Self {
+        Self::new(message, NotificationType::Success)
     }
 
     pub fn error(message: String) -> Self {
-        Self {
-            message,
-            notification_type: NotificationType::Error,
-            created_at: Instant::now(),
-            duration: Duration::from_secs(5),
-        }
+        Self::new(message, NotificationType::Error)
     }
 
     pub fn info(message: String) -> Self {
-        Self {
-            message,
-            notification_type: NotificationType::Info,
-            created_at: Instant::now(),
-            duration: Duration::from_secs(3),
-        }
+        Self::new(message, NotificationType::Info)
     }
 
     pub fn warning(message: String) -> Self {
-        Self {
-            message,
-            notification_type: NotificationType::Warning,
-            created_at: Instant::now(),
-            duration: Duration::from_secs(4),
-        }
+        Self::new(message, NotificationType::Warning)
     }
 
     pub fn is_expired(&self) -> bool {
         self.created_at.elapsed() > self.duration
+    }
+
+    /// Restart this notice's clock, as if it had just been raised.
+    fn restart(&mut self) {
+        self.created_at = Instant::now();
+        self.duration = notice_lifetime(&self.notification_type);
     }
 }
 
@@ -11662,9 +11698,66 @@ impl AppState {
         }
     }
 
-    /// Add a notification to the notification queue
+    /// Add a notification to the notification queue.
+    ///
+    /// Three things happen here that a bare `push` did not do, all of them
+    /// consequences of a notice now living for up to a minute instead of five
+    /// seconds:
+    ///
+    /// 1. **It is written to the app log first.** A notice that can expire or
+    ///    be dismissed must not be the only copy of a failure, or the surface
+    ///    starts losing information the operator never saw. The JSONL log the
+    ///    TUI already writes is the durable copy, and the Log History screen
+    ///    (`l` from home) already reads it.
+    /// 2. **An identical FAILURE already on screen is refreshed, not stacked.**
+    ///    A producer that fails once per refresh tick used to pile up five-
+    ///    second toasts that expired as fast as they arrived; at a minute each
+    ///    the same loop would paper over the screen with one message and hide
+    ///    every other failure behind it.
+    ///
+    ///    Errors and warnings only. An info or success notice is an
+    ///    announcement whose repetition can itself be the signal —
+    ///    [`Self::notify_codex_degraded`] raises the same sentence once per
+    ///    degraded session on purpose, and folding those together would
+    ///    answer the second session with a silence its own dedup went out of
+    ///    its way to avoid.
+    /// 3. **The queue is capped.** Coalescing handles a repeated message; the
+    ///    cap handles a stream of distinct ones (an id or a timestamp in the
+    ///    text defeats 2). Oldest go first — they are the ones closest to
+    ///    expiring anyway, and the log still has them.
     pub fn add_notification(&mut self, notification: Notification) {
+        Self::log_notification(&notification);
+
+        if coalesces(&notification.notification_type) {
+            if let Some(existing) = self.notifications.iter_mut().find(|n| {
+                n.notification_type == notification.notification_type
+                    && n.message == notification.message
+            }) {
+                existing.restart();
+                return;
+            }
+        }
+
         self.notifications.push(notification);
+        let overflow = self.notifications.len().saturating_sub(MAX_STORED_NOTIFICATIONS);
+        if overflow > 0 {
+            self.notifications.drain(..overflow);
+        }
+    }
+
+    /// Write a notice to the app log, at the level it was raised with.
+    ///
+    /// The durable half of the notification surface. Every message carries the
+    /// `notice` field so the Log History screen's filter can pick them out of
+    /// ordinary tracing output.
+    fn log_notification(notification: &Notification) {
+        let message = notification.message.as_str();
+        match notification.notification_type {
+            NotificationType::Error => error!(notice = "error", "{message}"),
+            NotificationType::Warning => warn!(notice = "warning", "{message}"),
+            NotificationType::Info => info!(notice = "info", "{message}"),
+            NotificationType::Success => info!(notice = "success", "{message}"),
+        }
     }
 
     /// Add a success notification
@@ -11759,6 +11852,27 @@ impl AppState {
     /// Remove expired notifications
     pub fn cleanup_expired_notifications(&mut self) {
         self.notifications.retain(|n| !n.is_expired());
+    }
+
+    /// Retire every notice currently on screen (`Ctrl+X`).
+    ///
+    /// Returns whether anything was actually showing, so the key can fall
+    /// through untouched when the corner is empty rather than silently
+    /// swallowing a chord no notice claimed.
+    ///
+    /// Clearing the queue loses nothing: [`Self::add_notification`] wrote each
+    /// message to the app log when it was raised.
+    pub fn dismiss_notifications(&mut self) -> bool {
+        if !self.has_visible_notifications() {
+            return false;
+        }
+        self.notifications.clear();
+        true
+    }
+
+    /// Is at least one notice on screen right now?
+    pub fn has_visible_notifications(&self) -> bool {
+        self.notifications.iter().any(|n| !n.is_expired())
     }
 
     /// Get current notifications (non-expired)

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -3897,3 +3897,187 @@ mod mcp_pool_config_screen_tests {
         assert_eq!(ctx.value.display(), "✗ Disabled");
     }
 }
+
+/// The notice surface: how long a message lives, how it is retired, and where
+/// it survives afterwards.
+#[cfg(test)]
+mod notice_surface_tests {
+    use crate::app::state::AppState;
+
+    /// Install a config whose notice lifetimes are known, so these assert
+    /// against the shipped behaviour and not the developer's own config.toml.
+    fn with_notice_config(error_secs: u64, info_secs: u64) -> crate::config::AppConfig {
+        let mut config = crate::config::AppConfig::default();
+        config.ui.notice_error_secs = error_secs;
+        config.ui.notice_info_secs = info_secs;
+        config
+    }
+
+    /// The number the user asked for. Pinned separately from every test that
+    /// exercises expiry, because none of those can afford to wait a minute —
+    /// they inject a short lifetime instead, and this is what stops the
+    /// shipped value drifting behind them.
+    #[test]
+    fn an_error_notice_lives_for_one_minute_out_of_the_box() {
+        let ui = crate::config::AppConfig::default().ui;
+        assert_eq!(ui.notice_error_secs, 60, "an error notice lasts a minute");
+        assert_eq!(
+            ui.notice_warning_secs, 20,
+            "a warning outlives an info and is outlived by an error"
+        );
+        assert_eq!(
+            ui.notice_info_secs, 10,
+            "an info notice lasts long enough to read"
+        );
+    }
+
+    #[test]
+    fn each_level_takes_its_lifetime_from_config() {
+        let _lock = crate::config::tunables::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::config::tunables::install_snapshot(with_notice_config(45, 7));
+
+        use crate::app::state::Notification;
+        assert_eq!(
+            Notification::error("boom".into()).duration,
+            std::time::Duration::from_secs(45)
+        );
+        assert_eq!(
+            Notification::info("fyi".into()).duration,
+            std::time::Duration::from_secs(7)
+        );
+        // A success is a receipt for something the operator just did and has
+        // no configurable lifetime at all.
+        assert_eq!(
+            Notification::success("done".into()).duration,
+            std::time::Duration::from_secs(3)
+        );
+
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+
+    /// A lifetime of zero would make a notice expire before its first repaint.
+    #[test]
+    fn a_zero_lifetime_still_leaves_the_notice_readable() {
+        let _lock = crate::config::tunables::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::config::tunables::install_snapshot(with_notice_config(0, 0));
+
+        let notice = crate::app::state::Notification::error("boom".into());
+        assert!(
+            notice.duration >= std::time::Duration::from_secs(1),
+            "a zero lifetime must not make an error invisible"
+        );
+
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+
+    #[test]
+    fn dismiss_clears_what_is_showing_and_reports_it() {
+        let mut state = AppState::new();
+        assert!(
+            !state.dismiss_notifications(),
+            "with an empty corner the chord must fall through, not be swallowed"
+        );
+
+        state.add_error_notification("a failure".to_string());
+        assert!(state.has_visible_notifications());
+        assert!(
+            state.dismiss_notifications(),
+            "a showing notice is dismissable"
+        );
+        assert!(state.get_current_notifications().is_empty());
+        assert!(!state.has_visible_notifications());
+    }
+
+    /// The flood guard. At five seconds a repeating producer's notices expired
+    /// about as fast as they arrived; at a minute each they would paper over
+    /// the screen instead — hiding the OTHER failures, which is the thing this
+    /// whole surface exists to prevent.
+    #[test]
+    fn an_identical_failure_refreshes_rather_than_stacks() {
+        let mut state = AppState::new();
+        for _ in 0..40 {
+            state.add_error_notification("the daemon is not answering".to_string());
+        }
+        assert_eq!(
+            state.get_current_notifications().len(),
+            1,
+            "the same failure repeated is still one failure"
+        );
+    }
+
+    /// An announcement is NOT folded together, because its repetition can be
+    /// the signal: `notify_codex_degraded` raises one identical sentence per
+    /// degraded session on purpose, and its own dedup exists specifically so
+    /// the second session is not answered with silence.
+    #[test]
+    fn an_announcement_is_not_folded_into_the_one_before_it() {
+        let mut state = AppState::new();
+        state.add_info_notification("started without shared remote control".to_string());
+        state.add_info_notification("started without shared remote control".to_string());
+        assert_eq!(
+            state.get_current_notifications().len(),
+            2,
+            "two announcements are two facts"
+        );
+    }
+
+    /// Coalescing only catches a repeated message. A producer that stamps an
+    /// id or a timestamp into the text defeats it, so the queue is capped too.
+    #[test]
+    fn a_stream_of_distinct_notices_is_capped() {
+        use crate::app::state::MAX_STORED_NOTIFICATIONS;
+        let mut state = AppState::new();
+        for i in 0..(MAX_STORED_NOTIFICATIONS * 3) {
+            state.add_error_notification(format!("failure {i}"));
+        }
+        let showing = state.get_current_notifications();
+        assert_eq!(showing.len(), MAX_STORED_NOTIFICATIONS);
+        // Oldest go first: they are nearest to expiring anyway, and the app
+        // log kept every one of them.
+        assert!(
+            showing
+                .last()
+                .unwrap()
+                .message
+                .ends_with(&format!("failure {}", MAX_STORED_NOTIFICATIONS * 3 - 1)),
+            "the newest failure must survive the cap"
+        );
+        assert!(
+            !showing.iter().any(|n| n.message == "failure 0"),
+            "the oldest failure is the one dropped"
+        );
+    }
+
+    /// Refreshing a duplicate must restart its clock, or a failure that keeps
+    /// happening would vanish on the FIRST one's schedule.
+    #[test]
+    fn a_refreshed_notice_restarts_its_clock() {
+        let _lock = crate::config::tunables::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::config::tunables::install_snapshot(with_notice_config(1, 1));
+
+        let mut state = AppState::new();
+        state.add_error_notification("still failing".to_string());
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+        assert!(
+            state.get_current_notifications().is_empty(),
+            "the injected one-second lifetime must actually expire"
+        );
+
+        state.add_error_notification("still failing".to_string());
+        state.cleanup_expired_notifications();
+        state.add_error_notification("still failing".to_string());
+        assert_eq!(
+            state.get_current_notifications().len(),
+            1,
+            "a re-raised failure is showing again on a fresh clock"
+        );
+
+        crate::config::tunables::install_snapshot(crate::config::AppConfig::default());
+    }
+}

--- a/ainb-tui/crates/ainb-core/src/components/help.rs
+++ b/ainb-tui/crates/ainb-core/src/components/help.rs
@@ -88,6 +88,10 @@ impl HelpComponent {
             ListItem::new(""),
             head("General:"),
             row("? / Shift+H", "Toggle this help"),
+            row(
+                "Ctrl+X",
+                "Dismiss the corner notices (they stay in the log: l from home)",
+            ),
             row("q / Esc", "Quit / home"),
             row("Ctrl+C", "Force quit"),
             row(

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -32,12 +32,38 @@ pub const NOTIFICATION_DISMISS_HINT: &str = "Ctrl+X dismiss";
 /// Where a dismissed or expired notice can still be read.
 pub const NOTIFICATION_LOG_HINT: &str = "l from home";
 
+/// The glyph a notice's level is drawn with.
+fn notice_icon(notification: &crate::app::state::Notification) -> &'static str {
+    match notification.notification_type {
+        crate::app::state::NotificationType::Success => "✓ ",
+        crate::app::state::NotificationType::Error => "✗ ",
+        crate::app::state::NotificationType::Warning => "⚠ ",
+        crate::app::state::NotificationType::Info => "ℹ ",
+    }
+}
+
+/// The colour a notice's level is drawn in.
+fn notice_color(notification: &crate::app::state::Notification) -> Color {
+    match notification.notification_type {
+        crate::app::state::NotificationType::Success => SELECTION_GREEN,
+        crate::app::state::NotificationType::Error => Color::Rgb(230, 100, 100),
+        crate::app::state::NotificationType::Warning => WARNING_ORANGE,
+        crate::app::state::NotificationType::Info => CORNFLOWER_BLUE,
+    }
+}
+
 /// Greedy word-wrap for a notice, with the level icon on the first row and the
 /// continuation rows indented under the text.
 ///
 /// Terminal cell width, not `char` count: an emoji in a message (this codebase
 /// puts them in plenty) is two cells wide and a `char`-counted wrap overflows
 /// the border by exactly as many emoji as the line holds.
+///
+/// Breaking between words is not enough. An ainb failure names worktree paths,
+/// tmux session names and URLs, and a single one of those is routinely wider
+/// than the whole box — so a token that cannot fit is split across rows rather
+/// than allowed to run past the border, where the `Paragraph` would clip it and
+/// take the rest of the message with it.
 fn wrap_notification(message: &str, icon: &str, width: usize) -> Vec<String> {
     use unicode_width::UnicodeWidthStr;
 
@@ -47,6 +73,19 @@ fn wrap_notification(message: &str, icon: &str, width: usize) -> Vec<String> {
     let mut rows: Vec<String> = Vec::new();
     let mut current = String::new();
     for word in message.split_whitespace() {
+        if UnicodeWidthStr::width(word) > body {
+            // Nothing to be gained by starting it on a fresh row: it does not
+            // fit on one either. Fill the current row, then break the rest at
+            // the border.
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            let mut chunks = split_to_width(&format!("{current}{word}"), body);
+            // The tail stays open so a following word can share its row.
+            current = chunks.pop().unwrap_or_default();
+            rows.extend(chunks);
+            continue;
+        }
         let candidate_width = if current.is_empty() {
             UnicodeWidthStr::width(word)
         } else {
@@ -74,6 +113,97 @@ fn wrap_notification(message: &str, icon: &str, width: usize) -> Vec<String> {
             }
         })
         .collect()
+}
+
+/// Cut `text` into pieces at most `width` CELLS wide.
+///
+/// Always advances by at least one character, so a character wider than
+/// `width` (a two-cell glyph in a one-cell budget) overflows by a cell rather
+/// than looping forever.
+fn split_to_width(text: &str, width: usize) -> Vec<String> {
+    use unicode_width::UnicodeWidthChar;
+
+    let width = width.max(1);
+    let mut pieces: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let cells = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if !current.is_empty() && used + cells > width {
+            pieces.push(std::mem::take(&mut current));
+            used = 0;
+        }
+        current.push(ch);
+        used += cells;
+    }
+    if !current.is_empty() {
+        pieces.push(current);
+    }
+    if pieces.is_empty() {
+        pieces.push(String::new());
+    }
+    pieces
+}
+
+/// Trim `rows` to `max`, replacing the last kept row with a marker naming what
+/// was dropped.
+///
+/// Silently dropping the tail is what the old fixed-height box did, and it is
+/// the reason messages were written short: a notice that stops mid-sentence
+/// with no marker tells the operator nothing was missing. Returns the rows to
+/// draw and how many were dropped.
+fn clamp_notice_rows(rows: Vec<String>, max: usize, width: usize) -> (Vec<String>, usize) {
+    if rows.len() <= max {
+        return (rows, 0);
+    }
+    let keep = max.saturating_sub(1);
+    let dropped = rows.len() - keep;
+    let mut kept: Vec<String> = rows.into_iter().take(keep).collect();
+    kept.push(more_lines_marker(dropped, width));
+    (kept, dropped)
+}
+
+/// The widest "N more lines" marker that fits `width` cells.
+fn more_lines_marker(dropped: usize, width: usize) -> String {
+    use unicode_width::UnicodeWidthStr;
+
+    for candidate in [
+        format!("… +{dropped} more lines — see the log"),
+        format!("… +{dropped} more lines"),
+        format!("… +{dropped}"),
+        "…".to_string(),
+    ] {
+        if UnicodeWidthStr::width(candidate.as_str()) <= width {
+            return candidate;
+        }
+    }
+    "…".to_string()
+}
+
+/// The bottom-border label for the last box drawn.
+///
+/// The dismiss hint is the part that cannot be dropped: it is the only place
+/// the chord is advertised while a notice is up, and no one guesses `Ctrl+X`.
+/// The suppressed-box count rides along when the border is wide enough for it.
+fn notice_footer(suppressed: usize, width: usize) -> String {
+    use unicode_width::UnicodeWidthStr;
+
+    let mut candidates = Vec::new();
+    if suppressed > 0 {
+        candidates.push(format!(
+            " +{suppressed} more · {NOTIFICATION_DISMISS_HINT} "
+        ));
+        candidates.push(format!("+{suppressed} more · {NOTIFICATION_DISMISS_HINT}"));
+    }
+    candidates.push(format!(" {NOTIFICATION_DISMISS_HINT} "));
+    candidates.push(NOTIFICATION_DISMISS_HINT.to_string());
+
+    for candidate in candidates {
+        if UnicodeWidthStr::width(candidate.as_str()) <= width {
+            return candidate;
+        }
+    }
+    NOTIFICATION_DISMISS_HINT.to_string()
 }
 
 use super::{
@@ -933,91 +1063,125 @@ impl LayoutComponent {
     /// about it. The old fixed 50x3 box silently clipped anything past ~48
     /// columns, which is why the messages feeding it were written terse.
     ///
-    /// Bounded three ways so a long-lived notice cannot take the screen: at
-    /// most [`MAX_VISIBLE_NOTIFICATIONS`] boxes, at most
-    /// [`NOTIFICATION_MAX_TEXT_ROWS`] wrapped rows each, and never past the
-    /// bottom of `area`. Anything suppressed is counted in a trailing "+N
-    /// more" so the surface never quietly shows less than it has.
+    /// Bounded so a long-lived notice cannot take the screen: at most
+    /// [`MAX_VISIBLE_NOTIFICATIONS`] boxes, at most
+    /// [`NOTIFICATION_MAX_TEXT_ROWS`] rows each, and never past the bottom of
+    /// `area`. Every bound announces itself — dropped rows leave a marker in
+    /// the box, dropped boxes are counted in the footer — because a surface
+    /// that quietly shows less than it has is the one this replaced.
+    ///
+    /// Planned before it is drawn. The dismiss hint has to land on whatever
+    /// element turns out to be last, and which element that is depends on how
+    /// much room the boxes above it took.
     fn render_notifications(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         let notifications = state.get_current_notifications();
         if notifications.is_empty() {
             return;
         }
+        if area.width < NOTIFICATION_MIN_WIDTH + 2 || area.height < 4 {
+            return; // Terminal too small to draw a box that says anything.
+        }
 
-        // Newest matter most, so an old notice is the one that gets dropped —
-        // but keep the surviving ones in arrival order, which is how they have
-        // always read top to bottom.
+        // Newest matter most, so an old notice is the one dropped — but keep
+        // the survivors in arrival order, which is how they have always read.
         let shown = notifications.len().min(MAX_VISIBLE_NOTIFICATIONS);
-        let suppressed = notifications.len() - shown;
         let visible = &notifications[notifications.len() - shown..];
 
         let width = NOTIFICATION_MAX_WIDTH
             .min(area.width.saturating_sub(4))
             .max(NOTIFICATION_MIN_WIDTH);
-        if area.width < NOTIFICATION_MIN_WIDTH + 2 || area.height < 4 {
-            return; // Terminal too small to draw a box that says anything.
-        }
         let text_width = width.saturating_sub(2) as usize;
         let x = area.width.saturating_sub(width + 2);
         let bottom = area.height.saturating_sub(1);
 
-        let mut y = 1;
-        let mut drawn = 0usize;
-        for (index, notification) in visible.iter().enumerate() {
-            let (icon, text_color) = match notification.notification_type {
-                crate::app::state::NotificationType::Success => ("✓ ", SELECTION_GREEN),
-                crate::app::state::NotificationType::Error => ("✗ ", Color::Rgb(230, 100, 100)),
-                crate::app::state::NotificationType::Warning => ("⚠ ", WARNING_ORANGE),
-                crate::app::state::NotificationType::Info => ("ℹ ", CORNFLOWER_BLUE),
-            };
+        // ── Plan ────────────────────────────────────────────────────────────
+        struct Planned<'a> {
+            notification: &'a crate::app::state::Notification,
+            rows: Vec<String>,
+            y: u16,
+            height: u16,
+        }
 
-            let rows = wrap_notification(&notification.message, icon, text_width);
-            let height = (rows.len() as u16 + 2).min(NOTIFICATION_MAX_TEXT_ROWS as u16 + 2);
-            if y + height > bottom {
-                break; // Out of screen; the rest are counted as suppressed.
+        let mut planned: Vec<Planned> = Vec::new();
+        let mut y = 1u16;
+        for notification in visible {
+            let room = bottom.saturating_sub(y);
+            if room < 3 {
+                break; // Not even a one-row box fits below what came before.
             }
+            // Shrink to the room actually left rather than skipping the box:
+            // a notice nobody can see is worse than a notice cut short and
+            // saying so.
+            let max_rows = NOTIFICATION_MAX_TEXT_ROWS.min(room as usize - 2);
+            let (rows, _dropped) = clamp_notice_rows(
+                wrap_notification(&notification.message, notice_icon(notification), text_width),
+                max_rows,
+                text_width,
+            );
+            let height = rows.len() as u16 + 2;
+            planned.push(Planned {
+                notification,
+                rows,
+                y,
+                height,
+            });
+            y += height;
+        }
+        if planned.is_empty() {
+            return;
+        }
 
+        // Boxes that never made it onto the screen, either past the visible
+        // cap or past the bottom of the frame.
+        let suppressed = notifications.len() - planned.len();
+        // A dedicated line is clearer than a border label, so use one when
+        // there is room. When there is not, the footer carries the count.
+        let more_line_fits = suppressed > 0 && y + 3 <= bottom;
+        let footer_suppressed = if more_line_fits { 0 } else { suppressed };
+        let footer = notice_footer(footer_suppressed, width.saturating_sub(2) as usize);
+
+        // ── Draw ────────────────────────────────────────────────────────────
+        let last_index = planned.len() - 1;
+        for (index, item) in planned.iter().enumerate() {
+            let color = notice_color(item.notification);
             let mut block = Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(text_color))
+                .border_style(Style::default().fg(color))
                 .style(Style::default().bg(PANEL_BG));
-            // The hint belongs on the control it operates, and the control is
-            // the stack, not any one box — so it goes on the last one drawn,
-            // unless a "+N more" line follows and carries it instead.
-            if index + 1 == visible.len() && suppressed == 0 {
+            // The hint belongs on the control it operates, and it must be on
+            // SOMETHING: this is the only place the chord is advertised while
+            // a notice is up.
+            if index == last_index && !more_line_fits {
                 block = block.title_bottom(
                     Line::from(Span::styled(
-                        format!(" {NOTIFICATION_DISMISS_HINT} "),
+                        footer.clone(),
                         Style::default().fg(MUTED_GRAY),
                     ))
                     .right_aligned(),
                 );
             }
 
-            let lines: Vec<Line> = rows
+            let lines: Vec<Line> = item
+                .rows
                 .iter()
-                .take(NOTIFICATION_MAX_TEXT_ROWS)
-                .map(|row| Line::from(Span::styled(row.clone(), Style::default().fg(text_color))))
+                .map(|row| Line::from(Span::styled(row.clone(), Style::default().fg(color))))
                 .collect();
 
             frame.render_widget(
                 Paragraph::new(lines).block(block),
                 Rect {
                     x,
-                    y,
+                    y: item.y,
                     width,
-                    height,
+                    height: item.height,
                 },
             );
-            y += height;
-            drawn += 1;
         }
 
-        let hidden = notifications.len() - drawn;
-        if hidden > 0 && y + 3 <= bottom {
+        if more_line_fits {
             let more = Paragraph::new(Line::from(Span::styled(
-                format!("+{hidden} more — see the log ({NOTIFICATION_LOG_HINT})"),
+                format!("+{suppressed} more — see the log ({NOTIFICATION_LOG_HINT})"),
                 Style::default().fg(MUTED_GRAY),
             )))
             .block(
@@ -1027,11 +1191,8 @@ impl LayoutComponent {
                     .border_style(Style::default().fg(SUBDUED_BORDER))
                     .style(Style::default().bg(PANEL_BG))
                     .title_bottom(
-                        Line::from(Span::styled(
-                            format!(" {NOTIFICATION_DISMISS_HINT} "),
-                            Style::default().fg(MUTED_GRAY),
-                        ))
-                        .right_aligned(),
+                        Line::from(Span::styled(footer, Style::default().fg(MUTED_GRAY)))
+                            .right_aligned(),
                     ),
             );
             frame.render_widget(
@@ -1836,11 +1997,242 @@ mod notification_layout_tests {
         assert_eq!(wrap_notification("", "ℹ ", 20).len(), 1);
     }
 
-    /// A word longer than the box (a path, a token) cannot be broken on
-    /// whitespace. It must not take the wrap loop with it.
+    /// A token wider than the box is BROKEN, not run past the border.
+    ///
+    /// The previous version of this test asserted only the row count, which
+    /// stayed true while the row itself overflowed and the `Paragraph` clipped
+    /// it — losing the rest of the message. Assert the width.
     #[test]
-    fn a_word_wider_than_the_box_does_not_hang_the_wrap() {
-        let rows = wrap_notification(&"x".repeat(200), "✗ ", 20);
-        assert_eq!(rows.len(), 1, "an unbreakable word occupies its own row");
+    fn a_word_wider_than_the_box_is_broken_to_fit() {
+        let width = 20;
+        let rows = wrap_notification(&"x".repeat(200), "✗ ", width);
+        assert!(
+            rows.len() > 1,
+            "a 200-cell token cannot occupy one 20-cell row"
+        );
+        for row in &rows {
+            assert!(
+                UnicodeWidthStr::width(row.as_str()) <= width,
+                "row runs past the border and will be clipped: {row:?}"
+            );
+        }
+    }
+
+    /// And breaking it loses nothing. This is the case that matters: ainb
+    /// failures name worktree paths, and a clipped path is a message whose
+    /// second half never reaches the screen.
+    #[test]
+    fn a_worktree_path_survives_the_wrap_intact() {
+        let path =
+            "/Users/dev/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-improve--17a4b207";
+        let message = format!("Failed to attach to '{path}': no such session.");
+        let rows = wrap_notification(&message, "✗ ", 40);
+        for row in &rows {
+            assert!(
+                UnicodeWidthStr::width(row.as_str()) <= 40,
+                "row overflows: {row:?}"
+            );
+        }
+        let rejoined: String = rows
+            .iter()
+            .map(|r| r.trim_start_matches(['✗', '\u{a0}', ' ']))
+            .collect::<Vec<_>>()
+            .concat()
+            .replace(' ', "");
+        assert!(
+            rejoined.contains(&path.replace(' ', "")),
+            "the path did not survive wrapping: {rejoined}"
+        );
+    }
+
+    /// A one-cell budget must terminate, not loop forever on a two-cell glyph.
+    #[test]
+    fn a_glyph_wider_than_the_budget_still_terminates() {
+        let rows = wrap_notification("🔥🔥🔥", "", 1);
+        assert_eq!(rows.len(), 3, "each glyph takes its own row: {rows:?}");
+    }
+
+    /// Rows past the cap are marked, not silently dropped. A message that ends
+    /// mid-sentence with no marker is what this whole surface replaced.
+    #[test]
+    fn dropped_rows_leave_a_marker_that_names_the_count() {
+        let rows: Vec<String> = (0..20).map(|i| format!("row {i}")).collect();
+        let (kept, dropped) = clamp_notice_rows(rows, 6, 40);
+        assert_eq!(kept.len(), 6, "the cap is honoured");
+        assert_eq!(dropped, 15, "fifteen rows went, and the caller is told so");
+        assert!(
+            kept.last().unwrap().contains("15"),
+            "the marker must name what is missing: {:?}",
+            kept.last()
+        );
+        assert!(kept.last().unwrap().starts_with('…'));
+    }
+
+    #[test]
+    fn rows_within_the_cap_are_left_alone() {
+        let rows: Vec<String> = (0..4).map(|i| format!("row {i}")).collect();
+        let (kept, dropped) = clamp_notice_rows(rows.clone(), 6, 40);
+        assert_eq!(kept, rows);
+        assert_eq!(dropped, 0);
+    }
+
+    /// The marker itself must fit the box it is marking.
+    #[test]
+    fn the_marker_shrinks_to_the_width_it_has() {
+        for width in 1..40usize {
+            let marker = more_lines_marker(12, width);
+            assert!(
+                UnicodeWidthStr::width(marker.as_str()) <= width.max(1),
+                "marker overflows a {width}-cell row: {marker:?}"
+            );
+        }
+    }
+
+    /// The dismiss hint is the one part of the footer that cannot be dropped:
+    /// it is the only advertisement of the chord while a notice is up.
+    #[test]
+    fn the_footer_keeps_the_hint_at_every_width() {
+        for width in 1..70usize {
+            for suppressed in [0usize, 3, 12] {
+                let footer = notice_footer(suppressed, width);
+                assert!(
+                    footer.contains(NOTIFICATION_DISMISS_HINT),
+                    "the hint vanished at width {width} with {suppressed} suppressed: {footer:?}"
+                );
+            }
+        }
+    }
+
+    /// And it fits, once the border is wide enough to hold it at all.
+    #[test]
+    fn the_footer_fits_the_border_it_is_drawn_on() {
+        let usable = (NOTIFICATION_MIN_WIDTH - 2) as usize;
+        for suppressed in [0usize, 3, 12] {
+            let footer = notice_footer(suppressed, usable);
+            assert!(
+                UnicodeWidthStr::width(footer.as_str()) <= usable,
+                "footer overflows the narrowest box: {footer:?}"
+            );
+        }
+    }
+}
+
+/// The notice stack rendered against a real backend.
+///
+/// The wrap maths and the footer text are unit tested above; what those cannot
+/// see is which element ends up LAST on a given screen, and the dismiss hint
+/// rides on whichever one that is. On a short terminal the boxes are cut by the
+/// bottom of the frame and the "+N more" line has nowhere to go, and that is
+/// precisely where the hint used to disappear — from the one surface whose
+/// point is that it can be dismissed, by a chord nobody guesses.
+#[cfg(test)]
+mod notification_render_tests {
+    use super::*;
+    use crate::app::state::AppState;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn screen(width: u16, height: u16, messages: &[&str]) -> String {
+        let mut state = AppState::default();
+        for message in messages {
+            state.add_error_notification((*message).to_string());
+        }
+        let component = LayoutComponent::new();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
+        terminal
+            .draw(|frame| component.render_notifications(frame, frame.area(), &state))
+            .expect("draw");
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area.height)
+            .map(|row| {
+                (0..buffer.area.width)
+                    .map(|col| buffer[(col, row)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn a_single_notice_carries_the_hint() {
+        let painted = screen(120, 20, &["the daemon is not answering"]);
+        assert!(
+            painted.contains(NOTIFICATION_DISMISS_HINT),
+            "no dismiss hint on screen:\n{painted}"
+        );
+        assert!(painted.contains("daemon is not answering"), "{painted}");
+    }
+
+    /// Boxes cut by the bottom of the frame, with no room left for the "+N
+    /// more" line either. The hint must still be somewhere.
+    #[test]
+    fn a_short_terminal_still_advertises_the_chord() {
+        let painted = screen(
+            120,
+            8,
+            &[
+                "first failure",
+                "second failure",
+                "third failure",
+                "fourth failure",
+            ],
+        );
+        assert!(
+            painted.contains(NOTIFICATION_DISMISS_HINT),
+            "the dismiss hint vanished on a short terminal:\n{painted}"
+        );
+    }
+
+    /// And what it could not show, it counts.
+    #[test]
+    fn what_does_not_fit_is_counted_not_dropped_in_silence() {
+        let painted = screen(
+            120,
+            8,
+            &[
+                "first failure",
+                "second failure",
+                "third failure",
+                "fourth failure",
+            ],
+        );
+        assert!(
+            painted.contains("more"),
+            "suppressed notices were not counted anywhere:\n{painted}"
+        );
+    }
+
+    /// A message longer than the box's row budget is cut with a marker naming
+    /// how much is missing, never trailing off mid-sentence.
+    #[test]
+    fn an_over_long_message_says_how_much_it_is_hiding() {
+        let long = format!("failure: {}", "detail ".repeat(120));
+        let painted = screen(120, 30, &[&long]);
+        assert!(
+            painted.contains("more lines"),
+            "a truncated message must say so:\n{painted}"
+        );
+    }
+
+    /// No row may run past the border. This is what a clipped path looked like
+    /// before the wrap learned to break a token.
+    #[test]
+    fn a_long_path_does_not_run_past_the_border() {
+        let path =
+            "/Users/dev/.agents-in-a-box/worktrees/by-name/agents-in-a-box--f-improve--17a4b207";
+        let painted = screen(120, 20, &[&format!("Failed to attach to '{path}': gone.")]);
+        // The right border column of every notice row must still be a border
+        // glyph. A row that overflowed would have overwritten it with text.
+        for line in painted.lines().filter(|l| l.contains('│') || l.contains('╮')) {
+            let trimmed = line.trim_end();
+            assert!(
+                trimmed.ends_with(['│', '╮', '╯']),
+                "text overwrote the notice border: {trimmed:?}"
+            );
+        }
+        assert!(
+            painted.contains("17a4b207"),
+            "the tail of the path never reached the screen:\n{painted}"
+        );
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -18,6 +18,64 @@ const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 
+/// Notice boxes drawn at once. The rest are counted in a "+N more" line.
+const MAX_VISIBLE_NOTIFICATIONS: usize = 4;
+/// Wrapped rows of message a single notice box may grow to.
+const NOTIFICATION_MAX_TEXT_ROWS: usize = 6;
+/// Widest a notice box gets, before the terminal's own width is applied.
+const NOTIFICATION_MAX_WIDTH: u16 = 64;
+/// Narrowest box still worth drawing a border around.
+const NOTIFICATION_MIN_WIDTH: u16 = 28;
+/// Printed on the notice stack itself, per the keybinding-hints-near-the-
+/// control rule. Matches the chord wired in `events::handle_key_event`.
+pub const NOTIFICATION_DISMISS_HINT: &str = "Ctrl+X dismiss";
+/// Where a dismissed or expired notice can still be read.
+pub const NOTIFICATION_LOG_HINT: &str = "l from home";
+
+/// Greedy word-wrap for a notice, with the level icon on the first row and the
+/// continuation rows indented under the text.
+///
+/// Terminal cell width, not `char` count: an emoji in a message (this codebase
+/// puts them in plenty) is two cells wide and a `char`-counted wrap overflows
+/// the border by exactly as many emoji as the line holds.
+fn wrap_notification(message: &str, icon: &str, width: usize) -> Vec<String> {
+    use unicode_width::UnicodeWidthStr;
+
+    let indent = " ".repeat(UnicodeWidthStr::width(icon));
+    let body = width.saturating_sub(UnicodeWidthStr::width(icon)).max(1);
+
+    let mut rows: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in message.split_whitespace() {
+        let candidate_width = if current.is_empty() {
+            UnicodeWidthStr::width(word)
+        } else {
+            UnicodeWidthStr::width(current.as_str()) + 1 + UnicodeWidthStr::width(word)
+        };
+        if !current.is_empty() && candidate_width > body {
+            rows.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() || rows.is_empty() {
+        rows.push(current);
+    }
+
+    rows.into_iter()
+        .enumerate()
+        .map(|(i, row)| {
+            if i == 0 {
+                format!("{icon}{row}")
+            } else {
+                format!("{indent}{row}")
+            }
+        })
+        .collect()
+}
+
 use super::{
     ClaudeChatComponent, ConfirmationDialogComponent, HelpComponent, LiveLogsStreamComponent,
     LogsViewerComponent, NewSessionComponent, SessionListComponent, TmuxPreviewPane,
@@ -868,74 +926,123 @@ impl LayoutComponent {
         frame.render_widget(status, area);
     }
 
+    /// Draw the notice stack in the top-right corner.
+    ///
+    /// Sized from the message rather than pinned at one line, because a notice
+    /// that lives for a minute can afford to say what happened and what to do
+    /// about it. The old fixed 50x3 box silently clipped anything past ~48
+    /// columns, which is why the messages feeding it were written terse.
+    ///
+    /// Bounded three ways so a long-lived notice cannot take the screen: at
+    /// most [`MAX_VISIBLE_NOTIFICATIONS`] boxes, at most
+    /// [`NOTIFICATION_MAX_TEXT_ROWS`] wrapped rows each, and never past the
+    /// bottom of `area`. Anything suppressed is counted in a trailing "+N
+    /// more" so the surface never quietly shows less than it has.
     fn render_notifications(&self, frame: &mut Frame, area: Rect, state: &AppState) {
         let notifications = state.get_current_notifications();
         if notifications.is_empty() {
             return;
         }
 
-        // Position notifications in the top-right corner
-        let notification_width = 50;
-        let notification_height = notifications.len() as u16 * 3; // 3 lines per notification
+        // Newest matter most, so an old notice is the one that gets dropped —
+        // but keep the surviving ones in arrival order, which is how they have
+        // always read top to bottom.
+        let shown = notifications.len().min(MAX_VISIBLE_NOTIFICATIONS);
+        let suppressed = notifications.len() - shown;
+        let visible = &notifications[notifications.len() - shown..];
 
-        let notification_area = Rect {
-            x: area.width.saturating_sub(notification_width + 2),
-            y: 1,
-            width: notification_width,
-            height: notification_height.min(area.height.saturating_sub(2)),
-        };
+        let width = NOTIFICATION_MAX_WIDTH
+            .min(area.width.saturating_sub(4))
+            .max(NOTIFICATION_MIN_WIDTH);
+        if area.width < NOTIFICATION_MIN_WIDTH + 2 || area.height < 4 {
+            return; // Terminal too small to draw a box that says anything.
+        }
+        let text_width = width.saturating_sub(2) as usize;
+        let x = area.width.saturating_sub(width + 2);
+        let bottom = area.height.saturating_sub(1);
 
-        // Render each notification
-        for (i, notification) in notifications.iter().enumerate() {
-            let y_offset = i as u16 * 3;
-            if y_offset >= notification_area.height {
-                break; // Don't render notifications that won't fit
+        let mut y = 1;
+        let mut drawn = 0usize;
+        for (index, notification) in visible.iter().enumerate() {
+            let (icon, text_color) = match notification.notification_type {
+                crate::app::state::NotificationType::Success => ("✓ ", SELECTION_GREEN),
+                crate::app::state::NotificationType::Error => ("✗ ", Color::Rgb(230, 100, 100)),
+                crate::app::state::NotificationType::Warning => ("⚠ ", WARNING_ORANGE),
+                crate::app::state::NotificationType::Info => ("ℹ ", CORNFLOWER_BLUE),
+            };
+
+            let rows = wrap_notification(&notification.message, icon, text_width);
+            let height = (rows.len() as u16 + 2).min(NOTIFICATION_MAX_TEXT_ROWS as u16 + 2);
+            if y + height > bottom {
+                break; // Out of screen; the rest are counted as suppressed.
             }
 
-            let single_notification_area = Rect {
-                x: notification_area.x,
-                y: notification_area.y + y_offset,
-                width: notification_area.width,
-                height: 3.min(notification_area.height - y_offset),
-            };
+            let mut block = Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(text_color))
+                .style(Style::default().bg(PANEL_BG));
+            // The hint belongs on the control it operates, and the control is
+            // the stack, not any one box — so it goes on the last one drawn,
+            // unless a "+N more" line follows and carries it instead.
+            if index + 1 == visible.len() && suppressed == 0 {
+                block = block.title_bottom(
+                    Line::from(Span::styled(
+                        format!(" {NOTIFICATION_DISMISS_HINT} "),
+                        Style::default().fg(MUTED_GRAY),
+                    ))
+                    .right_aligned(),
+                );
+            }
 
-            let (icon, text_color, border_color) = match notification.notification_type {
-                crate::app::state::NotificationType::Success => {
-                    ("✓ ", SELECTION_GREEN, SELECTION_GREEN)
-                }
-                crate::app::state::NotificationType::Error => {
-                    ("✗ ", Color::Rgb(230, 100, 100), Color::Rgb(230, 100, 100))
-                }
-                crate::app::state::NotificationType::Warning => {
-                    ("⚠ ", WARNING_ORANGE, WARNING_ORANGE)
-                }
-                crate::app::state::NotificationType::Info => {
-                    ("ℹ ", CORNFLOWER_BLUE, CORNFLOWER_BLUE)
-                }
-            };
+            let lines: Vec<Line> = rows
+                .iter()
+                .take(NOTIFICATION_MAX_TEXT_ROWS)
+                .map(|row| Line::from(Span::styled(row.clone(), Style::default().fg(text_color))))
+                .collect();
 
-            let notification_line = Line::from(vec![
-                Span::styled(
-                    icon,
-                    Style::default().fg(text_color).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    notification.message.as_str(),
-                    Style::default().fg(text_color),
-                ),
-            ]);
+            frame.render_widget(
+                Paragraph::new(lines).block(block),
+                Rect {
+                    x,
+                    y,
+                    width,
+                    height,
+                },
+            );
+            y += height;
+            drawn += 1;
+        }
 
-            let notification_widget = Paragraph::new(notification_line)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .border_type(BorderType::Rounded)
-                        .border_style(Style::default().fg(border_color))
-                        .style(Style::default().bg(PANEL_BG)),
-                )
-                .wrap(ratatui::widgets::Wrap { trim: true });
-
-            frame.render_widget(notification_widget, single_notification_area);
+        let hidden = notifications.len() - drawn;
+        if hidden > 0 && y + 3 <= bottom {
+            let more = Paragraph::new(Line::from(Span::styled(
+                format!("+{hidden} more — see the log ({NOTIFICATION_LOG_HINT})"),
+                Style::default().fg(MUTED_GRAY),
+            )))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(SUBDUED_BORDER))
+                    .style(Style::default().bg(PANEL_BG))
+                    .title_bottom(
+                        Line::from(Span::styled(
+                            format!(" {NOTIFICATION_DISMISS_HINT} "),
+                            Style::default().fg(MUTED_GRAY),
+                        ))
+                        .right_aligned(),
+                    ),
+            );
+            frame.render_widget(
+                more,
+                Rect {
+                    x,
+                    y,
+                    width,
+                    height: 3,
+                },
+            );
         }
     }
 
@@ -1653,5 +1760,87 @@ mod interactive_embed_size_tests {
     fn never_returns_zero_cells() {
         assert_eq!(interactive_embed_size(0, 0, 5, true), (1, 1));
         assert_eq!(interactive_embed_size(7, 14, 40, true), (1, 1));
+    }
+}
+
+#[cfg(test)]
+mod notification_layout_tests {
+    use super::*;
+    use unicode_width::UnicodeWidthStr;
+
+    /// Every row a notice draws must fit inside the box, or the border is
+    /// overwritten and the message reads as corrupted rather than long.
+    #[test]
+    fn no_wrapped_row_is_wider_than_the_box() {
+        let width = 40;
+        let message = "No session selected to attach. Pick a session row with the arrow keys \
+                       and press a again; press n to start one.";
+        for row in wrap_notification(message, "✗ ", width) {
+            assert!(
+                UnicodeWidthStr::width(row.as_str()) <= width,
+                "row overflows the {width}-cell box: {row:?}"
+            );
+        }
+    }
+
+    /// Cell width, not `char` count. This codebase puts emoji in plenty of
+    /// notices and each one is two cells wide; counting `char`s overflows the
+    /// border by exactly as many emoji as the row holds.
+    #[test]
+    fn an_emoji_counts_as_the_two_cells_it_paints() {
+        let width = 20;
+        let message = "⚠️ 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥";
+        for row in wrap_notification(message, "⚠ ", width) {
+            assert!(
+                UnicodeWidthStr::width(row.as_str()) <= width,
+                "emoji row overflows the {width}-cell box: {row:?}"
+            );
+        }
+    }
+
+    /// A detailed message is what the longer lifetime buys, so it must survive
+    /// the trip to the screen instead of being clipped to one line.
+    #[test]
+    fn a_detailed_message_wraps_instead_of_being_clipped() {
+        let message = "Codex bridge conflict. Restart Ainb, then retry. \
+                       Cause: Codex app-server WebSocket handshake failed: invalid token";
+        let rows = wrap_notification(message, "✗ ", 60);
+        assert!(rows.len() > 1, "a long message must occupy several rows");
+        let rejoined = rows.join(" ");
+        for word in ["Restart", "Cause:", "handshake", "token"] {
+            assert!(
+                rejoined.contains(word),
+                "wrapping dropped {word:?} from the notice: {rejoined:?}"
+            );
+        }
+    }
+
+    /// The first row carries the level icon and the rest line up under the
+    /// text, so a three-row failure reads as one message.
+    #[test]
+    fn continuation_rows_align_under_the_first() {
+        let rows = wrap_notification("one two three four five six seven eight", "✗ ", 14);
+        assert!(rows[0].starts_with("✗ "));
+        for row in &rows[1..] {
+            assert!(
+                row.starts_with("  "),
+                "continuation row not indented: {row:?}"
+            );
+        }
+    }
+
+    /// An empty message must still produce a row, or the box collapses to its
+    /// two borders and paints as a stray rectangle.
+    #[test]
+    fn an_empty_message_still_draws_one_row() {
+        assert_eq!(wrap_notification("", "ℹ ", 20).len(), 1);
+    }
+
+    /// A word longer than the box (a path, a token) cannot be broken on
+    /// whitespace. It must not take the wrap loop with it.
+    #[test]
+    fn a_word_wider_than_the_box_does_not_hang_the_wrap() {
+        let rows = wrap_notification(&"x".repeat(200), "✗ ", 20);
+        assert_eq!(rows.len(), 1, "an unbreakable word occupies its own row");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/config/registry.rs
+++ b/ainb-tui/crates/ainb-core/src/config/registry.rs
@@ -677,6 +677,27 @@ pub static CONFIG_REGISTRY: &[Entry] = &[
         help: "Milliseconds in which two clicks count as one double-click",
         kind: RowKind::Number { min: 50, max: 2000 },
     }),
+    Entry::Row(ConfigRow {
+        key: "ui.notice_error_secs",
+        category: C::Appearance,
+        label: "Error Notice Lifetime",
+        help: "Seconds an error notice stays up; Ctrl+X retires it sooner, the log keeps it after",
+        kind: RowKind::Number { min: 1, max: 3600 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.notice_warning_secs",
+        category: C::Appearance,
+        label: "Warning Notice Lifetime",
+        help: "Seconds a warning notice stays up before it retires itself",
+        kind: RowKind::Number { min: 1, max: 3600 },
+    }),
+    Entry::Row(ConfigRow {
+        key: "ui.notice_info_secs",
+        category: C::Appearance,
+        label: "Info Notice Lifetime",
+        help: "Seconds an info notice stays up before it retires itself",
+        kind: RowKind::Number { min: 1, max: 3600 },
+    }),
     // ── Docker ─────────────────────────────────────────────────────────────
     Entry::Row(ConfigRow {
         key: "docker.host",
@@ -1953,6 +1974,9 @@ mod tests {
                 attention_err_window_hours: 4,
                 inbox_list_limit: 100,
                 double_click_ms: 400,
+                notice_error_secs: 90,
+                notice_warning_secs: 30,
+                notice_info_secs: 15,
             },
             daemons: DaemonsConfig {
                 stale_after_ms: 120_000,

--- a/ainb-tui/crates/ainb-core/src/config/tunables.rs
+++ b/ainb-tui/crates/ainb-core/src/config/tunables.rs
@@ -400,6 +400,33 @@ pub struct UiConfig {
     /// edge. Raise it if your hands or your terminal are slow.
     #[serde(default = "default_double_click_ms")]
     pub double_click_ms: u64,
+
+    /// Seconds an ERROR notice stays on screen before it retires itself.
+    ///
+    /// Five seconds was not long enough to read a failure, let alone act on
+    /// one, so the message had to stay terse to be legible at all — the
+    /// surface was setting the wording. A minute is long enough to read, and
+    /// `Ctrl+X` retires it sooner for anyone who has. Nothing is lost either
+    /// way: every notice is written to the JSONL app log as it is raised, so
+    /// the Log History screen still has it afterwards.
+    #[serde(default = "default_notice_error_secs")]
+    pub notice_error_secs: u64,
+
+    /// Seconds a WARNING notice stays on screen.
+    ///
+    /// Shorter than an error because a warning reports a degraded outcome
+    /// rather than a failed one, longer than an info because the operator did
+    /// not ask for it and may not be looking.
+    #[serde(default = "default_notice_warning_secs")]
+    pub notice_warning_secs: u64,
+
+    /// Seconds an INFO notice stays on screen.
+    ///
+    /// Not all info is a receipt for something the operator just did — a
+    /// degraded Codex launch announces itself this way — so three seconds was
+    /// too short to finish a sentence in.
+    #[serde(default = "default_notice_info_secs")]
+    pub notice_info_secs: u64,
 }
 
 fn default_tick_rate_ms() -> u64 {
@@ -423,6 +450,15 @@ fn default_inbox_list_limit() -> u32 {
 fn default_double_click_ms() -> u64 {
     300
 }
+fn default_notice_error_secs() -> u64 {
+    60
+}
+fn default_notice_warning_secs() -> u64 {
+    20
+}
+fn default_notice_info_secs() -> u64 {
+    10
+}
 
 impl Default for UiConfig {
     fn default() -> Self {
@@ -434,6 +470,9 @@ impl Default for UiConfig {
             attention_err_window_hours: default_attention_err_window_hours(),
             inbox_list_limit: default_inbox_list_limit(),
             double_click_ms: default_double_click_ms(),
+            notice_error_secs: default_notice_error_secs(),
+            notice_warning_secs: default_notice_warning_secs(),
+            notice_info_secs: default_notice_info_secs(),
         }
     }
 }

--- a/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
+++ b/ainb-tui/crates/ainb-core/src/interactive/session_manager.rs
@@ -416,12 +416,23 @@ where
     }
 }
 
-/// Short actionable TUI message for a shared Codex bridge failure.
+/// Actionable TUI message for a shared Codex bridge failure, and the cause.
 ///
-/// The detailed transport error remains in daemon and client logs. Showing it in
-/// the three-line notification hid the user action behind nested RPC context.
-fn format_codex_remote_control_failure(cause: &str) -> &'static str {
-    if cause.contains("WebSocket handshake")
+/// The action stays FIRST. Leading with the transport error was the original
+/// complaint: nested RPC context buried the one line telling the user what to
+/// do, so the cause was dropped entirely to keep the message inside a
+/// three-line notification.
+///
+/// It comes back now because the notice grew. A notice box sizes itself to its
+/// message, lives for `[ui] notice_error_secs`, and can be retired with
+/// `Ctrl+X`, so a trailing cause costs nothing it used to cost — and without
+/// it, the fallback branch ("Check Hangar logs") sent the user to a log to
+/// learn something this function already had in its hand.
+///
+/// Trimmed to [`CAUSE_EXCERPT_CHARS`], because the full nested chain can run to
+/// several lines and the whole of it is in the app log either way.
+fn format_codex_remote_control_failure(cause: &str) -> String {
+    let action = if cause.contains("WebSocket handshake")
         || cause.contains("Handshake not finished")
         || cause.contains("invalid token")
     {
@@ -432,7 +443,32 @@ fn format_codex_remote_control_failure(cause: &str) -> &'static str {
         "Codex unavailable. Update Codex, then retry."
     } else {
         "Codex remote control unavailable. Check Hangar logs, then retry."
+    };
+
+    match cause_excerpt(cause) {
+        Some(excerpt) => format!("{action} Cause: {excerpt}"),
+        None => action.to_string(),
     }
+}
+
+/// Characters of the underlying error a notice carries.
+const CAUSE_EXCERPT_CHARS: usize = 160;
+
+/// One-line excerpt of `cause`, or `None` when there is nothing to add.
+///
+/// Truncates on a CHARACTER boundary. Byte-slicing a message that reached us
+/// from another process panics the moment the cut lands mid-codepoint, and a
+/// path or a model id is exactly where a non-ASCII byte turns up.
+fn cause_excerpt(cause: &str) -> Option<String> {
+    let flattened = cause.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.is_empty() {
+        return None;
+    }
+    if flattened.chars().count() <= CAUSE_EXCERPT_CHARS {
+        return Some(flattened);
+    }
+    let head: String = flattened.chars().take(CAUSE_EXCERPT_CHARS).collect();
+    Some(format!("{}…", head.trim_end()))
 }
 
 /// Wait briefly for the freshly started remote terminal to publish its exact
@@ -3793,26 +3829,59 @@ trust_level = "trusted"
     }
 
     #[test]
-    fn shared_remote_codex_failures_show_a_short_next_action() {
-        assert_eq!(
-            format_codex_remote_control_failure(
-                "Codex app-server WebSocket handshake failed: invalid token"
+    fn shared_remote_codex_failures_lead_with_the_next_action() {
+        for (cause, action) in [
+            (
+                "Codex app-server WebSocket handshake failed: invalid token",
+                "Codex bridge conflict. Restart Ainb, then retry.",
             ),
-            "Codex bridge conflict. Restart Ainb, then retry."
-        );
-        assert_eq!(
-            format_codex_remote_control_failure("Codex manager command timed out"),
-            "Codex bridge starting. Retry session in 5 seconds."
-        );
-        assert_eq!(
-            format_codex_remote_control_failure(
-                "installed Codex cannot generate app-server schema"
+            (
+                "Codex manager command timed out",
+                "Codex bridge starting. Retry session in 5 seconds.",
             ),
-            "Codex unavailable. Update Codex, then retry."
+            (
+                "installed Codex cannot generate app-server schema",
+                "Codex unavailable. Update Codex, then retry.",
+            ),
+            (
+                "daemon RPC rejected request",
+                "Codex remote control unavailable. Check Hangar logs, then retry.",
+            ),
+        ] {
+            let message = format_codex_remote_control_failure(cause);
+            assert!(
+                message.starts_with(action),
+                "the action must come first, not after the transport error: {message}"
+            );
+            assert!(
+                message.contains(cause),
+                "the cause the user needs is in hand and must be carried: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_long_cause_is_trimmed_on_a_character_boundary() {
+        // A multi-byte character straddling the cut is the panic this guards:
+        // `&s[..160]` on this input slices a 'é' in half.
+        let cause = "é".repeat(CAUSE_EXCERPT_CHARS * 2);
+        let message = format_codex_remote_control_failure(&cause);
+        assert!(
+            message.ends_with('…'),
+            "trimmed causes are marked: {message}"
         );
+        assert!(
+            message.chars().count() < cause.chars().count(),
+            "a long cause must actually shrink"
+        );
+    }
+
+    #[test]
+    fn a_cause_with_nothing_in_it_adds_nothing() {
         assert_eq!(
-            format_codex_remote_control_failure("daemon RPC rejected request"),
-            "Codex remote control unavailable. Check Hangar logs, then retry."
+            format_codex_remote_control_failure("   "),
+            "Codex remote control unavailable. Check Hangar logs, then retry.",
+            "an empty cause must not leave a dangling 'Cause:' on the notice"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1155,8 +1155,10 @@ async fn run_tui_loop(
                                     "[ACTION] Failed to attach to other tmux session '{}': {}",
                                     session_name, e
                                 );
-                                app.state
-                                    .add_error_notification(format!("Failed to attach: {}", e));
+                                app.state.add_error_notification(attach_failure_notice(
+                                    &session_name,
+                                    &e,
+                                ));
                             }
                         }
 
@@ -1861,8 +1863,10 @@ async fn run_tui_loop(
                                         "[ACTION] Failed to attach to tmux session '{}': {}",
                                         tmux_session_name, e
                                     );
-                                    app.state
-                                        .add_error_notification(format!("Failed to attach: {}", e));
+                                    app.state.add_error_notification(attach_failure_notice(
+                                        &tmux_session_name,
+                                        &e,
+                                    ));
                                 }
                             }
 
@@ -1919,6 +1923,26 @@ async fn run_tui_loop(
     }
 
     Ok(())
+}
+
+/// A tmux attach failure, naming the target and the two causes that produce it.
+///
+/// `Failed to attach: tmux attach-session failed with exit code: Some(1)` named
+/// neither the session nor anything the operator could act on. It is not
+/// laziness on the error's part: tmux prints its real reason to the terminal
+/// the TUI is about to repaint over, so an exit code is genuinely all that
+/// survives the round trip. What the caller knows and never said is the target
+/// and the two things that actually produce a bare exit 1 here.
+///
+/// Room for this is what `[ui] notice_error_secs` and `Ctrl+X` bought: at five
+/// seconds and one clipped line, a sentence like this would have been worse
+/// than the stub.
+fn attach_failure_notice(session_name: &str, error: &impl std::fmt::Display) -> String {
+    format!(
+        "Failed to attach to '{session_name}': {error}. Either the session ended after \
+         the list was drawn — press f to refresh — or it is the tmux session ainb is \
+         itself running in, which tmux refuses to nest."
+    )
 }
 
 fn setup_logging() {
@@ -2112,6 +2136,27 @@ where
         // Bare `ainb` (`None`) boots the TUI; any other subcommand (`run`,
         // `attach`, `auth`, …) is long-running — both take the JSONL file sink.
         _ => LogSink::JsonlFile,
+    }
+}
+
+#[cfg(test)]
+mod attach_failure_notice_tests {
+    use super::attach_failure_notice;
+
+    /// The three things the old one-liner never said.
+    #[test]
+    fn the_notice_names_the_target_the_error_and_what_to_do() {
+        let notice = attach_failure_notice(
+            "tmux_myrepo_main",
+            &"tmux attach-session failed with exit code: Some(1)",
+        );
+        assert!(notice.contains("tmux_myrepo_main"), "the target: {notice}");
+        assert!(notice.contains("exit code: Some(1)"), "the error: {notice}");
+        assert!(
+            notice.contains("press f to refresh"),
+            "the remedy: {notice}"
+        );
+        assert!(notice.contains("nest"), "the other cause: {notice}");
     }
 }
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_remove_live.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_core_skill_manager_remove_live.rs
@@ -103,13 +103,39 @@ fn launch_line(layout: &SandboxLayout, bin: &Path) -> String {
     s
 }
 
+/// Columns at the right edge a notice box can occupy.
+///
+/// Notices are a top-RIGHT corner overlay, at most 64 cells wide plus a
+/// two-cell margin; 70 leaves headroom. The Units table's own columns (`#`,
+/// name, kind, source) all sit far to the left of that on the 200-column pane
+/// this test drives, so dropping this many columns removes any overlay without
+/// touching a single table cell.
+const NOTICE_OVERLAY_COLUMNS: usize = 70;
+
 /// The Units table occupies the top band of the screen; the Detail pane
 /// is the lower band and keeps echoing the selected unit's name even
 /// after the table is rebuilt. Scope substring checks to the table by
 /// taking the first 20 rows (well clear of the Detail pane on a 50-row
 /// terminal). Mirrors the search tripwire's region-scoping helper.
+///
+/// The right edge of each line is dropped, because taking a RECTANGLE of the
+/// screen cannot tell a table row from something drawn on top of one. A notice
+/// legitimately overlays this corner, and the remove confirm quotes the full
+/// unit URI — so once notices stopped being clipped at 48 cells, the name this
+/// test looks for arrived inside the region from the OVERLAY while the table
+/// row was correctly gone. The assertion is about the table's own columns, and
+/// those are on the left.
 fn units_region(full: &str) -> String {
-    full.lines().take(20).collect::<Vec<_>>().join("\n")
+    full.lines()
+        .take(20)
+        .map(|line| {
+            let cells: Vec<char> = line.chars().collect();
+            cells[..cells.len().saturating_sub(NOTICE_OVERLAY_COLUMNS)]
+                .iter()
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[test]

--- a/ainb-tui/crates/ainb-core/tests/tripwire_notice_dismiss_and_expiry.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_notice_dismiss_and_expiry.rs
@@ -53,6 +53,15 @@ const DISMISS_HINT: &str = "Ctrl+X dismiss";
 /// The session list's tab strip, flattened. Unique to that screen.
 const SESSION_LIST_MARKER: &str = "preview ask err";
 
+/// The tail of the session name the attach failure quotes.
+///
+/// The name is deliberately longer than a notice row, so the box has to BREAK
+/// it rather than break before it. Doubled because a break lands every ~60
+/// cells and cannot fall inside both copies, so one always survives whole —
+/// and if the row were clipped at the border instead of broken, neither would
+/// reach the screen at all. That is the difference this asserts.
+const NAME_TAIL: &str = "tailmark";
+
 /// The warning `$` raises with no workspace selected. Deliberately unrelated
 /// wording, so the expiry half cannot pass on the dismiss half's leftovers.
 const WARNING_TEXT: &str = "No workspace selected";
@@ -259,7 +268,11 @@ fn an_error_notice_carries_its_remedy_is_dismissable_and_outlives_itself_in_the_
     seed_isolated_home(home_tmp.path());
     let tmux = Tmux {
         socket: format!("ainb-notice-{}", std::process::id()),
-        session: format!("tripwire-notice-{}", std::process::id()),
+        // Longer than a notice row on purpose: see NAME_TAIL.
+        session: format!(
+            "tripwire-notice-{}-a-name-long-enough-to-need-breaking-{NAME_TAIL}-{NAME_TAIL}",
+            std::process::id()
+        ),
     };
     launch_to_session_list(&tmux, home_tmp.path());
 
@@ -287,6 +300,16 @@ fn an_error_notice_carries_its_remedy_is_dismissable_and_outlives_itself_in_the_
         if !shown.contains(token) {
             tmux.bail(&format!("the notice is missing {token:?}"));
         }
+    }
+
+    // And the session name — one token wider than the box — was BROKEN across
+    // rows, not run past the border and clipped. Clipping would take the tail
+    // and everything after it, which is most of the message.
+    if !shown.contains(NAME_TAIL) {
+        tmux.bail(&format!(
+            "the quoted session name was clipped at the border: {NAME_TAIL:?} never \
+             reached the screen"
+        ));
     }
 
     // ── 2. The box advertises the key that retires it ───────────────────────

--- a/ainb-tui/crates/ainb-core/tests/tripwire_notice_dismiss_and_expiry.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_notice_dismiss_and_expiry.rs
@@ -1,0 +1,359 @@
+//! Tripwire: an error notice is READABLE, DISMISSABLE, and never the only copy.
+//!
+//! The complaint was one sentence with three things in it — "make it disappear
+//! after like a minute or dismissable sort of (so can add a bit more detail as
+//! well)". A five-second box clipped to one 48-column line was setting the
+//! wording of every message that went through it.
+//!
+//! What has to be true on a real screen, and none of which a unit test can
+//! reach (the wrap maths, the key routing and the log write are each unit
+//! tested; that all of them meet on one pane is not):
+//!
+//! - a failure paints its DETAIL, wrapped over several rows, not clipped;
+//! - the box advertises the key that retires it, on the box;
+//! - that key works, and works long before the notice would have expired;
+//! - a notice left alone retires itself on the configured clock;
+//! - and afterwards — dismissed and expired — both messages are still in the
+//!   app log, so nothing the operator did not read has been thrown away.
+//!
+//! Both halves run off ONE launch with two lifetimes seeded into `[ui]`:
+//! errors at [`ERROR_SECS`], so a notice that vanishes seconds after the chord
+//! cannot be a notice that timed out, and warnings at [`WARNING_SECS`], so
+//! expiry is observable without the suite sitting out the shipped minute. The
+//! shipped minute is pinned by the unit test
+//! `an_error_notice_lives_for_one_minute_out_of_the_box` — the only honest way
+//! to assert a duration nobody can afford to wait for.
+//!
+//! Runs on its OWN tmux server (`-L`), for two reasons. The TUI lists every
+//! session on whatever server it can see, so on a shared one this test's
+//! screen is whatever the machine happens to be running; and an attach driven
+//! by a test has no business reaching a real session. On a private server the
+//! only session is this test's own, which makes the failure it drives exact:
+//! tmux refuses to nest a session inside itself, every time.
+//!
+//! Skips gracefully if `tmux` isn't on `$PATH`. Plugins are disabled: the
+//! notice stack is host chrome.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Long enough that a dismissed notice cannot be mistaken for an expired one.
+const ERROR_SECS: u64 = 30;
+/// Short enough to watch a notice retire itself inside a test.
+const WARNING_SECS: u64 = 4;
+
+/// From the attach failure's REMEDY, not its headline. The headline is what
+/// fit in the old box; this is what the extra rows bought.
+const ERROR_REMEDY: &str = "press f to refresh";
+/// The hint painted on the box, per keybinding-hints-near-the-control.
+const DISMISS_HINT: &str = "Ctrl+X dismiss";
+/// The session list's tab strip, flattened. Unique to that screen.
+const SESSION_LIST_MARKER: &str = "preview ask err";
+
+/// The warning `$` raises with no workspace selected. Deliberately unrelated
+/// wording, so the expiry half cannot pass on the dismiss half's leftovers.
+const WARNING_TEXT: &str = "No workspace selected";
+
+fn ainb_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ainb"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A tmux server of this test's own, addressed by socket name.
+struct Tmux {
+    socket: String,
+    session: String,
+}
+
+impl Tmux {
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new("tmux")
+            .args(["-L", &self.socket])
+            .args(args)
+            .output()
+            .expect("tmux")
+    }
+
+    fn start(&self) {
+        let out = self.run(&[
+            "new-session",
+            "-d",
+            "-s",
+            &self.session,
+            "-x",
+            "200",
+            "-y",
+            "50",
+        ]);
+        assert!(
+            out.status.success(),
+            "tmux new-session failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn send_key(&self, key: &str) {
+        self.run(&["send-keys", "-t", &self.session, key]);
+    }
+
+    /// Send `text` as literal characters. `$` is not a tmux key name, and
+    /// putting it through the key parser is a coin toss not worth throwing.
+    fn send_literal(&self, text: &str) {
+        self.run(&["send-keys", "-t", &self.session, "-l", text]);
+    }
+
+    fn capture(&self) -> String {
+        String::from_utf8_lossy(&self.run(&["capture-pane", "-t", &self.session, "-p"]).stdout)
+            .to_string()
+    }
+
+    /// Capture with the box drawing removed and whitespace runs collapsed.
+    ///
+    /// A notice WRAPS now, so any phrase longer than a word is split across
+    /// rows with a border on each side. Searching the raw capture would fail
+    /// for exactly the reason this feature exists.
+    fn flat(&self) -> String {
+        let stripped: String = self
+            .capture()
+            .chars()
+            .map(|c| {
+                if ('\u{2500}'..='\u{257F}').contains(&c) {
+                    ' '
+                } else {
+                    c
+                }
+            })
+            .collect();
+        stripped.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn poll<F>(&self, deadline: Instant, mut ok: F) -> Option<String>
+    where
+        F: FnMut(&str) -> bool,
+    {
+        loop {
+            let flat = self.flat();
+            if ok(&flat) {
+                return Some(flat);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            thread::sleep(Duration::from_millis(300));
+        }
+    }
+
+    /// Kill this test's session, by EXACT name (`=`). Never a bulk kill and
+    /// never the server: `-L` already keeps this off everyone else's sessions,
+    /// and an exact target keeps it off theirs even if it did not.
+    fn kill(&self) {
+        self.run(&["kill-session", "-t", &format!("={}", self.session)]);
+    }
+
+    /// Abandon the run with the screen attached to the message.
+    fn bail(&self, what: &str) -> ! {
+        let last = self.capture();
+        self.kill();
+        panic!("{what}\n---\n{last}\n---");
+    }
+}
+
+fn seed_isolated_home(home: &Path) {
+    let cfg = home.join(".agents-in-a-box").join("config");
+    fs::create_dir_all(&cfg).expect("create isolated config dir");
+    fs::write(
+        cfg.join("onboarding.toml"),
+        format!(
+            "completed = true\n\
+             completed_at = \"2026-09-04T00:00:00+00:00\"\n\
+             version = \"{ver}\"\n\
+             skipped_dependencies = []\n\
+             git_directories = []\n",
+            ver = env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("seed onboarding.toml");
+    fs::write(
+        cfg.join("config.toml"),
+        format!("[ui]\nnotice_error_secs = {ERROR_SECS}\nnotice_warning_secs = {WARNING_SECS}\n"),
+    )
+    .expect("seed config.toml");
+    let install_record = r#"{"agents":[],"hook_script":"","claude_plugin_dir":null,"codex_hooks_json":null,"plugin_version":null,"prompt_dismissed":true}"#;
+    fs::write(
+        home.join(".agents-in-a-box").join("install.json"),
+        install_record,
+    )
+    .expect("seed install.json");
+}
+
+/// Everything the TUI logged this run. The Log History screen (`l` from home)
+/// reads this same directory.
+fn app_log(home: &Path) -> String {
+    let dir = home.join(".agents-in-a-box").join("logs");
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return String::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "jsonl"))
+        .filter_map(|e| fs::read_to_string(e.path()).ok())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn launch_to_session_list(tmux: &Tmux, home: &Path) {
+    tmux.start();
+    let cmd = format!(
+        "HOME={} AINB_DISABLE_PLUGINS=1 exec {} tui",
+        home.display(),
+        ainb_bin().display()
+    );
+    tmux.run(&["send-keys", "-t", &tmux.session, &cmd, "Enter"]);
+
+    if tmux
+        .poll(Instant::now() + Duration::from_secs(120), |c| {
+            c.contains("Stats") && c.contains("[i]")
+        })
+        .is_none()
+    {
+        tmux.bail("the home screen never rendered");
+    }
+
+    // `s` opens the session list, re-sent while the terminal settles because
+    // the pane paints before it accepts its first key.
+    //
+    // The marker is the session list's OWN tab strip. "Workspaces" is not: the
+    // home screen carries that word too, so keying off it returned a launcher
+    // still sitting on home and left the next step pressing `a` at a screen
+    // with no attach on it for the whole of its deadline.
+    let deadline = Instant::now() + Duration::from_secs(45);
+    loop {
+        tmux.send_key("s");
+        thread::sleep(Duration::from_millis(600));
+        if tmux.flat().contains(SESSION_LIST_MARKER) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            tmux.bail("the session list never opened");
+        }
+    }
+}
+
+#[test]
+fn an_error_notice_carries_its_remedy_is_dismissable_and_outlives_itself_in_the_log() {
+    if !tmux_available() {
+        eprintln!("SKIP: tmux not available");
+        return;
+    }
+    let home_tmp = tempfile::tempdir().expect("home tempdir");
+    seed_isolated_home(home_tmp.path());
+    let tmux = Tmux {
+        socket: format!("ainb-notice-{}", std::process::id()),
+        session: format!("tripwire-notice-{}", std::process::id()),
+    };
+    launch_to_session_list(&tmux, home_tmp.path());
+
+    // ── 1. A failure says what to do about it ───────────────────────────────
+    // On a private server the only session listed is this test's own, and `a`
+    // asks tmux to attach it to itself. tmux refuses to nest, so this is a
+    // real error notice off the real key handler, raised the same way it would
+    // be if the session had simply died.
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let shown = loop {
+        tmux.send_key("a");
+        thread::sleep(Duration::from_millis(700));
+        let flat = tmux.flat();
+        if flat.contains(ERROR_REMEDY) {
+            break flat;
+        }
+        if Instant::now() >= deadline {
+            tmux.bail("the attach failure never painted its remedy");
+        }
+    };
+
+    // The headline is what the old box could hold. These are the rows it could
+    // not, and they are the whole point of the longer lifetime.
+    for token in ["Failed to attach to", ERROR_REMEDY, "refuses to nest"] {
+        if !shown.contains(token) {
+            tmux.bail(&format!("the notice is missing {token:?}"));
+        }
+    }
+
+    // ── 2. The box advertises the key that retires it ───────────────────────
+    if !shown.contains(DISMISS_HINT) {
+        tmux.bail(&format!(
+            "the notice does not say how to dismiss it (expected {DISMISS_HINT:?})"
+        ));
+    }
+
+    // ── 3. And that key works, decisively before the notice would expire ────
+    let dismissed_at = Instant::now();
+    tmux.send_key("C-x");
+    if tmux
+        .poll(Instant::now() + Duration::from_secs(10), |c| {
+            !c.contains(ERROR_REMEDY)
+        })
+        .is_none()
+    {
+        tmux.bail("Ctrl+X did not dismiss the notice");
+    }
+    let elapsed = dismissed_at.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(ERROR_SECS),
+        "the notice went away after {elapsed:?}, which is its own {ERROR_SECS}s lifetime — \
+         that proves expiry, not dismissal"
+    );
+
+    // ── 4. A notice left alone retires itself ───────────────────────────────
+    // `$` with no workspace selected raises a warning, seeded at a lifetime
+    // short enough to sit through.
+    tmux.send_literal("$");
+    if tmux
+        .poll(Instant::now() + Duration::from_secs(20), |c| {
+            c.contains(WARNING_TEXT)
+        })
+        .is_none()
+    {
+        tmux.bail("the workspace warning never painted");
+    }
+    if tmux
+        .poll(
+            Instant::now() + Duration::from_secs(WARNING_SECS * 4 + 10),
+            |c| !c.contains(WARNING_TEXT),
+        )
+        .is_none()
+    {
+        tmux.bail(&format!(
+            "the warning never expired on its {WARNING_SECS}s clock"
+        ));
+    }
+
+    // ── 5. Neither message was thrown away ──────────────────────────────────
+    // The whole feature is only safe because the log has a copy. If this
+    // assertion goes, an expiring notice starts losing failures nobody read.
+    let log = app_log(home_tmp.path());
+    tmux.kill();
+
+    for token in ["Failed to attach to", WARNING_TEXT] {
+        assert!(
+            log.contains(token),
+            "a notice left the screen without leaving a copy in the app log: {token:?} \
+             missing from {} bytes of JSONL",
+            log.len()
+        );
+    }
+    assert!(
+        log.contains("\"notice\""),
+        "notices must be tagged in the log so they can be told from ordinary tracing"
+    );
+}


### PR DESCRIPTION
> "can you fix errors, make it disappear after like a minute or dismissable sort of .. (so can add a bit more detail as well)"

## What was already there

There WAS a TTL. `Notification::error` shipped `Duration::from_secs(5)`, info and success 3, warning 4, and `cleanup_expired_notifications` ran every tick. So this is not a missing mechanism; it is a duration that was too short, no way to clear a notice early, and a box (`50x3`, one visible line, ~48 columns) that silently clipped anything longer.

Those three are the same problem. `format_codex_remote_control_failure` says so out loud in its own doc comment — it dropped the transport error deliberately because "showing it in the three-line notification hid the user action". The surface was setting the wording.

## What changed

| | before | after |
|---|---|---|
| error lifetime | 5s | 60s (`[ui] notice_error_secs`) |
| warning / info | 4s / 3s | 20s / 10s (both on knobs) |
| success | 3s | 3s — a receipt for something you just did |
| dismiss | none | `Ctrl+X` |
| box | fixed 50x3, clipped | wraps, grows to 6 rows / 64 cols |
| stack | unbounded | 4 drawn, 12 kept, "+N more" |
| durability | none | every notice written to the app log as it is raised |

**Where a dismissed or expired error goes.** `add_notification` writes the message to the JSONL app log at its own level before it ever reaches the screen. That is the log the Log History screen (`l` from home) already reads. Dismissing or waiting out a notice cannot lose a failure, because the screen was never the only copy. The tripwire asserts this against the real log file after both a dismissal and an expiry.

**A minute-long notice must not bury the others.** Two guards: an identical failure refreshes the notice already showing rather than stacking behind it, and the queue is capped at 12 (coalescing only catches a repeated message; an id in the text defeats it). Coalescing is errors and warnings only — an announcement's repetition can be the signal, and `notify_codex_degraded` raises one identical sentence per degraded session on purpose.

**The chord.** Every printable letter is claimed by some screen's handler, and a notice can be up on any screen, so the dismiss key had to be a chord. It is claimed only while something is showing. One thing it does take, and only while there is something to dismiss: the session list matches a bare `Char('x')` without checking modifiers, so `Ctrl+X` there used to fall into Cleanup Orphaned. Plain `x` — that action's documented key — is untouched, and a test pins it.

## More detail, now that there is room

- `format_codex_remote_control_failure` keeps the action first and appends the cause, trimmed to 160 chars on a character boundary.
- tmux attach failures name the session and the two things that produce a bare exit 1, instead of `Failed to attach: tmux attach-session failed with exit code: Some(1)`.
- "No session selected to attach" says which keys select one.

## Verification

`tripwire_notice_dismiss_and_expiry.rs` drives the real TUI in tmux: presses `a`, reads the wrapped remedy and the `Ctrl+X dismiss` hint off the box, presses the chord, watches it clear well inside the notice's own 30s lifetime, then raises a 4s warning and watches it retire itself, then reads both messages out of the JSONL. It runs on its OWN tmux server (`-L`) — the TUI lists every session it can see, so on a shared server the screen under test is whatever the machine happens to be running, and an attach driven by a test has no business reaching a real session. Sessions are killed by exact name.

Lifetimes are injectable via `[ui]`, so nothing sleeps for a minute; the shipped 60s default is pinned by its own unit test.

Every guard was falsified — reverted, watched red, restored:

| reverted | went red |
|---|---|
| default 60 → 5 | `an_error_notice_lives_for_one_minute_out_of_the_box` (`left: 5, right: 60`) |
| display width → char count | `an_emoji_counts_as_the_two_cells_it_paints` (`emoji row overflows the 20-cell box`) |
| queue cap | `a_stream_of_distinct_notices_is_capped` (`left: 36, right: 12`) |
| coalescing made unconditional | `an_announcement_is_not_folded_into_the_one_before_it` (`left: 1, right: 2`) |
| dismiss chord | unit test + tripwire (`Ctrl+X did not dismiss the notice`) |
| log write | tripwire (`"No workspace selected" missing from 8931 bytes of JSONL`) |
| attach detail | unit test + tripwire (`the attach failure never painted its remedy`) |
| `is_expired` → false | tripwire (`the warning never expired on its 4s clock`) |

`cargo nextest run -p ainb --lib --tests -E 'not binary(/^tripwire_/)'` — **5125 passed, 0 failed, 17 skipped**. Tripwire green in 10s. `cargo fmt --check` clean. All four intermediate commits compile, so the history bisects.