### PR TITLE
fix(hangar): retire every live ACP session at boot

### DIFF
--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_pool.rs
@@ -1798,6 +1798,39 @@ pub async fn converge_dirty_sessions_at_boot(pool: &SqlitePool, events: &crate::
     }
 }
 
+/// The BOOT retire: every session a previous daemon left claiming to be live
+/// is `DEAD`, because its adapter cannot have survived.
+///
+/// The pool spawns each adapter as a CHILD of the daemon, so after a restart no
+/// adapter session is still running and any `ACTIVE`/`IDLE` row is stale by
+/// definition. [`converge_dirty_sessions_at_boot`] does not reach these: a
+/// session that was cleanly `IDLE` when the daemon died has no open turn and no
+/// `PENDING` leg, so it is not dirty and nothing ever revisits it.
+///
+/// Left alone, that row wedges its scope for good. The Fleet twin
+/// (`fleet_session.lifecycle_state`) is retired `EXITED` by the stale-session
+/// reaper while the ACP row stays `IDLE`, so the mint keeps handing the same
+/// dead session back and delivery keeps refusing it as `target_not_running`. A
+/// client cannot escape by re-minting, because the corpse still holds the
+/// scope.
+///
+/// MUST run after [`converge_dirty_sessions_at_boot`]: retiring first would
+/// take the dirty sessions out of that scan's reach and strand their open
+/// turns and pending legs unresolved.
+pub async fn retire_live_sessions_at_boot(pool: &SqlitePool) {
+    match FleetAcpSessionRepo::retire_live_sessions(pool, SystemClock.now_ms()).await {
+        Ok(0) => {}
+        Ok(retired) => tracing::info!(
+            sessions = retired,
+            "retired acp sessions left live by a previous daemon; \
+             their adapters died with it"
+        ),
+        Err(error) => {
+            tracing::error!(%error, "acp boot retire could not retire the live sessions");
+        }
+    }
+}
+
 /// Bring one ACP session back to a defined state, whatever left it dirty.
 ///
 /// THE shared routine (plan I16): [`converge_dirty_sessions_at_boot`] calls it,

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -922,6 +922,17 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
         // and deadline paths run, so the outcomes cannot drift.
         crate::acp_pool::converge_dirty_sessions_at_boot(store.pool(), &broker.sink()).await;
 
+        // Then retire what the scan could not see. An adapter is a CHILD of the
+        // daemon, so no ACP session survives a restart, yet a session that was
+        // cleanly IDLE when the previous daemon died is not dirty and the scan
+        // above never visits it. Its row keeps saying IDLE forever while the
+        // Fleet twin goes EXITED under the stale reaper, so the mint hands the
+        // same corpse back to every client and delivery refuses each prompt as
+        // `target_not_running`, with no way out because the dead row still holds
+        // the scope. AFTER the convergence, never before: retiring first would
+        // hide the dirty sessions from it and strand their open turns.
+        crate::acp_pool::retire_live_sessions_at_boot(store.pool()).await;
+
         // The confirm-card TTL, swept once at boot. The park's own bound is a
         // `tokio` timer inside a copilot turn, and a timer dies with the process:
         // without this, a card left open by a SIGKILLed or upgraded daemon keeps

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/rpc_acp.rs
@@ -367,6 +367,17 @@ async fn version_showing_ask(client: &mut Client, session_key: &str, fingerprint
     }
 }
 
+/// Wall-clock epoch milliseconds, the unit every stored timestamp carries.
+fn epoch_ms() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("the clock is after the epoch")
+            .as_millis(),
+    )
+    .expect("epoch milliseconds fit an i64")
+}
+
 struct Client {
     reader: BufReader<OwnedReadHalf>,
     writer: OwnedWriteHalf,
@@ -2232,6 +2243,118 @@ async fn transcript_prune_honours_an_explicit_no_export_and_refuses_both_at_once
             "{event_id} is outside the prune's blast radius and must survive"
         );
     }
+
+    harness.finish().await;
+}
+
+/// The RESTART WEDGE, end to end on the wire: a session left cleanly `IDLE` by a
+/// daemon that died is retired at boot, so its scope mints a FRESH session and
+/// the next prompt is delivered instead of refused forever.
+///
+/// The bug this pins is a disagreement between two tables, so a single-table
+/// assertion cannot see it. `fleet_acp_session.state` stayed `IDLE` because the
+/// dirty scan only visits sessions with an open turn or a `PENDING` leg, while
+/// `fleet_session.lifecycle_state` went `EXITED` under the stale reaper. The
+/// mint reads the first table and keeps handing back the dead session; delivery
+/// reads the second and refuses it `target_not_running`. A client that
+/// invalidates its cache and re-mints gets the same corpse, so the chat pane can
+/// never send again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_session_left_live_by_a_dead_daemon_is_retired_at_boot() {
+    use ainb_hangar_store::repo::fleet::FleetRepo;
+    use ainb_hangar_store::repo::fleet_acp_session::FleetAcpSessionRepo;
+
+    let harness = Harness::start(&[("FAKE_ACP_CHUNKS", "1")], |_| {}).await;
+    let mut client = harness.client().await;
+    let scope = "session:acp-restart";
+    let (stale, _) = harness.create_session(&mut client, Some(scope)).await;
+
+    // The previous daemon's death, in the state the two tables are ACTUALLY
+    // left in. Nothing touches the ACP row, and the Fleet twin is retired by
+    // the stale-session reaper, which is the real producer of the `EXITED` that
+    // delivery then refuses on. Driven through the reaper rather than a hand
+    // written UPDATE so the precondition cannot drift away from the code that
+    // creates it in production.
+    let events = EventBroker::new();
+    // A DAY past the row's own `last_observed_at`, which is wall-clock epoch
+    // milliseconds: the reaper compares the two directly, so a small sentinel
+    // reads as far in the PAST and retires nothing. A day is slack over the
+    // private staleness TTL rather than a copy of it.
+    let long_after = epoch_ms() + 24 * 60 * 60 * 1_000;
+    let retired = ainb_hangar_daemon::fleet::reap_stale_sessions(
+        harness.store.pool(),
+        &events.sink(),
+        long_after,
+    )
+    .await
+    .expect("reap the fleet twin");
+    assert!(retired >= 1, "the reaper must have retired the fleet twin");
+    let twin = FleetRepo::get_session(harness.store.pool(), &stale)
+        .await
+        .expect("fleet twin")
+        .expect("the twin row exists");
+    assert_eq!(twin.lifecycle_state, "EXITED", "the wedge's other half");
+    assert_eq!(
+        FleetAcpSessionRepo::get(harness.store.pool(), &stale)
+            .await
+            .expect("acp row")
+            .expect("the acp row exists")
+            .state,
+        "IDLE",
+        "the ACP row still claims a live adapter: this is the disagreement"
+    );
+
+    // Boot, in the daemon's own order: converge the dirty sessions first so
+    // open turns and pending legs still resolve, THEN retire what is left.
+    ainb_hangar_daemon::acp_pool::converge_dirty_sessions_at_boot(
+        harness.store.pool(),
+        &events.sink(),
+    )
+    .await;
+    ainb_hangar_daemon::acp_pool::retire_live_sessions_at_boot(harness.store.pool()).await;
+
+    assert_eq!(
+        FleetAcpSessionRepo::get(harness.store.pool(), &stale)
+            .await
+            .expect("acp row")
+            .expect("the acp row exists")
+            .state,
+        "DEAD",
+        "a session whose adapter died with the daemon is not live"
+    );
+
+    // The user-visible half: attaching to the same scope now yields a session
+    // that can actually be prompted.
+    let (fresh, fresh_scope) = harness.create_session(&mut client, Some(scope)).await;
+    assert_ne!(
+        fresh, stale,
+        "the retired session must not be handed back to the next mint"
+    );
+    assert_eq!(fresh_scope, scope, "on the SAME scope");
+
+    let sent = client
+        .call(
+            methods::FLEET_MESSAGE_SEND,
+            serde_json::json!({
+                "targets": [fresh],
+                "text": "after the restart",
+                "request_id": "req-acp-restart",
+            }),
+        )
+        .await;
+    assert!(sent["error"].is_null(), "{sent}");
+    let message_id = sent["result"]["message_id"].as_str().expect("message id").to_string();
+    let leg = &sent["result"]["deliveries"][0];
+    assert_ne!(
+        leg["detail"],
+        serde_json::json!("target_not_running"),
+        "the wedge is exactly this refusal: {sent}"
+    );
+    assert_eq!(
+        leg["state"], "PENDING",
+        "an ACP leg resolves at TURN END, not at write-ack: {sent}"
+    );
+    harness.await_delivered(&message_id, &fresh).await;
 
     harness.finish().await;
 }

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet_acp_session.rs
@@ -421,6 +421,41 @@ impl FleetAcpSessionRepo {
         rows.iter().map(row_from).collect()
     }
 
+    /// Retire every session still claiming to be live: `ACTIVE`/`IDLE` becomes
+    /// `DEAD`. Answers how many rows moved.
+    ///
+    /// FOR BOOT ONLY. The pool runs each adapter as a CHILD of the daemon, so
+    /// no adapter session outlives the process that spawned it and every row
+    /// still in a live state at boot is describing something that is gone. The
+    /// dirty-session scan ([`Self::list_dirty`]) cannot cover this: a session
+    /// that was cleanly `IDLE` when the daemon died has no open turn and no
+    /// `PENDING` leg, so nothing visits it and it keeps the scope forever.
+    ///
+    /// That stranded row is not inert. `fleet_session.lifecycle_state` for the
+    /// same session goes `EXITED` on its own (the stale-session reaper), while
+    /// [`Self::get_live_by_scope`] keeps handing the row back to every mint, so
+    /// a client re-mints onto the corpse and its every prompt is refused as
+    /// `target_not_running`. Two tables disagreeing, with no path back.
+    ///
+    /// `DEAD`, not a new state: it takes the row out of `get_live_by_scope`,
+    /// which frees the scope for a fresh mint (the live-scope unique index is
+    /// partial to `ACTIVE`/`IDLE`), and the pool's submit door already refuses
+    /// a `DEAD` row rather than spawning against it.
+    ///
+    /// Runs AFTER the dirty convergence, never before: convergence is what
+    /// turns an open turn into an `INTERRUPTED` marker and resolves the stuck
+    /// delivery legs, and it only visits sessions it can still read as dirty.
+    pub async fn retire_live_sessions(pool: &SqlitePool, now: i64) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE fleet_acp_session SET state = 'DEAD', last_active_at = ? \
+             WHERE state IN ('ACTIVE','IDLE')",
+        )
+        .bind(now)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Sessions whose open turn started at or before `cutoff_ms` (the turn
     /// deadline sweep: caller computes `now - deadline` and cancels each hit).
     pub async fn list_open_turns_older_than(
@@ -780,6 +815,61 @@ mod tests {
             dirty.iter().map(|s| s.session_key.as_str()).collect::<Vec<_>>(),
             vec!["acp:pending", "acp:turn"],
             "open turn OR pending delivery; the clean session stays out"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_retire_moves_only_the_live_states() {
+        let (_dir, store) = store().await;
+        for (key, state) in [
+            ("acp:active", "ACTIVE"),
+            ("acp:idle", "IDLE"),
+            ("acp:evicted", "EVICTED"),
+            ("acp:dead", "DEAD"),
+        ] {
+            let mut seed = session(key, &format!("session:{key}"));
+            seed.state = state.to_string();
+            FleetAcpSessionRepo::insert(store.pool(), &seed).await.unwrap();
+        }
+
+        let retired = FleetAcpSessionRepo::retire_live_sessions(store.pool(), 900).await.unwrap();
+        assert_eq!(retired, 2, "only ACTIVE and IDLE are live");
+
+        for key in ["acp:active", "acp:idle"] {
+            let row = FleetAcpSessionRepo::get(store.pool(), key).await.unwrap().unwrap();
+            assert_eq!(row.state, "DEAD", "{key} claimed a live adapter at boot");
+            assert_eq!(row.last_active_at, 900, "{key} is stamped with the retire");
+        }
+        // Already terminal: untouched, down to `last_active_at`, so a second
+        // boot writes nothing and no timestamp drifts forward.
+        for (key, state) in [("acp:evicted", "EVICTED"), ("acp:dead", "DEAD")] {
+            let row = FleetAcpSessionRepo::get(store.pool(), key).await.unwrap().unwrap();
+            assert_eq!(row.state, state, "{key} was already terminal");
+            assert_eq!(row.last_active_at, 100, "{key} keeps its own timestamp");
+        }
+
+        assert_eq!(
+            FleetAcpSessionRepo::retire_live_sessions(store.pool(), 1_000).await.unwrap(),
+            0,
+            "idempotent: the second boot finds nothing live"
+        );
+
+        // The scope is FREE again: the retired row no longer answers the mint's
+        // live lookup, and the partial unique index no longer covers it.
+        assert!(
+            FleetAcpSessionRepo::get_live_by_scope(store.pool(), "session:acp:idle")
+                .await
+                .unwrap()
+                .is_none(),
+            "a retired session must not be handed back to the next mint"
+        );
+        let fresh =
+            FleetAcpSessionRepo::insert(store.pool(), &session("acp:fresh", "session:acp:idle"))
+                .await
+                .unwrap();
+        assert_eq!(
+            fresh.session_key, "acp:fresh",
+            "the scope takes a NEW session rather than replaying onto the retired one"
         );
     }
 


### PR DESCRIPTION
## The bug

A daemon restart leaves any cleanly-idle ACP session permanently undeliverable, and the macOS chat pane has been sitting in exactly that state:

```
delivered to 0/1 · 1 not delivered · REJECTED acp:01m1pm15fj7g1471bg13qk14w0 · target_not_running
```

Two tables disagree about the same session:

| Table | Column | Value |
|---|---|---|
| `fleet_acp_session` | `state` | `IDLE` |
| `fleet_session` | `lifecycle_state` | `EXITED` |

The mint path reads the first and hands the session back. The delivery path reads the second, sees it exited, and rejects. So a client attaches, sends, is rejected, invalidates its cache, re-mints, and gets the same corpse. Forever.

## Why boot convergence missed it

`converge_dirty_sessions_at_boot` only visits what `list_dirty` returns, and that selects sessions with an open turn or a `PENDING` delivery leg. A session sitting cleanly idle when the daemon died is not dirty, so nothing touched it. `converge_dirty_session` also only moves `ACTIVE` to `IDLE`, never to a terminal state, which is right at runtime and wrong at boot.

## The invariant

An adapter is a `tokio` child with `kill_on_drop(true)`, and nothing attaches to an adapter the pool did not spawn. **No ACP session can outlive the daemon.** Any row still claiming `ACTIVE` or `IDLE` at boot is stale by definition.

Retirement runs *after* convergence, so open turns still become interrupted markers and pending legs still resolve before anything is retired.

It writes `DEAD`, which is the existing terminal vocabulary here rather than a new state: the pool's submit door already refuses it, `get_live_by_scope` already excludes it, and the provider-swap path already writes it.

## It frees the scope rather than wedging it

The live-scope unique index is partial:

```sql
CREATE UNIQUE INDEX idx_fleet_acp_session_scope_active
    ON fleet_acp_session(scope_key) WHERE state IN ('ACTIVE','IDLE');
```

A `DEAD` row falls outside it, so a fresh mint on that scope succeeds instead of being refused as scope-held. Asserted twice: the store test inserts on the retired scope, and the daemon test mints over the wire and gets a different key.

## What it costs

The agent loses thread memory across a restart. Message history survives, because the chat log is read by scope, but both continuity mechanisms key on `session_key`: `session/load` resumes from the stored `acp_session_id`, and the re-prime prelude uses `list_for_session`, whose own test is named `list_for_session_is_the_delivery_join_not_a_scope_filter`. So the first prompt after a restart takes the fresh path, and a user can read their own history back to an agent that has forgotten it.

In practice this is a few seconds of luck, not a feature. The stale reaper ticks every 3 seconds against a 15 minute staleness cutoff, so any real downtime has already marked the twin `EXITED` before this runs. For the row this was diagnosed on, the cost is zero: its twin is already exited and no path can prompt or resume it today.

## Safety on a live daemon

The retire sits after the single-instance lock is taken, and before the pool is installed, the socket serves, or the scheduler starts. Nothing can mint a session or spawn an adapter before it runs. It writes one column on one table, with no deletes.

## Tests

| Suite | Result |
|---|---|
| `cargo test -p ainb-hangar-store --lib` | 331 passed |
| `cargo test -p ainb-hangar-daemon --test rpc_acp` | 13 passed |
| `cargo test -p ainb-hangar-daemon` | 1285 passed |
| `cargo clippy -p ainb-hangar-daemon -p ainb-hangar-store --all-targets` | exit 0 |

Store and ACP suites re-run by me after rebasing onto current main.

The daemon test builds its precondition by driving the real stale-session reaper rather than hand-writing the exited state, so the setup cannot drift from the code that produces it in production.

Falsified in four steps, each restored. With the retire removed, the send comes back as the production symptom verbatim:

```json
{"deliveries":[{"session_key":"acp:01m23q8sjx7jj8etjm7gttqhwt","state":"REJECTED","detail":"target_not_running"}]}
```

## Not verified

Whether the macOS transcript pane renders empty for a rebuilt session. The transcript is stored per session key, so a fresh session starts with none; whether that is visible depends on what the pane reads from, and the Swift side was not checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically retires stale sessions left active after a daemon restart.
  - Prevents unavailable sessions from blocking new sessions for the same scope.
  - Restores message delivery after restart instead of returning a “target not running” error.
  - Preserves already completed or terminated sessions during recovery.
- **Reliability**
  - Boot-time recovery is safe to repeat and reports database failures without crashing the daemon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->