### PR TITLE
feat(fleet): reconcile a stale interview, and dial the copilot from the notch

### DIFF
--- a/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetDesktopController.swift
@@ -723,6 +723,29 @@ private struct FleetNotchDetail: View {
                     .font(.caption)
                     .help("Attach to this session in a terminal window")
             }
+            // No confirmation dialog, unlike Reject. This asks the daemon a
+            // QUESTION about the card in front of you; the only state it can
+            // change is clearing a card whose picker the daemon proves has
+            // already closed, which is the stale copy the button exists to get
+            // rid of. Guarding a read behind a dialog trains the dialog away.
+            //
+            // Shown only for a CLAUDE card, matching the terminal client, which
+            // decides whether the footer advertises `r Reconcile` at all rather
+            // than offering a dead key. `FleetInterviewDeck` gates on
+            // attention, capability, fingerprint and a parseable payload but
+            // NOT on provider, so without this a Codex interview would carry a
+            // permanently disabled button under a permanent "Claude-only"
+            // sentence, neither of which the operator can do anything about.
+            if store.offersReconcileControl(on: session) {
+                Button("Verify") {
+                    store.selectedSessionKey = session.sessionKey
+                    store.reconcileStructuredInterview(on: session)
+                }
+                .font(.caption)
+                .disabled(reconcileRefusal != nil || store.pendingIntentID != nil)
+                .help(reconcileRefusal ?? "Ask the daemon whether this interview is still live")
+                .accessibilityIdentifier("fleet.notch.interview.verify")
+            }
             if session.capabilities.structuredDismiss && !deck.mirroredPicker {
                 Button("Reject", role: .destructive) { rejectConfirmation = true }
                     .font(.caption)
@@ -739,6 +762,36 @@ private struct FleetNotchDetail: View {
                     .disabled(!complete(deck) || store.pendingIntentID != nil)
             }
         }
+
+        // The refusal READ OUT, not left in the tooltip. A disabled button
+        // swallows the click, so `help` is only reachable by hovering a
+        // control that looks broken, and the operator's question is why it is
+        // greyed out rather than what it would have done.
+        //
+        // Beside the button and under the same condition, so a card with no
+        // Verify control carries no sentence about one either. What is left is
+        // the set an operator can act on: a degraded session to repair, an
+        // interview that has moved on, a capability the daemon does not offer,
+        // and a request that has gone.
+        if store.offersReconcileControl(on: session), let reconcileRefusal {
+            Text("Verify unavailable: \(reconcileRefusal)")
+                .font(.caption2)
+                .foregroundStyle(FleetNotchPalette.muted)
+                .accessibilityIdentifier("fleet.notch.interview.verify.refusal")
+        }
+    }
+
+    /// Why Verify is greyed out, or `nil` when it is live.
+    ///
+    /// The store owns the rule; this only names it twice on screen, once as
+    /// the disabled state and once as the sentence under the row.
+    ///
+    /// It does NOT answer "an action is already running", which the store
+    /// deliberately leaves out of the refusal: the button disables on that
+    /// directly, the way Submit does, so a card busy with the operator's own
+    /// Submit does not sprout a sentence calling itself unavailable.
+    private var reconcileRefusal: String? {
+        store.reconcileBlockedReason(on: session)
     }
 
     /// Attach to a session in a real terminal window.

--- a/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
+++ b/apps/ainb-fleet-macos/Sources/App/FleetStore.swift
@@ -85,6 +85,17 @@ final class FleetStore: ObservableObject {
     @Published private(set) var quotaSummary: FleetQuotaSummaryResult?
     @Published private(set) var runtimeStatus: FleetRuntimeStatusResult?
     @Published private(set) var chat = FleetChatSurface()
+    /// The copilot's engine dial, held BESIDE `chat` rather than inside it.
+    ///
+    /// See `FleetCopilotDial`: nothing a chat page reads can rebuild this, so a
+    /// field on the surface would be wiped by the next safety-net page.
+    @Published private(set) var copilotDial = FleetCopilotDial()
+    /// Whether a `fleet/copilot_configure` is out.
+    ///
+    /// The engine dial's own mutual exclusion, published so the pickers grey
+    /// out while a swap is landing. Separate from `pendingIntentID` on purpose:
+    /// see `canConfigureCopilot`.
+    @Published private(set) var copilotConfigureInFlight = false
     @Published private(set) var pendingIntentID: String?
     @Published private(set) var controlNotice: String?
 
@@ -278,6 +289,36 @@ final class FleetStore: ObservableObject {
         connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.transcript.read") == true
     }
 
+    /// Whether this daemon will name the adapters it can spawn.
+    ///
+    /// `fleet.chat.read` is the id `handle_fleet_adapter_list` itself checks,
+    /// the same one the channel, confirm and activity reads use.
+    var canReadAdapters: Bool {
+        connectionState.isLive && negotiation?.capabilityIDs.contains("fleet.chat.read") == true
+    }
+
+    /// Whether this daemon will let this client move the copilot's dial.
+    ///
+    /// `fleet.copilot.configure` is the id `handle_fleet_copilot_configure`
+    /// checks, and it is gated SEPARATELY from `canReadAdapters` because the
+    /// daemon holds it behind a stronger capability on purpose: reading the
+    /// registry and reconfiguring the agent that holds destructive tools are
+    /// not the same permission. Assuming one id for both would either hide a
+    /// readable engine list or offer a picker that errors on the click.
+    ///
+    /// Held off by `copilotConfigureInFlight`, this surface's OWN busy flag,
+    /// not by `pendingIntentID`. That one is the notch's fleet-action gate, and
+    /// borrowing it here would couple two unrelated surfaces through a single
+    /// flag with nothing naming the coupling: an interview submit in the notch
+    /// would grey out the chat pane's engine picker, and a reader of either
+    /// would have no way to see why. The mutual exclusion each surface needs is
+    /// within itself, so each keeps its own.
+    var canConfigureCopilot: Bool {
+        canWrite
+            && negotiation?.capabilityIDs.contains("fleet.copilot.configure") == true
+            && !copilotConfigureInFlight
+    }
+
     #if DEBUG
     var debugConnectionTaskCount: Int {
         [connectionTask, reconnectTask].compactMap { $0 }.count
@@ -431,6 +472,98 @@ final class FleetStore: ObservableObject {
         )
     }
 
+    /// Why this session cannot be reconciled, or `nil` when it can.
+    ///
+    /// The FIVE row refusals are the terminal client's
+    /// `reconcile_blocked_reason` (`ainb-plugin-hangar/src/screen/fleet.rs`),
+    /// in its order and its wording, because the two surfaces must refuse the
+    /// same row for the same stated reason. An operator who is told "not
+    /// waiting on a structured question" in the pane and offered a live button
+    /// in the notch has no way to know which one is lying.
+    ///
+    /// The sixth is this client's own, and it comes LAST on purpose: the row
+    /// reasons are facts about the session that hold whatever this app's
+    /// connection is doing, so naming a transport problem ahead of them would
+    /// send the reader off to check the daemon for a card that was never
+    /// reconcilable.
+    ///
+    /// Single source of truth for the precondition, exactly as the terminal
+    /// client's is: `reconcileStructuredInterview` refuses when this returns
+    /// non-nil and the control is disabled when it does, so the button and the
+    /// intent cannot drift apart.
+    func reconcileBlockedReason(on session: FleetSession) -> String? {
+        if session.provider != .claude {
+            return "reconcile is a Claude-only action"
+        }
+        if session.management != .managed {
+            return "degraded session has no reconcile channel"
+        }
+        if session.attention != .ask {
+            return "session is not waiting on a structured question"
+        }
+        if !session.capabilities.structuredAnswer {
+            return "session lacks structured_answer capability"
+        }
+        // TRIMMED, where the terminal client asks only `is_none()`. Same
+        // refusal, one case wider: a fingerprint that is present but blank is
+        // not a request, and passing it on would ask the daemon's broker about
+        // the empty string. The wording is kept identical because it is the
+        // same fact, and the frame still carries the STORED value verbatim
+        // rather than a trimmed copy, since the daemon compares it to the row.
+        let fingerprint = session.currentRequestFingerprint?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if fingerprint.isEmpty {
+            return "no live structured request to reconcile"
+        }
+        if !canAddressSession(session) {
+            return "Fleet cannot send an action on this session right now"
+        }
+        return nil
+    }
+
+    func canReconcileStructuredInterview(on session: FleetSession) -> Bool {
+        reconcileBlockedReason(on: session) == nil
+    }
+
+    /// Whether the interview card puts a Verify control on screen at all.
+    ///
+    /// The terminal client's `reconcile_available` decides whether the footer
+    /// ADVERTISES `r Reconcile`, and this is the same decision: a card that can
+    /// never be reconciled shows nothing rather than a dead button under a
+    /// sentence the operator cannot act on.
+    ///
+    /// Only the provider, and that is the whole difference from
+    /// `reconcileBlockedReason`. The other refusals name states a session moves
+    /// through and can move out of, so a disabled control with the reason is
+    /// useful for those. Being a Codex session is not a state; it is what the
+    /// row IS, so for that one the honest answer is to offer nothing.
+    ///
+    /// The one place the view asks, so the control, its refusal sentence and
+    /// this test-visible answer cannot disagree about what is rendered.
+    func offersReconcileControl(on session: FleetSession) -> Bool {
+        session.provider == .claude
+    }
+
+    /// Ask the daemon whether this Claude interview is still live.
+    ///
+    /// Answers nothing and rejects nothing, so there is no confirmation step:
+    /// the worst outcome is a card the daemon proves is finished and therefore
+    /// clears, which is the state the operator was already looking at a stale
+    /// copy of.
+    func reconcileStructuredInterview(on session: FleetSession) {
+        if let reason = reconcileBlockedReason(on: session) {
+            controlNotice = reason
+            return
+        }
+        performStructured(
+            .reconcileStructured(requestFingerprint: session.currentRequestFingerprint ?? ""),
+            on: session,
+            allowed: true,
+            failurePrefix: "Interview check",
+            notice: Self.reconcileNotice
+        )
+    }
+
     func canDecideApproval(_ decision: FleetApprovalDecision, on session: FleetSession) -> Bool {
         guard session.attention == .approval,
               session.capabilities.approvals,
@@ -455,10 +588,36 @@ final class FleetStore: ObservableObject {
     }
 
     private func canPerformRequest(on session: FleetSession) -> Bool {
-        canWrite
+        canAddressSession(session)
             && pendingIntentID == nil
-            && negotiation?.capabilityIDs.contains("fleet.action.execute") == true
             && selectedSessionKey == session.sessionKey
+    }
+
+    /// Whether this client could address this session AT ALL, setting aside the
+    /// two things that change from one moment to the next.
+    ///
+    /// Neither the selection nor an action already in flight is asked about
+    /// here, and both omissions are deliberate.
+    ///
+    /// The SELECTION, because the controls on the notch detail card set it as
+    /// the first line of their own action: that card can be showing the route's
+    /// first session while `selectedSessionKey` is still nil, so a disabled
+    /// state that included it would grey out a button whose click would have
+    /// made itself valid.
+    ///
+    /// The IN-FLIGHT action, because this answers a question an operator reads
+    /// as a sentence, and "Fleet cannot send an action on this session right
+    /// now" is a poor account of a card that is busy doing what that same
+    /// operator just asked for. A control should not accuse itself of being
+    /// unavailable because it is working. Busy is a separate, transient
+    /// condition that the buttons disable on directly, the way Submit already
+    /// does.
+    ///
+    /// Both are still asked by `canPerformRequest`, which is what every send
+    /// goes through, so nothing here loosens what actually reaches the wire.
+    private func canAddressSession(_ session: FleetSession) -> Bool {
+        canWrite
+            && negotiation?.capabilityIDs.contains("fleet.action.execute") == true
             && !session.sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && session.version > 0
     }
@@ -467,7 +626,8 @@ final class FleetStore: ObservableObject {
         _ action: ControlAction,
         on session: FleetSession,
         allowed: Bool,
-        failurePrefix: String
+        failurePrefix: String,
+        notice: ((FleetActionReceipt) -> String)? = nil
     ) {
         guard canPerformRequest(on: session),
               allowed,
@@ -496,7 +656,8 @@ final class FleetStore: ObservableObject {
                     requestID: requestID,
                     action: action
                 ))
-                self.controlNotice = Self.controlNotice(for: result.receipt, failurePrefix: failurePrefix)
+                self.controlNotice = notice.map { $0(result.receipt) }
+                    ?? Self.controlNotice(for: result.receipt, failurePrefix: failurePrefix)
                 await self.refreshAuthoritativeState(using: connection)
             } catch {
                 self.controlNotice = "\(failurePrefix) refused: \(String(describing: error))"
@@ -615,6 +776,160 @@ final class FleetStore: ObservableObject {
             if chat != paged { chat = paged }
         } catch {
             controlNotice = "Chat refresh refused: \(String(describing: error))"
+        }
+    }
+
+    // MARK: - The copilot engine dial
+
+    /// Read the adapter registry, unless it has already answered.
+    ///
+    /// Called from the chat pane's bootstrap, which runs ONCE per appearance,
+    /// so this is not on the safety-net loop: the registry is host config and
+    /// does not move under a running daemon. A read that FAILED leaves
+    /// `adaptersListed` false, so the next time the pane opens it asks again,
+    /// and the header's own retry covers the case where the operator does not
+    /// want to close and reopen to get it.
+    func refreshAdaptersIfNeeded() {
+        guard !copilotDial.adaptersListed else { return }
+        refreshAdapters()
+    }
+
+    /// Re-read the adapter registry now.
+    ///
+    /// The two ways this cannot read are DIFFERENT absences and are handled
+    /// differently, which is the whole shape of the guard below.
+    ///
+    /// A connection that is not live yet says nothing about the registry, so
+    /// this says nothing either: it leaves the last known list on screen and
+    /// leaves `adaptersListed` false so the next attempt asks again. Clearing
+    /// here would undo what `beginConnection` deliberately preserves, and it is
+    /// reachable, because the chat pane's bootstrap sits above its own
+    /// `canReadChat` branch and therefore fires while the socket is down. An
+    /// operator who dropped a connection and switched back to Chat before it
+    /// came up would have watched the picker empty itself.
+    ///
+    /// A LIVE connection whose negotiation does not carry `fleet.chat.read` is
+    /// a fact about the daemon, and the only case in which this may say so.
+    /// Saying it while merely offline is a claim about a daemon nobody asked,
+    /// and it is usually false: the same daemon served the list a moment ago.
+    func refreshAdapters() {
+        guard connectionState.isLive, let connection else { return }
+        guard canReadAdapters else {
+            copilotDial.adapters = []
+            copilotDial.adaptersListed = false
+            copilotDial.detail = "This daemon does not serve the adapter registry."
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await connection.adapterList()
+                self.copilotDial.adapters = result.adapters
+                self.copilotDial.adaptersListed = true
+                self.copilotDial.detail = nil
+            } catch {
+                // The list is NOT cleared on a refusal. A registry that answered
+                // once is still the best account this client has of what the
+                // daemon can spawn, and blanking it would take the engine picker
+                // away over a transient error while leaving the dial's own
+                // settings on screen.
+                self.copilotDial.detail = "Adapter list refused: \(String(describing: error))"
+            }
+        }
+    }
+
+    /// Move the copilot's engine, guardrail dial or model.
+    ///
+    /// `provider` is required by the wire and this client cannot supply one it
+    /// was never told, which is why the header disables the mode and model
+    /// pickers until an engine has been chosen: naming the wrong adapter here
+    /// would not fail, it would SWAP to it.
+    ///
+    /// Nothing is adopted from a failed call, matching the daemon, which rolls
+    /// its own dial back for exactly this reason: a `yolo` that survived a
+    /// failed configure would be armed underneath a header still reading
+    /// `guarded`.
+    func configureCopilot(
+        provider: String,
+        mode: FleetCopilotMode? = nil,
+        model: String? = nil
+    ) {
+        let adapter = provider.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canConfigureCopilot, !adapter.isEmpty, let connection else {
+            copilotDial.detail = "Configuring the copilot is unavailable for this daemon."
+            return
+        }
+        // `.unknown` is the tolerant decode's fallback for a mode this build
+        // cannot name. Sending it back would be this client asking the daemon
+        // to set the literal string "unknown", which the daemon refuses, so the
+        // refusal is made here where it can be explained.
+        guard mode != .unknown else {
+            copilotDial.detail = "That guardrail mode is not one this build can set."
+            return
+        }
+        copilotConfigureInFlight = true
+        copilotDial.detail = nil
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.copilotConfigureInFlight = false }
+            let result: FleetCopilotConfigureResult
+            do {
+                result = try await connection.copilotConfigure(FleetCopilotConfigureParams(
+                    provider: adapter,
+                    copilotMode: mode,
+                    model: model,
+                    // Neither is settable from this surface. `reasoningEffort`
+                    // has no declared value set anywhere on the wire, so a
+                    // picker here would be free text, and `persona` is a system
+                    // prompt for an agent holding destructive tools which this
+                    // notch has no editor for. `nil` leaves each where it is,
+                    // so a dial turned here cannot silently clear either.
+                    reasoningEffort: nil,
+                    persona: nil
+                ))
+            } catch {
+                self.copilotDial.detail = "Copilot configure refused: \(String(describing: error))"
+                return
+            }
+            self.adopt(result)
+        }
+    }
+
+    /// Take on a landed configure, and deal with the session it may have
+    /// replaced.
+    ///
+    /// A swap RETIRES the copilot session and mints a new one on the same
+    /// channel scope, so this client's remembered session key is dead the
+    /// moment `sessionReplaced` is true. Both things standing on that key have
+    /// to go, and `forgetCopilotSession` is the one door to both: it bumps the
+    /// cache generation, which disowns any page already in flight, and drops
+    /// the mint so the next page asks the daemon for the live session.
+    ///
+    /// The carried transcript is the second, and it is handled by the mechanism
+    /// that already exists rather than a new one: `carryTranscriptForward`
+    /// carries rows only while the target session key is UNCHANGED, so the page
+    /// that mints the replacement drops them. That is the required behaviour,
+    /// not a happy accident, because the retired session's execution belongs to
+    /// a different adapter and painting it under the new one's name would
+    /// attribute one agent's work to another.
+    ///
+    /// The re-page is not optional. Forgetting alone leaves the old, dead
+    /// target on screen until the safety net fires half a minute later, and the
+    /// composer would aim every message in that window at a session nobody is
+    /// listening on.
+    private func adopt(_ result: FleetCopilotConfigureResult) {
+        copilotDial.engine = result.provider
+        copilotDial.mode = result.copilotMode
+        copilotDial.model = result.model
+        copilotDial.reasoningEffort = result.reasoningEffort
+        copilotDial.detail = result.sessionReplaced
+            ? "Engine set to \(result.provider). The copilot session was replaced."
+            : nil
+        guard result.sessionReplaced, let scope = chat.scopeKey, let connection else { return }
+        forgetCopilotSession(inScope: scope)
+        Task { [weak self] in
+            guard let self else { return }
+            self.publish(try? await self.pagedChat(using: connection))
         }
     }
 
@@ -1211,6 +1526,26 @@ final class FleetStore: ObservableObject {
         // page still in flight against the connection being replaced.
         copilotCacheGeneration &+= 1
         copilotSessionKeyByScope.removeAll()
+        // The dial goes back to "not told" for the SAME reason, and it is the
+        // reason this state is nil-until-told rather than defaulted. A daemon
+        // restart tears the copilot session down and resets `yolo` to
+        // `guarded`, so an engine and a mode remembered from the last
+        // connection describe a process that no longer exists. Carrying them
+        // across would put a header reading `yolo` over a channel that is now
+        // guarded, or an engine name over a session minted from config.
+        //
+        // The listed REGISTRY is kept on screen but marked unread, so the next
+        // pane bootstrap asks again without the picker going blank in the
+        // meantime. A reconnect can be to a different daemon home with a
+        // different `[acp.adapters]`, so treating the last one's answer as
+        // still current is the same class of stale claim as the settings above;
+        // showing the last known list while a fresh read is on its way is not,
+        // because nothing is asserted about it.
+        copilotDial.adaptersListed = false
+        copilotDial.engine = nil
+        copilotDial.mode = nil
+        copilotDial.model = nil
+        copilotDial.reasoningEffort = nil
         let generation = connectionGeneration
         let currentConnection = connection
         connection = nil
@@ -1561,6 +1896,50 @@ final class FleetStore: ObservableObject {
             return reason.isEmpty
                 ? "\(failurePrefix) \(outcome)."
                 : "\(failurePrefix) \(outcome): \(reason)"
+        }
+    }
+
+    /// What the operator is told after a reconcile, which is NOT what they are
+    /// told after any other action.
+    ///
+    /// `controlNotice(for:failurePrefix:)` renders `UNKNOWN` as "could not be
+    /// confirmed", grouped with `FAILED` and `REJECTED`, and for every other
+    /// action that is right: a decision the daemon could not confirm delivering
+    /// is a decision that may not have landed. Reconcile inverts it. The
+    /// daemon's own arm answers `UNKNOWN` for the case it has deliberately
+    /// decided in the operator's favour, keeping a card it cannot prove is
+    /// dead, and its detail says so ("Fleet card retained"). Rendering that
+    /// beside the two real failures would report the working outcome as a
+    /// broken one, and an operator reading "could not be confirmed" would go
+    /// looking for a fault that is not there.
+    ///
+    /// So the three the daemon can answer read as three different things:
+    /// `DELIVERED` is a settled question (either the interview is live or the
+    /// picker closed and the card was cleared), `UNKNOWN` is still open with
+    /// the card kept, and `FAILED` or `REJECTED` is the check itself not
+    /// running. The daemon's `detail` is carried verbatim in each, because it
+    /// is the only place the WHICH of those is written down.
+    ///
+    /// Exhaustive on purpose, like `ActionReceiptStatus.operatorToken`: a new
+    /// receipt state must be a compile error here, not silently the last arm.
+    nonisolated static func reconcileNotice(for receipt: FleetActionReceipt) -> String {
+        let reason = receipt.detail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        switch receipt.status {
+        case .delivered:
+            return reason.isEmpty
+                ? "Interview checked."
+                : "Interview checked: \(reason)"
+        case .unknown:
+            return reason.isEmpty
+                ? "Still checking. The Fleet card is kept."
+                : "Still checking: \(reason)"
+        case .pending:
+            return "Interview check accepted, awaiting delivery."
+        case .failed, .rejected:
+            let outcome = receipt.status.operatorToken
+            return reason.isEmpty
+                ? "Interview check \(outcome)."
+                : "Interview check \(outcome): \(reason)"
         }
     }
 

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPaneView.swift
@@ -59,6 +59,11 @@ struct FleetChatPaneView: View {
             // for nothing.
             store.chatPaneAppeared()
             defer { store.chatPaneDisappeared() }
+            // The registry, once. NOT in the loop below: the adapter list is
+            // the daemon's own config and does not move under a running
+            // daemon, so re-reading it every safety-net page would spend a
+            // round trip a minute to learn the same answer.
+            store.refreshAdaptersIfNeeded()
             while !Task.isCancelled {
                 await store.refreshChatOnce()
                 do {
@@ -74,26 +79,138 @@ struct FleetChatPaneView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
-            Text("Copilot chat")
-                .font(.title3.weight(.bold))
-            if let scope = store.chat.scopeKey {
-                Text(scope)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(FleetChatPalette.muted)
-                    .accessibilityIdentifier("fleet.chat.scope")
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Text("Copilot chat")
+                    .font(.title3.weight(.bold))
+                if let scope = store.chat.scopeKey {
+                    Text(scope)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(FleetChatPalette.muted)
+                        .accessibilityIdentifier("fleet.chat.scope")
+                }
+                Spacer(minLength: 0)
+                Button("Refresh") { store.refreshChat() }
+                    .disabled(!store.canReadChat)
+                    .accessibilityIdentifier("fleet.chat.refresh")
+                // Explicit, not Esc-only: the composer holds focus, and a surface
+                // whose only exit is a key the focused control might eat is a trap.
+                Button("Close", action: close)
+                    .accessibilityIdentifier("fleet.chat.close")
             }
-            Spacer(minLength: 0)
-            Button("Refresh") { store.refreshChat() }
-                .disabled(!store.canReadChat)
-                .accessibilityIdentifier("fleet.chat.refresh")
-            // Explicit, not Esc-only: the composer holds focus, and a surface
-            // whose only exit is a key the focused control might eat is a trap.
-            Button("Close", action: close)
-                .accessibilityIdentifier("fleet.chat.close")
+            engineDial
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 12)
+    }
+
+    /// The engine, guardrail and model the copilot is running under.
+    ///
+    /// Its own row under the title rather than more controls beside Refresh and
+    /// Close: these three describe the AGENT, while those two act on the pane,
+    /// and a swap here can replace the session the conversation is talking to.
+    ///
+    /// Every label reads what the store was TOLD, which is why the untouched
+    /// state of this row is three "not reported" values rather than a plausible
+    /// default. The daemon serves no read for the running adapter, so anything
+    /// else on this row before an operator has set one would be a guess.
+    @ViewBuilder private var engineDial: some View {
+        HStack(spacing: 8) {
+            Menu("Engine: \(FleetChatLabels.copilotEngine(store.copilotDial))") {
+                if store.copilotDial.adapters.isEmpty {
+                    Text(store.copilotDial.adaptersListed
+                         ? "No adapters in this daemon's registry"
+                         : "Reading the adapter registry")
+                }
+                ForEach(store.copilotDial.adapters) { adapter in
+                    Button(adapterLabel(adapter)) {
+                        store.configureCopilot(provider: adapter.name)
+                    }
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(!store.canConfigureCopilot || store.copilotDial.adapters.isEmpty)
+            .accessibilityIdentifier("fleet.chat.dial.engine")
+
+            // Both of these need an engine, and that is not a UI convenience.
+            // `provider` is required on every configure, so moving the mode
+            // with no engine known would mean naming one, and naming the wrong
+            // one does not fail, it SWAPS to it and retires the session.
+            Menu("Mode: \(FleetChatLabels.copilotMode(store.copilotDial))") {
+                ForEach([FleetCopilotMode.help, .guarded, .yolo], id: \.self) { mode in
+                    Button(mode.rawValue) {
+                        guard let engine = store.copilotDial.engine else { return }
+                        store.configureCopilot(provider: engine, mode: mode)
+                    }
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(!store.canConfigureCopilot || store.copilotDial.engine == nil)
+            .help(store.copilotDial.engine == nil
+                  ? "Pick an engine first: this daemon does not report the one in force"
+                  : "Move the copilot's guardrail dial")
+            .accessibilityIdentifier("fleet.chat.dial.mode")
+
+            Menu("Model: \(FleetChatLabels.copilotModel(store.copilotDial))") {
+                if store.copilotDial.models.isEmpty {
+                    Text("This adapter declares no models, so it runs its own default")
+                }
+                // Identified by POSITION, not by the string. These are operator
+                // -authored ids from `[acp.adapters.*].models`, so nothing stops
+                // the same one appearing twice, and two rows sharing an identity
+                // is undefined behaviour in SwiftUI rather than a cosmetic
+                // repeat. The engine picker above can key on the adapter name
+                // because that name is a registry KEY daemon-side and unique by
+                // construction; this list is a plain sequence and is not.
+                ForEach(Array(store.copilotDial.models.enumerated()), id: \.offset) { _, model in
+                    Button(model) {
+                        guard let engine = store.copilotDial.engine else { return }
+                        store.configureCopilot(provider: engine, model: model)
+                    }
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(!store.canConfigureCopilot
+                      || store.copilotDial.engine == nil
+                      || store.copilotDial.models.isEmpty)
+            .accessibilityIdentifier("fleet.chat.dial.model")
+
+            if let effort = store.copilotDial.reasoningEffort, !effort.isEmpty {
+                Text("Effort: \(effort)")
+                    .font(.caption)
+                    .foregroundStyle(FleetChatPalette.muted)
+                    .accessibilityIdentifier("fleet.chat.dial.effort")
+            }
+
+            Button("Retry") { store.refreshAdapters() }
+                .font(.caption)
+                .disabled(!store.canReadAdapters)
+                .accessibilityIdentifier("fleet.chat.dial.retry")
+
+            Spacer(minLength: 0)
+        }
+        .font(.caption)
+        // The last thing this row did, said out loud. A swap that replaced the
+        // session is the one an operator most needs to see, because the
+        // conversation below is now answered by a different process.
+        if let detail = store.copilotDial.detail {
+            Text(detail)
+                .font(.caption2)
+                .foregroundStyle(FleetChatPalette.muted)
+                .accessibilityIdentifier("fleet.chat.dial.detail")
+        }
+    }
+
+    /// An adapter's picker row: its name, and where it came from.
+    ///
+    /// The origin is shown because a name in `[acp.adapters]` and one from the
+    /// built-in floor behave identically here but are fixed in different
+    /// places when they are wrong.
+    private func adapterLabel(_ adapter: FleetAdapter) -> String {
+        adapter.builtIn ? adapter.name : "\(adapter.name) (config)"
     }
 
     private var unavailable: some View {

--- a/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetChat/FleetChatPresentation.swift
@@ -219,6 +219,41 @@ enum FleetChatLabels {
         }
     }
 
+    /// The engine the header shows, or the honest absence.
+    ///
+    /// "not reported" rather than a name, because the daemon serves no read for
+    /// the running adapter and a plausible-looking guess in this slot is worse
+    /// than a gap: an operator reading a wrong engine has no reason to look
+    /// again, while one reading "not reported" knows to pick.
+    static func copilotEngine(_ dial: FleetCopilotDial) -> String {
+        dial.engine ?? "not reported"
+    }
+
+    /// The guardrail dial the header shows.
+    ///
+    /// `.unknown` is the tolerant decode's fallback, so it means the daemon
+    /// named a mode this build cannot, which is a DIFFERENT fact from never
+    /// having been told and reads differently.
+    static func copilotMode(_ dial: FleetCopilotDial) -> String {
+        guard let mode = dial.mode else { return "not reported" }
+        switch mode {
+        case .help: return "help"
+        case .guarded: return "guarded"
+        case .yolo: return "yolo"
+        case .unknown: return "unrecognised mode"
+        }
+    }
+
+    /// The model the header shows.
+    ///
+    /// Three states, not two. No engine means nothing can be said about a
+    /// model; a known engine with no override is running the adapter's own
+    /// default, which is a fact rather than an absence.
+    static func copilotModel(_ dial: FleetCopilotDial) -> String {
+        if let model = dial.model, !model.isEmpty { return model }
+        return dial.engine == nil ? "not reported" : "adapter default"
+    }
+
     static func confirmState(_ state: FleetConfirmState) -> String {
         switch state {
         case .open: "OPEN"
@@ -334,6 +369,77 @@ enum FleetChatLabels {
             line += " · " + undelivered.map(receiptLine).joined(separator: " · ")
         }
         return line
+    }
+}
+
+/// The copilot's engine, guardrail dial and model: what is in force, what it
+/// can be moved to, and what the last move did.
+///
+/// DELIBERATELY NOT A FIELD ON `FleetChatSurface`, and that placement is the
+/// whole design rather than a filing choice. A page REBUILDS the surface from
+/// an empty one, and nothing a page reads can rebuild this: the registry comes
+/// from `fleet/adapter_list`, which no page calls, and the settings come from a
+/// `fleet/copilot_configure` result, which only an operator's own action
+/// produces. On the surface it would be wiped by the next safety-net page
+/// thirty seconds later, which is exactly the defect the transcript's carried
+/// state was introduced to fix. It lives beside the surface on the store, so it
+/// outlives every page and is untouched by one.
+///
+/// It is also a different LIFETIME. The surface belongs to one conversation;
+/// this belongs to the channel behind it, and survives the session swap that
+/// replaces the conversation's target outright.
+struct FleetCopilotDial: Equatable {
+    /// Every adapter the daemon named, in the order it named them.
+    var adapters: [FleetAdapter] = []
+    /// Whether `fleet/adapter_list` has answered on THIS connection.
+    ///
+    /// Distinguishes "the registry is empty" from "nobody has asked yet". They
+    /// render differently, because the first is a fact about the daemon's
+    /// config and the second is a pending read that would otherwise look like
+    /// that fact.
+    ///
+    /// Per connection, not per app run: a reconnect can be to a different
+    /// daemon home with a different `[acp.adapters]`. `beginConnection` clears
+    /// this while LEAVING `adapters` in place, so the next pane bootstrap
+    /// re-reads without the picker going blank while it does.
+    var adaptersListed: Bool = false
+    /// The adapter in force, or `nil` when this client HAS NOT BEEN TOLD.
+    ///
+    /// `nil` is the state a freshly opened pane is in and it stays that way
+    /// until an operator applies a configure, because the daemon serves no read
+    /// for it: `fleet/adapter_list` names what COULD be spawned, the copilot
+    /// channel's wire form carries no provider, and the roster files an ACP
+    /// session under the token `acp` rather than its concrete adapter.
+    ///
+    /// The terminal client's dial defaults this to the registry's first entry.
+    /// That is a GUESS, and on a machine whose copilot is running the second
+    /// adapter it is a wrong one displayed as a fact. This surface reports the
+    /// gap instead, because a header that says "not reported" sends an operator
+    /// to the right question and a header naming the wrong engine does not.
+    var engine: String? = nil
+    /// The guardrail dial in force, `nil` until told, for the same reason.
+    ///
+    /// NEVER `.guarded` as a stand-in. `guarded` is the daemon's default, so
+    /// showing it unasked would read as a fact about the running channel, and
+    /// the one value it would be wrong about is `yolo`.
+    var mode: FleetCopilotMode? = nil
+    /// The model override in force. `nil` means either untold or no override,
+    /// which is why the header words it against `engine` rather than alone.
+    var model: String? = nil
+    /// The reasoning-effort override in force, when the daemon reported one.
+    var reasoningEffort: String? = nil
+    /// Why the dial is empty or what the last call refused with. Kept verbatim:
+    /// the daemon's own wording names the adapter it did not know, or the
+    /// channel that has no live session, and nothing else says which.
+    var detail: String? = nil
+
+    /// The models the CURRENT engine declares, in picker order.
+    ///
+    /// Empty whenever the engine is unknown, which is not the same shape as an
+    /// engine that declares none, and the picker words the two differently.
+    var models: [String] {
+        guard let engine else { return [] }
+        return adapters.first(where: { $0.name == engine })?.models ?? []
     }
 }
 

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetConnection.swift
@@ -246,6 +246,34 @@ actor FleetConnection {
         return try await request("fleet/confirm_list", params: params, result: FleetConfirmListRawResult.self)
     }
 
+    /// Every adapter this daemon's registry can spawn.
+    ///
+    /// Gated by `fleet.chat.read`, which is what `handle_fleet_adapter_list`
+    /// checks. Its NEIGHBOUR on this surface, `copilotConfigure`, checks a
+    /// different and stronger id, so the two are gated SEPARATELY: a daemon can
+    /// serve the registry to a caller it will not let reconfigure the copilot,
+    /// and one combined gate would either hide the engine list or offer a
+    /// picker whose every choice answers -32601.
+    func adapterList() async throws -> FleetAdapterListResult {
+        try requireReadCapability("fleet.chat.read")
+        return try await request("fleet/adapter_list", params: FleetAdapterListParams(), result: FleetAdapterListResult.self)
+    }
+
+    /// Set the copilot session's adapter, guardrail dial and model.
+    ///
+    /// Gated by `fleet.copilot.configure`, its OWN id and not the
+    /// `fleet.chat.write` its channel neighbour uses: the daemon holds this
+    /// behind a stronger capability because the persona it can carry is a
+    /// system prompt for an agent holding destructive tools.
+    ///
+    /// A result whose `sessionReplaced` is true means the caller's previous
+    /// copilot session key is DEAD: a provider swap retires the old session and
+    /// mints a new one on the same channel scope.
+    func copilotConfigure(_ params: FleetCopilotConfigureParams) async throws -> FleetCopilotConfigureResult {
+        try requireWriteCapability("fleet.copilot.configure")
+        return try await request("fleet/copilot_configure", params: params, result: FleetCopilotConfigureResult.self)
+    }
+
     func confirmAnswer(_ params: FleetConfirmAnswerParams) async throws -> FleetConfirmAnswerResult {
         try requireWriteCapability("fleet.confirm.answer")
         return try await request("fleet/confirm_answer", params: params, result: FleetConfirmAnswerResult.self)
@@ -329,6 +357,25 @@ actor FleetConnection {
         }
         try Self.writeAll(frame, to: descriptor)
     }
+
+    #if DEBUG
+    /// One request with a caller-supplied params type, for the contract suite's
+    /// NEGATIVE tests.
+    ///
+    /// The proofs it exists for are ones this client's own types cannot express
+    /// by design: `FleetCopilotConfigureParams` deliberately has no
+    /// permission-mode field, because a settable one would be a remote
+    /// off-switch for the guardrails, and the test that the daemon's door is
+    /// shut has to knock on it. Debug-only and unused by the app, so the shape
+    /// the shipped client can build is still exactly the shape its types allow.
+    func requestForTesting<Params: Encodable, Result: Decodable>(
+        _ method: String,
+        params: Params,
+        result: Result.Type
+    ) async throws -> Result {
+        try await request(method, params: params, result: result)
+    }
+    #endif
 
     private func request<Params: Encodable, Result: Decodable>(
         _ method: String,

--- a/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
+++ b/apps/ainb-fleet-macos/Sources/FleetRPC/FleetWire.swift
@@ -420,6 +420,19 @@ enum ControlAction: Codable, Equatable {
     case structuredAnswer(requestFingerprint: String, requestIdentity: FleetRequestIdentity?, answers: [FleetQuestionAnswer])
     case dismissStructured(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case releaseStructured(requestFingerprint: String)
+    /// Ask the daemon whether this Claude interview is still live.
+    ///
+    /// A VERIFICATION, not a decision: it answers nothing and rejects nothing.
+    /// The daemon asks the notifyd broker whether the request is still waiting
+    /// and, for a native or mirrored picker only, whether that picker has
+    /// closed. A card it cannot prove either way is KEPT, which is why an
+    /// `UNKNOWN` receipt from this action is a normal outcome rather than a
+    /// failure. See `FleetStore.reconcileNotice`.
+    ///
+    /// Gated by `structured_answer`, the SAME capability the answer and the
+    /// release use, not one of its own: `action_capability` in the daemon's
+    /// `rpc/mod.rs` groups the three together.
+    case reconcileStructured(requestFingerprint: String)
     case approve(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case approveForSession(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
     case deny(requestFingerprint: String, requestIdentity: FleetRequestIdentity?)
@@ -430,7 +443,7 @@ enum ControlAction: Codable, Equatable {
     case restart, stop, kill, archive
 
     private enum CodingKeys: String, CodingKey { case action, requestFingerprint = "request_fingerprint", requestIdentity = "request_identity", answers, key, text, provider, cwd, prompt }
-    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", dismissStructured = "dismiss_structured", releaseStructured = "release_structured", approve, approveForSession = "approve_for_session", deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
+    private enum Tag: String, Codable { case structuredAnswer = "structured_answer", dismissStructured = "dismiss_structured", releaseStructured = "release_structured", reconcileStructured = "reconcile_structured", approve, approveForSession = "approve_for_session", deny, verifiedPicker = "verified_picker", sendPrompt = "send_prompt", `continue`, retry, interrupt, start, restart, stop, kill, archive }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -438,6 +451,7 @@ enum ControlAction: Codable, Equatable {
         case .structuredAnswer: self = .structuredAnswer(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity), answers: try c.decode([FleetQuestionAnswer].self, forKey: .answers))
         case .dismissStructured: self = .dismissStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .releaseStructured: self = .releaseStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint))
+        case .reconcileStructured: self = .reconcileStructured(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint))
         case .approve: self = .approve(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .approveForSession: self = .approveForSession(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
         case .deny: self = .deny(requestFingerprint: try c.decode(String.self, forKey: .requestFingerprint), requestIdentity: try c.decodeIfPresent(FleetRequestIdentity.self, forKey: .requestIdentity))
@@ -463,6 +477,8 @@ enum ControlAction: Codable, Equatable {
             try c.encode(Tag.dismissStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
         case let .releaseStructured(fingerprint):
             try c.encode(Tag.releaseStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint)
+        case let .reconcileStructured(fingerprint):
+            try c.encode(Tag.reconcileStructured, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint)
         case let .approve(fingerprint, identity):
             try c.encode(Tag.approve, forKey: .action); try c.encode(fingerprint, forKey: .requestFingerprint); try c.encodeIfPresent(identity, forKey: .requestIdentity)
         case let .approveForSession(fingerprint, identity):
@@ -1096,6 +1112,66 @@ struct FleetChannelListParams: Codable, Equatable { init() {} }
 
 struct FleetChannelListResult: Codable, Equatable {
     let channels: [FleetChannel]
+}
+
+/// One ACP adapter the daemon's registry can spawn.
+///
+/// The registry is `[acp.adapters.*]` in the host config plus the built-in
+/// floor, so it grows by editing config rather than by shipping a build. That
+/// is why `name` is a STRING everywhere it appears on the copilot wire and why
+/// the engine picker reads this list instead of a set compiled in here: an
+/// adapter an operator installed is selectable without a new client.
+struct FleetAdapter: Codable, Equatable, Identifiable {
+    /// The registry key, and the token `provider` carries on a configure.
+    let name: String
+    /// The program the daemon spawns, as configured.
+    let command: String
+    /// The mode pinned at `session/new`. Reported so an operator can SEE it; it
+    /// is not settable over this wire, deliberately.
+    let permissionMode: String
+    /// Whether this came from the built-in floor rather than config.
+    let builtIn: Bool
+    /// The model ids an operator declared, in picker order.
+    ///
+    /// EMPTY IS THE ANSWER, not a missing one: ACP has no model-discovery call,
+    /// so an empty list means the adapter runs its own default and the picker
+    /// must say that rather than offering a guess.
+    let models: [String]
+
+    var id: String { name }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, command, models
+        case permissionMode = "permission_mode"
+        case builtIn = "built_in"
+    }
+
+    init(name: String, command: String, permissionMode: String, builtIn: Bool, models: [String]) {
+        self.name = name
+        self.command = command
+        self.permissionMode = permissionMode
+        self.builtIn = builtIn
+        self.models = models
+    }
+
+    /// Hand-written because `models` is `#[serde(default)]` on the Rust side.
+    /// The synthesized decoder would reject a daemon that omitted the key, and
+    /// an adapter with no declared models is the ordinary case rather than an
+    /// error.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        command = try container.decode(String.self, forKey: .command)
+        permissionMode = try container.decode(String.self, forKey: .permissionMode)
+        builtIn = try container.decode(Bool.self, forKey: .builtIn)
+        models = try container.decodeIfPresent([String].self, forKey: .models) ?? []
+    }
+}
+
+struct FleetAdapterListParams: Codable, Equatable { init() {} }
+
+struct FleetAdapterListResult: Codable, Equatable {
+    let adapters: [FleetAdapter]
 }
 
 /// Params for `fleet/copilot_configure`.

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetChatPresentationTests.swift
@@ -348,6 +348,86 @@ final class FleetChatPresentationTests: XCTestCase {
         XCTAssertEqual(copilotDefaultProvider, "claude-agent-acp")
     }
 
+    // MARK: - The copilot engine dial
+
+    /// An adapter that declares no models decodes, and declares none.
+    ///
+    /// `models` is `#[serde(default)]` on the Rust side, so a daemon simply
+    /// omits the key for the ordinary adapter: ACP has no model-discovery call.
+    /// The synthesized Swift decoder would have thrown on that, and the result
+    /// decodes as an ARRAY, so one such adapter would have emptied the whole
+    /// engine picker rather than losing a field.
+    func testAnAdapterWithNoDeclaredModelsDecodesWithAnEmptyList() throws {
+        let frame = Data(#"""
+        {"adapters":[
+          {"name":"claude-agent-acp","command":"/bin/claude","permission_mode":"default","built_in":true},
+          {"name":"house","command":"/bin/house","permission_mode":"acceptEdits","built_in":false,"models":["fast"]}
+        ]}
+        """#.utf8)
+        let result = try JSONDecoder().decode(FleetAdapterListResult.self, from: frame)
+
+        XCTAssertEqual(result.adapters.map(\.name), ["claude-agent-acp", "house"])
+        XCTAssertEqual(result.adapters[0].models, [], "an omitted models key is an adapter with none, not a decode failure")
+        XCTAssertTrue(result.adapters[0].builtIn)
+        XCTAssertEqual(result.adapters[1].models, ["fast"])
+        XCTAssertEqual(result.adapters[1].permissionMode, "acceptEdits")
+        XCTAssertFalse(result.adapters[1].builtIn)
+    }
+
+    /// The header words an unread dial as UNREAD, never as a default.
+    ///
+    /// The daemon serves no read for the running adapter or the channel's
+    /// guardrail, so every one of these slots starts as a gap. Filling one with
+    /// the registry's first entry or with `guarded` would print a guess in the
+    /// place an operator checks before turning `yolo` on.
+    func testAnUntoldDialReadsAsNotReportedRatherThanADefault() {
+        var dial = FleetCopilotDial()
+        dial.adapters = [
+            FleetAdapter(name: "claude-agent-acp", command: "/bin/claude", permissionMode: "default", builtIn: true, models: ["opus"]),
+        ]
+        dial.adaptersListed = true
+
+        XCTAssertEqual(FleetChatLabels.copilotEngine(dial), "not reported")
+        XCTAssertEqual(FleetChatLabels.copilotMode(dial), "not reported")
+        XCTAssertEqual(FleetChatLabels.copilotModel(dial), "not reported")
+        XCTAssertEqual(dial.models, [], "no engine means no adapter whose models these are")
+    }
+
+    /// Once told, each slot reads what it was told, and a known engine with no
+    /// model override reads as the adapter's own default rather than a gap.
+    func testAToldDialReadsTheSettingsAndNamesTheAdapterDefault() {
+        var dial = FleetCopilotDial()
+        dial.adapters = [
+            FleetAdapter(name: "claude-agent-acp", command: "/bin/claude", permissionMode: "default", builtIn: true, models: ["opus", "sonnet"]),
+        ]
+        dial.engine = "claude-agent-acp"
+        dial.mode = .yolo
+
+        XCTAssertEqual(FleetChatLabels.copilotEngine(dial), "claude-agent-acp")
+        XCTAssertEqual(FleetChatLabels.copilotMode(dial), "yolo")
+        XCTAssertEqual(FleetChatLabels.copilotModel(dial), "adapter default")
+        XCTAssertEqual(dial.models, ["opus", "sonnet"])
+
+        dial.model = "sonnet"
+        XCTAssertEqual(FleetChatLabels.copilotModel(dial), "sonnet")
+    }
+
+    /// A guardrail value this build cannot name is a DIFFERENT fact from never
+    /// having been told, and reads differently.
+    ///
+    /// `.unknown` is the tolerant decode's fallback, so it means a newer daemon
+    /// named a mode this client does not have. Rendering that as "not reported"
+    /// would hide a real answer, and rendering it as one of the three would
+    /// claim a guardrail nobody set.
+    func testAnUnrecognisedGuardrailIsNotTheSameAsAnUnreadOne() {
+        var dial = FleetCopilotDial()
+        dial.mode = .unknown
+        XCTAssertEqual(FleetChatLabels.copilotMode(dial), "unrecognised mode")
+
+        dial.mode = nil
+        XCTAssertEqual(FleetChatLabels.copilotMode(dial), "not reported")
+    }
+
     // MARK: - Copilot mint ladder
 
     /// The refusals a REAL daemon sends, verbatim.

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetConnectionTests.swift
@@ -284,6 +284,45 @@ final class FleetConnectionTests: XCTestCase {
         XCTAssertEqual(try JSONDecoder().decode(ControlAction.self, from: bypassData), bypass)
     }
 
+    /// The reconcile frame this client sends, key by key.
+    ///
+    /// The tag is what the daemon dispatches on and what a durable receipt
+    /// records as `action_kind`, so a misspelling here is an action the daemon
+    /// answers `-32602` for and a receipt nobody can search. The fingerprint is
+    /// the staleness check: without it the daemon would reconcile whatever
+    /// question the session happens to be on now.
+    ///
+    /// The frame carries NO `request_identity`, because the Rust variant has no
+    /// such field: reconcile asks the broker about a fingerprint, it does not
+    /// route an answer into a provider request.
+    func testReconcileStructuredEncodesTheDaemonsTagAndOnlyItsFingerprint() throws {
+        let action = ControlAction.reconcileStructured(requestFingerprint: "sha256:interview")
+        let data = try JSONEncoder().encode(action)
+        let encoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        XCTAssertEqual(encoded?["action"] as? String, "reconcile_structured")
+        XCTAssertEqual(encoded?["request_fingerprint"] as? String, "sha256:interview")
+        XCTAssertNil(
+            encoded?["request_identity"],
+            "the Rust variant has no identity field, so sending one asks the daemon to parse a key it does not know"
+        )
+        XCTAssertEqual(
+            Set((encoded ?? [:]).keys), ["action", "request_fingerprint"],
+            "the frame must carry exactly the two fields the variant declares"
+        )
+        XCTAssertEqual(try JSONDecoder().decode(ControlAction.self, from: data), action)
+    }
+
+    /// A daemon-shaped frame decodes back into the case, so the enum stays
+    /// exhaustive in BOTH directions.
+    func testReconcileStructuredDecodesADaemonFramedAction() throws {
+        let frame = Data(#"{"action":"reconcile_structured","request_fingerprint":"sha256:x"}"#.utf8)
+        XCTAssertEqual(
+            try JSONDecoder().decode(ControlAction.self, from: frame),
+            .reconcileStructured(requestFingerprint: "sha256:x")
+        )
+    }
+
     func testUnavailablePromptNeverWritesActionWire() async throws {
         var descriptors = [Int32](repeating: 0, count: 2)
         XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
@@ -1660,6 +1699,357 @@ final class FleetConnectionTests: XCTestCase {
         }
     }
 
+    // MARK: - The copilot engine dial (PR E)
+
+    /// The registry read that fills the engine picker, and the ONE thing this
+    /// client refuses to guess.
+    ///
+    /// `fleet/adapter_list` names what the daemon COULD spawn. Nothing on the
+    /// wire names what it IS running: the copilot channel carries no provider
+    /// and the roster files an ACP session under the token `acp`. So a list
+    /// that has answered must leave `engine` nil, and the header must say "not
+    /// reported" rather than the first adapter's name, which is what the
+    /// terminal client's dial shows and is a guess.
+    func testTheAdapterListFillsThePickerWithoutClaimingWhichEngineIsRunning() async throws {
+        let counts = ChatServerCounts(adapters: [
+            Self.adapterObject(name: "claude-agent-acp", models: ["opus", "sonnet"]),
+            Self.adapterObject(name: "house-adapter", builtIn: false),
+        ])
+        try await withChatStore(serveCopilotDial: true, counts: counts) { store, _ in
+            await MainActor.run { store.refreshAdaptersIfNeeded() }
+            let listed = await Self.waitUntil {
+                await MainActor.run { store.copilotDial.adaptersListed }
+            }
+            XCTAssertTrue(listed, "the registry read never answered")
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.copilotDial.adapters.map(\.name),
+                    ["claude-agent-acp", "house-adapter"],
+                    "the picker must offer the daemon's live registry, in its order"
+                )
+                XCTAssertNil(
+                    store.copilotDial.engine,
+                    "the registry says what CAN be spawned; defaulting to its first entry states a fact nobody sent"
+                )
+                XCTAssertEqual(FleetChatLabels.copilotEngine(store.copilotDial), "not reported")
+                XCTAssertEqual(
+                    store.copilotDial.models, [],
+                    "with no engine known there is no adapter whose models these would be"
+                )
+            }
+        }
+    }
+
+    /// A refresh with the socket down keeps the registry on screen and blames
+    /// no daemon for it.
+    ///
+    /// Two absences that had been collapsed into one guard. "Not connected yet"
+    /// says nothing about what the daemon serves, so this must say nothing
+    /// either; only a LIVE negotiation missing `fleet.chat.read` is grounds for
+    /// the "does not serve" sentence. Collapsed, the offline path emptied the
+    /// picker and told the operator the daemon serves no registry, about a
+    /// daemon that had answered with one seconds earlier.
+    ///
+    /// It is reached in the app because the chat pane's bootstrap sits on the
+    /// outer stack, above its own `canReadChat` branch, so it runs while the
+    /// socket is down; a reconnect marks the registry unread, and switching
+    /// back to Chat before the socket comes up calls straight into this.
+    func testAnOfflineRefreshKeepsTheRegistryAndBlamesNoDaemon() async throws {
+        let counts = ChatServerCounts(adapters: [Self.adapterObject(name: "claude-agent-acp")])
+        try await withChatStore(serveCopilotDial: true, counts: counts) { store, server in
+            await MainActor.run { store.refreshAdaptersIfNeeded() }
+            let listed = await Self.waitUntil {
+                await MainActor.run { store.copilotDial.adaptersListed }
+            }
+            XCTAssertTrue(listed, "the registry read never answered, so there is nothing to preserve")
+
+            Darwin.shutdown(server, SHUT_RDWR)
+            let offline = await Self.waitUntil {
+                await MainActor.run { !store.connectionState.isLive }
+            }
+            XCTAssertTrue(offline, "the connection never dropped")
+
+            await MainActor.run {
+                store.refreshAdapters()
+                XCTAssertEqual(
+                    store.copilotDial.adapters.map(\.name), ["claude-agent-acp"],
+                    "an offline refresh emptied the engine picker the last live one had filled"
+                )
+                XCTAssertNotEqual(
+                    store.copilotDial.detail,
+                    "This daemon does not serve the adapter registry.",
+                    "a dropped socket is not a daemon that serves no registry, and it served one a moment ago"
+                )
+            }
+        }
+    }
+
+    /// A LIVE daemon that does not advertise `fleet.chat.read` is the one case
+    /// that MAY clear the registry and say so.
+    ///
+    /// The other half of the split above. Without this, an over-corrected guard
+    /// that never cleared would leave a stale picker up against a daemon that
+    /// genuinely cannot serve it.
+    func testALiveDaemonWithoutTheChatCapabilityClearsTheRegistryAndSaysSo() async throws {
+        var descriptors = [Int32](repeating: 0, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors), 0)
+        let serverDescriptor = descriptors[1]
+        defer { Darwin.close(serverDescriptor) }
+        let location = try Self.testLocation()
+        defer { try? FileManager.default.removeItem(at: location.home) }
+        let serverDone = expectation(description: "capability-free server finished")
+        let serverResult = SocketServerResult()
+
+        DispatchQueue.global().async {
+            defer { serverDone.fulfill() }
+            do {
+                // A live, writable connection whose catalogue names only the
+                // action capability: no `fleet.chat.read` anywhere.
+                try Self.serveStoreBootstrap(
+                    descriptor: serverDescriptor,
+                    subscriptionSnapshot: try Self.snapshotObject(head: 1, sessions: []),
+                    eventBeforeSubscriptionResponse: false,
+                    snapshotAfterEvent: try Self.snapshotObject(head: 1, sessions: []),
+                    capabilityIDs: ["fleet.action.execute"]
+                )
+                while true {
+                    _ = try Self.readRequest(from: serverDescriptor)
+                }
+            } catch StoreServerError.closed {
+                // The client hung up at the end of the test. Not a failure.
+            } catch {
+                serverResult.record(error)
+            }
+        }
+
+        let store = await MainActor.run {
+            FleetStore(
+                location: location,
+                makeConnection: { _ in FleetConnection(location: location, injectedDescriptor: descriptors[0]) },
+                reconnectDelayNanoseconds: { _ in 10_000_000_000 }
+            )
+        }
+        await MainActor.run { store.start() }
+        let live = await Self.waitUntil {
+            await MainActor.run { store.connectionState.isLive }
+        }
+        XCTAssertTrue(live, "the fixture never reached a live connection")
+
+        await MainActor.run {
+            XCTAssertFalse(store.canReadAdapters, "the catalogue has no fleet.chat.read, so the registry is unreadable")
+            store.refreshAdapters()
+            XCTAssertEqual(
+                store.copilotDial.adapters, [],
+                "a daemon that cannot serve the registry must not leave one on screen"
+            )
+            XCTAssertFalse(store.copilotDial.adaptersListed)
+            XCTAssertEqual(store.copilotDial.detail, "This daemon does not serve the adapter registry.")
+            store.stop()
+        }
+        await fulfillment(of: [serverDone], timeout: 5)
+        try serverResult.throwIfRecorded()
+    }
+
+    /// The swap, and the two pieces of client state it must take with it.
+    ///
+    /// `session_replaced` says the daemon retired the copilot session and
+    /// minted a new one on the same channel scope, so this client is holding a
+    /// dead key in TWO places. The mint cache would send the operator's next
+    /// message to a session nobody is listening on. The carried transcript
+    /// would paint the RETIRED adapter's execution under the new one's name.
+    ///
+    /// The transcript half is falsified rather than assumed: the fixture's
+    /// chunks are emptied before the swap, so a row still on screen afterwards
+    /// can only have been carried across the boundary.
+    func testASwapThatReplacesTheSessionRetargetsThePaneAndDropsTheOldTranscript() async throws {
+        let counts = ChatServerCounts(
+            transcriptHeadOrder: 5,
+            transcriptChunks: [Self.transcriptChunkObject(order: 5, text: "the retired adapter's work")],
+            adapters: [
+                Self.adapterObject(name: "claude-agent-acp"),
+                Self.adapterObject(name: "house-adapter", builtIn: false),
+            ]
+        )
+        try await withChatStore(serveCopilotDial: true, counts: counts) { store, _ in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+            await MainActor.run {
+                XCTAssertEqual(store.chat.targetSessionKey, "acp:1")
+                XCTAssertEqual(
+                    store.chat.transcriptState.rows.map(\.body),
+                    ["the retired adapter's work"],
+                    "the swap needs a transcript on screen to be able to drop one"
+                )
+            }
+            XCTAssertEqual(counts.acpCreates, 1)
+
+            // What the daemon does on a provider swap: a new session key on the
+            // same scope, and a transcript that no longer holds the old rows.
+            counts.acpSessionKey = "acp:2"
+            counts.transcriptChunks = []
+            counts.copilotConfigureResult = [
+                "session_key": "acp:2",
+                "provider": "house-adapter",
+                "copilot_mode": "guarded",
+                "session_replaced": true,
+                "persona_set": false,
+            ]
+
+            await MainActor.run { store.configureCopilot(provider: "house-adapter") }
+            let retargeted = await Self.waitUntil {
+                await MainActor.run { store.chat.targetSessionKey == "acp:2" }
+            }
+            XCTAssertTrue(
+                retargeted,
+                "the pane kept aiming at the retired session, so the next message goes nowhere"
+            )
+
+            await MainActor.run {
+                XCTAssertEqual(store.copilotDial.engine, "house-adapter")
+                XCTAssertEqual(store.copilotDial.mode, .guarded)
+                // The replacement is asserted through what the OPERATOR is
+                // shown, which is the only place this client reports it. There
+                // is no separate flag to check, deliberately: nothing on screen
+                // read one, so a field carrying it would have been state kept
+                // alive by its own test.
+                XCTAssertEqual(
+                    store.copilotDial.detail,
+                    "Engine set to house-adapter. The copilot session was replaced.",
+                    "a swap that retired the conversation's session must say so on screen"
+                )
+                XCTAssertEqual(
+                    store.chat.transcriptState.rows, [],
+                    "the retired adapter's transcript was carried onto the new session's pane"
+                )
+            }
+            XCTAssertEqual(
+                counts.acpCreates, 2,
+                "the mint cache still held the retired key, so no page asked the daemon for the live one"
+            )
+            let configures = counts.copilotConfigures
+            XCTAssertEqual(configures.count, 1)
+            let params = configures[0]["params"] as? [String: Any]
+            XCTAssertEqual(params?["provider"] as? String, "house-adapter")
+            XCTAssertNil(
+                params?["copilot_mode"],
+                "an engine pick must not also move the guardrail dial"
+            )
+            XCTAssertNil(params?["persona"], "this surface has no persona editor and must send none")
+        }
+    }
+
+    /// A refused configure changes NOTHING this client displays.
+    ///
+    /// The daemon rolls its own dial back on a failure for a stated reason: the
+    /// client adopts a mode only from a successful configure, so a `yolo` that
+    /// survived a failure would be armed underneath a header still reading
+    /// `guarded`. That contract only holds if this side keeps its half.
+    func testARefusedConfigureLeavesTheDialOnTheLastSettingsThatLanded() async throws {
+        let counts = ChatServerCounts(
+            adapters: [
+                Self.adapterObject(name: "claude-agent-acp"),
+                Self.adapterObject(name: "house-adapter", builtIn: false),
+            ],
+            copilotConfigureResult: [
+                "session_key": "acp:1",
+                "provider": "claude-agent-acp",
+                "copilot_mode": "help",
+                "session_replaced": false,
+                "model": "opus",
+                "persona_set": false,
+            ]
+        )
+        try await withChatStore(serveCopilotDial: true, counts: counts) { store, _ in
+            await MainActor.run { store.chatPaneAppeared() }
+            await store.refreshChatOnce()
+
+            // A configure that LANDS, so the dial holds something a failure
+            // could plausibly move. Without this the assertions below cannot
+            // tell "does not adopt on failure" from "resets on failure", and
+            // both would pass against an untouched dial.
+            await MainActor.run { store.configureCopilot(provider: "claude-agent-acp", mode: .help) }
+            let landed = await Self.waitUntil {
+                await MainActor.run { store.copilotDial.engine == "claude-agent-acp" }
+            }
+            XCTAssertTrue(landed, "the first configure never landed, so there is no state to preserve")
+            await MainActor.run {
+                XCTAssertEqual(store.copilotDial.mode, .help)
+                XCTAssertEqual(store.copilotDial.model, "opus")
+            }
+
+            // Now one that fails, asking for a different engine and the
+            // loosest guardrail: the two values a rollback bug would leak.
+            counts.copilotConfigureResult = nil
+            await MainActor.run { store.configureCopilot(provider: "house-adapter", mode: .yolo) }
+            let refused = await Self.waitUntil {
+                await MainActor.run { store.copilotDial.detail?.hasPrefix("Copilot configure refused") == true }
+            }
+            XCTAssertTrue(refused, "a refused configure must say so")
+
+            await MainActor.run {
+                XCTAssertEqual(
+                    store.copilotDial.engine, "claude-agent-acp",
+                    "a failed swap must neither name the engine it asked for nor forget the one in force"
+                )
+                XCTAssertEqual(
+                    store.copilotDial.mode, .help,
+                    "adopting the requested mode from a failure arms a guardrail the daemon rolled back"
+                )
+                XCTAssertEqual(store.copilotDial.model, "opus", "a failed configure must not clear the model in force")
+                XCTAssertEqual(store.chat.targetSessionKey, "acp:1", "nothing was replaced, so nothing is retargeted")
+            }
+            XCTAssertEqual(counts.acpCreates, 1, "a failed configure must not spend a re-mint")
+        }
+    }
+
+    /// A daemon that serves the chat but not `fleet.copilot.configure` gets a
+    /// dark dial rather than a picker whose every choice answers -32601.
+    ///
+    /// The two ids are checked by different daemon arms, so the registry can be
+    /// readable while the write is not, and this asserts the client splits them
+    /// the same way.
+    func testTheDialIsGatedOnTheCapabilityItsOwnDaemonArmChecks() async throws {
+        let counts = ChatServerCounts(adapters: [Self.adapterObject(name: "claude-agent-acp")])
+        try await withChatStore(serveCopilotDial: false, counts: counts) { store, _ in
+            await MainActor.run {
+                XCTAssertTrue(store.canReadAdapters, "fleet.chat.read is served, so the registry is readable")
+                XCTAssertFalse(
+                    store.canConfigureCopilot,
+                    "fleet.copilot.configure is absent, so the picker must not be offered"
+                )
+                store.configureCopilot(provider: "claude-agent-acp")
+                XCTAssertEqual(
+                    store.copilotDial.detail,
+                    "Configuring the copilot is unavailable for this daemon."
+                )
+            }
+            XCTAssertTrue(counts.copilotConfigures.isEmpty, "a gated-out dial must not reach the wire")
+        }
+    }
+
+    /// One `FleetAdapter` in the shape the daemon frames it.
+    ///
+    /// `models` is omitted when empty, which is the ordinary shape: the Rust
+    /// field is `#[serde(default)]` and ACP has no model-discovery call, so an
+    /// adapter that declares none simply has no key here.
+    private static func adapterObject(
+        name: String,
+        builtIn: Bool = true,
+        models: [String] = []
+    ) -> [String: Any] {
+        var object: [String: Any] = [
+            "name": name,
+            "command": "/usr/local/bin/\(name)",
+            "permission_mode": "default",
+            "built_in": builtIn,
+        ]
+        if !models.isEmpty {
+            object["models"] = models
+        }
+        return object
+    }
+
     /// Bring a store up against TWO scripted chat connections, so a test can
     /// drop the first and watch what the second asks for.
     ///
@@ -1800,6 +2190,7 @@ final class FleetConnectionTests: XCTestCase {
         pagesReturnMarkerRows: Bool = false,
         serveTranscript: Bool = true,
         refuseAcpSessionCreate: Bool = false,
+        serveCopilotDial: Bool = false,
         counts providedCounts: ChatServerCounts? = nil,
         _ body: (FleetStore, Int32) async throws -> Void
     ) async throws {
@@ -1824,7 +2215,14 @@ final class FleetConnectionTests: XCTestCase {
                     capabilityIDs: [
                         "fleet.chat.read", "fleet.chat.write",
                         "fleet.message.read", "fleet.message.send", "fleet.acp.spawn",
-                    ] + (serveTranscript ? ["fleet.transcript.read"] : []),
+                    ]
+                        + (serveTranscript ? ["fleet.transcript.read"] : [])
+                        // Opt-in, so a daemon that serves the chat but not the
+                        // dial stays the DEFAULT shape every other test here
+                        // runs against. `fleet.copilot.configure` is its own id
+                        // on the daemon side and this fixture keeps it separate
+                        // for the same reason.
+                        + (serveCopilotDial ? ["fleet.copilot.configure"] : []),
                     refuseMessageSubscribe: refuseMessageSubscribe
                 )
                 while true {
@@ -1905,10 +2303,18 @@ final class FleetConnectionTests: XCTestCase {
                 return
             }
             try writeResponse(to: descriptor, request: request, result: [
-                "session_key": "acp:1",
+                "session_key": counts.acpSessionKey,
                 "scope_key": "channel:c1",
                 "turn_deadline_ms": 1_800_000,
             ])
+        case "fleet/adapter_list":
+            try writeResponse(to: descriptor, request: request, result: ["adapters": counts.adapters])
+        case "fleet/copilot_configure":
+            guard let result = counts.recordCopilotConfigure(request) else {
+                try writeError(to: descriptor, request: request)
+                return
+            }
+            try writeResponse(to: descriptor, request: request, result: result)
         case "fleet/message_list":
             // The page's first call AFTER the mint decision, which makes it the
             // window a test needs to invalidate the cache in.
@@ -2345,7 +2751,73 @@ private final class ChatServerCounts: @unchecked Sendable {
     /// one. The store measures its page window back from this.
     let transcriptHeadOrder: Int64?
     /// The chunks `fleet/transcript_list` answers with.
-    let transcriptChunks: [[String: Any]]
+    ///
+    /// SETTABLE mid-test, so a test can prove the difference between rows the
+    /// store CARRIED and rows a page re-read: empty the fixture, page again,
+    /// and whatever is still on screen was carried.
+    var transcriptChunks: [[String: Any]] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return scriptedTranscriptChunks
+        }
+        set {
+            lock.lock()
+            scriptedTranscriptChunks = newValue
+            lock.unlock()
+        }
+    }
+    private var scriptedTranscriptChunks: [[String: Any]]
+    /// The session key `fleet/acp_session_create` mints, settable so a test can
+    /// script the REPLACEMENT a copilot engine swap mints on the same scope.
+    var acpSessionKey: String {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return scriptedAcpSessionKey
+        }
+        set {
+            lock.lock()
+            scriptedAcpSessionKey = newValue
+            lock.unlock()
+        }
+    }
+    private var scriptedAcpSessionKey = "acp:1"
+    /// Every `fleet/copilot_configure` frame the store sent.
+    private var copilotConfigureRequests: [[String: Any]] = []
+    /// What the scripted `fleet/copilot_configure` answers with, or nil to
+    /// refuse. Settable because the two outcomes a client must tell apart, a
+    /// same-adapter configure and a swap, differ only in this result.
+    var copilotConfigureResult: [String: Any]? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return scriptedCopilotConfigureResult
+        }
+        set {
+            lock.lock()
+            scriptedCopilotConfigureResult = newValue
+            lock.unlock()
+        }
+    }
+    private var scriptedCopilotConfigureResult: [String: Any]?
+    /// The adapters `fleet/adapter_list` answers with. Fixed at construction,
+    /// which is before the server thread exists, so it needs no lock.
+    let adapters: [[String: Any]]
+
+    /// Record the configure and answer with whatever is scripted, or refuse.
+    func recordCopilotConfigure(_ request: [String: Any]) -> [String: Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        copilotConfigureRequests.append(request)
+        return scriptedCopilotConfigureResult
+    }
+
+    var copilotConfigures: [[String: Any]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return copilotConfigureRequests
+    }
     /// Whether the scripted tail read says it left older rows behind.
     let transcriptTruncated: Bool
     /// Which `fleet/transcript_subscribe` calls are refused, counted from one.
@@ -2362,14 +2834,18 @@ private final class ChatServerCounts: @unchecked Sendable {
         transcriptHeadOrder: Int64? = nil,
         transcriptChunks: [[String: Any]] = [],
         transcriptTruncated: Bool = false,
-        refusedTranscriptSubscribes: Set<Int> = []
+        refusedTranscriptSubscribes: Set<Int> = [],
+        adapters: [[String: Any]] = [],
+        copilotConfigureResult: [String: Any]? = nil
     ) {
         self.refusedTranscriptSubscribes = refusedTranscriptSubscribes
         self.rejectionDetail = rejectionDetail
         self.pagesReturnMarkerRows = pagesReturnMarkerRows
         self.transcriptHeadOrder = transcriptHeadOrder
-        self.transcriptChunks = transcriptChunks
+        self.scriptedTranscriptChunks = transcriptChunks
         self.transcriptTruncated = transcriptTruncated
+        self.adapters = adapters
+        self.scriptedCopilotConfigureResult = copilotConfigureResult
     }
 
     let refusedTranscriptSubscribes: Set<Int>

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetDaemonContractTests.swift
@@ -707,6 +707,245 @@ final class FleetDaemonContractTests: XCTestCase {
         XCTAssertEqual(acknowledgement.headOrder, orders.last)
     }
 
+    // MARK: - Reconcile and the copilot dial (PRs D and E)
+
+    /// The reconcile frame reaches the daemon's own dispatch, against a real
+    /// daemon, and is refused for a reason that is about the SESSION.
+    ///
+    /// The Swift unit tests prove which frame the case builds; only this proves
+    /// the daemon parses `reconcile_structured` at all. A tag the daemon does
+    /// not know fails at `parse_params` with `-32602` naming the action, which
+    /// is a different refusal from the version conflict a known tag gets
+    /// against a session that does not exist, and telling the two apart is the
+    /// whole assertion.
+    func testRealDaemonParsesTheReconcileActionRatherThanRejectingItsTag() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        do {
+            _ = try await connection.action(FleetActionParams(
+                sessionKey: "claude:absent",
+                expectedVersion: 1,
+                requestID: UUID().uuidString,
+                action: .reconcileStructured(requestFingerprint: "sha256:interview")
+            ))
+            XCTFail("a session that does not exist must not produce a receipt")
+        } catch let FleetConnectionError.rpc(refusal) {
+            XCTAssertFalse(
+                refusal.message.lowercased().contains("unknown variant"),
+                "the daemon could not parse the action tag, so this client is naming a variant it does not have: \(refusal)"
+            )
+            XCTAssertFalse(
+                refusal.message.contains("reconcile_structured"),
+                "a refusal quoting the tag back is a parse failure, not a session one: \(refusal)"
+            )
+        }
+    }
+
+    /// `fleet/adapter_list` answers a real daemon's live registry, and every
+    /// row decodes through this client's model.
+    ///
+    /// The built-in floor is what makes this assertable without a config file:
+    /// `chat_adapters` falls back to the config seed, which on a fixture home
+    /// is the two adapters compiled in. The assertion is on the SHAPE rather
+    /// than the exact names, because the registry is host config and a machine
+    /// with `[acp.adapters]` entries legitimately answers with more.
+    func testRealDaemonNamesItsAdapterRegistry() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let adapters = try await connection.adapterList().adapters
+        XCTAssertFalse(
+            adapters.isEmpty,
+            "a daemon with no spawnable adapter cannot open a copilot at all, so the registry must never be empty"
+        )
+        XCTAssertTrue(
+            adapters.contains { $0.name == copilotDefaultProvider },
+            "the adapter the copilot scope is minted with must be one the registry offers: \(adapters.map(\.name))"
+        )
+        for adapter in adapters {
+            XCTAssertFalse(adapter.name.isEmpty)
+            XCTAssertFalse(adapter.command.isEmpty, "\(adapter.name) names no program to spawn")
+            XCTAssertFalse(adapter.permissionMode.isEmpty, "\(adapter.name) reports no pinned permission mode")
+        }
+    }
+
+    /// `fleet/copilot_configure` refuses an adapter the registry does not know,
+    /// and says so as an invalid parameter rather than attempting a spawn.
+    ///
+    /// This is why `provider` can be a validated STRING on the wire. The client
+    /// offers only names `fleet/adapter_list` gave it, and the daemon is the
+    /// backstop for everything else, so a name that reached this call by any
+    /// other route is never a spawn request for an arbitrary program.
+    func testRealDaemonRefusesAnAdapterItsRegistryDoesNotKnow() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        do {
+            _ = try await connection.copilotConfigure(FleetCopilotConfigureParams(
+                provider: "not-an-adapter",
+                copilotMode: nil,
+                model: nil,
+                reasoningEffort: nil,
+                persona: nil
+            ))
+            XCTFail("the daemon must not accept a provider its registry cannot spawn")
+        } catch let FleetConnectionError.rpc(refusal) {
+            XCTAssertEqual(refusal.code, -32602, "\(refusal)")
+            XCTAssertTrue(
+                refusal.message.contains("unknown adapter"),
+                "the refusal must name the cause an operator can fix: \(refusal)"
+            )
+        }
+    }
+
+    /// The engine swap, end to end against a real daemon: a configure naming a
+    /// DIFFERENT adapter answers `session_replaced`, with a new session key on
+    /// the same channel scope, and a same-adapter one does not.
+    ///
+    /// This is the fact the client's invalidation hangs on. `session_replaced`
+    /// is the only signal that the copilot session key this client is holding
+    /// is dead, and everything the store does with it, dropping the mint,
+    /// disowning the in-flight page, refusing to carry the transcript, follows
+    /// from believing it. A scripted socket can only prove the store reacts;
+    /// this proves the daemon sends it, and sends it for the right call.
+    ///
+    /// The attach that follows is the other half. The client learns the
+    /// replacement's key by re-minting, not from the configure result, so the
+    /// assertion that matters is that an `acp_session_create` naming neither
+    /// provider nor cwd now answers with the NEW session.
+    func testRealDaemonSwapsTheCopilotEngineAndReportsTheReplacedSession() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        let adapters = try await connection.adapterList().adapters
+        let names = adapters.map(\.name)
+        guard let other = names.first(where: { $0 != copilotDefaultProvider }) else {
+            throw XCTSkip("this daemon's registry holds one adapter, so there is no swap to make: \(names)")
+        }
+
+        let channel = try await connection.channelCreate(
+            FleetChannelCreateParams(kind: .copilot, name: "copilot", recipients: nil)
+        ).channel
+        let opened = try await connection.acpSessionCreate(FleetAcpSessionCreateParams(
+            provider: copilotDefaultProvider,
+            cwd: "/work",
+            scopeKey: channel.scopeKey
+        ))
+
+        // The same adapter is a settings change, not a swap.
+        let unchanged = try await connection.copilotConfigure(FleetCopilotConfigureParams(
+            provider: copilotDefaultProvider,
+            copilotMode: .help,
+            model: nil,
+            reasoningEffort: nil,
+            persona: nil
+        ))
+        XCTAssertFalse(
+            unchanged.sessionReplaced,
+            "a configure that did not change the adapter must not retire the conversation"
+        )
+        XCTAssertEqual(unchanged.sessionKey, opened.sessionKey)
+        XCTAssertEqual(unchanged.copilotMode, .help)
+
+        // A different adapter is a different process, so the session goes.
+        let swapped = try await connection.copilotConfigure(FleetCopilotConfigureParams(
+            provider: other,
+            copilotMode: nil,
+            model: nil,
+            reasoningEffort: nil,
+            persona: nil
+        ))
+        XCTAssertTrue(swapped.sessionReplaced, "swapping the adapter must retire the session it was running")
+        XCTAssertNotEqual(
+            swapped.sessionKey, opened.sessionKey,
+            "a replaced session must carry a new key, or a client cannot tell it apart from the dead one"
+        )
+        XCTAssertEqual(swapped.provider, other)
+        XCTAssertEqual(
+            swapped.copilotMode, .help,
+            "an omitted copilot_mode leaves the guardrail where the last call put it"
+        )
+
+        let attached = try await connection.acpSessionCreate(
+            FleetAcpSessionCreateParams(provider: nil, cwd: nil, scopeKey: channel.scopeKey)
+        )
+        XCTAssertEqual(
+            attached.sessionKey, swapped.sessionKey,
+            "the re-mint the store does after a swap must land on the replacement, not the retired session"
+        )
+        XCTAssertEqual(attached.scopeKey, channel.scopeKey, "the swap keeps the channel's scope")
+    }
+
+    /// The permission mode is NOT settable per session, and the daemon refuses
+    /// the frame before it parses anything else.
+    ///
+    /// A settable mode here is a remote off-switch for the whole permission
+    /// surface, so this client must never grow a field for it. The assertion is
+    /// against a hand-built frame rather than `FleetCopilotConfigureParams`,
+    /// because the type deliberately has no such property: the test that the
+    /// door is shut has to knock on it.
+    func testRealDaemonRefusesAPermissionModeOnTheCopilotWire() async throws {
+        let fixture = try FixtureDaemon()
+        defer { fixture.stop() }
+        let connection = try await fixture.authenticatedAndNegotiatedConnection()
+        defer { Task { await connection.close() } }
+
+        for forbidden in [ForbiddenModeKey.permissionMode, .mode] {
+            do {
+                _ = try await connection.requestForTesting(
+                    "fleet/copilot_configure",
+                    params: ForbiddenModeParams(provider: copilotDefaultProvider, key: forbidden),
+                    result: FleetCopilotConfigureResult.self
+                )
+                XCTFail("\(forbidden.rawValue) must be refused on the copilot wire")
+            } catch let FleetConnectionError.rpc(refusal) {
+                XCTAssertEqual(refusal.code, -32602, "\(forbidden.rawValue): \(refusal)")
+                XCTAssertTrue(
+                    refusal.message.contains("not settable per session"),
+                    "\(forbidden.rawValue): \(refusal)"
+                )
+            }
+        }
+    }
+
+    /// The keys the daemon refuses outright on `fleet/copilot_configure`.
+    private enum ForbiddenModeKey: String {
+        case permissionMode = "permission_mode"
+        case mode
+    }
+
+    /// A configure frame carrying one of the refused keys.
+    ///
+    /// Hand-encoded because the shipped params type cannot carry them, which is
+    /// the property under test.
+    private struct ForbiddenModeParams: Encodable {
+        let provider: String
+        let key: ForbiddenModeKey
+
+        private struct RawKey: CodingKey {
+            let stringValue: String
+            var intValue: Int? { nil }
+            init(_ stringValue: String) { self.stringValue = stringValue }
+            init?(stringValue: String) { self.stringValue = stringValue }
+            init?(intValue: Int) { nil }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: RawKey.self)
+            try container.encode(provider, forKey: RawKey("provider"))
+            try container.encode("bypassPermissions", forKey: RawKey(key.rawValue))
+        }
+    }
+
     /// The next `fleet/transcript_event`, or a FAILURE within `timeout`.
     ///
     /// Bounded for the reason its message sibling is: the failure under test is

--- a/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
+++ b/apps/ainb-fleet-macos/Tests/FleetRPCTests/FleetReceiptNoticeTests.swift
@@ -1,12 +1,20 @@
 import XCTest
 @testable import AINBFleet
 
-/// REGRESSION. A `fleet/action` that round-trips is not an action that landed.
-/// The daemon answers a refused action with a successful RPC carrying a
-/// non-delivered status plus a `detail`; the surface used to report
-/// "Delivered. Confirming Fleet state." for every non-throwing call, so a
-/// mirrored picker that refused the answer, sent ZERO keys and left the target
-/// session sitting on its question still read as success here.
+/// What the operator is told about a `fleet/action`, before it is sent and
+/// after it comes back.
+///
+/// REGRESSION, on the shared notice. A `fleet/action` that round-trips is not
+/// an action that landed. The daemon answers a refused action with a successful
+/// RPC carrying a non-delivered status plus a `detail`; the surface used to
+/// report "Delivered. Confirming Fleet state." for every non-throwing call, so
+/// a mirrored picker that refused the answer, sent ZERO keys and left the
+/// target session sitting on its question still read as success here.
+///
+/// The reconcile cases cover the ONE action that inverts that shared reading,
+/// where `UNKNOWN` is the daemon deliberately keeping a card rather than a
+/// delivery it could not confirm, and the gate cases cover the refusals the
+/// notch must state in the same order and words the terminal client does.
 final class FleetReceiptNoticeTests: XCTestCase {
     func testFailedReceiptIsNotReportedAsDelivered() {
         let notice = FleetStore.controlNotice(
@@ -43,6 +51,288 @@ final class FleetReceiptNoticeTests: XCTestCase {
     func testMissingDetailStillProducesAReadableNotice() {
         let notice = FleetStore.controlNotice(for: receipt(.failed, detail: "   "), failurePrefix: "Interview")
         XCTAssertEqual(notice, "Interview failed.")
+    }
+
+    /// The one action whose `UNKNOWN` is a WORKING outcome, not a failure.
+    ///
+    /// `reconcile_claude_structured` answers `UNKNOWN` for the case it has
+    /// decided in the operator's favour: it cannot prove the interview is
+    /// finished, so it KEEPS the card. Rendering that through the shared notice
+    /// would put "could not be confirmed" beside a real delivery failure and
+    /// send the reader looking for a fault that is not there.
+    func testAnUnknownReconcileReadsAsStillCheckingRatherThanAFailure() {
+        let retained = receipt(.unknown, detail: "Claude interview liveness is unresolved; Fleet card retained")
+        let notice = FleetStore.reconcileNotice(for: retained)
+
+        XCTAssertTrue(notice.hasPrefix("Still checking"), notice)
+        XCTAssertTrue(
+            notice.contains("Fleet card retained"),
+            "the daemon's own account of what it did with the card is the actionable half: \(notice)"
+        )
+        XCTAssertFalse(
+            notice.contains("could not be confirmed"),
+            "the shared wording groups UNKNOWN with the failures, which inverts this arm's meaning: \(notice)"
+        )
+        XCTAssertNotEqual(
+            notice,
+            FleetStore.controlNotice(for: retained, failurePrefix: "Interview check"),
+            "a retained card must not read the way a refused delivery does"
+        )
+    }
+
+    /// The two settled outcomes and the two broken ones stay apart.
+    ///
+    /// `DELIVERED` covers both halves of a settled question, the interview
+    /// being live and the picker having closed, and the daemon's detail is the
+    /// only thing that says which, so it is carried verbatim. `FAILED` and
+    /// `REJECTED` mean the CHECK did not run and read as the failures they are.
+    func testReconcileTellsASettledCheckApartFromABrokenOne() {
+        let live = FleetStore.reconcileNotice(for: receipt(.delivered, detail: "Claude interview is live"))
+        XCTAssertEqual(live, "Interview checked: Claude interview is live")
+
+        let cleared = FleetStore.reconcileNotice(
+            for: receipt(.delivered, detail: "Claude native picker completed, cleared Fleet card")
+        )
+        XCTAssertTrue(cleared.contains("cleared Fleet card"), cleared)
+
+        for status in [ActionReceiptStatus.failed, .rejected] {
+            let broken = FleetStore.reconcileNotice(for: receipt(status, detail: "broker socket missing"))
+            XCTAssertTrue(broken.hasPrefix("Interview check \(status.operatorToken)"), broken)
+            XCTAssertTrue(broken.contains("broker socket missing"), broken)
+            XCTAssertFalse(broken.contains("Still checking"), "a broken check must not read as an open one: \(broken)")
+        }
+    }
+
+    /// A receipt with no detail still reads as a sentence rather than trailing
+    /// a bare colon.
+    func testReconcileWithoutADetailStillReadsAsASentence() {
+        XCTAssertEqual(FleetStore.reconcileNotice(for: receipt(.delivered, detail: "  ")), "Interview checked.")
+        XCTAssertEqual(
+            FleetStore.reconcileNotice(for: receipt(.unknown, detail: nil)),
+            "Still checking. The Fleet card is kept."
+        )
+        XCTAssertEqual(
+            FleetStore.reconcileNotice(for: receipt(.pending, detail: nil)),
+            "Interview check accepted, awaiting delivery."
+        )
+    }
+
+    /// The WORDING of each of the five row refusals, one failing condition at
+    /// a time.
+    ///
+    /// Mirrored from `reconcile_blocked_reason` in
+    /// `ainb-plugin-hangar/src/screen/fleet.rs`. Every case here fails exactly
+    /// one predicate, so this pins the five sentences and says nothing about
+    /// which one wins when a row fails several. That is a separate property and
+    /// it has its own test below, because a helper that defaults every
+    /// dimension to a passing value cannot express it.
+    @MainActor
+    func testTheReconcileGateWordsEachRefusalTheWayTheTerminalClientDoes() throws {
+        let store = FleetStore()
+
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(provider: .codex, attention: .ask, structuredAnswer: true)),
+            "reconcile is a Claude-only action"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(management: .degraded, attention: .ask, structuredAnswer: true)),
+            "degraded session has no reconcile channel"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(attention: .approval, structuredAnswer: true)),
+            "session is not waiting on a structured question"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(attention: .ask, structuredAnswer: false)),
+            "session lacks structured_answer capability"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(attention: .ask, structuredAnswer: true, fingerprint: nil)),
+            "no live structured request to reconcile"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(attention: .ask, structuredAnswer: true, fingerprint: "  ")),
+            "no live structured request to reconcile",
+            "a blank fingerprint is no fingerprint; sending it would ask the daemon about the empty string"
+        )
+    }
+
+    /// A row that fails SEVERAL predicates is refused by the earliest one, in
+    /// the terminal client's order.
+    ///
+    /// This is the case the mirror exists for and the one the wording test
+    /// cannot reach. `reconcile_blocked_reason` returns on its first match, so
+    /// a row failing two names whichever predicate the author put first, and
+    /// the two surfaces have to put them in the same place: an operator told
+    /// "not waiting on a structured question" in the pane and "Claude-only" in
+    /// the notch has no way to know which one to believe.
+    ///
+    /// Each case below fails at least two conditions and asserts the earlier
+    /// wins, so reordering the predicates in `reconcileBlockedReason` fails
+    /// here rather than passing quietly.
+    @MainActor
+    func testTheReconcileGateNamesTheEarliestRefusalWhenARowFailsSeveral() throws {
+        let store = FleetStore()
+
+        XCTAssertEqual(
+            store.reconcileBlockedReason(
+                on: try session(provider: .codex, management: .degraded, attention: .ask, structuredAnswer: true)
+            ),
+            "reconcile is a Claude-only action",
+            "the provider is checked before the management state, as it is in the terminal client"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(
+                on: try session(management: .degraded, attention: .approval, structuredAnswer: true)
+            ),
+            "degraded session has no reconcile channel",
+            "the management state is checked before the attention state"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(
+                on: try session(attention: .approval, structuredAnswer: false)
+            ),
+            "session is not waiting on a structured question",
+            "the attention state is checked before the capability"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(
+                on: try session(attention: .ask, structuredAnswer: false, fingerprint: nil)
+            ),
+            "session lacks structured_answer capability",
+            "the capability is checked before the fingerprint"
+        )
+        XCTAssertEqual(
+            store.reconcileBlockedReason(
+                on: try session(provider: .codex, management: .degraded, attention: .approval, structuredAnswer: false, fingerprint: nil)
+            ),
+            "reconcile is a Claude-only action",
+            "a row that fails every predicate must still name the first one"
+        )
+    }
+
+    /// A row that clears all five is still refused by this client's own state,
+    /// and that refusal comes LAST.
+    ///
+    /// The store under test has never connected, so it can send nothing. The
+    /// assertion is that the row reasons are still reported first for a row
+    /// that fails one: a transport complaint in front of "Claude-only" sends
+    /// the reader to check the daemon for a card that was never reconcilable.
+    @MainActor
+    func testTheClientsOwnRefusalComesAfterEveryRowReason() throws {
+        let store = FleetStore()
+        let reconcilable = try session(attention: .ask, structuredAnswer: true)
+
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: reconcilable),
+            "Fleet cannot send an action on this session right now"
+        )
+        XCTAssertFalse(store.canReconcileStructuredInterview(on: reconcilable))
+        XCTAssertEqual(
+            store.reconcileBlockedReason(on: try session(provider: .codex, attention: .ask, structuredAnswer: true)),
+            "reconcile is a Claude-only action",
+            "the row's own fact must outrank this client's transport state"
+        )
+    }
+
+    /// The store's own second lock: a reconcile that reaches it while blocked
+    /// is refused with the reason, never silently dropped.
+    ///
+    /// NOT reachable from the Verify button, and the doc used to imply it was.
+    /// That button is hidden for a non-Claude card and disabled for every other
+    /// refusal, so the UI never delivers a blocked click here. This is the lock
+    /// behind the control, for the paths a disabled button does not cover: a
+    /// row whose state moved between the render and the click, and any future
+    /// caller of the store API that has not consulted the gate. Both leave the
+    /// operator with a stated reason rather than a button that did nothing.
+    @MainActor
+    func testABlockedReconcileReachingTheStoreIsRefusedWithItsReason() throws {
+        let store = FleetStore()
+        store.reconcileStructuredInterview(on: try session(provider: .codex, attention: .ask, structuredAnswer: true))
+        XCTAssertEqual(store.controlNotice, "reconcile is a Claude-only action")
+    }
+
+    /// A Codex interview card renders, and carries no Verify control at all.
+    ///
+    /// The terminal client hides `r Reconcile` rather than advertising a key
+    /// that refuses, and this is the notch's version of that decision.
+    /// `FleetInterviewDeck` gates on attention, capability, fingerprint and a
+    /// parseable payload but NOT on provider, so a Codex session genuinely
+    /// reaches this card. Asserting the deck exists first is what makes the
+    /// second assertion mean "the card is here and the button is not" rather
+    /// than "there is no card".
+    ///
+    /// `offersReconcileControl` is the predicate the view itself branches on,
+    /// for both the button and the sentence beneath it, so this is a claim
+    /// about what is rendered rather than about a parallel rule.
+    @MainActor
+    func testACodexInterviewCardRendersWithNoVerifyControl() throws {
+        let store = FleetStore()
+        let codex = try session(provider: .codex, request: Self.interviewPayload)
+        let claude = try session(request: Self.interviewPayload)
+
+        XCTAssertNotNil(
+            FleetInterviewDeck(session: codex),
+            "the Codex card must still form a deck, or this test proves nothing about hiding a control on one"
+        )
+        XCTAssertFalse(
+            store.offersReconcileControl(on: codex),
+            "a Codex card cannot ever be reconciled, so it must carry no button and no sentence about one"
+        )
+
+        XCTAssertNotNil(FleetInterviewDeck(session: claude))
+        XCTAssertTrue(
+            store.offersReconcileControl(on: claude),
+            "hiding the control for the provider must not hide it for the one provider it works on"
+        )
+    }
+
+    /// One structured interview in the shape the daemon sends it.
+    private static let interviewPayload = """
+    {"questions":[{"id":"q1","header":"Scope","question":"Which files?","options":["all","some"]}]}
+    """
+
+    private func session(
+        provider: FleetProvider = .claude,
+        management: ManagementState = .managed,
+        attention: AttentionState = .ask,
+        structuredAnswer: Bool = true,
+        fingerprint: String? = "sha256:interview",
+        request: String? = nil
+    ) throws -> FleetSession {
+        FleetSession(
+            sessionKey: "claude:abc",
+            provider: provider,
+            providerSessionID: "sess-1",
+            tmuxTarget: nil,
+            processStartFingerprint: nil,
+            cwd: "/work",
+            displayName: "work",
+            lifecycle: .running,
+            activeWorkCount: nil,
+            attention: attention,
+            currentRequestFingerprint: fingerprint,
+            currentRequest: try request.map { try JSONDecoder().decode(JSONValue.self, from: Data($0.utf8)) },
+            management: management,
+            transportHealth: .healthy,
+            capabilities: FleetCapabilities(
+                structuredAnswer: structuredAnswer, approvals: false, sendPrompt: false,
+                continueTurn: false, retry: false, interrupt: false, start: false, stop: false,
+                restart: false, kill: false, archive: false, tmuxAttach: false, tmuxText: false,
+                verifiedPicker: false
+            ),
+            provenance: .authoritative,
+            confidence: .high,
+            discoveredAt: 0,
+            lastObservedAt: 0,
+            lifecycleUpdatedAt: 0,
+            attentionUpdatedAt: 0,
+            version: 1,
+            updatedRevision: 1,
+            model: nil,
+            reasoningEffort: nil,
+            modelUpdatedAt: nil
+        )
     }
 
     private func receipt(_ status: ActionReceiptStatus, detail: String?) -> FleetActionReceipt {


### PR DESCRIPTION
## What this adds

The last two gaps from `docs/plans/2026-09-07-notch-gaps.md`. Both call daemon RPCs that have existed for a while and that this client never touched.

**Reconcile a stale interview.** A card can outlive the request it describes, and the operator had no way to ask whether the interview behind it is still live. The gate mirrors the terminal client's `reconcile_blocked_reason` predicate for predicate, in the same order and the same words, so the two surfaces refuse for the same reason when a row fails several conditions at once.

**Dial the copilot.** `fleet/adapter_list` and `fleet/copilot_configure`. The adapter an operator had configured was invisible in the notch and changeable only from a terminal.

## Three decisions worth reading

**The control is hidden, not disabled, for a non-Claude session.** The interview deck gates on attention, capability and fingerprint but not provider, so a disabled button meant every Codex interview card grew a dead control with "reconcile is a Claude-only action" printed under it forever. A provider is what a row *is*, not a state it moves through. The four refusals an operator can actually clear still speak.

**The dial lives on the store, not the chat surface.** A surface field would be rebuilt by the next safety-net page thirty seconds later, because the registry comes from a call no page makes and the settings only from a configure result. That is the trap that cost two defects on the transcript work, so it is answered at the declaration rather than in a copy function.

**The busy flag is its own.** Borrowing the fleet-action flag meant submitting an interview greyed out the engine picker. A control has no business accusing itself of being unavailable because it is busy. The in-flight check moved up rather than away, so nothing reaching the wire got looser.

## Two bugs found in review

- `refreshAdapters` blanked the registry and asserted "This daemon does not serve the adapter registry" whenever the connection was not yet live, undoing what reconnect deliberately preserves twenty lines away, and blaming a daemon that had served it a second earlier. Reachable, because the pane's task sits above its own capability branch. Now the offline case returns early and touches nothing, and only a live daemon lacking the capability clears and says so.
- A test claimed to assert the refusal *order* while nothing in its body distinguished order. Every case failed exactly one condition, so an arbitrary reorder of the gate kept it green. The gate itself was correct; the claim was not. There is now a test whose five cases each fail at least two conditions, chained across adjacent pairs, so any transposition breaks an assertion.

## Tests

272 executed, 0 failures, reproduced independently of the author. Six of them run against the real fixture daemon.

Every fix was falsified. Three regressions applied at once failed exactly the three intended tests and nothing else. Under a deliberate reorder of the gate, the old order test stayed green, which is what proved its claim was empty.

One debug-only generic request was added to the connection, which otherwise keeps its call private on purpose. It exists so a negative contract test can prove the daemon refuses a permission-mode field that `FleetCopilotConfigureParams` deliberately cannot express: testing that a door is shut requires knocking on it. Unreachable from the shipped app.

## Not verified

The pane has never been rendered in a window. XCTest is wedged on the development machine, so the Verify control and the engine row have no visual proof, and the Codex-card test is an honest store-level proxy that says so.

## Found, not fixed

`apps/ainb-fleet-macos/ci/check-swift-boundary.sh` cannot pass on this branch or on main. Its forbidden-literal loop runs before its allowlist, and the allowlist only covers unrelated fragments, so the loop can never be reached by it. Pre-existing; deliberately left for its own change.
