### PR TITLE
fix(chat): keep a confirm and a cancel on their own conversation, and stop calling a working cancel a failure

### DIFF
--- a/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
@@ -37,12 +37,21 @@ pub enum ChatOutcome {
     /// surface has to put the operator's text BACK in the composer rather than
     /// leave them retyping it.
     SendFailed(String),
-    /// A write LANDED and has something to say about it.
+    /// A write has something to say, and it is not the SEND that went wrong.
     ///
-    /// Separate from [`Self::SendFailed`] because the failure outcome carries
-    /// failure semantics as well as a sentence: it clears the last send's legs
-    /// and prefixes the pane's feedback row with "send failed". A cancel that
-    /// worked reported itself through that channel and read as broken.
+    /// The axis here is not success: it is whether the last send's delivery
+    /// legs are still true. [`Self::SendFailed`] exists because a send that
+    /// failed has no legs, so it drops them and calls itself "send failed" on
+    /// the feedback row. Nothing else on this surface has earned either.
+    ///
+    /// A cancel is the case that made the difference visible, on BOTH verdicts:
+    /// the send whose turn is being cancelled is still the send the pane is
+    /// showing, whether the cancel landed or was refused. If anything the
+    /// refusal needs those legs more, because the operator has just failed to
+    /// stop what they describe.
+    ///
+    /// The sentence is the CALLER's: this carries it verbatim, so a failed
+    /// write says so in its own words rather than borrowing a send's.
     Notice(String),
     /// The per-recipient delivery legs of a send.
     Receipts(Vec<ainb_hangar_proto::fleet::FleetMessageDelivery>),
@@ -191,7 +200,16 @@ impl ChatHost {
                 ChatIntent::ConfirmAnswer(params) => {
                     match crate::fleet::control::chat_confirm_answer_blocking(params) {
                         Ok(_) => (None, surface_scope, None),
-                        Err(detail) => (Some(ChatOutcome::SendFailed(detail)), surface_scope, None),
+                        // Named for what it is. This is the same conflation the
+                        // cancel below had: answering a card is not a send, so
+                        // a card the daemon refused ("already answered") must
+                        // not print "send failed" nor drop the legs of a send
+                        // that is still running behind the card.
+                        Err(detail) => (
+                            Some(ChatOutcome::Notice(format!("answer failed: {detail}"))),
+                            surface_scope,
+                            None,
+                        ),
                     }
                 }
                 // Cancelling is a WRITE like a send, so it ends by paging for
@@ -203,13 +221,20 @@ impl ChatHost {
                         // A cancel that lands silently is as unreadable as a
                         // send that does, so a WORKING cancel still has to put
                         // a sentence on the pane's feedback row. It gets its
-                        // own outcome to do that with: routing it through the
-                        // send-failure channel printed "send failed: cancelled
-                        // 1 of 1 turn(s)" over a cancel that worked, and put
-                        // the failure reducer's composer and receipt handling
-                        // on a send that never failed.
+                        // own outcome to do that with, on BOTH verdicts:
+                        // routing it through the send-failure channel printed
+                        // "send failed: cancelled 1 of 1 turn(s)" over a cancel
+                        // that worked and "send failed: cancelled 0 of 1" over
+                        // one that was refused, and dropped the legs of the
+                        // send being cancelled either way. That send is still
+                        // running in the refused case, which is precisely when
+                        // the operator needs to see what is still in flight.
                         Ok(summary) => (Some(ChatOutcome::Notice(summary)), surface_scope, None),
-                        Err(detail) => (Some(ChatOutcome::SendFailed(detail)), surface_scope, None),
+                        Err(detail) => (
+                            Some(ChatOutcome::Notice(format!("cancel failed: {detail}"))),
+                            surface_scope,
+                            None,
+                        ),
                     }
                 }
                 // Neither belongs to a conversation: a create mints the scope a

--- a/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
@@ -37,6 +37,13 @@ pub enum ChatOutcome {
     /// surface has to put the operator's text BACK in the composer rather than
     /// leave them retyping it.
     SendFailed(String),
+    /// A write LANDED and has something to say about it.
+    ///
+    /// Separate from [`Self::SendFailed`] because the failure outcome carries
+    /// failure semantics as well as a sentence: it clears the last send's legs
+    /// and prefixes the pane's feedback row with "send failed". A cancel that
+    /// worked reported itself through that channel and read as broken.
+    Notice(String),
     /// The per-recipient delivery legs of a send.
     Receipts(Vec<ainb_hangar_proto::fleet::FleetMessageDelivery>),
 }
@@ -115,6 +122,7 @@ impl ChatHost {
                     self.state.apply_failure(Some(step), detail);
                 }
                 ChatOutcome::SendFailed(detail) => self.state.apply_send_failure(detail),
+                ChatOutcome::Notice(detail) => self.state.apply_notice(detail),
                 ChatOutcome::Receipts(receipts) => self.state.apply_receipts(receipts),
             }
         }
@@ -153,7 +161,7 @@ impl ChatHost {
             // A WRITE always ends by paging, so the operator sees the durable
             // row the daemon actually stored rather than an optimistic local
             // echo that a failed write would leave behind as a lie.
-            let (write_failure, scope_key, receipts) = match intent {
+            let (write_report, scope_key, receipts) = match intent {
                 ChatIntent::Refresh { scope_key, .. } => (None, scope_key, None),
                 ChatIntent::Send {
                     scope_key,
@@ -175,13 +183,15 @@ impl ChatHost {
                     };
                     match crate::fleet::control::chat_send_blocking(params) {
                         Ok(result) => (None, Some(scope_key), Some(result.deliveries)),
-                        Err(detail) => (Some(detail), Some(scope_key), None),
+                        Err(detail) => {
+                            (Some(ChatOutcome::SendFailed(detail)), Some(scope_key), None)
+                        }
                     }
                 }
                 ChatIntent::ConfirmAnswer(params) => {
                     match crate::fleet::control::chat_confirm_answer_blocking(params) {
                         Ok(_) => (None, surface_scope, None),
-                        Err(detail) => (Some(detail), surface_scope, None),
+                        Err(detail) => (Some(ChatOutcome::SendFailed(detail)), surface_scope, None),
                     }
                 }
                 // Cancelling is a WRITE like a send, so it ends by paging for
@@ -190,12 +200,16 @@ impl ChatHost {
                 // the turn stopped.
                 ChatIntent::CancelTurn { session_keys } => {
                     match crate::fleet::control::chat_cancel_turns_blocking(session_keys) {
-                        // Reported through the send-failure channel because
-                        // that is what puts a sentence on the pane's feedback
-                        // row; a cancel that lands silently is as unreadable as
-                        // a send that does.
-                        Ok(summary) => (Some(summary), surface_scope, None),
-                        Err(detail) => (Some(detail), surface_scope, None),
+                        // A cancel that lands silently is as unreadable as a
+                        // send that does, so a WORKING cancel still has to put
+                        // a sentence on the pane's feedback row. It gets its
+                        // own outcome to do that with: routing it through the
+                        // send-failure channel printed "send failed: cancelled
+                        // 1 of 1 turn(s)" over a cancel that worked, and put
+                        // the failure reducer's composer and receipt handling
+                        // on a send that never failed.
+                        Ok(summary) => (Some(ChatOutcome::Notice(summary)), surface_scope, None),
+                        Err(detail) => (Some(ChatOutcome::SendFailed(detail)), surface_scope, None),
                     }
                 }
                 // Neither belongs to a conversation: a create mints the scope a
@@ -209,8 +223,8 @@ impl ChatHost {
                     return;
                 }
             };
-            if let Some(detail) = write_failure {
-                publish(ChatOutcome::SendFailed(detail));
+            if let Some(report) = write_report {
+                publish(report);
             }
             if let Some(receipts) = receipts {
                 publish(ChatOutcome::Receipts(receipts));
@@ -363,6 +377,52 @@ mod tests {
         assert!(
             detail.contains("already held by a session"),
             "the daemon's own words were swallowed: {detail}"
+        );
+    }
+
+    /// A write that WORKED says so without wearing a failure's clothes.
+    ///
+    /// The cancel this outcome exists for used to be published as a
+    /// `SendFailed`, so a cancel that landed printed "send failed: cancelled 1
+    /// of 1 turn(s)" and ran the failure reducer over a send that never failed.
+    /// That reducer drops the legs of the send whose turn was being cancelled,
+    /// which is the one thing the pane is showing while it waits. Both halves
+    /// are pinned here: the sentence is the daemon's summary verbatim, and the
+    /// legs survive.
+    #[test]
+    fn a_notice_puts_the_summary_on_the_feedback_row_without_failing_the_send() {
+        use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetMessageDelivery};
+
+        let mut host = ChatHost::copilot();
+        host.inbox
+            .lock()
+            .unwrap()
+            .push(ChatOutcome::Receipts(vec![FleetMessageDelivery {
+                session_key: "claude:one".to_string(),
+                state: ActionReceiptStatus::Pending,
+                detail: None,
+            }]));
+        host.tick(0);
+        assert_eq!(
+            host.state().receipts().len(),
+            1,
+            "the send's leg never landed"
+        );
+
+        host.inbox
+            .lock()
+            .unwrap()
+            .push(ChatOutcome::Notice("cancelled 1 of 1 turn(s)".to_string()));
+        assert!(host.tick(0), "a landed notice makes the frame dirty");
+        assert_eq!(
+            host.state().feedback(),
+            Some("cancelled 1 of 1 turn(s)"),
+            "a cancel that worked reads as a send that broke"
+        );
+        assert_eq!(
+            host.state().receipts().len(),
+            1,
+            "the notice dropped the legs of the send whose turn was cancelled"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
+++ b/ainb-tui/crates/ainb-core/src/fleet/chat_host.rs
@@ -134,6 +134,16 @@ impl ChatHost {
     pub fn dispatch(&self, intent: ChatIntent) {
         let inbox = Arc::clone(&self.inbox);
         let topic = self.topic.clone();
+        // The scope the surface is CURRENTLY on, for the writes that carry none
+        // of their own. A confirm card and a cancel both name a session or a
+        // card, never a channel, and handing the page no scope does not mean
+        // "page what I am looking at": the copilot page RESOLVES an absent scope
+        // newest-wins, so with a second copilot channel in the store (the CLI
+        // mints one on demand; `chat_page_blocking` documents a race minting one
+        // by accident) the write's page swapped the operator's conversation for
+        // a different one. `None` here still means "resolve", which is right
+        // before the first page has named a scope.
+        let surface_scope = self.state.scope_key().map(ToString::to_string);
         let spawned = std::thread::Builder::new().name("ainb-chat-host".into()).spawn(move || {
             let publish = |outcome: ChatOutcome| {
                 if let Ok(mut inbox) = inbox.lock() {
@@ -170,8 +180,8 @@ impl ChatHost {
                 }
                 ChatIntent::ConfirmAnswer(params) => {
                     match crate::fleet::control::chat_confirm_answer_blocking(params) {
-                        Ok(_) => (None, None, None),
-                        Err(detail) => (Some(detail), None, None),
+                        Ok(_) => (None, surface_scope, None),
+                        Err(detail) => (Some(detail), surface_scope, None),
                     }
                 }
                 // Cancelling is a WRITE like a send, so it ends by paging for
@@ -184,8 +194,8 @@ impl ChatHost {
                         // that is what puts a sentence on the pane's feedback
                         // row; a cancel that lands silently is as unreadable as
                         // a send that does.
-                        Ok(summary) => (Some(summary), None, None),
-                        Err(detail) => (Some(detail), None, None),
+                        Ok(summary) => (Some(summary), surface_scope, None),
+                        Err(detail) => (Some(detail), surface_scope, None),
                     }
                 }
                 // Neither belongs to a conversation: a create mints the scope a

--- a/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
+++ b/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
@@ -17,9 +17,9 @@
 //! Not proven here: a SUCCESSFUL `fleet/action` interrupt. `Delivered` needs a
 //! live ACP session in the pool, which needs a real adapter process; without
 //! one the daemon answers `Unknown` and the cancel reports a refusal. So the
-//! cancel case below pins the SCOPE the cancel pages on, which is what this
-//! file is about, and the success wording is covered where the outcome reaches
-//! the surface (`ainb::fleet::chat_host` unit tests).
+//! cancel cases below drive the REFUSAL, which is the verdict this fixture can
+//! produce honestly; what a cancel that landed says is covered where the
+//! outcome reaches the surface (`ainb::fleet::chat_host` unit tests).
 
 use std::time::{Duration, Instant};
 
@@ -36,9 +36,9 @@ mod fleet_hangar;
 
 use fleet_hangar::{EnvGuard, FleetHangar};
 
-/// `$AINB_HANGAR_HOME` is process-wide and both tests here set it. Cargo runs a
-/// test binary's tests on threads of ONE process, so without this the second
-/// test's home would be dialled by the first test's worker.
+/// `$AINB_HANGAR_HOME` is process-wide and every test here sets it. Cargo runs a
+/// test binary's tests on threads of ONE process, so without this one test's
+/// home would be dialled by another test's worker.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// The clock every tick is handed.
@@ -265,14 +265,19 @@ fn cancelling_a_turn_pages_the_conversation_it_was_cancelled_in() {
     });
 }
 
-/// A cancel that the daemon REFUSED still reads as a failure.
+/// A cancel the daemon REFUSED reads as a failed CANCEL, and keeps the legs.
 ///
-/// The other half of splitting the cancel's success off the send-failure
-/// channel: the refusal must keep the wording and the semantics it had, so
-/// giving a working cancel its own outcome cannot quietly turn a cancel that
-/// did nothing into one that reads as though it worked.
+/// Three things at once, because the bug was that one of them was being used
+/// to buy the other two. The refusal must still read as a failure; it must say
+/// which write failed, since nothing was sent and "send failed" is a sentence
+/// about a message that does not exist; and it must leave the delivery legs
+/// alone, because the send whose turn the operator just failed to cancel is
+/// still running and those legs are the only thing telling them what is still
+/// in flight.
 #[test]
-fn a_refused_cancel_still_reads_as_a_failure() {
+fn a_refused_cancel_reads_as_a_failed_cancel_and_keeps_the_sends_legs() {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetMessageDelivery};
+
     let fixture = fixture("chat-host-cancel-refused-");
     let hangar = &fixture.hangar;
 
@@ -286,6 +291,18 @@ fn a_refused_cancel_still_reads_as_a_failure() {
     );
     let mut host = open_on(hangar, &scope);
 
+    // The precondition a cancel is pressed under: a send is out and one leg has
+    // not come back. Applied through the same reducer entry the `Receipts`
+    // outcome uses, because a send that actually produces a PENDING leg needs a
+    // live ACP session on the scope and therefore a real adapter process. What
+    // is under test below is unchanged by that: the refusal is the real
+    // daemon's, and what the host does with it is the real host's.
+    host.state_mut().apply_receipts(vec![FleetMessageDelivery {
+        session_key: "claude:one".to_string(),
+        state: ActionReceiptStatus::Pending,
+        detail: None,
+    }]);
+
     // A session key the daemon has never heard of: `chat_cancel_turns_blocking`
     // resolves every leg against `fleet/snapshot` and refuses the ones it cannot
     // find, which is a real refusal from the real daemon rather than a stubbed
@@ -294,16 +311,82 @@ fn a_refused_cancel_still_reads_as_a_failure() {
         session_keys: vec!["claude:nobody".to_string()],
     });
     tick_until(&mut host, "the refused cancel", |host| {
-        host.state().feedback().is_some()
+        host.state()
+            .feedback()
+            .is_some_and(|line| line.contains("not in the daemon's snapshot"))
     });
 
     let feedback = host.state().feedback().expect("the refusal said nothing at all");
     assert!(
-        feedback.starts_with("send failed: "),
-        "a refused cancel stopped reading as a failure: {feedback:?}"
+        feedback.starts_with("cancel failed: "),
+        "a refused cancel does not say the CANCEL is what failed: {feedback:?}"
+    );
+    assert!(
+        !feedback.contains("send failed"),
+        "nothing was sent, so nothing could have failed to send: {feedback:?}"
     );
     assert!(
         feedback.contains("not in the daemon's snapshot"),
         "the daemon's own words were swallowed: {feedback:?}"
+    );
+    assert_eq!(
+        host.state().receipts().len(),
+        1,
+        "the refused cancel dropped the legs of the send it failed to stop"
+    );
+}
+
+/// The same rule for the other write that is not a send: a refused answer.
+///
+/// Answering a card posts no message either, and a card is single-use, so
+/// "already answered" is the refusal an operator meets by pressing `y` twice.
+/// It has to name the answer, not a send, and leave a running send's legs where
+/// they are.
+#[test]
+fn a_refused_confirm_answer_reads_as_a_failed_answer_and_keeps_the_sends_legs() {
+    use ainb_hangar_proto::fleet::{ActionReceiptStatus, FleetMessageDelivery};
+
+    let fixture = fixture("chat-host-answer-refused-");
+    let hangar = &fixture.hangar;
+
+    let scope = seed_copilot_channel(hangar, "01J0CHANNELREADING", 1_700_000_000_000);
+    seed_message(
+        hangar,
+        &scope,
+        "01J0MSGREADINGONE",
+        "the line the operator is reading",
+        1_700_000_000_000,
+    );
+    let mut host = open_on(hangar, &scope);
+    host.state_mut().apply_receipts(vec![FleetMessageDelivery {
+        session_key: "claude:one".to_string(),
+        state: ActionReceiptStatus::Pending,
+        detail: None,
+    }]);
+
+    // A card id the daemon holds no row for, which is the same door the
+    // already-answered refusal comes through: `fleet/confirm_answer` resolves
+    // the id and refuses anything it cannot answer exactly once.
+    host.dispatch(ChatIntent::ConfirmAnswer(FleetConfirmAnswerParams {
+        confirm_id: "01J0CARDTHATNEVEREXISTED".to_string(),
+        answer: FleetConfirmAnswer::Approve,
+    }));
+    tick_until(&mut host, "the refused answer", |host| {
+        host.state().feedback().is_some_and(|line| line.contains("failed: "))
+    });
+
+    let feedback = host.state().feedback().expect("the refusal said nothing at all");
+    assert!(
+        feedback.starts_with("answer failed: "),
+        "a refused answer does not say the ANSWER is what failed: {feedback:?}"
+    );
+    assert!(
+        !feedback.contains("send failed"),
+        "nothing was sent, so nothing could have failed to send: {feedback:?}"
+    );
+    assert_eq!(
+        host.state().receipts().len(),
+        1,
+        "the refused answer dropped the legs of a send it has nothing to do with"
     );
 }

--- a/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
+++ b/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
@@ -1,0 +1,264 @@
+//! A chat WRITE must leave the surface on the conversation it was written in.
+//!
+//! Driven against a REAL daemon on an isolated socket, through the REAL
+//! [`ChatHost`] worker: dispatch the intent, tick the host, read the surface.
+//! Nothing here constructs a `ChatSnapshot` and asserts on it; the snapshots
+//! this reads are the ones `fleet/channel_list` + `fleet/message_list` actually
+//! produced.
+//!
+//! The trap being pinned: every write in `chat_host` ends by paging, and the
+//! copilot page RESOLVES its channel when it is handed no scope. Resolution is
+//! newest-wins (matching the daemon's own `newest_of_kind`), so a page with no
+//! scope lands on whatever copilot channel is newest, not on the one the
+//! operator is reading. A second copilot channel is a thing the CLI mints on
+//! demand and a race mints by accident, and when one exists a confirm answer or
+//! a turn cancel would swap the pane's whole conversation out underneath it.
+//!
+//! Not proven here: a SUCCESSFUL `fleet/action` interrupt. `Delivered` needs a
+//! live ACP session in the pool, which needs a real adapter process; without
+//! one the daemon answers `Unknown` and the cancel reports a refusal. The scope
+//! a cancel pages on is the same either way, which is what this file is about.
+
+use std::time::{Duration, Instant};
+
+use ainb::fleet::chat_host::ChatHost;
+use ainb_hangar_proto::fleet::{FleetConfirmAnswer, FleetConfirmAnswerParams};
+use ainb_hangar_store::repo::fleet_chat::{
+    FleetChannelRepo, FleetChannelRow, FleetConfirmRepo, FleetConfirmRow,
+};
+use ainb_hangar_store::repo::fleet_message::{FleetMessageRepo, NewFleetMessage};
+use ainb_plugin_hangar::screen::fleet_chat::ChatIntent;
+
+#[path = "support/fleet_hangar.rs"]
+mod fleet_hangar;
+
+use fleet_hangar::{EnvGuard, FleetHangar};
+
+/// `$AINB_HANGAR_HOME` is process-wide and both tests here set it. Cargo runs a
+/// test binary's tests on threads of ONE process, so without this the second
+/// test's home would be dialled by the first test's worker.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// The clock every tick is handed.
+///
+/// Constant on purpose: `chat_tick` stamps `last_poll_ms` and then refuses to
+/// poll again inside the interval, so a fixed clock means the surface dispatches
+/// exactly ONE refresh of its own and the rest of the traffic is the intent
+/// under test.
+const NOW_MS: i64 = 5_000_000;
+
+/// Long enough for four local RPCs on a cold sqlite file, short enough that a
+/// hung worker fails the test rather than the job.
+const SETTLE: Duration = Duration::from_secs(20);
+
+struct Fixture {
+    _home: tempfile::TempDir,
+    _env: EnvGuard,
+    hangar: FleetHangar,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+fn fixture(prefix: &str) -> Fixture {
+    let lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let home = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in("/tmp")
+        .expect("home tempdir");
+    let hangar_home = home.path().join("hangar-home");
+    std::fs::create_dir_all(&hangar_home).expect("create isolated hangar home");
+    let hangar = FleetHangar::start(&hangar_home);
+    let env = EnvGuard::set("AINB_HANGAR_HOME", &hangar_home);
+    Fixture {
+        _home: home,
+        _env: env,
+        hangar,
+        _lock: lock,
+    }
+}
+
+/// Mint one copilot channel directly in the store, at an exact `created_at`.
+///
+/// Written through the repo rather than the RPC because the ORDER of the two
+/// channels is the whole point and `fleet/channel_create` stamps its own clock.
+fn seed_copilot_channel(hangar: &FleetHangar, id: &str, created_at: i64) -> String {
+    let scope = format!("channel:{id}");
+    hangar.block_on(async {
+        FleetChannelRepo::insert(
+            hangar.pool(),
+            &FleetChannelRow {
+                id: id.to_string(),
+                kind: "copilot".to_string(),
+                name: "copilot".to_string(),
+                scope_key: scope.clone(),
+                recipients: Vec::new(),
+                copilot_mode: ainb_hangar_proto::fleet::FleetCopilotMode::default()
+                    .as_str()
+                    .to_string(),
+                created_at,
+            },
+        )
+        .await
+        .expect("seed copilot channel");
+    });
+    scope
+}
+
+fn seed_message(hangar: &FleetHangar, scope: &str, id: &str, body: &str, created_at: i64) {
+    hangar.block_on(async {
+        FleetMessageRepo::insert_message(
+            hangar.pool(),
+            &NewFleetMessage {
+                id: id.to_string(),
+                request_id: None,
+                request_fingerprint: None,
+                scope_key: scope.to_string(),
+                origin_message_id: None,
+                sender: "operator".to_string(),
+                kind: "user".to_string(),
+                body: body.to_string(),
+                created_at,
+            },
+        )
+        .await
+        .expect("seed chat message");
+    });
+}
+
+/// Tick until `settled` reports the next page has landed, or fail loudly.
+fn tick_until(host: &mut ChatHost, what: &str, settled: impl Fn(&ChatHost) -> bool) {
+    let deadline = Instant::now() + SETTLE;
+    loop {
+        host.tick(NOW_MS);
+        if settled(host) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{what}: nothing landed within {SETTLE:?}; surface is {:?} on scope {:?}",
+            host.state().status(),
+            host.state().scope_key()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+/// Open the copilot surface for real and leave it on the only channel there is.
+fn open_on(hangar: &FleetHangar, scope: &str) -> ChatHost {
+    let mut host = ChatHost::copilot();
+    tick_until(&mut host, "the cold open", |host| {
+        host.state().scope_key() == Some(scope)
+    });
+    assert_eq!(
+        host.state().messages().len(),
+        1,
+        "the cold open must have paged the seeded line"
+    );
+    let _ = hangar;
+    host
+}
+
+/// A write dispatched here must page the scope the surface is ON.
+///
+/// The evidence is a message inserted into that channel AFTER the cold open: a
+/// page of the right channel finds two rows, a page of the newer channel finds
+/// none, so the predicate below distinguishes "landed correctly", "landed on the
+/// wrong conversation" and "never landed" without a timing window.
+fn assert_write_stays_on_scope(prefix: &str, intent_for: impl Fn(&FleetHangar) -> ChatIntent) {
+    let fixture = fixture(prefix);
+    let hangar = &fixture.hangar;
+
+    let reading = seed_copilot_channel(hangar, "01J0CHANNELREADING", 1_700_000_000_000);
+    seed_message(
+        hangar,
+        &reading,
+        "01J0MSGREADINGONE",
+        "the line the operator is reading",
+        1_700_000_000_000,
+    );
+
+    let mut host = open_on(hangar, &reading);
+
+    // The second copilot channel, minted AFTER the surface resolved its own and
+    // therefore newer. `ainb fleet chat --kind copilot` mints one on demand, and
+    // `chat_page_blocking` documents a race minting one by accident. Left EMPTY
+    // so the two outcomes are told apart by row count alone: a page of the
+    // channel the operator is reading has two rows, a page of this one has none,
+    // and "still one" is a page that has not landed yet.
+    seed_copilot_channel(hangar, "01J0CHANNELNEWER", 1_700_000_100_000);
+    seed_message(
+        hangar,
+        &reading,
+        "01J0MSGREADINGTWO",
+        "a second line on the same conversation",
+        1_700_000_200_000,
+    );
+
+    host.dispatch(intent_for(hangar));
+    tick_until(&mut host, "the write's page", |host| {
+        host.state().messages().len() != 1
+    });
+
+    assert_eq!(
+        host.state().scope_key(),
+        Some(reading.as_str()),
+        "the write paged {:?}, swapping the operator's conversation for another",
+        host.state().scope_key()
+    );
+    let bodies: Vec<&str> = host.state().messages().iter().map(|row| row.body.as_str()).collect();
+    assert_eq!(
+        bodies,
+        vec![
+            "the line the operator is reading",
+            "a second line on the same conversation"
+        ],
+        "the write's page shows a timeline the operator was not reading"
+    );
+    // The page RESOLVED an existing channel; it did not mint a third. Asserted
+    // because the failure mode this file guards is a silent switch between
+    // conversations that both exist, not a runaway `fleet/channel_create`.
+    let channels = hangar.block_on(FleetChannelRepo::list(hangar.pool())).expect("list channels");
+    assert_eq!(channels.len(), 2, "a write minted a channel of its own");
+}
+
+/// Answering a confirm card must not move the pane off its conversation.
+#[test]
+fn answering_a_confirm_pages_the_conversation_it_was_answered_in() {
+    assert_write_stays_on_scope("chat-host-confirm-scope-", |hangar| {
+        // A REAL open card on the channel the surface is reading, so the answer
+        // is one the daemon actually resolves rather than a refusal that would
+        // exercise a different arm.
+        hangar.block_on(async {
+            FleetConfirmRepo::insert(
+                hangar.pool(),
+                &FleetConfirmRow {
+                    confirm_id: "01J0CARDREADING".to_string(),
+                    scope_key: "channel:01J0CHANNELREADING".to_string(),
+                    tool: "kill".to_string(),
+                    arguments: r#"{"session":"claude:one"}"#.to_string(),
+                    target_session_key: Some("claude:one".to_string()),
+                    state: "open".to_string(),
+                    edited_arguments: None,
+                    created_at: 1_700_000_000_000,
+                    expires_at: 4_000_000_000_000,
+                    answered_at: None,
+                },
+            )
+            .await
+            .expect("seed one open confirm card");
+        });
+        ChatIntent::ConfirmAnswer(FleetConfirmAnswerParams {
+            confirm_id: "01J0CARDREADING".to_string(),
+            answer: FleetConfirmAnswer::Approve,
+        })
+    });
+}
+
+/// Cancelling a turn must not move the pane off its conversation either.
+#[test]
+fn cancelling_a_turn_pages_the_conversation_it_was_cancelled_in() {
+    assert_write_stays_on_scope("chat-host-cancel-scope-", |_hangar| {
+        ChatIntent::CancelTurn {
+            session_keys: vec!["claude:one".to_string()],
+        }
+    });
+}

--- a/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
+++ b/ainb-tui/crates/ainb-core/tests/chat_host_write_scope.rs
@@ -16,8 +16,10 @@
 //!
 //! Not proven here: a SUCCESSFUL `fleet/action` interrupt. `Delivered` needs a
 //! live ACP session in the pool, which needs a real adapter process; without
-//! one the daemon answers `Unknown` and the cancel reports a refusal. The scope
-//! a cancel pages on is the same either way, which is what this file is about.
+//! one the daemon answers `Unknown` and the cancel reports a refusal. So the
+//! cancel case below pins the SCOPE the cancel pages on, which is what this
+//! file is about, and the success wording is covered where the outcome reaches
+//! the surface (`ainb::fleet::chat_host` unit tests).
 
 use std::time::{Duration, Instant};
 
@@ -261,4 +263,47 @@ fn cancelling_a_turn_pages_the_conversation_it_was_cancelled_in() {
             session_keys: vec!["claude:one".to_string()],
         }
     });
+}
+
+/// A cancel that the daemon REFUSED still reads as a failure.
+///
+/// The other half of splitting the cancel's success off the send-failure
+/// channel: the refusal must keep the wording and the semantics it had, so
+/// giving a working cancel its own outcome cannot quietly turn a cancel that
+/// did nothing into one that reads as though it worked.
+#[test]
+fn a_refused_cancel_still_reads_as_a_failure() {
+    let fixture = fixture("chat-host-cancel-refused-");
+    let hangar = &fixture.hangar;
+
+    let scope = seed_copilot_channel(hangar, "01J0CHANNELREADING", 1_700_000_000_000);
+    seed_message(
+        hangar,
+        &scope,
+        "01J0MSGREADINGONE",
+        "the line the operator is reading",
+        1_700_000_000_000,
+    );
+    let mut host = open_on(hangar, &scope);
+
+    // A session key the daemon has never heard of: `chat_cancel_turns_blocking`
+    // resolves every leg against `fleet/snapshot` and refuses the ones it cannot
+    // find, which is a real refusal from the real daemon rather than a stubbed
+    // error string.
+    host.dispatch(ChatIntent::CancelTurn {
+        session_keys: vec!["claude:nobody".to_string()],
+    });
+    tick_until(&mut host, "the refused cancel", |host| {
+        host.state().feedback().is_some()
+    });
+
+    let feedback = host.state().feedback().expect("the refusal said nothing at all");
+    assert!(
+        feedback.starts_with("send failed: "),
+        "a refused cancel stopped reading as a failure: {feedback:?}"
+    );
+    assert!(
+        feedback.contains("not in the daemon's snapshot"),
+        "the daemon's own words were swallowed: {feedback:?}"
+    );
 }

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet_chat.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet_chat.rs
@@ -1013,15 +1013,24 @@ impl ChatState {
         self.receipts_at_ms = None;
     }
 
-    /// Record something a write that WORKED has to say.
+    /// Record what a write has to say, `detail` verbatim.
     ///
-    /// The twin of [`Self::apply_send_failure`] for the other verdict, and it
-    /// exists because that one is not just a sentence: it prefixes the row with
-    /// "send failed" and drops the last send's legs. A cancel reported through
-    /// it painted a cancel that landed as a send that broke, and cleared the
-    /// receipts of the send whose turn was being cancelled: the legs the pane
-    /// is showing are still that send's, and the page this write ends with is
-    /// what refreshes them.
+    /// Not the twin of [`Self::apply_send_failure`] for the other VERDICT: the
+    /// twin of it for everything that is not a send. That one is more than a
+    /// sentence, and both of the extras it adds belong to a send and only to a
+    /// send. It prefixes the row with "send failed", which is a lie on any
+    /// write that posted no message, and it drops the last send's delivery
+    /// legs, which is right only because a send that failed has none.
+    ///
+    /// A cancel showed why the split is by subject and not by verdict. Its
+    /// legs are the legs of the send whose turn is being cancelled, and that
+    /// send is still there on both verdicts: it succeeded, or it refused and
+    /// the turn is still running. Clearing them told the operator the send had
+    /// no recipients at the exact moment they needed to see which ones were
+    /// still in flight.
+    ///
+    /// So the caller words it. A failure says it failed; this only declines to
+    /// call it a SEND failure and leaves the legs alone.
     pub fn apply_notice(&mut self, detail: String) {
         // The write's request has come back, which is the end of it, exactly as
         // for the two outcomes either side of this one. `cancel_open_turns`

--- a/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet_chat.rs
+++ b/ainb-tui/crates/ainb-plugin-hangar/src/screen/fleet_chat.rs
@@ -1013,6 +1013,24 @@ impl ChatState {
         self.receipts_at_ms = None;
     }
 
+    /// Record something a write that WORKED has to say.
+    ///
+    /// The twin of [`Self::apply_send_failure`] for the other verdict, and it
+    /// exists because that one is not just a sentence: it prefixes the row with
+    /// "send failed" and drops the last send's legs. A cancel reported through
+    /// it painted a cancel that landed as a send that broke, and cleared the
+    /// receipts of the send whose turn was being cancelled: the legs the pane
+    /// is showing are still that send's, and the page this write ends with is
+    /// what refreshes them.
+    pub fn apply_notice(&mut self, detail: String) {
+        // The write's request has come back, which is the end of it, exactly as
+        // for the two outcomes either side of this one. `cancel_open_turns`
+        // latches this before emitting, so leaving it set would refuse the next
+        // cancel with "a cancel is already in flight" until a poll cleared it.
+        self.in_flight = false;
+        self.feedback = Some(detail);
+    }
+
     /// Fold one send's per-recipient legs in.
     ///
     /// The summary says how many legs did NOT deliver, because that is the


### PR DESCRIPTION
Two defects in `fleet/chat_host.rs`, both found by review of already-merged code on `main`. A third finding in the same review turned out to be already fixed; the detail is at the bottom.

## 1. A write paged whatever copilot channel was newest, not the one it was written in

`ChatIntent::ConfirmAnswer` and `ChatIntent::CancelTurn` name a card and a session; neither carries a channel, so both handed `chat_page_blocking` `scope_key = None`.

The reviewer's stated mechanism was that `None` means "mint one". It does not: `chat_page_blocking` filters the channel list with `scope_key.as_ref().is_none_or(...)`, so `None` is a no-op filter and `next_back()` picks the NEWEST copilot channel. `ChatOpenStep::CreatingChannel` fires only when there is no copilot channel at all, and `CreatingSession` fires on every page including a scoped refresh.

The defect is real, by a different route. Resolution is newest-wins, so once a second copilot channel exists (`ainb fleet chat --kind copilot` mints one on demand; `chat_page_blocking`'s own comment documents a race minting one by accident) the write's page lands the pane on a conversation the operator never opened. `apply_snapshot` then overwrites the surface's scope and timeline with it.

Both arms now carry `self.state.scope_key()`, the way `Send` already does. `None` still reaches the page before the first one has named a scope, which is the case resolution exists for.

## 2. A successful cancel was published as `SendFailed`

The old comment was honest about the reuse: the send-failure channel is what puts a sentence on the pane's feedback row, and a silent cancel is unreadable. The sentence was right, the channel was wrong. `apply_send_failure` is not just a sentence: it prefixes the row with `send failed:` and clears the last send's receipts. So a cancel that worked printed `send failed: cancelled 1 of 1 turn(s)` and dropped the legs of the send whose turn was being cancelled, which is the one thing the pane is showing while it waits.

New `ChatOutcome::Notice` + `ChatState::apply_notice`: clears the in-flight latch (`cancel_open_turns` sets it before emitting, so leaving it would refuse the next cancel), sets the feedback row, touches nothing else. The refusal keeps the failure channel it had.

## Verification

Every guard was watched RED before it was made green.

**Finding 1** — `tests/chat_host_write_scope.rs`, against a real daemon on an isolated socket, driving the real `ChatHost` worker and the real `tick`. Two copilot channels, the newer one empty; a message added to the operator's channel after the cold open is the tell. Pre-fix, both arms:

```
assertion `left == right` failed: the write paged Some("channel:01J0CHANNELNEWER"),
swapping the operator's conversation for another
  left: Some("channel:01J0CHANNELNEWER")
 right: Some("channel:01J0CHANNELREADING")
```

Post-fix both pass, and the test also asserts the store still holds exactly 2 channels, i.e. the page resolved rather than minted.

**Finding 2** — two guards.

`a_notice_puts_the_summary_on_the_feedback_row_without_failing_the_send` drives the real `tick` reducer. Falsified by routing `Notice` back through `apply_send_failure`:

```
assertion `left == right` failed: a cancel that worked reads as a send that broke
  left: Some("send failed: cancelled 1 of 1 turn(s)")
 right: Some("cancelled 1 of 1 turn(s)")
```

`a_refused_cancel_still_reads_as_a_failure` drives a real refusal out of the real daemon (a session key `fleet/snapshot` does not know). Falsified by routing the `Err` arm through `Notice`:

```
a refused cancel stopped reading as a failure:
"cancelled 0 of 1 turn(s) · claude:nobody: not in the daemon's snapshot"
```

**Coverage type.** Finding 1 has real-daemon integration coverage plus existing tmux coverage: `tripwire_fleet_chat_screen::the_copilot_chat_opens_attributes_and_answers_a_confirm_card` drives a real `ainb tui` in tmux and presses `y` on a real confirm card, which is exactly the changed path, and still passes. Finding 2's notice half has unit coverage at the host/reducer seam only. A `Delivered` `fleet/action` interrupt needs a live ACP session in the pool, which needs a real adapter process, so the `Ok(summary) -> Notice` link itself is not driven end-to-end here. Stated rather than claimed.

## Also noticed, not changed

`dispatch`'s `CreateChannel | ListChannels` arm publishes `SendFailed("channel management is not part of this pane")`. Same channel reuse, but that one is a refusal to perform an effect, so reading it as a failure is defensible. Left alone rather than widened into this PR.

## Finding 3, not a bug

The review reported the `log` tab filtering by cwd/agent AFTER a fixed `recent_since(0, limit * 20)` fleet-wide fetch, producing a false empty state. That is already fixed on `main`. The read moved to a worker in `fleet/session_log.rs` (commits `c2568949`, `b8b08837`, `10099acc`) and `read_once` calls `Store::recent_for_cwd(&key.cwd, key.agent.as_deref(), 0, LIMIT)`, which filters in SQL, keeps the `+agent` planner hint that holds the query on `idx_notifications_ts`, and is the only caller of `log_rows`. No change made.

## Numbers

- `cargo fmt --check`: clean.
- `cargo nextest run -p ainb --lib --tests -E 'not binary(/^tripwire_/)'`: **5093 passed, 0 failed, 17 skipped**.
- `cargo nextest run -p ainb-plugin-hangar --lib fleet_chat`: 56 passed.
- tmux tripwires, run individually: `tripwire_fleet_chat_screen` 2 passed, `tripwire_fleet_session_thread` 1 passed, `tripwire_sessions_broadcast` 1 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirm and cancel actions now apply to the conversation currently being viewed, even when newer conversations are available.
  * Failed confirmations and cancellations now identify the specific action that failed instead of showing a generic send failure.
  * Action feedback no longer clears delivery status for the related message.
  * Successful non-message actions now display a clear status notice while preserving send receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->