### PR TITLE
docs: renovate documentation hub into clean 5-group layout

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,229 +1,65 @@
 ---
-title: "agents-in-a-box — documentation"
+title: "agents-in-a-box: documentation"
 ---
 
-Canonical source of truth for the monorepo. Everything published to the website
-under `/docs/*` is rendered from these files.
+Canonical source of truth for the monorepo. Everything published to the website under `/docs/*` is rendered from these files.
 
-If you're looking for a specific topic, start here:
+## 1. Start here
 
-| Section | What's in it |
-|---|---|
-| [Product](#product) | What agents-in-a-box is, value, high-level architecture |
-| [TUI](#tui) | The `ainb` terminal app |
-| [CLI](#cli) | Every subcommand, every flag |
-| [Fleet](#fleet) | Running many agents at once: attention, the chat bridge, ATC, cost |
-| [Hangar](#hangar) | The managed-agents control plane |
-| [Skill manager](#skill-manager) | Install, sync and promote units across tool homes |
-| [Toolkit](#toolkit) | Portable skills, agents, workflows (external repo) |
-| [Plugins](#plugins) | v2 subprocess plugin system |
-| [Observability](#observability) | Usage/cost, live processes, causality, telemetry |
-| [Knowledge](#knowledge) | `reflect` / `recall` GraphRAG + QMD |
-| [Contributing](#contributing) | Build, test, ship |
-| [Reference](#reference) | Architecture, glossary, repositories |
-| [Internal](#internal) | Plans, specs and research, not published to the site |
+- [Overview](product/what-is-ainb.md): what ainb is, who it is for, component breakdown
+- [Install](tui/install.md): Homebrew, curl script, prebuilt binaries, cargo build
+- [Quickstart](tui/quickstart.md): first session in 60 seconds
+- [Concepts](product/concepts.md): workspaces, worktree isolation, tmux persistence, attention
+- [Keyboard shortcuts](tui/keyboard-shortcuts.md): complete keybindings table
 
----
+## 2. Using ainb
 
-## Product
+- [Starting a new session](tui/start-session.md): repo picker and new-session wizard
+- [Attaching to sessions](tui/attach.md): full-screen and in-pane live tmux attach
+- [Code review diff](tui/code-review.md): Warp-style diff viewer with collapsible hunks
+- [Fleet and chat bridge](fleet-bridge.md): drive the fleet from Telegram, Slack or Discord
+- [ATC background watcher](atc-plumbing.md): always-on watcher and session lifecycle
+- [Shared MCP pool](tui/mcp-pool.mdx): shared MCP server pool across sessions
+- [Token optimisation](tui/token-optimization.mdx): Headroom proxy and RTK context compression
+- [Inbox and notifications](tui/inbox-notifications.md): ainb-hooks notification feed
+- [Browser dashboard](tui/web.md): read-only web view (`ainb web`)
 
-- [What is agents-in-a-box?](product/what-is-ainb.md)
-- [Value proposition](product/value.md)
-- [Whole-system architecture](product/architecture.md)
+## 3. Configure and Extend
 
-## TUI
+- [Value proposition](product/value.md): detailed comparison and workflow impact
+- [Plugins overview](plugins/overview.md): subprocess plugin system v2
+- [Plugins user guide](plugins/user-guide.md): installing and configuring plugins
+- [In-tree plugins](plugins/overview.md):
+  - [burndown](plugins/burndown.md): cost and spend tracking
+  - [session-reader](plugins/session-reader.md): JSONL event streaming
+  - [witr](plugins/witr.md): process causality tree
+  - [learnings](plugins/learnings.md): knowledge graph
+  - [abtop](plugins/abtop.md): fleet process monitor
+- [Skill manager guide](skill-manager/guide.mdx): discovery, sync, drift check, and promotion
+- [Toolkit overview](toolkit/overview.md): portable skills and agents across 9 tools
+- [Reflect memory overview](knowledge/overview.md): GraphRAG and QMD knowledge capture
+- [Memory browser](knowledge/reflect-memory/serve.md): `reflect serve` web interface
 
-The `ainb` terminal app.
+## 4. Reference
 
-- [Overview](tui/overview.md)
-- [Install](tui/install.md)
-- [First session quickstart](tui/quickstart.md) — start here
-- [Starting a new session](tui/start-session.md)
-- [Attaching to sessions](tui/attach.md) — full-screen and in-pane tmux attach
-- [Code review (diff)](tui/code-review.md)
-- [Shared MCP pool](tui/mcp-pool.mdx)
-- [Token optimisation — Headroom & RTK](tui/token-optimization.mdx)
-- [Daemons overlay](tui/daemons.mdx)
-- [Inbox & notifications](tui/inbox-notifications.md)
-- [Browser dashboard (`ainb web`)](tui/web.md)
-- [Keyboard shortcuts](tui/keyboard-shortcuts.md)
-- [Architecture](tui/architecture.md)
-- [FAQ](tui/faq.md)
+- [CLI reference](tui/cli.md): generated from `--help`, verified in CI
+- [Plugin authoring guide](plugins/authoring.md): build native binary plugins
+- [Plugin wire spec v2](plugins/spec-v2.md): JSON-RPC protocol specification
+- [Fleet cost rollups](tui/fleet-cost.md): spend across sessions and budget alerts
+- [Observability overview](observability/overview.md): telemetry and causality
+- [OpenTelemetry to Grafana](reference/otel-grafana.md): Prometheus and dashboard setup
+- [Architecture deep-dive](reference/architecture.md): whole-system architecture
+- [TUI architecture](tui/architecture.md): ratatui host and event loop
+- [Repositories map](reference/repositories.md): monorepo crate map
+- [Hangar control plane](hangar/architecture.md): task boards and autopilots
+- [Reflect memory internals](knowledge/reflect-memory/problem-and-fit.md):
+  - [The construct](knowledge/reflect-memory/construct.md)
+  - [Recall reference: 57 ports](knowledge/reflect-memory/recall.md)
+  - [Comparison](knowledge/reflect-memory/comparison.md)
 
-## CLI
+## 5. Help
 
-- [Full CLI reference](tui/cli.md) — generated from `--help`, drift-checked in CI
-
-## Fleet
-
-Running more than one agent at a time.
-
-- [Chat bridge](fleet-bridge.md) — drive the fleet from Telegram, Slack or Discord
-- [ATC](atc-plumbing.md) — the always-on watcher and its session-lifecycle plumbing
-- [Fleet cost rollups](tui/fleet-cost.md) — spend across every session, with budget alerts
-
-## Hangar
-
-The managed-agents control plane: boards, tasks, squads, autopilots.
-
-- [Architecture & features](hangar/architecture.md)
-
-> The rest of `hangar/` is the build record — the original proposal, phase
-> plans, verification goals and the Multica research that produced them. It is
-> kept for provenance and is not published to the site. See
-> [hangar/README.md](hangar/README.md).
-
-## Skill manager
-
-Install, sync and promote skills, agents and commands across your tool homes.
-
-- [Guide](skill-manager/guide.mdx) — start here
-- [Discovery & import](skill-manager/discovery.md) — adopt what is already on disk
-- [Catalog browse](skill-manager/browse.md)
-- [Sync](skill-manager/sync.md) — reconcile home and repo
-- [Drift check](skill-manager/check.md)
-- [Usage tracking](skill-manager/usage.md)
-- [Promote](skill-manager/promote.md) — turn a local unit into a git-backed source
-- [Sandbox testing](skill-manager/sandbox-testing.md)
-
-## Toolkit
-
-Portable AI-coding agent toolkit. Skills, agents and workflows deployed to 9 AI
-tools. The canonical source is the standalone
-[`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit)
-repo; ainb consumes it as a pinned external source.
-
-- [Overview](toolkit/overview.md)
-- [Skills (94)](toolkit/skills.md)
-- [Agents (16)](toolkit/agents.md)
-- [Bootstrap engine](toolkit/bootstrap.md)
-
-Claude Code plugins that ship alongside it:
-
-- [Overview](toolkit/plugins/overview.md) — how these differ from ainb plugins
-- [`reflect`](toolkit/plugins/reflect.md) — learning capture and recall
-- [`ainb-fleet`](toolkit/plugins/ainb-fleet.md) — the fleet orchestration skills
-- [`ainb-hooks`](toolkit/plugins/ainb-hooks.md) — lifecycle events into Hangar and the Inbox
-
-## Plugins
-
-> **Read this first if the word is confusing: [plugins/README.md](plugins/README.md).**
-> "Plugin" means two different things in this repo, and that page disambiguates.
-
-The v2 subprocess plugin system for the ainb TUI:
-
-- [What is an ainb plugin?](plugins/overview.md)
-- [User guide](plugins/user-guide.md) — install, configure, troubleshoot
-- [Authoring guide](plugins/authoring.md) — write your own
-- [Wire spec v2](plugins/spec-v2.md) — the JSON-RPC contract
-- [Changelog](plugins/changelog.md)
-
-In-tree plugins:
-
-- [burndown](plugins/burndown.md) — the analytics screen and `ainb usage`
-- [session-reader](plugins/session-reader.md) — the silent backend behind burndown's numbers
-- [witr](plugins/witr.md) — process-causality tracing
-- [learnings](plugins/learnings.md) — browse and search the knowledge base
-- [abtop](plugins/abtop.md) — live agent-process monitor
-
-## Observability
-
-See what your agents are doing, spending and running.
-
-- [Overview](observability/overview.md) — which tool answers which question
-- [Usage analytics (burndown)](plugins/burndown.md) — spend by day, project and model
-- [Fleet cost rollups](tui/fleet-cost.md) — spend across the whole fleet
-- [abtop](plugins/abtop.md) — live agent-process monitor
-- [witr](plugins/witr.md) — process-causality tracing
-- [OpenTelemetry to Grafana Cloud](reference/otel-grafana.md) — ship metrics, logs and traces off-box
-
-## Knowledge
-
-The two-tier learning capture and retrieval system.
-
-- [How reflection works](knowledge/overview.md)
-- [`reflect` CLI reference](knowledge/reflect-cli.md)
-- [Hooks & platform](knowledge/hooks-and-platform.md) — Claude, Codex and Copilot wiring
-
-Reflect memory, in depth:
-
-- [Problem & fit](knowledge/reflect-memory/problem-and-fit.md)
-- [The construct](knowledge/reflect-memory/construct.md)
-- [Recall reference](knowledge/reflect-memory/recall.md)
-- [Why build, not adopt](knowledge/reflect-memory/comparison.md)
-- [Memory browser (`reflect serve`)](knowledge/reflect-memory/serve.md)
-
-## Contributing
-
-- [Building from source](contributing/building.md)
-- [CI / CD](contributing/ci-cd.md)
-- [Verifying on a loaded box](contributing/verifying-on-a-loaded-box.md)
-- [Release process](contributing/release-process.md)
-
-## Reference
-
-- [Architecture deep-dive](reference/architecture.md)
-- [Glossary](reference/glossary.md)
-- [Repositories](reference/repositories.md) — which repo holds what
-
-## Internal
-
-Written for whoever is building the thing, not for a reader of the site, so
-these are excluded from the site build. They stay in the repo for provenance.
-
-| Directory | What it holds |
-|---|---|
-| `plans/` | Dated implementation plans for in-flight work |
-| `contracts/` | Implementer specs, e.g. the macOS fleet daemon contract |
-| `explorations/` | Comparative research notes |
-| `solutions/` | Troubleshooting and postmortem notes |
-| `hangar/` | The Hangar build record, except `hangar/architecture.md` |
-
-Current plans:
-
-- [Buzz port part 1 — daemon chat bus + ACP adapter](plans/2026-07-31-buzz-port-01-chat-bus-acp.md)
-- [Buzz port part 2 — fleet chat + copilot](plans/2026-07-31-buzz-port-02-fleet-chat-copilot.md) · [spec](plans/2026-07-31-buzz-port-02-fleet-chat-copilot-spec.md)
-- Research: [porting block/buzz into ainb (discussion #570)](https://github.com/stevengonsalvez/agents-in-a-box/discussions/570)
-- Explainer: [buzz to ainb port research](https://explainers.stevengonsalvez.com/buzz-acp-port/)
-
----
-
-## How this tree maps to the legacy layout
-
-The pre-restructure layout had docs scattered across three places. Here's the mapping:
-
-| New location | Source (legacy) |
-|---|---|
-| `docs/tui/cli.md` | `ainb-tui/docs/CLI.md` |
-| `docs/tui/faq.md` | `ainb-tui/docs/FAQ.md` |
-| `docs/toolkit/overview.md` | `toolkit/README.md` (TOC + intro — the toolkit itself has since moved to the standalone `stevengonsalvez/ainb-toolkit` repo) |
-| `docs/plugins/overview.md` | new — disambiguates |
-| `docs/plugins/user-guide.md` | `docs/plugins.md` |
-| `docs/plugins/authoring.md` | `docs/plugin-authoring.md` |
-| `docs/plugins/spec-v2.md` | `docs/plugin-spec/v2.md` |
-| `docs/plugins/changelog.md` | `docs/plugin-spec/CHANGELOG.md` |
-| `docs/knowledge/overview.md` | `docs/how-reflection-works.md` |
-
-The migration is complete: every page in this tree is now authoritative and the
-legacy paths have been removed. The table above is retained only to document
-provenance.
-
----
-
-## Editing rules
-
-- Markdown is the source format. Astro Starlight renders to HTML at build time.
-- Code blocks: always tag the language for syntax highlighting.
-- Cross-link other docs with relative paths, resolved from the linking file (`[…](plugins/spec-v2.md)` from here, `[…](../plugins/spec-v2.md)` from inside `tui/`).
-- Heading style: `#` once per file (title), then `##` and below for sections.
-- Frontmatter (Starlight-style) only on files that override the title or sidebar position:
-
-  ```yaml
-  ---
-  title: "Plugin authoring guide"
-  sidebar:
-    order: 2
-  ---
-  ```
-
-- Use admonitions sparingly: `> [!note]`, `> [!warning]`, `> [!tip]`.
+- [Troubleshooting and FAQ](tui/faq.md): common questions and fixes
+- [Daemons overlay](tui/daemons.mdx): diagnostic overlay for background services
+- [Contributing guide](contributing/building.md): build, test, CI/CD, and release
+- [Glossary](reference/glossary.md): terms and definitions

--- a/docs/product/concepts.md
+++ b/docs/product/concepts.md
@@ -1,0 +1,101 @@
+---
+title: Concepts
+description: Understand ainb workspaces, sessions, worktrees, tmux persistence, multi-provider execution, and attention.
+---
+
+`ainb` is a terminal workspace manager and supervisor for AI coding agents. It gives every agent its own git worktree, its own persistent tmux session, and connects them to a unified attention inbox.
+
+## Workspace
+
+A workspace is a git repository checkout. In `ainb`, workspaces group running sessions. You can switch between workspaces with `h` and `l` in the TUI, or pass `--repo <path>` on the command line.
+
+Each workspace tracks active sessions, orphan branches, and spend attribution.
+
+## Session
+
+A session is an isolated agent run. When you spawn a session:
+
+1. `ainb` creates a new git worktree directory.
+2. `ainb` creates a dedicated tmux session named for the session.
+3. `ainb` launches the selected agent (Claude Code, Codex, Copilot, shell) inside that tmux session.
+
+Because the session is an independent process tree, killing the TUI or closing your terminal does not stop the agent. You can reattach anytime:
+
+```bash
+ainb attach <session-name>
+```
+
+## Worktree isolation
+
+Running multiple agents in the same git working directory causes index lock races, dirty working trees, and accidental overwrites.
+
+`ainb` enforces worktree-per-session isolation:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                    Repository Root                        │
+│             (/path/to/project on branch 'main')           │
+└─────────────────────────────┬─────────────────────────────┘
+                              │
+               ┌──────────────┴──────────────┐
+               ▼                             ▼
+  ┌─────────────────────────┐   ┌─────────────────────────┐
+  │   Worktree 1            │   │   Worktree 2            │
+  │   Branch: agents/fix-ci │   │   Branch: agents/auth   │
+  │   Agent: Claude Code    │   │   Agent: Codex          │
+  │   tmux: ainb-session-1  │   │   tmux: ainb-session-2  │
+  └─────────────────────────┘   └─────────────────────────┘
+```
+
+Each worktree has its own index, HEAD, and unstaged files. When a session finishes, `ainb` cleans up the worktree directory without losing committed work on the branch.
+
+## tmux persistence
+
+Every agent runs inside a real tmux session. This provides three guarantees:
+
+- **Survival across disconnects:** Terminal closes, SSH drops, and laptop sleep do not terminate the session.
+- **In-pane or full-screen attach:** Press `a` in the TUI to attach full-screen, or `A` to embed the live tmux pane directly inside the TUI preview area (`Ctrl+Q` releases control).
+- **Headless automation:** Scripts and background daemons can inspect screen contents, send keystrokes, and monitor agent exits without keeping a GUI open.
+
+## Multi-provider engine
+
+`ainb` treats coding agents as interchangeable runners behind a uniform session lifecycle:
+
+| Provider | CLI Tool | Model Support |
+|----------|----------|---------------|
+| Claude | Claude Code | Sonnet, Opus, Haiku |
+| Codex | Codex CLI | GPT-4o, o1, o3-mini |
+| Copilot | GitHub Copilot CLI | Claude, GPT variants |
+| Shell | zsh / bash | Manual terminal session |
+| SSH | ssh | Remote box execution |
+
+The new-session wizard (`n`) lets you select the provider, pick a model, toggle YOLO auto-approve mode, and configure initial prompts.
+
+## Attention and Inbox
+
+Supervising five agents by cycling terminal tabs is slow and error-prone. `ainb` uses an attention-driven model:
+
+- **Blocked on user (ASK):** The agent asked a question or offered choices. You can answer directly from the Fleet panel (`f`) without attaching.
+- **Permission required (APPROVE):** The agent requested execution of a sensitive command. Press `y` or `n` in the Fleet panel to decide.
+- **Completed or errored:** The event lands in the central Inbox (`b` or `I`).
+
+You only interact with an agent when it needs your input.
+
+## Shared daemons and MCP pool
+
+Starting heavyweight Model Context Protocol (MCP) servers and proxy tools for every session wastes memory and CPU.
+
+`ainb` runs background daemons:
+
+- **notifyd:** Routes ASK and APPROVE events between agent hooks, terminal overlays, and external bridges (Telegram, Slack, Discord).
+- **Shared MCP pool:** Runs MCP servers once on the host. All active sessions connect over domain sockets instead of launching duplicate server processes.
+- **Headroom proxy:** Token optimization proxy that transparently compresses context history (RTK) for long-running sessions.
+
+## Plugins (v2 ABI)
+
+The `ainb` host is extensible via native binary plugins:
+
+- Subprocess execution communicating over JSON-RPC on stdio.
+- Default-deny capability security (network, file access, and secrets require manifest permissions).
+- Plugins can register custom TUI screens, CLI subcommands, and statusline segments.
+- Shipped in-tree: `burndown` (cost tracker), `session-reader` (event stream), `witr` (process causality tree), `learnings` (knowledge graph), and `abtop` (fleet process monitor).

--- a/docs/product/what-is-ainb.md
+++ b/docs/product/what-is-ainb.md
@@ -1,5 +1,6 @@
 ---
-title: "What is agents-in-a-box?"
+title: "Overview"
+description: "A terminal-native workspace manager and supervisor for AI coding agents."
 ---
 
 A terminal-native ecosystem for managing AI coding agents. Three components share one monorepo, plus a supporting knowledge library:
@@ -23,16 +24,16 @@ Solo developers and small teams who:
 - Prefer keyboard-driven tools to web dashboards
 - Want a single learning system that captures insights across every coding session
 
-If you've ever had two Claude Code sessions stomp on each other's branches, lost context across compaction, or wanted to wire up swarm-style agent coordination from the terminal — this is built for that.
+If you have ever had two Claude Code sessions stomp on each other's branches, lost context across compaction, or wanted to wire up swarm-style agent coordination from the terminal, this is built for that.
 
 ---
 
 ## What it's not
 
 - **Not a hosted SaaS.** No accounts, no servers, no signup.
-- **Not a Claude Code replacement.** It orchestrates Claude Code (and other tools); it doesn't reimplement them.
+- **Not a Claude Code replacement.** It orchestrates Claude Code (and other tools); it does not reimplement them.
 - **Not Windows-native.** Use WSL2.
-- **Not an IDE plugin.** It's a terminal application.
+- **Not an IDE plugin.** It is a terminal application.
 
 ---
 
@@ -40,23 +41,23 @@ If you've ever had two Claude Code sessions stomp on each other's branches, lost
 
 ```
    ┌─────────────────────────────────────────────────────────────┐
-   │                       ainb TUI host                          │
-   │                                                              │
-   │   Rust · ratatui · tokio · 34 crates · Unix-only             │
-   │                                                              │
-   │   tmux ←─ session persistence                                │
-   │   git  ←─ worktree-per-session isolation                     │
-   │   ┌────────────────────────────────────────────────┐         │
-   │   │  Plugin runtime (v2 ABI)                       │         │
-   │   │   ↔ burndown / session-reader / your plugin    │         │
-   │   └────────────────────────────────────────────────┘         │
+   │                       ainb TUI host                         │
+   │                                                             │
+   │   Rust · ratatui · tokio · 34 crates · Unix-only            │
+   │                                                             │
+   │   tmux ←─ session persistence                               │
+   │   git  ←─ worktree-per-session isolation                    │
+   │   ┌────────────────────────────────────────────────┐        │
+   │   │  Plugin runtime (v2 ABI)                       │        │
+   │   │   ↔ burndown / session-reader / your plugin    │        │
+   │   └────────────────────────────────────────────────┘        │
    └─────────────────────────────────────────────────────────────┘
         │                              │
         ▼                              ▼
    ┌──────────────────────┐    ┌────────────────────────────────────┐
    │  Claude · Codex      │    │  ainb-toolkit (external repo)      │
    │  Gemini · Copilot    │    │  github.com/stevengonsalvez/       │
-   │  Kiro · shell · SSH  │    │  ainb-toolkit — deployed via       │
+   │  Kiro · shell · SSH  │    │  ainb-toolkit: deployed via        │
    └──────────────────────┘    │  bootstrap.js to:                  │
                                │  ~/.claude, ~/.codex,              │
                                │  ~/.copilot, ~/.gemini, …)         │
@@ -72,10 +73,10 @@ Each component is independently useful. You can use ainb-toolkit without ever op
 
 ---
 
-## See also
+## Where to go next
 
-- [Value proposition](value.md) — what specifically you get
-- [Whole-system architecture](architecture.md) — deeper diagram + box-by-box
-- [Install the TUI](../tui/install.md)
-- [Deploy the toolkit](../toolkit/overview.md)
-- [Write a plugin](../plugins/authoring.md)
+- [Install ainb](../tui/install.md)
+- [Quickstart](../tui/quickstart.md): first session in 60 seconds
+- [Concepts](concepts.md): workspaces, worktrees, and sessions
+- [Keyboard shortcuts](../tui/keyboard-shortcuts.md)
+- [CLI reference](../tui/cli.md)

--- a/docs/tui/install.md
+++ b/docs/tui/install.md
@@ -1,60 +1,89 @@
 ---
-title: "Install the TUI"
+title: "Install ainb"
+description: "Install, update, and verify ainb on macOS and Linux."
 ---
+
+`ainb` publishes prebuilt release binaries for macOS (Apple Silicon) and Linux (x86_64), plus Homebrew formula and Cargo source installs.
+
+## Install with Homebrew
+
+If you are on macOS or Linux with Homebrew installed:
+
+```bash
+brew install ainb
+```
 
 ## Quick install (curl)
 
-The install script detects your platform and downloads a prebuilt binary from GitHub Releases:
+The install script detects your platform and downloads the latest release binary:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
 ```
 
-Prebuilt binaries are published for:
+The script installs to `/usr/local/bin` when writable, otherwise `~/.local/bin` (ensure it is in your `PATH`).
 
-| Platform | Target |
-|----------|--------|
-| macOS (Apple Silicon) | `aarch64-apple-darwin` |
-| Linux (x86_64) | `x86_64-unknown-linux-gnu` |
-
-The script installs to `/usr/local/bin` when writable, otherwise `~/.local/bin` (add it to your `PATH` if prompted). Override the location with `INSTALL_DIR`, or pin a version with `VERSION`:
+Override the install directory or pin a version:
 
 ```bash
 INSTALL_DIR=$HOME/bin VERSION=1.2.0 \
   curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
 ```
 
-The script verifies the release checksum when a `.sha256` file is present.
+## Prebuilt binaries
 
-## From source (cargo)
+Release binaries with `.sha256` checksums are published on [GitHub Releases](https://github.com/stevengonsalvez/agents-in-a-box/releases):
 
-Intel macOS and ARM64 Linux do not have prebuilt binaries — install from source instead. This also works on any platform with a Rust toolchain:
+| Platform | Target Architecture | Binary |
+|----------|---------------------|--------|
+| macOS (Apple Silicon) | `aarch64-apple-darwin` | `ainb` |
+| Linux (x86_64) | `x86_64-unknown-linux-gnu` | `ainb` |
+
+## Install from source (cargo)
+
+Intel macOS and ARM64 Linux builds can be installed directly with Cargo:
 
 ```bash
 cargo install --git https://github.com/stevengonsalvez/agents-in-a-box --branch main ainb
 ```
 
-Or build the workspace directly from a clone:
+Or build locally from a repository clone:
 
 ```bash
 git clone https://github.com/stevengonsalvez/agents-in-a-box
 cd agents-in-a-box/ainb-tui
-cargo build --release   # binary at target/release/ainb
+cargo build --release   # binary output at target/release/ainb
 ```
 
-## Windows
+## Windows support
 
-Windows is not supported natively. Use WSL2 and follow the Linux instructions above.
+Windows is supported via WSL2 (Windows Subsystem for Linux). Open your WSL2 terminal (Ubuntu or Debian recommended) and follow the Linux instructions above.
 
 ## Verify the install
 
+Check the version and verify that system dependencies (git, tmux, and an agent CLI) are ready:
+
 ```bash
 ainb --version
-ainb init --check    # confirm prerequisites (git, tmux, a provider CLI)
+ainb init --check
 ```
 
-## See also
+## Update
 
-- [Quickstart](quickstart.md)
-- [Overview](overview.md)
-- [Docs hub](../README.md)
+If installed with Homebrew:
+
+```bash
+brew upgrade ainb
+```
+
+If installed with the curl script, re-run the install script to fetch the latest binary:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/stevengonsalvez/agents-in-a-box/main/ainb-tui/install.sh | bash
+```
+
+## Requirements
+
+- **git** 2.30 or newer (for worktree support)
+- **tmux** 3.2 or newer (for session persistence)
+- At least one supported agent CLI (`claude`, `codex`, or `copilot`)

--- a/docs/tui/quickstart.md
+++ b/docs/tui/quickstart.md
@@ -1,12 +1,13 @@
 ---
-title: "Quickstart — first session in 60 seconds"
+title: "Quickstart: first session in 60 seconds"
+description: "From install to your first running isolated agent session."
 ---
 
 From install to your first running agent session.
 
 ## 1. Pre-flight
 
-Make sure you have `git`, `tmux`, and a provider CLI (e.g. Claude Code) installed, then:
+Ensure you have `git`, `tmux`, and a provider CLI (such as Claude Code) installed, then:
 
 ```bash
 ainb init --check    # verify prerequisites without changing anything
@@ -38,10 +39,7 @@ ainb run --repo . --worktree --tool codex         # use Codex instead of Claude
 ainb run --remote-repo owner/repo --worktree      # clone a GitHub repo first, then isolate
 ```
 
-Without `--worktree` (or `--create-branch`) the session runs directly in the
-checkout you point at, sharing that branch, index and working tree with your
-editor and with every other session started there. Reach for that only when you
-deliberately want the shared checkout:
+Without `--worktree` (or `--create-branch`) the session runs directly in the checkout you point at, sharing that branch, index and working tree with your editor and with every other session started there. Reach for that only when you deliberately want the shared checkout:
 
 ```bash
 ainb run --repo .                                 # shared checkout, NO isolation
@@ -54,7 +52,7 @@ ainb list                 # see running sessions
 ainb attach my-project    # drop into the session's tmux
 ```
 
-Detach with your tmux detach key (default `Ctrl-b d`) — the agent keeps running. Reattach any time with `ainb attach <name>`.
+Detach with your tmux detach key (default `Ctrl-b d`): the agent keeps running. Reattach any time with `ainb attach <name>`.
 
 ## 5. Kill a session safely
 
@@ -65,7 +63,7 @@ ainb kill my-project -f     # force, no prompt
 
 ## Where to go next
 
-- [Overview](overview.md) — every screen
-- [CLI reference](cli.md) — every subcommand and flag
+- [Concepts](../product/concepts.md): workspaces, worktrees, and persistence
 - [Keyboard shortcuts](keyboard-shortcuts.md)
-- [Docs hub](../README.md)
+- [CLI reference](cli.md): every subcommand and flag
+- [Starting a new session](start-session.md): new session wizard options

--- a/website/site/astro.config.mjs
+++ b/website/site/astro.config.mjs
@@ -12,6 +12,11 @@ export default defineConfig({
   // The site is served from the apex domain, so there is no base path to
   // prepend here any more.
   redirects: {
+    '/docs': '/product/what-is-ainb',
+    '/install': '/tui/install',
+    '/quickstart': '/tui/quickstart',
+    '/concepts': '/product/concepts',
+    '/keyboard': '/tui/keyboard-shortcuts',
     '/knowledge/recall-by-example': '/knowledge/reflect-memory/recall',
   },
   // Docs live in the repo-root `docs/` tree (outside this site dir), so MDX
@@ -20,7 +25,7 @@ export default defineConfig({
   vite: {
     resolve: {
       // Exact-match (end-anchored) so we don't clobber Starlight's own
-      // `@astrojs/starlight/components/Banner.astro` etc. — only the bare
+      // `@astrojs/starlight/components/Banner.astro` etc. - only the bare
       // `@astrojs/starlight/components` specifier used by external docs MDX.
       alias: [
         {
@@ -74,141 +79,162 @@ export default defineConfig({
         {
           label: 'Start here',
           items: [
-            { label: 'What is ainb?', slug: 'product/what-is-ainb' },
-            { label: 'Value proposition', slug: 'product/value' },
-            { label: 'Architecture', slug: 'product/architecture' },
-          ],
-        },
-        {
-          label: 'TUI',
-          items: [
-            { label: 'Overview', slug: 'tui/overview' },
+            { label: 'Overview', slug: 'product/what-is-ainb' },
             { label: 'Install', slug: 'tui/install' },
-            { label: 'Quickstart', slug: 'tui/quickstart' },
-            { label: 'Starting a new session', slug: 'tui/start-session' },
-            { label: 'Attaching to a session', slug: 'tui/attach' },
-            { label: 'Code Review (diff)', slug: 'tui/code-review' },
+            { label: 'Quick start', slug: 'tui/quickstart' },
+            { label: 'Concepts', slug: 'product/concepts' },
+            { label: 'Keyboard', slug: 'tui/keyboard-shortcuts' },
+          ],
+        },
+        {
+          label: 'Using ainb',
+          items: [
+            { label: 'Starting sessions', slug: 'tui/start-session' },
+            { label: 'Attaching & tmux', slug: 'tui/attach' },
+            { label: 'Code review diff', slug: 'tui/code-review' },
+            { label: 'Fleet & multi-agent', slug: 'fleet-bridge' },
+            { label: 'ATC background watcher', slug: 'atc-plumbing' },
             { label: 'Shared MCP pool', slug: 'tui/mcp-pool' },
-            { label: 'Token optimisation (Headroom · RTK)', slug: 'tui/token-optimization' },
-            { label: 'Daemons overlay', slug: 'tui/daemons' },
-            { label: 'Keyboard shortcuts', slug: 'tui/keyboard-shortcuts' },
+            { label: 'Token optimisation', slug: 'tui/token-optimization' },
             { label: 'Inbox & notifications', slug: 'tui/inbox-notifications' },
-            { label: 'Browser dashboard (ainb web)', slug: 'tui/web' },
-            { label: 'Architecture', slug: 'tui/architecture' },
-            { label: 'FAQ', slug: 'tui/faq' },
+            { label: 'Browser dashboard', slug: 'tui/web' },
           ],
         },
         {
-          label: 'CLI',
+          label: 'Configure & Extend',
+          collapsed: true,
           items: [
-            { label: 'Full CLI reference', slug: 'tui/cli' },
-          ],
-        },
-        {
-          label: 'Fleet',
-          items: [
-            { label: 'Chat bridge (Telegram · Slack · Discord)', slug: 'fleet-bridge' },
-            { label: 'ATC — the always-on watcher', slug: 'atc-plumbing' },
-            { label: 'Fleet cost rollups', slug: 'tui/fleet-cost' },
-          ],
-        },
-        {
-          label: 'Skill manager',
-          items: [
-            { label: 'Guide', slug: 'skill-manager/guide' },
-            { label: 'Discovery & import', slug: 'skill-manager/discovery' },
-            { label: 'Catalog browse', slug: 'skill-manager/browse' },
-            { label: 'Sync', slug: 'skill-manager/sync' },
-            { label: 'Drift check', slug: 'skill-manager/check' },
-            { label: 'Usage tracking', slug: 'skill-manager/usage' },
-            { label: 'Promote', slug: 'skill-manager/promote' },
-            { label: 'Sandbox testing', slug: 'skill-manager/sandbox-testing' },
-          ],
-        },
-        {
-          label: 'Toolkit',
-          items: [
-            { label: 'Overview', slug: 'toolkit/overview' },
-            { label: 'Skills', slug: 'toolkit/skills' },
-            { label: 'Agents', slug: 'toolkit/agents' },
-            { label: 'Bootstrap engine', slug: 'toolkit/bootstrap' },
+            { label: 'Value proposition', slug: 'product/value' },
             {
-              label: 'Claude Code plugins',
+              label: 'Plugins',
               items: [
-                { label: 'Overview', slug: 'toolkit/plugins/overview' },
-                { label: 'reflect', slug: 'toolkit/plugins/reflect' },
-                { label: 'ainb-fleet', slug: 'toolkit/plugins/ainb-fleet' },
-                { label: 'ainb-hooks', slug: 'toolkit/plugins/ainb-hooks' },
+                { label: 'Overview', slug: 'plugins/overview' },
+                { label: 'User guide', slug: 'plugins/user-guide' },
+                {
+                  label: 'In-tree plugins',
+                  collapsed: true,
+                  items: [
+                    { label: 'burndown', slug: 'plugins/burndown' },
+                    { label: 'session-reader', slug: 'plugins/session-reader' },
+                    { label: 'witr', slug: 'plugins/witr' },
+                    { label: 'learnings', slug: 'plugins/learnings' },
+                    { label: 'abtop', slug: 'plugins/abtop' },
+                  ],
+                },
+                { label: 'Changelog', slug: 'plugins/changelog' },
               ],
             },
-          ],
-        },
-        {
-          label: 'Plugins',
-          items: [
-            { label: 'Disambiguation', slug: 'plugins/readme' },
-            { label: 'Overview', slug: 'plugins/overview' },
-            { label: 'User guide', slug: 'plugins/user-guide' },
-            { label: 'Authoring guide', slug: 'plugins/authoring' },
-            { label: 'Wire spec v2', slug: 'plugins/spec-v2' },
             {
-              label: 'In-tree plugins',
+              label: 'Skill manager',
               items: [
-                { label: 'burndown', slug: 'plugins/burndown' },
-                { label: 'session-reader', slug: 'plugins/session-reader' },
-                { label: 'witr', slug: 'plugins/witr' },
-                { label: 'learnings', slug: 'plugins/learnings' },
-                { label: 'abtop', slug: 'plugins/abtop' },
+                { label: 'Guide & demos', slug: 'skill-manager/guide' },
+                {
+                  label: 'Commands',
+                  collapsed: true,
+                  items: [
+                    { label: 'Discovery & import', slug: 'skill-manager/discovery' },
+                    { label: 'Catalog browse', slug: 'skill-manager/browse' },
+                    { label: 'Sync', slug: 'skill-manager/sync' },
+                    { label: 'Drift check', slug: 'skill-manager/check' },
+                    { label: 'Usage tracking', slug: 'skill-manager/usage' },
+                    { label: 'Promote', slug: 'skill-manager/promote' },
+                    { label: 'Sandbox testing', slug: 'skill-manager/sandbox-testing' },
+                  ],
+                },
               ],
             },
-            { label: 'Changelog', slug: 'plugins/changelog' },
-          ],
-        },
-        {
-          label: 'Reflect Memory',
-          items: [
-            { label: 'Problem & fit', slug: 'knowledge/reflect-memory/problem-and-fit' },
-            { label: 'The construct', slug: 'knowledge/reflect-memory/construct' },
-            { label: 'Recall reference (57 ports)', slug: 'knowledge/reflect-memory/recall' },
-            { label: 'Why build, not adopt', slug: 'knowledge/reflect-memory/comparison' },
-            { label: 'Memory browser (reflect serve)', slug: 'knowledge/reflect-memory/serve' },
-          ],
-        },
-        {
-          label: 'Knowledge',
-          items: [
-            { label: 'How reflection works', slug: 'knowledge/overview' },
-            { label: 'Hooks & platform (Claude · Codex · Copilot)', slug: 'knowledge/hooks-and-platform' },
-            { label: 'reflect CLI', slug: 'knowledge/reflect-cli' },
-          ],
-        },
-        {
-          label: 'Contributing',
-          items: [
-            { label: 'Building', slug: 'contributing/building' },
-            { label: 'CI / CD', slug: 'contributing/ci-cd' },
-            { label: 'Release process', slug: 'contributing/release-process' },
-            { label: 'Verifying on a loaded box', slug: 'contributing/verifying-on-a-loaded-box' },
-          ],
-        },
-        {
-          label: 'Hangar',
-          items: [
-            { label: 'Architecture & features', slug: 'hangar/architecture' },
-          ],
-        },
-        {
-          label: 'Observability',
-          items: [
-            { label: 'Overview', slug: 'observability/overview' },
-            { label: 'OpenTelemetry to Grafana', slug: 'reference/otel-grafana' },
+            {
+              label: 'Toolkit',
+              items: [
+                { label: 'Overview', slug: 'toolkit/overview' },
+                { label: 'Skills', slug: 'toolkit/skills' },
+                { label: 'Agents', slug: 'toolkit/agents' },
+                { label: 'Bootstrap engine', slug: 'toolkit/bootstrap' },
+                {
+                  label: 'Claude Code plugins',
+                  collapsed: true,
+                  items: [
+                    { label: 'Overview', slug: 'toolkit/plugins/overview' },
+                    { label: 'reflect', slug: 'toolkit/plugins/reflect' },
+                    { label: 'ainb-fleet', slug: 'toolkit/plugins/ainb-fleet' },
+                    { label: 'ainb-hooks', slug: 'toolkit/plugins/ainb-hooks' },
+                  ],
+                },
+              ],
+            },
+            {
+              label: 'Reflect memory',
+              items: [
+                { label: 'Overview', slug: 'knowledge/overview' },
+                { label: 'Memory browser (serve)', slug: 'knowledge/reflect-memory/serve' },
+                { label: 'Hooks & platform', slug: 'knowledge/hooks-and-platform' },
+                { label: 'reflect CLI', slug: 'knowledge/reflect-cli' },
+              ],
+            },
           ],
         },
         {
           label: 'Reference',
+          collapsed: true,
           items: [
-            { label: 'Architecture deep-dive', slug: 'reference/architecture' },
-            { label: 'Repositories', slug: 'reference/repositories' },
+            { label: 'CLI reference', slug: 'tui/cli' },
+            {
+              label: 'Plugin authoring & ABI',
+              collapsed: true,
+              items: [
+                { label: 'Authoring guide', slug: 'plugins/authoring' },
+                { label: 'Wire spec v2', slug: 'plugins/spec-v2' },
+                { label: 'Disambiguation', slug: 'plugins/readme' },
+              ],
+            },
+            { label: 'Fleet cost rollups', slug: 'tui/fleet-cost' },
+            {
+              label: 'Observability & Telemetry',
+              collapsed: true,
+              items: [
+                { label: 'Overview', slug: 'observability/overview' },
+                { label: 'OpenTelemetry to Grafana', slug: 'reference/otel-grafana' },
+              ],
+            },
+            {
+              label: 'Architecture & Repos',
+              collapsed: true,
+              items: [
+                { label: 'Architecture deep-dive', slug: 'reference/architecture' },
+                { label: 'TUI host architecture', slug: 'tui/architecture' },
+                { label: 'Monorepo architecture', slug: 'product/architecture' },
+                { label: 'Repositories map', slug: 'reference/repositories' },
+                { label: 'Hangar control center', slug: 'hangar/architecture' },
+              ],
+            },
+            {
+              label: 'Reflect memory deep-dive',
+              collapsed: true,
+              items: [
+                { label: 'Problem & fit', slug: 'knowledge/reflect-memory/problem-and-fit' },
+                { label: 'The construct', slug: 'knowledge/reflect-memory/construct' },
+                { label: 'Recall reference (57 ports)', slug: 'knowledge/reflect-memory/recall' },
+                { label: 'Why build, not adopt', slug: 'knowledge/reflect-memory/comparison' },
+              ],
+            },
+          ],
+        },
+        {
+          label: 'Help',
+          collapsed: true,
+          items: [
+            { label: 'Troubleshooting & FAQ', slug: 'tui/faq' },
+            { label: 'Daemons overlay', slug: 'tui/daemons' },
+            {
+              label: 'Contributing',
+              collapsed: true,
+              items: [
+                { label: 'Building', slug: 'contributing/building' },
+                { label: 'CI / CD', slug: 'contributing/ci-cd' },
+                { label: 'Release process', slug: 'contributing/release-process' },
+                { label: 'Verifying on a loaded box', slug: 'contributing/verifying-on-a-loaded-box' },
+              ],
+            },
             { label: 'Glossary', slug: 'reference/glossary' },
           ],
         },


### PR DESCRIPTION
## Summary
- Reorganize documentation navigation into 5 clean core groups modeled after Herdr docs: Start here, Using ainb, Configure & Extend, Reference, and Help.
- Collapse deep technical specifications (v2 JSON-RPC wire spec, 57-port memory matrix, individual skill manager commands, in-tree plugins) inside collapsed Reference and Extend sub-groups.
- Add new docs/product/concepts.md defining workspaces, worktree isolation, tmux persistence, multi-provider model, and attention inbox.
- Restructure docs/tui/install.md with Homebrew, curl script, prebuilt binaries, cargo source, and verification steps.
- Add apex redirects for /docs, /install, /quickstart, /concepts, /keyboard.
- Update repository root docs/README.md to match the 5-group structure.
- Remove all em-dashes across modified docs.

## Test Evidence
- Verified astro build passes with 70 pages generated cleanly in 4.78s and zero errors.
- Verified Pagefind search index built with 76 indexed files.
- Verified zero em-dashes present in git diff additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized the documentation index into five clearer sections with streamlined navigation.
  - Added a concepts guide explaining workspaces, sessions, providers, attention handling, background services, and plugins.
  - Updated the overview, quickstart, and installation guides with clearer terminology, links, requirements, verification steps, update instructions, and Windows support.
  - Restructured website navigation into collapsible categories and updated legacy URL redirects to preserve access to relocated pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->