### PR TITLE
docs: clean internal link targets and enforce zero em-dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ __pycache__/
 /explainers/
 .herenow/
 .impeccable/
+.tmux-dev-session.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,60 +6,60 @@ Canonical source of truth for the monorepo. Everything published to the website 
 
 ## 1. Start here
 
-- [Overview](product/what-is-ainb.md): what ainb is, who it is for, component breakdown
-- [Install](tui/install.md): Homebrew, curl script, prebuilt binaries, cargo build
-- [Quickstart](tui/quickstart.md): first session in 60 seconds
-- [Concepts](product/concepts.md): workspaces, worktree isolation, tmux persistence, attention
-- [Keyboard shortcuts](tui/keyboard-shortcuts.md): complete keybindings table
+- [Overview](/product/what-is-ainb): what ainb is, who it is for, component breakdown
+- [Install](/tui/install): Homebrew, curl script, prebuilt binaries, cargo build
+- [Quickstart](/tui/quickstart): first session in 60 seconds
+- [Concepts](/product/concepts): workspaces, worktree isolation, tmux persistence, attention
+- [Keyboard shortcuts](/tui/keyboard-shortcuts): complete keybindings table
 
 ## 2. Using ainb
 
-- [Starting a new session](tui/start-session.md): repo picker and new-session wizard
-- [Attaching to sessions](tui/attach.md): full-screen and in-pane live tmux attach
-- [Code review diff](tui/code-review.md): Warp-style diff viewer with collapsible hunks
-- [Fleet and chat bridge](fleet-bridge.md): drive the fleet from Telegram, Slack or Discord
-- [ATC background watcher](atc-plumbing.md): always-on watcher and session lifecycle
-- [Shared MCP pool](tui/mcp-pool.mdx): shared MCP server pool across sessions
-- [Token optimisation](tui/token-optimization.mdx): Headroom proxy and RTK context compression
-- [Inbox and notifications](tui/inbox-notifications.md): ainb-hooks notification feed
-- [Browser dashboard](tui/web.md): read-only web view (`ainb web`)
+- [Starting a new session](/tui/start-session): repo picker and new-session wizard
+- [Attaching to sessions](/tui/attach): full-screen and in-pane live tmux attach
+- [Code review diff](/tui/code-review): Warp-style diff viewer with collapsible hunks
+- [Fleet and chat bridge](/fleet-bridge): drive the fleet from Telegram, Slack or Discord
+- [ATC background watcher](/atc-plumbing): always-on watcher and session lifecycle
+- [Shared MCP pool](/tui/mcp-pool): shared MCP server pool across sessions
+- [Token optimisation](/tui/token-optimization): Headroom proxy and RTK context compression
+- [Inbox and notifications](/tui/inbox-notifications): ainb-hooks notification feed
+- [Browser dashboard](/tui/web): read-only web view (`ainb web`)
 
 ## 3. Configure and Extend
 
-- [Value proposition](product/value.md): detailed comparison and workflow impact
-- [Plugins overview](plugins/overview.md): subprocess plugin system v2
-- [Plugins user guide](plugins/user-guide.md): installing and configuring plugins
-- [In-tree plugins](plugins/overview.md):
-  - [burndown](plugins/burndown.md): cost and spend tracking
-  - [session-reader](plugins/session-reader.md): JSONL event streaming
-  - [witr](plugins/witr.md): process causality tree
-  - [learnings](plugins/learnings.md): knowledge graph
-  - [abtop](plugins/abtop.md): fleet process monitor
-- [Skill manager guide](skill-manager/guide.mdx): discovery, sync, drift check, and promotion
-- [Toolkit overview](toolkit/overview.md): portable skills and agents across 9 tools
-- [Reflect memory overview](knowledge/overview.md): GraphRAG and QMD knowledge capture
-- [Memory browser](knowledge/reflect-memory/serve.md): `reflect serve` web interface
+- [Value proposition](/product/value): detailed comparison and workflow impact
+- [Plugins overview](/plugins/overview): subprocess plugin system v2
+- [Plugins user guide](/plugins/user-guide): installing and configuring plugins
+- [In-tree plugins](/plugins/overview):
+  - [burndown](/plugins/burndown): cost and spend tracking
+  - [session-reader](/plugins/session-reader): JSONL event streaming
+  - [witr](/plugins/witr): process causality tree
+  - [learnings](/plugins/learnings): knowledge graph
+  - [abtop](/plugins/abtop): fleet process monitor
+- [Skill manager guide](/skill-manager/guide): discovery, sync, drift check, and promotion
+- [Toolkit overview](/toolkit/overview): portable skills and agents across 9 tools
+- [Reflect memory overview](/knowledge/overview): GraphRAG and QMD knowledge capture
+- [Memory browser](/knowledge/reflect-memory/serve): `reflect serve` web interface
 
 ## 4. Reference
 
-- [CLI reference](tui/cli.md): generated from `--help`, verified in CI
-- [Plugin authoring guide](plugins/authoring.md): build native binary plugins
-- [Plugin wire spec v2](plugins/spec-v2.md): JSON-RPC protocol specification
-- [Fleet cost rollups](tui/fleet-cost.md): spend across sessions and budget alerts
-- [Observability overview](observability/overview.md): telemetry and causality
-- [OpenTelemetry to Grafana](reference/otel-grafana.md): Prometheus and dashboard setup
-- [Architecture deep-dive](reference/architecture.md): whole-system architecture
-- [TUI architecture](tui/architecture.md): ratatui host and event loop
-- [Repositories map](reference/repositories.md): monorepo crate map
-- [Hangar control plane](hangar/architecture.md): task boards and autopilots
-- [Reflect memory internals](knowledge/reflect-memory/problem-and-fit.md):
-  - [The construct](knowledge/reflect-memory/construct.md)
-  - [Recall reference: 57 ports](knowledge/reflect-memory/recall.md)
-  - [Comparison](knowledge/reflect-memory/comparison.md)
+- [CLI reference](/tui/cli): generated from `--help`, verified in CI
+- [Plugin authoring guide](/plugins/authoring): build native binary plugins
+- [Plugin wire spec v2](/plugins/spec-v2): JSON-RPC protocol specification
+- [Fleet cost rollups](/tui/fleet-cost): spend across sessions and budget alerts
+- [Observability overview](/observability/overview): telemetry and causality
+- [OpenTelemetry to Grafana](/reference/otel-grafana): Prometheus and dashboard setup
+- [Architecture deep-dive](/reference/architecture): whole-system architecture
+- [TUI architecture](/tui/architecture): ratatui host and event loop
+- [Repositories map](/reference/repositories): monorepo crate map
+- [Hangar control plane](/hangar/architecture): task boards and autopilots
+- [Reflect memory internals](/knowledge/reflect-memory/problem-and-fit):
+  - [The construct](/knowledge/reflect-memory/construct)
+  - [Recall reference: 57 ports](/knowledge/reflect-memory/recall)
+  - [Comparison](/knowledge/reflect-memory/comparison)
 
 ## 5. Help
 
-- [Troubleshooting and FAQ](tui/faq.md): common questions and fixes
-- [Daemons overlay](tui/daemons.mdx): diagnostic overlay for background services
-- [Contributing guide](contributing/building.md): build, test, CI/CD, and release
-- [Glossary](reference/glossary.md): terms and definitions
+- [Troubleshooting and FAQ](/tui/faq): common questions and fixes
+- [Daemons overlay](/tui/daemons): diagnostic overlay for background services
+- [Contributing guide](/contributing/building): build, test, CI/CD, and release
+- [Glossary](/reference/glossary): terms and definitions

--- a/docs/atc-plumbing.md
+++ b/docs/atc-plumbing.md
@@ -1,13 +1,13 @@
 ---
-title: "ATC plumbing — event-driven orchestration"
+title: "ATC plumbing: event-driven orchestration"
 ---
 
-# ATC plumbing — event-driven orchestration
+# ATC plumbing: event-driven orchestration
 
 The ATC plumbing upgrades **Air Traffic Control** from *poll-mode* (act on the
 next OS-timer heartbeat) to *event-driven* (act the instant a child session
 finishes). It is shared session-lifecycle infrastructure in `ainb-core`
-(`fleet::plumbing`) + the `ainb-hooks` shell shim — **not** inside `/ainb-fleet`;
+(`fleet::plumbing`) + the `ainb-hooks` shell shim: **not** inside `/ainb-fleet`;
 ATC merely consumes it. The phone bridge and ainb itself can consume it too.
 
 The mechanism mirrors agent-deck's chain:
@@ -21,7 +21,7 @@ lifecycle hooks ──▶ atomic status files
 When a child's turn ends, its `Stop` hook commits a completion to its **parent's**
 durable inbox. The parent's own `Stop` hook drains that inbox and returns
 `{"decision":"block","reason":<completions>}`, which Claude Code feeds back as the
-parent's next turn — so the parent (ATC) reacts immediately instead of waiting for
+parent's next turn: so the parent (ATC) reacts immediately instead of waiting for
 its heartbeat. Empty inbox ⇒ no block, no writes (every leaf session pays nothing).
 
 ---
@@ -103,7 +103,7 @@ not patched.
 ## Hook event set
 
 The full lifecycle set is installed into Claude Code's `~/.claude/settings.json`
-by `ainb fleet atc setup` (read-preserve-modify-write — see below). Each managed
+by `ainb fleet atc setup` (read-preserve-modify-write: see below). Each managed
 entry runs the shared `notify.sh` with `AINB_HOOK_EVENT=<event> AINB_MANAGED=atc`,
 which forwards to `ainb fleet atc hook`:
 
@@ -120,7 +120,7 @@ which forwards to `ainb fleet atc hook`:
 The merge into `settings.json` is **read-preserve-modify-write**: every ATC entry
 is tagged `"_ainb_atc_managed": true`, so a re-install replaces exactly the prior
 ATC entries and re-running is byte-idempotent. Crucially it **preserves all other
-hooks** on the same events — the reflect plugin's `Stop`/`PreCompact`/`SessionStart`/
+hooks** on the same events: the reflect plugin's `Stop`/`PreCompact`/`SessionStart`/
 `UserPromptSubmit`/`PostToolUse` hooks and the ainb-hooks/notifyd `Notification`/
 `Stop` hooks all survive untouched. Uninstall (on the last ATC teardown) strips
 exactly the ATC block back out.
@@ -141,7 +141,7 @@ On a parent's synchronous `Stop` hook:
 
 ## Parent linkage
 
-A child records its parent — the inbox routing key — two ways, resolved in this
+A child records its parent: the inbox routing key: two ways, resolved in this
 order by the Stop hook:
 
 1. `AINB_PARENT_SESSION` env var, seeded into the child's tmux session by
@@ -165,7 +165,7 @@ ATC session's own inbox first**: any child completions are prepended to the
 roster. A pending completion overrides idle-pause (a finished child wakes ATC even
 during a quiet window). The poll-mode `fleet needs` path remains the always-on
 fallback, so ATC behaves identically whether or not any child has the hooks
-installed — the plumbing is a pure drop-in enhancement.
+installed: the plumbing is a pure drop-in enhancement.
 
 ### Operator / debug verbs
 

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -5,7 +5,7 @@ title: "Building from source"
 > **Status:** stub. Authoritative content currently lives at `ainb-tui/CLAUDE.md + main README §Development`.
 > Migration of that file into this path is gated on Stevie's approval.
 
-Build the TUI and plugins locally. The ainb-toolkit lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo — clone it separately if you need to work on skills/agents/workflows.
+Build the TUI and plugins locally. The ainb-toolkit lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo: clone it separately if you need to work on skills/agents/workflows.
 
 ## What this page will contain
 
@@ -17,4 +17,4 @@ Build the TUI and plugins locally. The ainb-toolkit lives in the standalone [`st
 
 ## See also
 
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -4,39 +4,39 @@ title: "CI / CD"
 
 Four GitHub Actions workflows live under `.github/workflows/`. Each is path-filtered so it only runs when the area it covers changes.
 
-## `ci.yml` — Rust CI
+## `ci.yml`: Rust CI
 
 Runs on push and PR to `main` / `v2` when `ainb-tui/**`, `plugins/ainb-hooks/**`, `Cargo.*`, or the workflow itself changes. Jobs:
 
-- **Rustfmt** — `cargo fmt --all --check` (Ubuntu).
-- **Test** — `cargo nextest run --lib --all-features --no-fail-fast` on a `ubuntu-latest` + `macos-latest` matrix, skipping a small set of environment-dependent tests (`docker::`, a Claude provider-install test, and an inclusive-range usage test).
-- **ainb-hooks** — daemon + plugin integration on both OSes: parses `plugins/ainb-hooks/hooks/notify.sh`, runs `ainb-plugin-notifyd` lib tests and the `end_to_end` (hook → socket → SQLite) test, plus the `tripwire_inbox_opens_and_renders` tripwire against the `ainb` binary. Installs `tmux` + `jq` on the Linux runner.
-- **Cargo Machete** — `bnjbvr/cargo-machete` unused-dependency scan against `ainb-tui/Cargo.toml`.
+- **Rustfmt**: `cargo fmt --all --check` (Ubuntu).
+- **Test**: `cargo nextest run --lib --all-features --no-fail-fast` on a `ubuntu-latest` + `macos-latest` matrix, skipping a small set of environment-dependent tests (`docker::`, a Claude provider-install test, and an inclusive-range usage test).
+- **ainb-hooks**: daemon + plugin integration on both OSes: parses `plugins/ainb-hooks/hooks/notify.sh`, runs `ainb-plugin-notifyd` lib tests and the `end_to_end` (hook → socket → SQLite) test, plus the `tripwire_inbox_opens_and_renders` tripwire against the `ainb` binary. Installs `tmux` + `jq` on the Linux runner.
+- **Cargo Machete**: `bnjbvr/cargo-machete` unused-dependency scan against `ainb-tui/Cargo.toml`.
 
-## `release.yml` — tagged release + Homebrew tap
+## `release.yml`: tagged release + Homebrew tap
 
 Manual `workflow_dispatch` (inputs: `version`, `prerelease`). Jobs run in sequence:
 
-- **Prepare Release** — validates the semver `version`, generates changelog notes from conventional commits, bumps `ainb-tui/Cargo.toml`, updates `CHANGELOG.md`, commits, and creates + pushes the `v<version>` tag.
-- **Build** — cross-platform release binaries on a matrix of `aarch64-apple-darwin` (macOS) and `x86_64-unknown-linux-gnu` (Linux), packaged as `.tar.gz` + `.sha256`.
-- **Create Release** — `softprops/action-gh-release` publishes a GitHub Release with the artifacts and install instructions.
-- **Update Homebrew Tap** — regenerates `Formula/ainb.rb` in `stevengonsalvez/homebrew-agents-in-a-box` with the new version and per-platform SHA256s, then commits and pushes.
+- **Prepare Release**: validates the semver `version`, generates changelog notes from conventional commits, bumps `ainb-tui/Cargo.toml`, updates `CHANGELOG.md`, commits, and creates + pushes the `v<version>` tag.
+- **Build**: cross-platform release binaries on a matrix of `aarch64-apple-darwin` (macOS) and `x86_64-unknown-linux-gnu` (Linux), packaged as `.tar.gz` + `.sha256`.
+- **Create Release**: `softprops/action-gh-release` publishes a GitHub Release with the artifacts and install instructions.
+- **Update Homebrew Tap**: regenerates `Formula/ainb.rb` in `stevengonsalvez/homebrew-agents-in-a-box` with the new version and per-platform SHA256s, then commits and pushes.
 
-## `toolkit-validation.yml` — Skill Manager & Catalog CI
+## `toolkit-validation.yml`: Skill Manager & Catalog CI
 
-> **Note:** the toolkit now lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo (flattened layout — no `packages/` wrapper). This workflow validates the ainb-side skill-manager integration and, at release time, generates the catalog index by cloning `ainb-toolkit` at the pinned tag (Option B). Path trigger is `.github/workflows/toolkit-validation.yml` itself; the toolkit source is cloned, not checked-in.
+> **Note:** the toolkit now lives in the standalone [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo (flattened layout: no `packages/` wrapper). This workflow validates the ainb-side skill-manager integration and, at release time, generates the catalog index by cloning `ainb-toolkit` at the pinned tag (Option B). Path trigger is `.github/workflows/toolkit-validation.yml` itself; the toolkit source is cloned, not checked-in.
 
 Jobs:
 
-- **Validate Packages Structure** — clones `ainb-toolkit@<pinned-tag>` and asserts `agents/`, `skills/`, `workflows/`, `utilities/` exist at the repo root; enforces minimum counts (agents ≥ 30, skills ≥ 60).
-- **Test Tool Installations** — runs `bootstrap.js` (ainb-toolkit root) into a fake `$HOME` for a `claude-code-4.5` / `codex` / `gemini` matrix, asserting the install dir, a minimum file count (≥ 100), a `skills/` dir, and an `agents/` dir for `claude-code-4.5`.
-- **Check Template Substitution** — installs `claude-code-4.5` and greps for unsubstituted `{{TOOL_DIR}}` / `{{HOME_TOOL_DIR}}` placeholders.
-- **Verify claude-code-4.5 is thin layer** — asserts the `claude-code-4.5` adapter in ainb-toolkit carries only the thin-layer files (no `agents`/`commands`/`skills`/etc. dirs).
+- **Validate Packages Structure**: clones `ainb-toolkit@<pinned-tag>` and asserts `agents/`, `skills/`, `workflows/`, `utilities/` exist at the repo root; enforces minimum counts (agents ≥ 30, skills ≥ 60).
+- **Test Tool Installations**: runs `bootstrap.js` (ainb-toolkit root) into a fake `$HOME` for a `claude-code-4.5` / `codex` / `gemini` matrix, asserting the install dir, a minimum file count (≥ 100), a `skills/` dir, and an `agents/` dir for `claude-code-4.5`.
+- **Check Template Substitution**: installs `claude-code-4.5` and greps for unsubstituted `{{TOOL_DIR}}` / `{{HOME_TOOL_DIR}}` placeholders.
+- **Verify claude-code-4.5 is thin layer**: asserts the `claude-code-4.5` adapter in ainb-toolkit carries only the thin-layer files (no `agents`/`commands`/`skills`/etc. dirs).
 
-## `deploy-pages.yml` — docs site to GitHub Pages
+## `deploy-pages.yml`: docs site to GitHub Pages
 
 Runs on push to `main` touching `website/site/**`, `docs/**`, or the workflow itself (also `workflow_dispatch`). Builds the Astro + Starlight site under `website/site` with Node 22 and `npm ci` + `npm run build`, then deploys to GitHub Pages, served at the custom domain `https://ainb.app/` via `website/site/public/CNAME`. Uses a `pages` concurrency group so an in-flight deploy finishes while queued runs are cancelled.
 
 ## See also
 
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -18,4 +18,4 @@ How a release is cut, tagged, built, and shipped.
 
 ## See also
 
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/fleet-bridge.md
+++ b/docs/fleet-bridge.md
@@ -73,6 +73,6 @@ Logs are written to `~/.agents-in-a-box/phone-bridge.log`.
 
 ## Next steps
 
-- [ATC background watcher](atc-plumbing.md): always-on session watcher
-- [Attaching to sessions](tui/attach.md): terminal attachment controls
-- [CLI reference](tui/cli.md): fleet bridge command flags
+- [ATC background watcher](/atc-plumbing): always-on session watcher
+- [Attaching to sessions](/tui/attach): terminal attachment controls
+- [CLI reference](/tui/cli): fleet bridge command flags

--- a/docs/hangar/architecture.md
+++ b/docs/hangar/architecture.md
@@ -1,11 +1,11 @@
 ---
-title: "Hangar — architecture & features"
+title: "Hangar: architecture & features"
 description: "Hangar is ainb's TUI-first managed-agents control plane (a Multica feature replica): daemon + plugin over unix-socket JSON-RPC, with issues, autopilots, skills, a kanban board, and an agent fleet."
 ---
 
-Hangar gives `ainb` a **managed-agent control plane**: file work as *issues*, assign them to *agents* (Claude / Codex / Gemini), watch tasks march through a lifecycle on a *kanban board*, schedule recurring work with *autopilots*, curate reusable *skills* and *agent templates*, and observe the whole fleet's health — all from the terminal. It is a feature replica of Multica, built natively inside ainb.
+Hangar gives `ainb` a **managed-agent control plane**: file work as *issues*, assign them to *agents* (Claude / Codex / Gemini), watch tasks march through a lifecycle on a *kanban board*, schedule recurring work with *autopilots*, curate reusable *skills* and *agent templates*, and observe the whole fleet's health: all from the terminal. It is a feature replica of Multica, built natively inside ainb.
 
-It is deliberately **loosely coupled**. A standalone `ainb-hangar-daemon` owns the data plane (SQLite, the task FSM, the cron scheduler, the agent runner). The TUI is a **plugin** (`hangar-tui`) that the host `ainb` binary loads and that talks to the daemon over a unix-socket JSON-RPC contract. The plugin holds *zero* domain logic — it subscribes, pulls snapshots, renders, and forwards key intents. So the control plane keeps running (autopilots fire, tasks dispatch) whether or not a TUI is attached.
+It is deliberately **loosely coupled**. A standalone `ainb-hangar-daemon` owns the data plane (SQLite, the task FSM, the cron scheduler, the agent runner). The TUI is a **plugin** (`hangar-tui`) that the host `ainb` binary loads and that talks to the daemon over a unix-socket JSON-RPC contract. The plugin holds *zero* domain logic: it subscribes, pulls snapshots, renders, and forwards key intents. So the control plane keeps running (autopilots fire, tasks dispatch) whether or not a TUI is attached.
 
 | | | How to re-derive |
 |---|---|---|
@@ -19,12 +19,12 @@ It is deliberately **loosely coupled**. A standalone `ainb-hangar-daemon` owns t
 > produces it, because the previous set (4 crates, 17 RPC methods, migrations
 > 0001–0010) was a pre-e38 snapshot that stayed on the page long after the
 > code moved. The reconciliation in
-> [`proofs/multica-comparison.md`](proofs/multica-comparison.md) is itself
+> [`proofs/multica-comparison.md`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/docs/hangar/proofs/multica-comparison.md) is itself
 > now behind: it records 39 RPC methods and 23 migrations.
 
 ## System architecture
 
-Five Rust components in three planes: the **host + plugin** (presentation), the **daemon** (control), and the **store + SQLite** (data). Two cross-cutting crates — `ainb-hangar-core` (IO-free domain types) and `ainb-hangar-proto` (wire types) — are shared by everything.
+Five Rust components in three planes: the **host + plugin** (presentation), the **daemon** (control), and the **store + SQLite** (data). Two cross-cutting crates: `ainb-hangar-core` (IO-free domain types) and `ainb-hangar-proto` (wire types): are shared by everything.
 
 ![Hangar layered system architecture](./diagrams/arch-system.svg)
 
@@ -37,12 +37,12 @@ Five Rust components in three planes: the **host + plugin** (presentation), the 
 | **`ainb-hangar-core`** | IO-free domain layer: typed ids, the `HangarClock`/`IdGen` traits, the task-status FSM table, the cron parser, env-allowlist policy, skill + autopilot service traits, PR-URL parser, token mint/verify, `TaskResult`. |
 | **`ainb-hangar-proto`** | JSON-RPC wire types + method-name constants shared by daemon and plugin. Plus the plugin SDK (`ainb-plugin-protocol` / `ainb-plugin-sdk-rust`). |
 
-The plugin dials `~/.ainb/hangar/hangar.sock` via the host `unix_socket_dial` capability. The daemon resolves a workspace identifier (slug *or* id) to the real row before scoping any query — the guard that closed the cross-tenant IDOR. Plugin subprocesses are spawned with `kill_on_drop(true)` plus an OS leak-guard (`PR_SET_PDEATHSIG` on Linux, `setpgid` + `kill(-pgid)` on macOS).
+The plugin dials `~/.ainb/hangar/hangar.sock` via the host `unix_socket_dial` capability. The daemon resolves a workspace identifier (slug *or* id) to the real row before scoping any query: the guard that closed the cross-tenant IDOR. Plugin subprocesses are spawned with `kill_on_drop(true)` plus an OS leak-guard (`PR_SET_PDEATHSIG` on Linux, `setpgid` + `kill(-pgid)` on macOS).
 
 ## Dependency graph
 
 ```text
-ainb-hangar-core   (foundation — IO-free; no internal deps)
+ainb-hangar-core   (foundation: IO-free; no internal deps)
       ▲          ▲              ▲
       │          │              │
 ainb-hangar-store │       ainb-hangar-proto
@@ -56,13 +56,13 @@ ainb-hangar-store │       ainb-hangar-proto
         hangar-tui plugin  (deps: proto + plugin-sdk)  ◀── loaded by ──  ainb (host + plugin-runtime v2)
 ```
 
-`core` is the root and depends on nothing internal, so it stays IO-free and trivially testable. `store` and `proto` both build on `core`; the `daemon` ties all three together. The plugin depends only on `proto` + the SDK — never on the daemon or store crates — so it cannot smuggle in domain logic.
+`core` is the root and depends on nothing internal, so it stays IO-free and trivially testable. `store` and `proto` both build on `core`; the `daemon` ties all three together. The plugin depends only on `proto` + the SDK: never on the daemon or store crates: so it cannot smuggle in domain logic.
 
 ### Key external dependencies
 
 | Crate | Purpose |
 |-------|---------|
-| `tokio` | Async runtime — daemon server, claim loop, scheduler, runner, plugin stdio. |
+| `tokio` | Async runtime: daemon server, claim loop, scheduler, runner, plugin stdio. |
 | `sqlx` (SQLite) | Async, runtime-checked queries; migrations 0001–0010. Postgres-compatible schema for a future backend. |
 | `ratatui` + `crossterm` | TUI rendering (host + plugin screens). |
 | `cron` v0.12 | Cron parsing (6-field; 5-field POSIX normalised by prepending `0 `). |
@@ -75,24 +75,24 @@ ainb-hangar-store │       ainb-hangar-proto
 
 ## Data & control flow
 
-Two loops run continuously and independently: the **dispatch loop** (control plane — turns issues into running agent tasks) and the **render loop** (data plane — turns daemon state into TUI pixels).
+Two loops run continuously and independently: the **dispatch loop** (control plane: turns issues into running agent tasks) and the **render loop** (data plane: turns daemon state into TUI pixels).
 
 ![Hangar control and data flow](./diagrams/arch-dataflow.svg)
 
 **Dispatch loop (control):**
 
 1. `ainb hangar issue create --assign <agent>` (or an autopilot tick) enqueues an `agent_task_queue` row.
-2. The daemon **claim loop** atomically claims the most urgent (then oldest) queued task for an idle runtime (`queued → dispatched`) — `ORDER BY priority DESC, created_at, id` — respecting per-agent `max_concurrent_tasks` and the per-(issue, agent) active-set guard.
-3. It **materialises skills** into the task's per-task directory at the provider-native path (`.claude/skills/`, `.codex/skills/`, `.agent_context/skills/` …) — copied, scripts `chmod 0755`, kept outside the worktree git root so `git status` stays clean.
+2. The daemon **claim loop** atomically claims the most urgent (then oldest) queued task for an idle runtime (`queued → dispatched`): `ORDER BY priority DESC, created_at, id`: respecting per-agent `max_concurrent_tasks` and the per-(issue, agent) active-set guard.
+3. It **materialises skills** into the task's per-task directory at the provider-native path (`.claude/skills/`, `.codex/skills/`, `.agent_context/skills/` …): copied, scripts `chmod 0755`, kept outside the worktree git root so `git status` stays clean.
 4. It spawns the provider in an isolated git worktree (`dispatched → running`), streaming the transcript.
 5. On a terminal transition the **FSM finalize** path runs idempotently: it stamps `done/failed/cancelled`, cascades `autopilot_run.completed_at` when the task belongs to an autopilot run, and captures any `gh pr create` URL into `result.pr_url`.
 
 **Render loop (data):**
 
 1. The plugin sends `workspace/subscribe` for the active workspace; the daemon registers the (authenticated) connection as a workspace-scoped event subscriber.
-2. On the ack it fires snapshot RPCs — `hangar/issues_list`, `tasks_list`, `agents_list`, `skills_list`, `autopilots_list`, `daemon_health` — which the daemon answers from the store (resolving slug→id, scoping by workspace).
+2. On the ack it fires snapshot RPCs: `hangar/issues_list`, `tasks_list`, `agents_list`, `skills_list`, `autopilots_list`, `daemon_health`: which the daemon answers from the store (resolving slug→id, scoping by workspace).
 3. The plugin folds the wire rows into screen state and renders.
-4. The daemon **pushes** `hangar/event` notifications over the same subscription (this closed parity-review design gap 02 — the channel used to be decode-only with zero emission sites): the claim loop emits `TaskStarted` and the terminal `TaskFinished` as the FSM finalizes, the Kanban `task_transition` RPC emits the matching lifecycle event when a card actually moves, and the autopilot scheduler / fire-now path emits `AutopilotRunChanged` (fired and skipped ticks). Events are scoped to the subscribed workspace's resolved row id — a tenant never sees another tenant's frames — and only authenticated, subscribed connections receive them. Delivery is best-effort instant feedback; the next snapshot reconciles authoritatively, so a dropped event self-heals.
+4. The daemon **pushes** `hangar/event` notifications over the same subscription (this closed parity-review design gap 02: the channel used to be decode-only with zero emission sites): the claim loop emits `TaskStarted` and the terminal `TaskFinished` as the FSM finalizes, the Kanban `task_transition` RPC emits the matching lifecycle event when a card actually moves, and the autopilot scheduler / fire-now path emits `AutopilotRunChanged` (fired and skipped ticks). Events are scoped to the subscribed workspace's resolved row id: a tenant never sees another tenant's frames: and only authenticated, subscribed connections receive them. Delivery is best-effort instant feedback; the next snapshot reconciles authoritatively, so a dropped event self-heals.
 
 ## Task lifecycle (FSM)
 
@@ -100,12 +100,12 @@ Every unit of agent work is an `agent_task_queue` row walking a strict finite-st
 
 ![Task FSM state machine](./diagrams/arch-task-fsm.svg)
 
-- **Per-(issue, agent) concurrency** — task work on one issue serialises per **agent**, not globally (decision: adopt Multica's `ClaimAgentTask` model, closing parity-review design gap 03). The partial unique index `idx_one_pending_task_per_issue_agent` (migration 0012, replacing 0004's global-per-issue scope) allows at most one *pending* (`queued`/`dispatched`) task per `(issue_id, agent_id)`, and the claim SQL's `NOT EXISTS` active-set guard refuses to dispatch an agent a second `queued`/`dispatched`/`running` task for an issue it is already working — so different agents work one issue in parallel while the same agent's duplicate fires still coalesce.
-- **Priority ordering** — the claim drains `ORDER BY priority DESC, created_at, id` (decision: adopt Multica's `priority DESC, created_at` claim ordering, closing the parity-review "no expedite path" design gap). `agent_task_queue.priority` (migration 0013) is an integer **0..3 mapping P3..P0 — higher = more urgent**: `0` = P3 (the routine default, so untouched enqueue paths stay strict-FIFO), `3` = P0 (claimed first). Equal priorities keep the FIFO `created_at, id` tiebreak. `ainb hangar issue create --priority N --assign <agent>` stamps it onto the enqueued task; a retry child inherits its parent's priority.
-- **Idempotent finalize** — concurrent complete-vs-cancel resolves deterministically (first wins, loser no-ops); a terminal row never re-transitions.
-- **Retry** — a failure with a *retryable* reason (e.g. runtime offline) spawns a child task linked by `parent_task_id`, capped by `max_attempts`; `agent_error` does not retry.
-- **TTL sweepers** — stale `queued` (2h) / `dispatched` (5min) / `running` (2.5h) rows are swept to `failed` in idempotent batches (cap 500).
-- **Autopilot cascade** — finalising a task carrying an `autopilot_run_id` stamps the run's `completed_at` in the same path.
+- **Per-(issue, agent) concurrency**: task work on one issue serialises per **agent**, not globally (decision: adopt Multica's `ClaimAgentTask` model, closing parity-review design gap 03). The partial unique index `idx_one_pending_task_per_issue_agent` (migration 0012, replacing 0004's global-per-issue scope) allows at most one *pending* (`queued`/`dispatched`) task per `(issue_id, agent_id)`, and the claim SQL's `NOT EXISTS` active-set guard refuses to dispatch an agent a second `queued`/`dispatched`/`running` task for an issue it is already working: so different agents work one issue in parallel while the same agent's duplicate fires still coalesce.
+- **Priority ordering**: the claim drains `ORDER BY priority DESC, created_at, id` (decision: adopt Multica's `priority DESC, created_at` claim ordering, closing the parity-review "no expedite path" design gap). `agent_task_queue.priority` (migration 0013) is an integer **0..3 mapping P3..P0: higher = more urgent**: `0` = P3 (the routine default, so untouched enqueue paths stay strict-FIFO), `3` = P0 (claimed first). Equal priorities keep the FIFO `created_at, id` tiebreak. `ainb hangar issue create --priority N --assign <agent>` stamps it onto the enqueued task; a retry child inherits its parent's priority.
+- **Idempotent finalize**: concurrent complete-vs-cancel resolves deterministically (first wins, loser no-ops); a terminal row never re-transitions.
+- **Retry**: a failure with a *retryable* reason (e.g. runtime offline) spawns a child task linked by `parent_task_id`, capped by `max_attempts`; `agent_error` does not retry.
+- **TTL sweepers**: stale `queued` (2h) / `dispatched` (5min) / `running` (2.5h) rows are swept to `failed` in idempotent batches (cap 500).
+- **Autopilot cascade**: finalising a task carrying an `autopilot_run_id` stamps the run's `completed_at` in the same path.
 
 ## Data model
 
@@ -199,12 +199,12 @@ time.
 
 > **Verification captures.** `assets/journeys/` holds ~68 more files (~16MB)
 > from the e38 parity run, indexed by
-> [`verify-converged-goal.md`](verify-converged-goal.md). They are evidence
+> [`verify-converged-goal.md`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/docs/hangar/verify-converged-goal.md). They are evidence
 > that a behaviour was exercised, not illustrations: most are 2200x1000 frames
 > where the content occupies a small corner, and the `ch2`-`ch7` set has no
 > reproducer script. Use them to check a claim, not to learn the product.
 
-## Feature catalogue — what a user does
+## Feature catalogue: what a user does
 
 Every Hangar feature is reachable two ways: a **TUI screen** (open Hangar with `g`, then a hotkey) and/or the `ainb hangar <noun>` **CLI**.
 
@@ -238,7 +238,7 @@ ainb hangar beads      reconcile        ainb hangar daemon  status
 
 ## Feature × test coverage
 
-Built test-first: every feature carries an **acceptance test** (unit/integration), and most carry an **e2e tripwire** — a real test that drives `ainb tui` in a `tmux` pane (or the daemon over its real socket) and asserts the rendered/persisted result, per the `tmux-ui-tripwire` discipline.
+Built test-first: every feature carries an **acceptance test** (unit/integration), and most carry an **e2e tripwire**: a real test that drives `ainb tui` in a `tmux` pane (or the daemon over its real socket) and asserts the rendered/persisted result, per the `tmux-ui-tripwire` discipline.
 
 Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only · file references are verifiable in-tree.
 
@@ -247,7 +247,7 @@ Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
 | Create / list / show issue | CLI | `hangar_cli_integration.rs` (4) + `cli::hangar` parse (3) | `tripwire_hangar_issue_roundtrip.rs` | ✅ |
-| Persist issue + assignee | store | `repo_issue.rs` (4) | — (via roundtrip) | ✅ |
+| Persist issue + assignee | store | `repo_issue.rs` (4) |: (via roundtrip) | ✅ |
 | Issue list screen (nav/filter/create) | TUI | `issue_list_reducer_test.rs` (7) | `tripwire_p4_issue_list_renders.rs` | ✅ |
 | Kanban board (4 cols, card move) | TUI | `kanban_reducer` (10) + `rpc_over_socket` + `snapshot` (5) | `tripwire_kanban_columns_render.rs` | ✅ |
 
@@ -256,24 +256,24 @@ Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
 | Task FSM (claim/start/complete/fail/cancel) | store+core | `finalize_idempotency` (22) + `claim_task_integration` + `task_state_transitions` | `tripwire_task_happy_path_claude_provider.rs` | ✅ |
-| Retry chain (parent/child, max-attempts) | store | `retry_chain.rs` (8) | — | ✅ (acc.) |
+| Retry chain (parent/child, max-attempts) | store | `retry_chain.rs` (8) |: | ✅ (acc.) |
 | TTL sweep (stale → fail) | daemon | `sweeper_ttls.rs` (10) | `tripwire_ttl_sweeper_fails_stale_dispatched.rs` | ✅ |
 | Task detail + transcript screen | TUI | `transcript_reducer` (10) + `render_snapshot` (2) | `tripwire_p4_task_detail_streams.rs` | ✅ |
-| Task CLI (list/cancel/retry) | CLI | `hangar_cli_integration` + parse | — | ✅ (acc.) |
-| Task-started banner | TUI | `banner_reducer_test.rs` (6) | — | ✅ (acc.) |
+| Task CLI (list/cancel/retry) | CLI | `hangar_cli_integration` + parse |: | ✅ (acc.) |
+| Task-started banner | TUI | `banner_reducer_test.rs` (6) |: | ✅ (acc.) |
 
 ### Agents
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
 | Agent picker (assign agent) | TUI | `agent_picker_reducer_test.rs` (8) | `tripwire_p4_agent_picker_opens.rs` | ✅ |
-| agents_list snapshot | daemon/store | `repo_agent.rs` + `rpc_server.rs` | — (in picker tripwire) | ✅ |
+| agents_list snapshot | daemon/store | `repo_agent.rs` + `rpc_server.rs` |: (in picker tripwire) | ✅ |
 
 ### Skills
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
-| Skill repo CRUD (scoping, cascade) | store+core | `skill_repo_tests` (9) + `skill_service` inline | — | ✅ (acc.) |
+| Skill repo CRUD (scoping, cascade) | store+core | `skill_repo_tests` (9) + `skill_service` inline |: | ✅ (acc.) |
 | Skills sync importer (idempotent) | daemon/CLI | `tripwire_skills_sync_idempotent.rs` (5) + parse | `screens_render_from_daemon` (sync RPC) | ✅ |
 | Skill manager screen (attach/detach/sync) | TUI | `skill_manager_reducer` (9) + `snapshot` (2) | `tripwire_p4_skill_manager_lists.rs` | ✅ |
 | Dispatch-time materialisation | daemon | `materialise_skills_tests.rs` (8) | `tripwire_skill_import_and_dispatch.rs` | ✅ |
@@ -282,26 +282,26 @@ Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only 
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
-| 10 curated templates (embedded, resolve) | core | `template_registry_tests.rs` (5) | — | ✅ (acc.) |
-| templates list / show / use | CLI+daemon | `template_use_tests` (6) + parse | — | ✅ (acc.) |
+| 10 curated templates (embedded, resolve) | core | `template_registry_tests.rs` (5) |: | ✅ (acc.) |
+| templates list / show / use | CLI+daemon | `template_use_tests` (6) + parse |: | ✅ (acc.) |
 
 ### Autopilots
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
-| Cron CRUD (reject invalid cron) | store+core | `repo_autopilot` (14) + `cron.rs` inline (12) | — | ✅ (acc.) |
+| Cron CRUD (reject invalid cron) | store+core | `repo_autopilot` (14) + `cron.rs` inline (12) |: | ✅ (acc.) |
 | Scheduler fires on schedule | daemon | `scheduler_loop` + `repo_autopilot_enqueue` | `tripwire_autopilot_fires_on_schedule.rs` | ✅ |
 | Scheduler skips when in-flight | daemon | `scheduler_loop::skip_when_prior_run_in_flight` | `tripwire_autopilot_skips_when_running.rs` | ✅ |
-| Autopilots manager screen | TUI | `autopilots_reducer` (6) + `snapshot` (4) + `rpc_over_socket` | — (real-socket, no tmux) | ✅ |
-| autopilot CLI (create/list/disable/run) | CLI | `hangar_autopilot_cli.rs` (2) + parse | — | ✅ |
+| Autopilots manager screen | TUI | `autopilots_reducer` (6) + `snapshot` (4) + `rpc_over_socket` |: (real-socket, no tmux) | ✅ |
+| autopilot CLI (create/list/disable/run) | CLI | `hangar_autopilot_cli.rs` (2) + parse |: | ✅ |
 
 ### Auth / Secrets
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
 | OS keychain store/get/delete | secrets | `backend.rs` (7) | `tripwire_keychain_roundtrip.rs` *(#[ignore], dev-mac)* | ✅ |
-| secret_store_get cap gating | runtime | `secret_store_cap.rs` (5) | — | ✅ (acc.) |
-| PAT / daemon tokens (hash-only) | store+core | `repo_token` (11) + `token.rs` inline (3) + cli | — | ✅ (acc.) |
+| secret_store_get cap gating | runtime | `secret_store_cap.rs` (5) |: | ✅ (acc.) |
+| PAT / daemon tokens (hash-only) | store+core | `repo_token` (11) + `token.rs` inline (3) + cli |: | ✅ (acc.) |
 | Env allowlist (block LD_PRELOAD) | core+daemon | `env_policy` (5) + `env_allow_config` (3) + runner | `tripwire_env_allowlist_blocks_ld_preload` / `_passes_home` | ✅ |
 | danger-full-access first-run warning | core+daemon | `warnings.rs` inline (4) | `tripwire_warning_shown_on_first_provider_use.rs` | ✅ |
 | Workspace switching in Settings | TUI+runtime | `settings_reducer` + `workspace_cap.rs` (7) | `tripwire_workspace_switch_e2e.rs` | ✅ |
@@ -311,11 +311,11 @@ Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only 
 
 | Feature | Layer | Acceptance | e2e tripwire | |
 |---|---|---|---|---|
-| Tracing JSONL sink | daemon | `it_subscriber_writes_jsonl.rs` | — | ✅ (acc.) |
+| Tracing JSONL sink | daemon | `it_subscriber_writes_jsonl.rs` |: | ✅ (acc.) |
 | OTLP exporter (otlp feature) | daemon | `it_otlp_export_when_endpoint_set.rs` *(--features otlp)* | `tripwire_otel_export_when_endpoint_set.rs` | ✅ |
-| Instrumented service spans (8 methods) | store+daemon | `service_spans_emit` + `beads_sync_spans_emit` | — | ✅ (acc.) |
+| Instrumented service spans (8 methods) | store+daemon | `service_spans_emit` + `beads_sync_spans_emit` |: | ✅ (acc.) |
 | Daemon health pane + sparkline | TUI+daemon | `snapshot_daemon_health.rs` (5) | `tripwire_daemon_health_sparkline.rs` | ✅ |
-| logs tail CLI + logs screen | CLI+TUI | `logs.rs` inline (8) + cli + `snapshot_logs_screen` (3) | — (no tmux for logs screen) | ✅ (acc.) |
+| logs tail CLI + logs screen | CLI+TUI | `logs.rs` inline (8) + cli + `snapshot_logs_screen` (3) |: (no tmux for logs screen) | ✅ (acc.) |
 
 ### gh integration
 
@@ -333,22 +333,22 @@ Legend: **✅** = acceptance + e2e tripwire · **✅ (acc.)** = acceptance only 
 | workspace/subscribe + event stream | proto+daemon+plugin | `event_roundtrip` (6) + `stream_decode` (8) + `daemon_dial` + `rpc_event_push.rs` (3: push, workspace isolation, no-op silence) | `tripwire_detects_daemon_drop` | ✅ |
 | Cross-screen navigation | TUI | `screen_router_test.rs` (5) | `tripwire_p4_cross_screen_navigation.rs` | ✅ |
 | Beads bidirectional sync | daemon | `beads_adapter`/`reconcile`/`inbound`/`outbound`/`cli` (50+) | `tripwire_beads_roundtrip.rs` | ✅ |
-| Claude runner exec (env/exit/stream/timeout) | daemon | `runner_claude.rs` (6) | — (in happy-path) | ✅ |
-| Full-suite e2e guard (no shrink) | daemon | — | `tripwire_full_e2e.rs` | ✅ |
+| Claude runner exec (env/exit/stream/timeout) | daemon | `runner_claude.rs` (6) |: (in happy-path) | ✅ |
+| Full-suite e2e guard (no shrink) | daemon |: | `tripwire_full_e2e.rs` | ✅ |
 
 ### Coverage summary
 
-- **22 features have a full e2e tripwire** — 11 via real `tmux` driving `ainb tui`, 11 via daemon-over-real-socket.
-- **12 are acceptance-only** (strong unit/integration; no tmux) — task retry, task/templates/token CLIs, skill CRUD, autopilot CRUD, JSONL sink, service spans, logs screen.
-- **0 are untested** — every feature has at least an acceptance test.
+- **22 features have a full e2e tripwire**: 11 via real `tmux` driving `ainb tui`, 11 via daemon-over-real-socket.
+- **12 are acceptance-only** (strong unit/integration; no tmux): task retry, task/templates/token CLIs, skill CRUD, autopilot CRUD, JSONL sink, service spans, logs screen.
+- **0 are untested**: every feature has at least an acceptance test.
 
-:::caution[Honest gaps — coverage shape, not regressions]
+:::caution[Honest gaps: coverage shape, not regressions]
 - The **logs screen** and **autopilots manager screen** have reducer + snapshot + real-socket coverage but no `tmux capture-pane` proof of the rendered screen.
 - The `task` / `templates` / `token` CLIs are acceptance-only, versus the `issue` path which has a full tmux roundtrip.
 - The keychain roundtrip tripwire is `#[ignore]` by default (needs a real dev-mac keychain prompt); the in-memory + cfg-gated backend tests are the authoritative proof.
 :::
 
-## How it was built — phases P0–P9
+## How it was built: phases P0–P9
 
 Per-bead TDD (RED → GREEN → review → scoped gate → close), each phase capped by e2e tripwires.
 

--- a/docs/knowledge/hooks-and-platform.md
+++ b/docs/knowledge/hooks-and-platform.md
@@ -1,17 +1,17 @@
 ---
 title: "Hooks & Platform · how reflect captures and recalls across Claude + Codex"
-description: "Visual deep-dive into the reflect plugin's hook architecture, recall flows, capture flows, status line integration, and cross-tool drain — across Claude Code and Codex CLI."
+description: "Visual deep-dive into the reflect plugin's hook architecture, recall flows, capture flows, status line integration, and cross-tool drain: across Claude Code and Codex CLI."
 ---
 
-> **The short version** — Three harnesses (Claude Code, Codex CLI, GitHub Copilot) wire the same
+> **The short version**: Three harnesses (Claude Code, Codex CLI, GitHub Copilot) wire the same
 > hook scripts into different config files (`~/.claude/settings.json` vs `~/.codex/hooks.json` vs
 > `~/.copilot/hooks/reflect.json`) and share one on-disk knowledge base (`~/.reflect/` queue +
 > `~/.learnings/` documents + GraphRAG index). **SessionStart** fires the baseline recall + the
 > bg-drainer; **UserPromptSubmit** fires the intent-sharp recall with per-session dedupe;
 > **PreCompact**, **Stop**, and **PostToolUse** capture learnings into the shared store. A codex
-> session can enqueue a reflection that a later Claude session drains — and vice versa.
+> session can enqueue a reflection that a later Claude session drains: and vice versa.
 >
-> **No extra LLM/embedding config** on any harness — recall/index use a local model (no key);
+> **No extra LLM/embedding config** on any harness: recall/index use a local model (no key);
 > capture reuses the harness LLM (`claude -p`), so Codex/Copilot need the `claude` CLI on PATH for
 > the drain. Copilot drops `userPromptSubmitted` hook output, so per-prompt recall there is manual
 > `/recall` (SessionStart auto-recall works).
@@ -53,14 +53,14 @@ flow; dashed clay arrows are recall (read into context); dashed olive arrows are
           <text x="290" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Claude Code session</text>
           <text x="290" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.claude/settings.json</tspan></text>
           <text x="290" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by plugin.json autowire (CLAUDE_PLUGIN_ROOT)</text>
-          <text x="290" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">— OR — manual claude_adapter.py install</text>
+          <text x="290" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">,  OR: manual claude_adapter.py install</text>
         </g>
         <g>
           <rect x="600" y="30" width="380" height="110" rx="12" ry="12" fill="#A8C5E6" stroke="#3D3D3A" stroke-width="1.5"/>
           <text x="790" y="58" font-size="15" font-weight="600" fill="#141413" text-anchor="middle">Codex CLI session</text>
           <text x="790" y="80" font-size="12" fill="#3D3D3A" text-anchor="middle">reads hooks from <tspan font-family="ui-monospace, monospace" fill="#141413">~/.codex/hooks.json</tspan></text>
           <text x="790" y="100" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">wired by codex_adapter.py install</text>
-          <text x="790" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">(no plugin runtime — adapter autowires itself)</text>
+          <text x="790" y="122" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">(no plugin runtime: adapter autowires itself)</text>
         </g>
         <!-- ============ HOOK SCRIPTS BAND ============ -->
         <g>
@@ -99,7 +99,7 @@ flow; dashed clay arrows are recall (read into context); dashed olive arrows are
           <text x="240" y="508" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">one line per queued transcript</text>
           <text x="240" y="525" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">{transcript_path, session_id,</text>
           <text x="240" y="540" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">trigger, harness, queued_at}</text>
-          <text x="240" y="572" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">harness-agnostic — any harness</text>
+          <text x="240" y="572" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">harness-agnostic: any harness</text>
           <text x="240" y="589" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">writes, any harness drains</text>
         </g>
         <g>
@@ -132,7 +132,7 @@ flow; dashed clay arrows are recall (read into context); dashed olive arrows are
           <text x="540" y="756" font-size="12" fill="#141413" text-anchor="middle" font-style="italic">"extract the learnings from this transcript"</text>
           <text x="540" y="782" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--output-format json · --max-turns 25</text>
           <text x="540" y="799" font-size="11" font-family="ui-monospace, monospace" fill="#3D3D3A" text-anchor="middle">--permission-mode bypassPermissions</text>
-          <text x="540" y="823" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">always claude — even when a codex session triggered the drain</text>
+          <text x="540" y="823" font-size="11" fill="#3D3D3A" text-anchor="middle" font-style="italic">always claude: even when a codex session triggered the drain</text>
         </g>
         <!-- ============ ARROWS ============ -->
         <!-- 1: SessionStart → recall (both harnesses) -->
@@ -250,7 +250,7 @@ A horizontal view of what fires when. Hook events show above the spine; data I/O
         <text x="370" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">User prompts</text>
         <text x="370" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">conversation</text>
         <!-- no hook -->
-        <text x="370" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <text x="370" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">, </text>
         <!-- data below -->
         <text x="370" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">model context</text>
         <text x="370" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">+ learnings</text>
@@ -259,7 +259,7 @@ A horizontal view of what fires when. Hook events show above the spine; data I/O
         <circle cx="510" cy="126" r="7" fill="#FAF9F5" stroke="#3D3D3A" stroke-width="1.5"/>
         <text x="510" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Tool uses</text>
         <text x="510" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">edits / runs</text>
-        <text x="510" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <text x="510" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">, </text>
         <!-- data below -->
         <text x="510" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript grows;</text>
         <text x="510" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">~/.claude/ JSONL</text>
@@ -268,7 +268,7 @@ A horizontal view of what fires when. Hook events show above the spine; data I/O
         <circle cx="640" cy="126" r="7" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1.5"/>
         <text x="640" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Context fills</text>
         <text x="640" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">approaching limit</text>
-        <text x="640" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <text x="640" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">, </text>
         <!-- data below -->
         <text x="640" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness detects</text>
         <text x="640" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">token threshold</text>
@@ -291,7 +291,7 @@ A horizontal view of what fires when. Hook events show above the spine; data I/O
         <circle cx="900" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
         <text x="900" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Compaction</text>
         <text x="900" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">harness compresses</text>
-        <text x="900" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <text x="900" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">, </text>
         <!-- data below -->
         <text x="900" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">transcript archived;</text>
         <text x="900" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">context window reset</text>
@@ -300,7 +300,7 @@ A horizontal view of what fires when. Hook events show above the spine; data I/O
         <circle cx="1040" cy="126" r="7" fill="#E8E6E3" stroke="#3D3D3A" stroke-width="1.5"/>
         <text x="1040" y="162" font-size="11" font-family="ui-monospace,monospace" fill="#3D3D3A" text-anchor="middle" font-weight="600">Session ends</text>
         <text x="1040" y="175" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">process exits</text>
-        <text x="1040" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">—</text>
+        <text x="1040" y="36" font-size="9.5" font-family="ui-monospace,monospace" fill="#D1CFC5" text-anchor="middle">, </text>
         <!-- data below -->
         <text x="1040" y="220" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">queue entry waits;</text>
         <text x="1040" y="233" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">drained next start</text>
@@ -471,7 +471,7 @@ point at the same hook scripts and the same shared knowledge base.
         <rect x="776" y="30" width="318" height="276" rx="14" fill="#FFFFFF" stroke="#3D3D3A" stroke-width="2"/>
         <text x="935" y="60" font-size="14" font-weight="600" fill="#141413" text-anchor="middle" font-family="ui-monospace,monospace">~/.reflect/ + ~/.learnings/</text>
         <line x1="794" y1="70" x2="1076" y2="70" stroke="#E8E6E3" stroke-width="1"/>
-        <text x="935" y="88" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">shared by ALL harnesses — same directory</text>
+        <text x="935" y="88" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">shared by ALL harnesses: same directory</text>
         <!-- KB tier 1 -->
         <rect x="794" y="100" width="282" height="52" rx="8" fill="#F4E4C1" stroke="#3D3D3A" stroke-width="1"/>
         <text x="935" y="122" font-size="11" font-weight="600" fill="#141413" text-anchor="middle">pending queue</text>
@@ -509,7 +509,7 @@ point at the same hook scripts and the same shared knowledge base.
         <path d="M 776 255 Q 760 305 560 305 Q 450 305 430 280" fill="none" stroke="#D97757" stroke-width="2" stroke-dasharray="5,4" marker-end="url(#c-clay)"/>
         <text x="640" y="320" font-size="9.5" font-family="ui-monospace,monospace" fill="#D97757" text-anchor="middle">recall · top-3 learnings injected into session context</text>
         <!-- "one shared KB" note -->
-        <text x="935" y="326" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">ALL adapters point here — harness-agnostic</text>
+        <text x="935" y="326" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">ALL adapters point here: harness-agnostic</text>
       </svg>
 </div>
 
@@ -629,13 +629,13 @@ command.
       </svg>
 </div>
 
-The `reflect` plugin now ships from its own repo, [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) (plugin under `plugin/`), not this monorepo's marketplace — so `/plugin install reflect@agents-in-a-box` no longer resolves. Clone that repo (or use `ainb reflect bootstrap`, which installs from it) and run the adapters from its `plugin/adapters/` directory:
+The `reflect` plugin now ships from its own repo, [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) (plugin under `plugin/`), not this monorepo's marketplace: so `/plugin install reflect@agents-in-a-box` no longer resolves. Clone that repo (or use `ainb reflect bootstrap`, which installs from it) and run the adapters from its `plugin/adapters/` directory:
 
 ```bash
-# Claude Code — install from the ainb-reflect-memory plugin/ dir via your
+# Claude Code: install from the ainb-reflect-memory plugin/ dir via your
 # harness's plugin runtime (see the repo README).
 
-# Codex CLI — adapter does the autowire (paths relative to the new repo's plugin/ dir)
+# Codex CLI: adapter does the autowire (paths relative to the new repo's plugin/ dir)
 python plugin/adapters/codex/codex_adapter.py install
 # or skip the bg drain on codex-only machines without claude on PATH:
 python plugin/adapters/codex/codex_adapter.py install --no-bg-drain
@@ -645,7 +645,7 @@ python plugin/adapters/codex/codex_adapter.py install --no-bg-drain
 
 ## Recall · UserPromptSubmit primary, SessionStart baseline, per-session dedupe
 
-SessionStart fires *before* the user has typed anything — its recall query has to be
+SessionStart fires *before* the user has typed anything: its recall query has to be
 inferred from cwd, branch, and recent commits. UserPromptSubmit has the actual user prompt
 to query against, which gives much sharper hits. Both fire; UserPromptSubmit dedupes against
 learnings already injected this session so the same memory doesn't re-inject on every prompt.
@@ -741,7 +741,7 @@ learnings already injected this session so the same memory doesn't re-inject on 
       </svg>
 </div>
 
-**Dedupe state** lives at `~/.reflect/session-injected/<session_id>.json` — a per-session
+**Dedupe state** lives at `~/.reflect/session-injected/<session_id>.json`: a per-session
 set of learning IDs already injected. UserPromptSubmit recall queries the KB, intersects
 with the dedupe set, and only injects new hits as `additionalContext`.
 
@@ -752,7 +752,7 @@ with the dedupe set, and only injects new hits as `additionalContext`.
 PreCompact handles the high-cost full reflection (`claude -p /reflect`). Two more hooks
 cover gaps:
 
-- **PostToolUse** captures cheap mini-learnings inline — on tool failure, arms a watcher
+- **PostToolUse** captures cheap mini-learnings inline: on tool failure, arms a watcher
   for the next user prompt; if the prompt looks like a correction (`"try X instead"`),
   write a low-confidence learning directly to disk. No LLM run needed.
 - **Stop** catches short sessions that end before PreCompact ever fires. Enqueues the
@@ -881,18 +881,18 @@ Both harnesses give visual feedback, but through different mechanisms.
         <text x="978" y="242" font-size="10" font-family="ui-monospace,monospace" fill="#87867F" text-anchor="middle">main · ./repo · 4%</text>
         <!-- Asymmetry callout -->
         <text x="36" y="286" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
-          ★ Claude has a custom shell statusline — we get persistent counters (recalled N · queued M). Codex's status line is a fixed token list;
+          ★ Claude has a custom shell statusline: we get persistent counters (recalled N · queued M). Codex's status line is a fixed token list;
         </text>
         <text x="36" y="302" font-size="10.5" font-family="ui-monospace,monospace" fill="#87867F">
-          we use the per-hook statusMessage field — shows ephemerally during hook execution only. Full parity blocked on a codex custom-token API.
+          we use the per-hook statusMessage field: shows ephemerally during hook execution only. Full parity blocked on a codex custom-token API.
         </text>
       </svg>
 </div>
 
-- **Claude Code** — hooks write `~/.reflect/last-event.json`; the user's
+- **Claude Code**: hooks write `~/.reflect/last-event.json`; the user's
   `~/.claude/statusline.sh` reads it and renders a persistent reflect fragment
   (`🧠 3 recalled · 1 queued`).
-- **Codex CLI** — hooks declare a `statusMessage` field in `hooks.json`. Codex shows it
+- **Codex CLI**: hooks declare a `statusMessage` field in `hooks.json`. Codex shows it
   ephemerally *during* hook execution (`🧠 recalling...`). The static `[tui] status_line`
   config can't carry a custom token yet, so persistent codex-side counters wait on a
   codex API extension.
@@ -984,22 +984,22 @@ and an afternoon Codex session on the same repo.
       </svg>
 </div>
 
-1. **09:14 · Claude SessionStart** — recall on `cwd=auth-service` returns L₁ ("OAuth state
+1. **09:14 · Claude SessionStart**: recall on `cwd=auth-service` returns L₁ ("OAuth state
    handling"). Injected as baseline.
-2. **09:14 · UserPromptSubmit** — user types "fix the OAuth redirect bug". Sharp query
+2. **09:14 · UserPromptSubmit**: user types "fix the OAuth redirect bug". Sharp query
    pulls L₂, L₃. L₁ skipped (already injected). Dedupe set: `{L₁, L₂, L₃}`.
-3. **09:18 · PostToolUse** — `curl` returns 500. Mini-learning watcher arms.
-4. **09:18 · UserPromptSubmit** — user types "use `--insecure` for local dev". Watcher
+3. **09:18 · PostToolUse**: `curl` returns 500. Mini-learning watcher arms.
+4. **09:18 · UserPromptSubmit**: user types "use `--insecure` for local dev". Watcher
    sees correction pattern, writes mini-learning directly to disk. No LLM run.
-5. **10:42 · PreCompact** — context 90% full. Transcript path enqueued to
+5. **10:42 · PreCompact**: context 90% full. Transcript path enqueued to
    `~/.reflect/pending_reflections.jsonl`.
-6. **11:05 · Stop** — agent finishes. `stop_reflect.py` checks queue, sees PreCompact
+6. **11:05 · Stop**: agent finishes. `stop_reflect.py` checks queue, sees PreCompact
    already enqueued this session_id → skips.
-7. **14:30 · Codex SessionStart** — different harness, same repo. `reflect-drain-bg.sh`
+7. **14:30 · Codex SessionStart**: different harness, same repo. `reflect-drain-bg.sh`
    starts in background, finds the morning queue entry, spawns `claude -p /reflect`
    headless. Writes L₄ ("OAuth state mismatch on redirect").
-8. **14:31 · Codex UserPromptSubmit** — user types "add OAuth refresh tokens". Recall pulls
-   L₂, L₃, L₄ — including the learning Claude just wrote this morning.
+8. **14:31 · Codex UserPromptSubmit**: user types "add OAuth refresh tokens". Recall pulls
+   L₂, L₃, L₄: including the learning Claude just wrote this morning.
 
 The codex session benefits from the morning's Claude work without anyone moving files
 around. The queue and the learnings store are the only handoff.
@@ -1032,7 +1032,7 @@ The plugin-internal files below now live under `plugin/` in the standalone [stev
 
 **Why doesn't SessionStart recall use the user's first prompt?**
 SessionStart fires *before* the user has typed anything. Its query has to be inferred from
-cwd, branch, and recent commits — coarse but immediate. UserPromptSubmit fills the
+cwd, branch, and recent commits: coarse but immediate. UserPromptSubmit fills the
 prompt-aware recall slot.
 
 **What stops UserPromptSubmit recall from re-injecting the same learning every prompt?**
@@ -1051,12 +1051,12 @@ first; Stop is a fallback for sessions that never compact.
 
 **Where does `~/.reflect/` live, and is it portable?**
 Under `$HOME/.reflect/` by default; overridable via `REFLECT_STATE_DIR`. Contents are
-JSONL/Markdown/YAML — fully grep-able, version-control friendly, and portable across
+JSONL/Markdown/YAML: fully grep-able, version-control friendly, and portable across
 machines via filesystem sync.
 
 ---
 
-> **Try it** — see the standalone visual posters with the same diagrams:
+> **Try it**: see the standalone visual posters with the same diagrams:
 > - Prose explainer + small SVG: <https://unfold-ledger-qjhe.here.now/>
 > - Full platform poster: <https://saffron-mesa-9nz2.here.now/>
 

--- a/docs/knowledge/overview.md
+++ b/docs/knowledge/overview.md
@@ -5,11 +5,11 @@ title: "Knowledge & Memory System"
 > "Correct once, never again. Solve once, never re-research."
 
 This document explains the complete knowledge capture, storage, indexing, and
-retrieval system in agents-in-a-box — including all memory tiers, the reflection
+retrieval system in agents-in-a-box: including all memory tiers, the reflection
 pipeline, semantic search engines, micro-learnings, and session context loading.
 
 
-> **Heads-up — reflect now lives in its own repo.** The reflect engine (`reflect-kb`) and its
+> **Heads-up: reflect now lives in its own repo.** The reflect engine (`reflect-kb`) and its
 > Claude Code plugin were extracted from this monorepo into
 > **[github.com/stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory)**
 > (flattened: engine at the repo root, plugin under `plugin/`). Install the CLI with
@@ -17,9 +17,9 @@ pipeline, semantic search engines, micro-learnings, and session context loading.
 > and the plugin with `claude plugin install reflect@ainb-reflect-memory`. The concepts below are unchanged.
 
 :::tip[New here? Start with reflect-memory]
-For the newcomer's path — what bare-harness memory does **not** do, the capture→index→recall
-mental model, and every recall feature with an example — see the dedicated
-**[Reflect Memory](/knowledge/reflect-memory/problem-and-fit/)** section. This page is the deeper
+For the newcomer's path: what bare-harness memory does **not** do, the capture→index→recall
+mental model, and every recall feature with an example: see the dedicated
+**[Reflect Memory](/knowledge/reflect-memory/problem-and-fit)** section. This page is the deeper
 architecture reference.
 :::
 
@@ -108,7 +108,7 @@ architecture reference.
 
 ## Tier 1: Context Window Memory
 
-Memory that is **always loaded** into every conversation turn — no search required.
+Memory that is **always loaded** into every conversation turn: no search required.
 
 | Source | Location | Scope |
 |--------|----------|-------|
@@ -138,7 +138,7 @@ into every conversation automatically.
 Project-scoped memory committed to the repo. Shared across all team members
 and agents. `/reflect` routes project-specific gotchas here.
 
-**200-line limit** — if exceeded, verbose items should be moved to skills or docs/solutions/.
+**200-line limit**: if exceeded, verbose items should be moved to skills or docs/solutions/.
 
 ---
 
@@ -213,7 +213,7 @@ Cross-project knowledge indexed with **dual search engines** that run in paralle
 └── qmd/                       # QMD embeddings
 ```
 
-### Search Engine 1: QMD — "What matches?"
+### Search Engine 1: QMD: "What matches?"
 
 Hybrid search combining three strategies for best-in-class retrieval:
 
@@ -230,7 +230,7 @@ Query ──┬──► BM25 keyword matching     (exact terms)
 - Embedding model: `all-mpnet-base-v2` on CPU/MPS
 - Best for: finding documents that directly match a query
 
-### Search Engine 2: GraphRAG — "What's connected?"
+### Search Engine 2: GraphRAG: "What's connected?"
 
 Entity graph traversal that discovers relationships invisible to keyword search:
 
@@ -273,10 +273,10 @@ They are **complementary, not fallback**. Both run in parallel and results merge
 
 ### Key Architecture Decisions
 
-- **Passthrough LLM**: Pre-extracted `.entities.yaml` sidecars feed GraphRAG directly — no external LLM API calls during indexing
-- **Batch inserts only**: Never call `insert()` sequentially — use `insert_documents_batch()` or `learnings reindex`
+- **Passthrough LLM**: Pre-extracted `.entities.yaml` sidecars feed GraphRAG directly: no external LLM API calls during indexing
+- **Batch inserts only**: Never call `insert()` sequentially: use `insert_documents_batch()` or `learnings reindex`
 - **File-based locks**: fcntl locks with 5-minute timeout for multi-process safety
-- **Local embedding**: `all-mpnet-base-v2` runs on CPU/MPS — zero cloud dependency
+- **Local embedding**: `all-mpnet-base-v2` runs on CPU/MPS: zero cloud dependency
 
 ---
 
@@ -284,14 +284,14 @@ They are **complementary, not fallback**. Both run in parallel and results merge
 
 The derived vector + graph store runs **local** per-machine (default) or **shared** on one Supabase
 Postgres so every machine queries the same memory. The markdown notes stay the source of truth and
-all LLM/embedding work stays client-side either way — no extra API key.
+all LLM/embedding work stays client-side either way: no extra API key.
 
 ➡️ Full treatment (topology, the two modes, threat model) lives on the reflect-memory
-**[Construct](/knowledge/reflect-memory/construct/#backend-local-or-shared-postgres)** page.
+**[Construct](/knowledge/reflect-memory/construct#backend-local-or-shared-postgres)** page.
 
 ---
 
-## Tier 4: Instincts — Micro-Learnings
+## Tier 4: Instincts: Micro-Learnings
 
 Lightweight YAML rules with confidence scoring (0.3–0.9). Too small for a full
 knowledge note, but important enough to remember.
@@ -338,7 +338,7 @@ instincts:
 
 ---
 
-## /reflect — Knowledge Capture Pipeline
+## /reflect: Knowledge Capture Pipeline
 
 `/reflect` analyses conversations to extract two signal types and route them
 to the appropriate memory tier.
@@ -494,7 +494,7 @@ relationships:
 
 ---
 
-## /research — Knowledge Retrieval Pipeline
+## /research: Knowledge Retrieval Pipeline
 
 `/research` spawns parallel sub-agents to search all sources, then synthesises
 findings into a single report.
@@ -561,7 +561,7 @@ findings into a single report.
 
 ---
 
-## /prime — Session Context Loading
+## /prime: Session Context Loading
 
 `/prime` runs at session start to load relevant knowledge into the conversation.
 
@@ -634,10 +634,10 @@ findings into a single report.
 │  │                                                                   │       │
 │  │  Writes to:                                                       │       │
 │  │    • Agent files        (behavioral corrections)                  │       │
-│  │    • docs/solutions/    (knowledge notes — Tier 2)                │       │
-│  │    • ~/.learnings/      (knowledge notes — Tier 3, dual-indexed)  │       │
-│  │    • .agents/MEMORY.md  (project gotchas — Tier 1)                │       │
-│  │    • instincts.yaml     (micro-learnings — Tier 4)                │       │
+│  │    • docs/solutions/    (knowledge notes: Tier 2)                │       │
+│  │    • ~/.learnings/      (knowledge notes: Tier 3, dual-indexed)  │       │
+│  │    • .agents/MEMORY.md  (project gotchas: Tier 1)                │       │
+│  │    • instincts.yaml     (micro-learnings: Tier 4)                │       │
 │  └──────────────────────────────────────────────────────────────────┘       │
 │                               │                                             │
 │                               ▼                                             │
@@ -660,7 +660,7 @@ tools via the `ainb` skill manager (`ainb-tui/`):
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │  ainb-toolkit: skills/                                           │
-│  (github.com/stevengonsalvez/ainb-toolkit — canonical source)   │
+│  (github.com/stevengonsalvez/ainb-toolkit: canonical source)   │
 │                                                                  │
 │  ├── reflect/          ├── research/       ├── prime/            │
 │  ├── instincts/        └── compound-docs/                        │
@@ -681,7 +681,7 @@ tools via the `ainb` skill manager (`ainb-tui/`):
   {{HOME_TOOL_DIR}} → ~/.claude / ~/.codex / ~/.copilot
 ```
 
-The global knowledge base (`~/.learnings/`) is shared across all tools — a
+The global knowledge base (`~/.learnings/`) is shared across all tools: a
 learning captured in Claude Code is searchable from Codex or Copilot.
 
 ---
@@ -763,7 +763,7 @@ search-learnings.sh "query"
 
   /prime loads Tier 1 + relevant Tier 3 at session start.
   /research searches Tier 2 + Tier 3 on demand.
-  Tier 1 is always in the context window — no search needed.
+  Tier 1 is always in the context window: no search needed.
   Tier 4 instincts live in context but promote to Tier 3 over time.
 ```
 
@@ -773,10 +773,10 @@ search-learnings.sh "query"
 
 | Guardrail | Mechanism |
 |-----------|-----------|
-| **Human-in-the-loop** | `/reflect` NEVER auto-applies — all changes require explicit approval |
+| **Human-in-the-loop** | `/reflect` NEVER auto-applies: all changes require explicit approval |
 | **Git versioning** | Every capture is committed with descriptive message; `git revert` for rollback |
 | **De-duplication** | QMD similarity check prevents knowledge base bloat |
 | **Conflict detection** | Warns if proposed rule contradicts existing rule |
 | **File-based locks** | fcntl locks with 5-minute timeout prevent concurrent index corruption |
-| **Incremental only** | Reflect only adds to sections — never deletes or rewrites existing rules |
+| **Incremental only** | Reflect only adds to sections: never deletes or rewrites existing rules |
 | **Metrics tracking** | `~/.learnings/metrics.yaml` tracks signal counts, acceptance rates |

--- a/docs/knowledge/reflect-cli.md
+++ b/docs/knowledge/reflect-cli.md
@@ -17,7 +17,7 @@ There are **two** independent versions and they are easy to confuse:
 
 ## Install
 
-Recommended — `uv tool install` with the `[graph]` extra (pulls the full GraphRAG + vector stack):
+Recommended: `uv tool install` with the `[graph]` extra (pulls the full GraphRAG + vector stack):
 
 ```bash
 uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'
@@ -63,7 +63,7 @@ reflect timeline --explain TOK
 
 The CLI is the data layer; it knows nothing about Claude Code. Knowledge content lives in a separate directory at `~/.claude/global-learnings/` (override with `$GLOBAL_LEARNINGS_PATH`), holding `documents/*.md`, `documents/*.entities.yaml` sidecars, the gitignored `nano_graphrag_cache/` index, and the rotated `metrics.jsonl` telemetry log.
 
-> **Note:** the plugin-side recall/reflect/drain code (`recall.py`, `graphml_repair.py`, `reflect_synthesis.py`) canonically reads from `~/.learnings/` and treats `~/.claude/global-learnings/` as a legacy/deprecated fallback (the self-heal and synthesis scripts glob **both** paths). Both resolve in practice; `~/.learnings/` is the current canonical root in the plugin's architecture docs. The `reflect init` default above describes the `reflect-kb` CLI's own behaviour — verify with `reflect --help` for your installed version.
+> **Note:** the plugin-side recall/reflect/drain code (`recall.py`, `graphml_repair.py`, `reflect_synthesis.py`) canonically reads from `~/.learnings/` and treats `~/.claude/global-learnings/` as a legacy/deprecated fallback (the self-heal and synthesis scripts glob **both** paths). Both resolve in practice; `~/.learnings/` is the current canonical root in the plugin's architecture docs. The `reflect init` default above describes the `reflect-kb` CLI's own behaviour: verify with `reflect --help` for your installed version.
 
 ## Plugin: skills, adapters and hooks
 
@@ -86,11 +86,11 @@ The `reflect` plugin (version `5.2.5`) wires the CLI into the agent harness. It 
 
 | Hook | Action |
 |---|---|
-| `SessionStart` | Runs `recall` and kicks off the background drain (`reflect-drain-bg.sh`) — the sole consumer of the pending-reflections queue as of plugin 4.0.0. |
+| `SessionStart` | Runs `recall` and kicks off the background drain (`reflect-drain-bg.sh`): the sole consumer of the pending-reflections queue as of plugin 4.0.0. |
 | `UserPromptSubmit` | Runs `recall` against the prompt. |
 | `PostToolUse` | Arms low-cost mini-learning capture. |
-| `Stop` | Gates ($0) and **queues** a short-session transcript for the bg-drain cascade — does not reflect synchronously. |
-| `PreCompact` | Runs `precompact_reflect.py --auto --verbose` — **auto-installed**. Hook scripts can't run an LLM, so it gates ($0) and **queues** the transcript for the bg-drain cascade rather than reflecting inline. |
+| `Stop` | Gates ($0) and **queues** a short-session transcript for the bg-drain cascade: does not reflect synchronously. |
+| `PreCompact` | Runs `precompact_reflect.py --auto --verbose`: **auto-installed**. Hook scripts can't run an LLM, so it gates ($0) and **queues** the transcript for the bg-drain cascade rather than reflecting inline. |
 
 The producer hooks (`Stop`, `PreCompact`) only enqueue; reflection itself runs later in the background drain. As of plugin 4.0.0 the drain gates + slices each transcript and invokes `/reflect` on **Sonnet** by default under hard caps. Cost-control env vars consumed by the drain:
 
@@ -111,11 +111,11 @@ Inspect drain spend with `reflect cost`. See the plugin [`CHANGELOG.md`](https:/
 ## Memory browser
 
 `reflect serve` launches a local, loopback-only web app for browsing, searching, graphing, and
-curating the same KB this CLI reads and writes — no separate index, no auth, no cloud. See the
-[memory browser guide](/knowledge/reflect-memory/serve/) for the subcommand's flags and views.
+curating the same KB this CLI reads and writes: no separate index, no auth, no cloud. See the
+[memory browser guide](/knowledge/reflect-memory/serve) for the subcommand's flags and views.
 
 ## See also
 
-- [Knowledge base overview](./overview.md)
+- [Knowledge base overview](/knowledge/overview)
 - [ainb-reflect-memory README](https://github.com/stevengonsalvez/ainb-reflect-memory/blob/main/README.md)
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/knowledge/reflect-memory/comparison.md
+++ b/docs/knowledge/reflect-memory/comparison.md
@@ -1,5 +1,5 @@
 ---
-title: "Why build, not adopt — the agent-memory landscape"
+title: "Why build, not adopt: the agent-memory landscape"
 description: "Eight coding-agent memory systems (Hindsight, Mem0, ByteRover, claude-mem, agentmemory, Honcho, OpenViking) compared on four deciding axes, with a LOCOMO benchmark and an honest build-vs-adopt verdict for reflect."
 ---
 
@@ -11,27 +11,27 @@ description: "Eight coding-agent memory systems (Hindsight, Mem0, ByteRover, cla
 :::tip[Interactive version]
 A richer, standalone version of this page (option cards, scored matrix, the full critique) is published at
 **[explainers.stevengonsalvez.com/agent-memory-landscape](https://explainers.stevengonsalvez.com/agent-memory-landscape/)**.
-For the newcomer framing see [Problem & fit](/knowledge/reflect-memory/problem-and-fit/).
+For the newcomer framing see [Problem & fit](/knowledge/reflect-memory/problem-and-fit).
 :::
 
 ## The problem: context engineering, not a bigger file
 
 Every coding harness gives you one persistent-memory primitive: a static instructions file you
 maintain by hand (`CLAUDE.md`, `AGENTS.md`, `MEMORY.md`), front-loaded into the context window every
-session. The window is finite and **shared with the task** — every line you front-load "just in case"
+session. The window is finite and **shared with the task**: every line you front-load "just in case"
 is bloat the moment this session doesn't need it. The real problem is **retrieval**: store the
 signal-bearing moments and query the right one at the right time. That's why a class of "agent memory"
 products exists. This page compares them and explains why we built rather than adopted.
 
 ## The four deciding axes
 
-1. **Store everything vs selectively** — whole-session / fire-hose capture is useful but accretes
+1. **Store everything vs selectively**: whole-session / fire-hose capture is useful but accretes
    noise and unbounded data over time.
-2. **Separate LLM/embedding key** — your coding agent already has a model + subscription; most memory
+2. **Separate LLM/embedding key**: your coding agent already has a model + subscription; most memory
    tools make you configure and pay for a *second* provider just for memory.
-3. **Infrastructure** — an always-on server (Postgres, Redis, a Rust/Bun daemon, a vector DB) is
+3. **Infrastructure**: an always-on server (Postgres, Redis, a Rust/Bun daemon, a vector DB) is
    operational weight, and often cloud-bound.
-4. **First-class coding-signal capture** — corrections, test outcomes, git events, skill upgrades
+4. **First-class coding-signal capture**: corrections, test outcomes, git events, skill upgrades
    captured *structurally*, or only as prose an LLM might (or might not) extract?
 
 ## The eight systems
@@ -39,10 +39,10 @@ products exists. This page compares them and explains why we built rather than a
 We score each system on the four facets shown as bars on every card; the **weighted total** also
 folds in two more criteria (selective capture / noise-control and license / portability).
 
-- **Signals** — captures coding signals (corrections, tests, git, skills) as *typed* events, or hopes an LLM extracts them from prose?
-- **No key** — runs on the agent's own model, or needs a *second* LLM/embedding key + subscription?
-- **Local** — runs from local files, or needs an always-on server / cloud?
-- **Retrieval** — hybrid + rerank + graph + temporal quality.
+- **Signals**: captures coding signals (corrections, tests, git, skills) as *typed* events, or hopes an LLM extracts them from prose?
+- **No key**: runs on the agent's own model, or needs a *second* LLM/embedding key + subscription?
+- **Local**: runs from local files, or needs an always-on server / cloud?
+- **Retrieval**: hybrid + rerank + graph + temporal quality.
 
 <div class="rm-opts">
 
@@ -50,7 +50,7 @@ folds in two more criteria (selective capture / noise-control and license / port
     <span class="lab">Built</span>
     <h4>reflect</h4>
     <div class="lic">MIT · local-first · cross-harness</div>
-    <p class="desc">Selective learnings; markdown is the source of truth. Reuses the agent's own model (<code>claude -p</code>) + a local embedder — no extra key. First-class typed signals.</p>
+    <p class="desc">Selective learnings; markdown is the source of truth. Reuses the agent's own model (<code>claude -p</code>) + a local embedder: no extra key. First-class typed signals.</p>
     <div class="bars">
       <div class="brow"><span class="bl">Signals</span><span class="track"><span class="fill" style="width:100%"></span></span><span class="bv">5</span></div>
       <div class="brow"><span class="bl">No key</span><span class="track"><span class="fill" style="width:100%"></span></span><span class="bv">5</span></div>
@@ -78,7 +78,7 @@ folds in two more criteria (selective capture / noise-control and license / port
     <span class="lab">Closest on cost</span>
     <h4><a href="https://github.com/thedotmack/claude-mem">claude-mem</a></h4>
     <div class="lic">Apache-2.0 · thedotmack</div>
-    <p class="desc">Compresses every tool call into observations. Reuses Claude auth + local embeddings (no extra key — ties reflect here). But unbounded growth, no native prune, ChromaDB fragility, probabilistic extraction.</p>
+    <p class="desc">Compresses every tool call into observations. Reuses Claude auth + local embeddings (no extra key: ties reflect here). But unbounded growth, no native prune, ChromaDB fragility, probabilistic extraction.</p>
     <div class="bars">
       <div class="brow"><span class="bl">Signals</span><span class="track"><span class="fill" style="width:40%"></span></span><span class="bv">2</span></div>
       <div class="brow"><span class="bl">No key</span><span class="track"><span class="fill" style="width:100%"></span></span><span class="bv">5</span></div>
@@ -92,7 +92,7 @@ folds in two more criteria (selective capture / noise-control and license / port
     <span class="lab">Curated tree</span>
     <h4><a href="https://github.com/campfirein/byterover-cli">ByteRover</a></h4>
     <div class="lic">Elastic-2.0 (not OSS)</div>
-    <p class="desc">Curate-before-store markdown tree, local-first, importance decay. But curation makes its own LLM calls and is <em>agent-directed</em>, not passive — nothing captured unless the agent calls <code>curate</code>.</p>
+    <p class="desc">Curate-before-store markdown tree, local-first, importance decay. But curation makes its own LLM calls and is <em>agent-directed</em>, not passive: nothing captured unless the agent calls <code>curate</code>.</p>
     <div class="bars">
       <div class="brow"><span class="bl">Signals</span><span class="track"><span class="fill" style="width:40%"></span></span><span class="bv">2</span></div>
       <div class="brow"><span class="bl">No key</span><span class="track"><span class="fill" style="width:60%"></span></span><span class="bv">3</span></div>
@@ -134,7 +134,7 @@ folds in two more criteria (selective capture / noise-control and license / port
     <span class="lab">Personalization</span>
     <h4><a href="https://github.com/plastic-labs/honcho">Honcho</a></h4>
     <div class="lic">AGPL-3.0 · Plastic Labs</div>
-    <p class="desc">Theory-of-mind models of users/peers — built for end-user personalization, not coding signals. Self-host needs 1–3 provider keys + Postgres + Redis + a deriver worker; cloud is per-query.</p>
+    <p class="desc">Theory-of-mind models of users/peers: built for end-user personalization, not coding signals. Self-host needs 1–3 provider keys + Postgres + Redis + a deriver worker; cloud is per-query.</p>
     <div class="bars">
       <div class="brow"><span class="bl">Signals</span><span class="track"><span class="fill" style="width:20%"></span></span><span class="bv">1</span></div>
       <div class="brow"><span class="bl">No key</span><span class="track"><span class="fill" style="width:40%"></span></span><span class="bv">2</span></div>
@@ -148,7 +148,7 @@ folds in two more criteria (selective capture / noise-control and license / port
     <span class="lab">Context DB</span>
     <h4><a href="https://github.com/volcengine/OpenViking">OpenViking</a></h4>
     <div class="lic">AGPL-3.0 · ByteDance</div>
-    <p class="desc">Tiered (L0/L1/L2) LLM-extracted memories/skills with conflict-aware dedup. Strong on noise — but OpenAI/Volcengine by default (separate key) and a Rust+Go+C++ always-on server.</p>
+    <p class="desc">Tiered (L0/L1/L2) LLM-extracted memories/skills with conflict-aware dedup. Strong on noise: but OpenAI/Volcengine by default (separate key) and a Rust+Go+C++ always-on server.</p>
     <div class="bars">
       <div class="brow"><span class="bl">Signals</span><span class="track"><span class="fill" style="width:40%"></span></span><span class="bv">2</span></div>
       <div class="brow"><span class="bl">No key</span><span class="track"><span class="fill" style="width:40%"></span></span><span class="bv">2</span></div>
@@ -161,7 +161,7 @@ folds in two more criteria (selective capture / noise-control and license / port
 </div>
 
 ¹ Hindsight's `retain` needs an LLM; its "reuse your Claude subscription" loopback is documented as
-**personal-use-only per Anthropic's terms** — not shippable as a default.
+**personal-use-only per Anthropic's terms**: not shippable as a default.
 
 The pattern: the only other system that matches reflect on *no extra key* (claude-mem) collapses on
 *selective/noise*; the systems that curate well (Hindsight, OpenViking, ByteRover) lose on *no extra
@@ -171,7 +171,7 @@ key* or *local-first*; and **first-class signal capture is a wall of "no."**
 
 Weighted to a **coding-agent self-improvement** workflow (capture corrections → behaviour, cheaply,
 no infra). Darker green = stronger fit, rust = weak; bottom row is the weighted total out of 5.
-Re-weight toward pure retrieval quality and Hindsight leads — see the sensitivity note below.
+Re-weight toward pure retrieval quality and Hindsight leads: see the sensitivity note below.
 
 <div class="rm-matrix">
 <table>
@@ -190,11 +190,11 @@ Re-weight toward pure retrieval quality and Hindsight leads — see the sensitiv
 
 ## How reflect works
 
-![Timeline of one coding session and where reflect operates — recall at SessionStart and each prompt; typed signals + capture at tool calls, Stop and PreCompact; the index closing the loop to the next session](../../assets/reflect-session-timeline.svg)
+![Timeline of one coding session and where reflect operates: recall at SessionStart and each prompt; typed signals + capture at tool calls, Stop and PreCompact; the index closing the loop to the next session](../../assets/reflect-session-timeline.svg)
 
-![reflect component topology — local by default (QMD sqlite + nano-graphrag), optional shared Postgres; the markdown KB stays the source of truth either way](../../assets/reflect-topology.svg)
+![reflect component topology: local by default (QMD sqlite + nano-graphrag), optional shared Postgres; the markdown KB stays the source of truth either way](../../assets/reflect-topology.svg)
 
-## Benchmark — LOCOMO
+## Benchmark: LOCOMO
 
 reflect 4.1.0 on [LOCOMO](https://github.com/snap-research/locomo) (long-term conversational memory).
 **Preliminary**: a category-stratified pilot graded by an **Opus** reference LLM-judge. Retrieval runs
@@ -211,16 +211,16 @@ reflect's real engine; the dialogue→note extraction is a documented LOCOMO-dom
 
 The retrieval fixes are two additive, env-gated, **zero-new-API-key** knobs: a stronger local embedder
 (`REFLECT_EMBED_MODEL=BAAI/bge-base-en-v1.5`) and **HyDE** query-expansion (`REFLECT_RECALL_HYDE=1`,
-reusing reflect's own `claude -p`). Both default off — shipped behaviour is unchanged.
+reusing reflect's own `claude -p`). Both default off: shipped behaviour is unchanged.
 
-![LOCOMO positioning — reflect vs other memory systems](../../assets/locomo-positioning.png)
+![LOCOMO positioning: reflect vs other memory systems](../../assets/locomo-positioning.png)
 
-reflect lands mid-field — on par with Memobase / Zep, above Mem0 — while the newest systems (ByteRover,
+reflect lands mid-field: on par with Memobase / Zep, above Mem0: while the newest systems (ByteRover,
 Honcho, Hindsight) sit higher but are self-reported on their own harnesses. Judges and harnesses differ
 across the field, so treat this as **directional placement, not a strict ranking**. Full methodology:
 [`tests/eval/locomo/REPORT.md`](https://github.com/stevengonsalvez/ainb-reflect-memory/blob/main/tests/eval/locomo/REPORT.md).
 
-## Token economics — both sides of the ledger
+## Token economics: both sides of the ledger
 
 Memory looks cheap if you only price retrieval. The real cost is the **write side** (LLM
 extraction/consolidation) plus the **read side** (context injection).
@@ -229,45 +229,45 @@ extraction/consolidation) plus the **read side** (context injection).
 <table>
 <thead><tr><th class="rowh">System</th><th class="wrap">Write side</th><th class="wrap">Read side</th><th class="wrap">Net extra spend</th></tr></thead>
 <tbody>
-<tr class="me"><td class="rowh">reflect</td><td class="wrap">reuses harness LLM (<code>claude -p</code>), gated + queued; local embed</td><td class="wrap">local — vector + BM25 + graph, no LLM</td><td class="wrap"><strong>$0 extra</strong> (rides your existing sub)</td></tr>
+<tr class="me"><td class="rowh">reflect</td><td class="wrap">reuses harness LLM (<code>claude -p</code>), gated + queued; local embed</td><td class="wrap">local: vector + BM25 + graph, no LLM</td><td class="wrap"><strong>$0 extra</strong> (rides your existing sub)</td></tr>
 <tr><td class="rowh">claude-mem</td><td class="wrap">Haiku on your Claude auth, per tool-call batch</td><td class="wrap">FTS5 + local ONNX vectors</td><td class="wrap">$0 extra, but high write volume</td></tr>
 <tr><td class="rowh">Hindsight</td><td class="wrap"><code>retain</code> = LLM extraction; cloud $15/M tokens</td><td class="wrap">vector/graph; synthesis costs</td><td class="wrap">separate key or $15/M retain</td></tr>
 <tr><td class="rowh">Mem0</td><td class="wrap">OpenAI extraction at ingest</td><td class="wrap">vector/BM25; graph = Pro $249/mo</td><td class="wrap">separate OpenAI key + tier</td></tr>
 <tr><td class="rowh">OpenViking</td><td class="wrap">VLM extraction + L0/L1 summaries</td><td class="wrap">vector recursive (no LLM)</td><td class="wrap">separate provider key</td></tr>
 <tr><td class="rowh">Honcho</td><td class="wrap">deriver LLM ("dreaming") per batch</td><td class="wrap"><code>context()</code> free; dialectic up to $0.50/query</td><td class="wrap">1–3 keys (self-host) or per-query</td></tr>
-<tr><td class="rowh">agentmemory</td><td class="wrap">optional LLM compression (off by default)</td><td class="wrap">local embed; triple-stream RRF</td><td class="wrap">$0 if LLM off — value degrades</td></tr>
+<tr><td class="rowh">agentmemory</td><td class="wrap">optional LLM compression (off by default)</td><td class="wrap">local embed; triple-stream RRF</td><td class="wrap">$0 if LLM off: value degrades</td></tr>
 <tr><td class="rowh">ByteRover</td><td class="wrap">curation = own LLM calls</td><td class="wrap">BM25 → LLM fallback</td><td class="wrap">own key tokens or Pro $19/mo</td></tr>
 </tbody>
 </table>
 </div>
 
 :::caution[Dangerous default to watch]
-**Auto-retain every turn + large auto-recall** is how memory tools quietly burn a subscription —
+**Auto-retain every turn + large auto-recall** is how memory tools quietly burn a subscription , 
 agentmemory has documented incidents of exhausting a Claude Pro quota in a handful of messages.
 reflect's capture is **gated and queued** (not every turn), and recall is **OOD-gated +
-token-budgeted** — it injects nothing when nothing fits.
+token-budgeted**: it injects nothing when nothing fits.
 :::
 
 ## Observability & correction
 
 When the memory is wrong, can you see it, edit it, delete it, and trace where it came from?
 
-- **reflect** — learnings are plain markdown you open, edit or delete in your editor; volatile signals
+- **reflect**: learnings are plain markdown you open, edit or delete in your editor; volatile signals
   live in a DB sidecar (clean git diffs); each learning links back to its source transcript + chunk;
   per-row TTL + contradiction handling expire stale beliefs.
-- **Most others** — facts live in Postgres + vector DBs, inspected via API or SQL, not your editor.
+- **Most others**: facts live in Postgres + vector DBs, inspected via API or SQL, not your editor.
   claude-mem ships a web viewer but observations are DB rows; ByteRover is the exception (an editable
   markdown tree). Correcting a wrong memory usually means an API call or a re-curation pass.
 
-## Self-improvement — how a correction becomes behaviour
+## Self-improvement: how a correction becomes behaviour
 
 This is the wedge. In every other system a correction is, at best, a sentence in a transcript an
-extraction LLM *might* turn into a fact — Hindsight literally files capturing a skill update as a
+extraction LLM *might* turn into a fact: Hindsight literally files capturing a skill update as a
 *bug*. reflect routes it as **typed signals** at hook time (`SG1`–`SG8`: contradiction, git
 commit/revert, test pass/fail, tool-loop, permission reply, idle sweep, negative-recall gaps) and
 **auto-refreshes the skills those learnings affect** (`R13`/`R14`).
 
-> Everyone else remembers **what was said**. reflect captures **what changed** — and turns it into the
+> Everyone else remembers **what was said**. reflect captures **what changed**: and turns it into the
 > next session's behaviour.
 
 ## Recommendation & decision rule
@@ -276,30 +276,30 @@ commit/revert, test pass/fail, tool-loop, permission reply, idle sweep, negative
 Adopt an external memory provider **only if** it (a) needs no second API key or subscription, (b) runs
 without a mandatory always-on server, and (c) captures coding signals as typed events. **No single
 external tool clears all three.** So: build the thin, differentiated layer (capture + typed signals +
-local-first), and **port — don't re-invent forever — the commodity retrieval**, keeping it behind a
+local-first), and **port: don't re-invent forever: the commodity retrieval**, keeping it behind a
 seam so a stronger backend can be swapped in later.
 :::
 
 **Verdict: build + port, with eyes open.** reflect ported Hindsight's retrieval ideas
 (graph-expansion arm, RRF fusion, cross-encoder rerank, temporal arm) across a
-[57-port effort](/knowledge/reflect-memory/recall/) — so it has the retrieval brains without the
+[57-port effort](/knowledge/reflect-memory/recall): so it has the retrieval brains without the
 infra/LLM/ToS baggage, at the cost of owning that code.
 
 :::caution[Honest sensitivity note]
-These weights favour self-improvement and zero-friction operation — reflect's strengths. Re-weight
+These weights favour self-improvement and zero-friction operation: reflect's strengths. Re-weight
 toward **pure retrieval quality and ecosystem maturity** and **Hindsight wins**: MIT, production-grade,
 94.6% LongMemEval, ~48 integrations, 62 releases. If your priority is "best recall, least code I
 maintain," adopting Hindsight (as a retrieval backend) is the smarter call. The build case rests on
-valuing *no-extra-key capture* and *typed signals* — which is why retrieval is kept swappable.
+valuing *no-extra-key capture* and *typed signals*: which is why retrieval is kept swappable.
 :::
 
-## If you'd adopt instead — four pilot acceptance tests
+## If you'd adopt instead: four pilot acceptance tests
 
-1. **Zero extra credentials** — install on a fresh machine with only the coding agent's existing auth.
+1. **Zero extra credentials**: install on a fresh machine with only the coding agent's existing auth.
    Does capture + recall work with no new key or account? *(reflect / claude-mem: pass · most: fail)*
-2. **No always-on server** — reboot. Does memory work with nothing running in the background?
+2. **No always-on server**: reboot. Does memory work with nothing running in the background?
    *(reflect: pass · daemon-based tools: fail)*
-3. **Correction → behaviour** — correct the agent once; next session, does the rule resurface
-   *without* manual curation? *(the typed-signal test — reflect's wedge)*
-4. **Noise over 30 days** — run daily for a month. Is recall still sharp, or flooded with stale /
+3. **Correction → behaviour**: correct the agent once; next session, does the rule resurface
+   *without* manual curation? *(the typed-signal test: reflect's wedge)*
+4. **Noise over 30 days**: run daily for a month. Is recall still sharp, or flooded with stale /
    duplicate / fire-hosed entries? *(fire-hose tools degrade here)*

--- a/docs/knowledge/reflect-memory/construct.md
+++ b/docs/knowledge/reflect-memory/construct.md
@@ -1,21 +1,21 @@
 ---
-title: "reflect-memory — the construct"
+title: "reflect-memory: the construct"
 description: "The capture → index → recall mental model, the two indices (QMD lexical + nano-graphrag vector/graph), and the local vs shared (Postgres) backend."
 ---
 
 > One loop: **capture** what you teach the agent, **index** it three ways, **recall** the right
-> piece into the next session. Everything in the [Recall reference](/knowledge/reflect-memory/recall/)
+> piece into the next session. Everything in the [Recall reference](/knowledge/reflect-memory/recall)
 > is a tuning knob on this loop.
 
 For *why* this exists and how it compares to bare-harness memory, see
-[Problem & fit](/knowledge/reflect-memory/problem-and-fit/).
+[Problem & fit](/knowledge/reflect-memory/problem-and-fit).
 
 ## The loop
 
 <pre class="rm-ascii">
    ┌─────────┐  signal   ┌──────────┐  markdown   ┌──────────────┐
    │ session │ ───────▶  │ capture  │ ─────────▶  │  KB (notes)  │ ◀── source of truth
-   └─────────┘ "no—don't"└──────────┘  + sidecar  └──────┬───────┘
+   └─────────┘ "no, don't"└──────────┘  + sidecar  └──────┬───────┘
                                                           │ index
                                 ┌─────────────────────────┼─────────────────────────┐
                                 ▼                          ▼                          ▼
@@ -31,13 +31,13 @@ For *why* this exists and how it compares to bare-harness memory, see
 
 | Stage | What happens | Where it lives |
 |---|---|---|
-| **Capture** | A hook detects a correction/decision signal, slices just the relevant dialogue window, and the drain writes a structured learning (title/category/tags/confidence/problem/fix/rule) plus an entity **sidecar** (`A —[relation]→ B`). Capture summarisation reuses the harness LLM (`claude -p`) — no extra key. | `~/.learnings/` markdown + sidecars |
+| **Capture** | A hook detects a correction/decision signal, slices just the relevant dialogue window, and the drain writes a structured learning (title/category/tags/confidence/problem/fix/rule) plus an entity **sidecar** (`A , [relation]→ B`). Capture summarisation reuses the harness LLM (`claude -p`): no extra key. | `~/.learnings/` markdown + sidecars |
 | **Index** | `reflect reindex` registers each note in **three** arms: BM25 lexical (QMD), vector embedding (nano-graphrag, `all-mpnet-base-v2`), and the entity graph (nano-graphrag). | QMD `index.sqlite` + nano-graphrag store |
 | **Recall** | Build a query from project/branch/prompt context, run the arms, **RRF-fuse** the rankings, **cross-encoder rerank**, **OOD-gate** (inject nothing if nothing fits), then **token-budget** pack the survivors into the inject block. | client-side, every session |
 
 The split that makes it cheap and private: **the brain is client-side** (embedding + clustering +
 capture LLM all run on your machine / your harness's model), and **the store is dumb** (it indexes
-and returns rows — it never calls an LLM).
+and returns rows: it never calls an LLM).
 
 ## The two indices
 
@@ -48,25 +48,25 @@ reflect runs two complementary search engines, fused at recall time:
 | **QMD** | "what *matches* these words?" | BM25 over `~/.cache/qmd/index.sqlite` | exact terms, file names, error strings |
 | **nano-graphrag** | "what's *connected* / what *means* this?" | vector ANN (hnswlib) + entity graph (`.graphml`) | semantics + multi-hop ("what caused X?") |
 
-Neither alone is enough — BM25 misses paraphrase, vectors miss exact tokens, and only the graph
+Neither alone is enough: BM25 misses paraphrase, vectors miss exact tokens, and only the graph
 hops to the note you never lexically matched. RRF fusion is what lets all three vote.
 
 ## Physical topology
 
-![reflect component topology — harness hooks feed the engine; the markdown KB is the source of truth; the derived store runs either local (QMD sqlite + nano-graphrag hnswlib/graphml) or shared (Supabase Postgres + pgvector)](../../assets/reflect-topology.svg)
+![reflect component topology: harness hooks feed the engine; the markdown KB is the source of truth; the derived store runs either local (QMD sqlite + nano-graphrag hnswlib/graphml) or shared (Supabase Postgres + pgvector)](../../assets/reflect-topology.svg)
 
 ## Backend: local or shared (Postgres)
 
 The markdown notes are **always** the local source of truth, and **all LLM / embedding / clustering
-always stays client-side — no extra API key**. Only the *derived* vector + graph store has two modes:
+always stays client-side: no extra API key**. Only the *derived* vector + graph store has two modes:
 
-| | **Mode 1 — Local** (default) | **Mode 2 — Shared** (Postgres) |
+| | **Mode 1: Local** (default) | **Mode 2: Shared** (Postgres) |
 |---|---|---|
 | Derived store | per-machine: QMD `index.sqlite` (BM25) + nano-graphrag (hnswlib + `.graphml`) | one **Supabase Postgres** (pgvector) for everyone |
 | Setup | nothing | `REFLECT_PG_DSN` + `REFLECT_WORKSPACE_ID` + 2 migrations |
-| Share across machines | git-sync the notes, then `reflect reindex` on each machine | automatic — every machine queries the same store |
+| Share across machines | git-sync the notes, then `reflect reindex` on each machine | automatic: every machine queries the same store |
 
-In Mode 2, nano-graphrag runs **unchanged** — it's handed Postgres-backed storage classes (the same
+In Mode 2, nano-graphrag runs **unchanged**: it's handed Postgres-backed storage classes (the same
 way it ships `Neo4jStorage`). The DB stays dumb (no LLM/embeddings); tenant isolation is RLS
 (fail-closed) + explicit `workspace_id` scoping; writes need a `service_role` DSN.
 
@@ -75,5 +75,5 @@ way it ships `Neo4jStorage`). The DB stays dumb (no LLM/embeddings); tenant isol
 
 ## Next
 
-Each stage above has knobs. The [Recall reference](/knowledge/reflect-memory/recall/) documents every
-recall-time feature with a concrete example and the counterfactual — what you'd get without it.
+Each stage above has knobs. The [Recall reference](/knowledge/reflect-memory/recall) documents every
+recall-time feature with a concrete example and the counterfactual: what you'd get without it.

--- a/docs/knowledge/reflect-memory/problem-and-fit.md
+++ b/docs/knowledge/reflect-memory/problem-and-fit.md
@@ -1,46 +1,46 @@
 ---
-title: "reflect-memory — the problem & where it fits"
+title: "reflect-memory: the problem & where it fits"
 description: "Context engineering, not a bigger instructions file: why front-loading CLAUDE.md/AGENTS.md hits a wall, how reflect captures and recalls the right knowledge at the right time, and how it compares to Mem0, Hindsight, ByteRover, claude-mem, agentmemory, Honcho and OpenViking."
 ---
 
-> **reflect-memory** captures what you teach a coding agent — corrections, decisions, the architecture
-> reasons you keep re-explaining — and recalls the *right* piece into the *right* moment of the next
+> **reflect-memory** captures what you teach a coding agent: corrections, decisions, the architecture
+> reasons you keep re-explaining: and recalls the *right* piece into the *right* moment of the next
 > session. Across machines and harnesses, reusing the agent's own model, with **no extra API key**.
 
-![Timeline of one coding session and where reflect operates — recall injects prior learnings at SessionStart and each prompt; signals + capture write out at tool calls, Stop and PreCompact; the index closes the loop to the next session](../../assets/reflect-session-timeline.svg)
+![Timeline of one coding session and where reflect operates: recall injects prior learnings at SessionStart and each prompt; signals + capture write out at tool calls, Stop and PreCompact; the index closes the loop to the next session](../../assets/reflect-session-timeline.svg)
 
 ## The real problem: context engineering, not a bigger file
 
 Every harness gives you one persistent memory primitive: a **static instructions file you maintain by
-hand** — `CLAUDE.md`, `AGENTS.md`, `MEMORY.md`, `copilot-instructions.md`. It is front-loaded into the
+hand**: `CLAUDE.md`, `AGENTS.md`, `MEMORY.md`, `copilot-instructions.md`. It is front-loaded into the
 context window at the start of every session.
 
 That has a hard ceiling. The context window is finite and **shared with the actual task**. Every line
-you front-load "just in case" is bloat the moment this particular session doesn't need it — and it
+you front-load "just in case" is bloat the moment this particular session doesn't need it: and it
 crowds out the files, diffs, and reasoning the task *does* need.
 
 <pre class="rm-ascii">
    context window  =  [ task: files · diffs · plan · tool output ]  +  [ memory ]
                                                           ▲                    ▲
                             this is the work ─────────────┘                    │
-                            front-loaded "just in case" — bloat when ──────────┘
+                            front-loaded "just in case": bloat when ──────────┘
                             irrelevant, and you can only fit so much
 </pre>
 
 So a bigger instructions file is the wrong axis. The questions that actually matter:
 
 - A correction you made three weeks ago ("don't bump the shared proto without regenerating clients")
-  — how does it reach the agent *only* in the session that's about to touch that proto?
+ : how does it reach the agent *only* in the session that's about to touch that proto?
 - The architecture *reason* behind a non-obvious choice ("the double `recalcTax` call fixes an EU-VAT
-  rounding bug") — how is it recalled when someone questions that code, and stays invisible otherwise?
-- A hard-won veering ("we migrated off JWT to server-side sessions in June") — how does it override the
+  rounding bug"): how is it recalled when someone questions that code, and stays invisible otherwise?
+- A hard-won veering ("we migrated off JWT to server-side sessions in June"): how does it override the
   stale fact, instead of sitting in a file nobody re-reads?
 
-The goal isn't to store *more* — it's to store the signal-bearing moments and **query the right one at
+The goal isn't to store *more*: it's to store the signal-bearing moments and **query the right one at
 the right time**, spending context only when it pays. That is a retrieval problem, not a file-size
 problem. It's why a class of "agent memory" products exists.
 
-## The memory-product landscape — and where each one pinches
+## The memory-product landscape: and where each one pinches
 
 Several tools attack this. They differ on four axes that decide whether they actually fit a
 coding-agent workflow:
@@ -50,9 +50,9 @@ coding-agent workflow:
 2. **Do they need a separate LLM/embedding key?** Your coding agent already has a model+subscription.
    Most memory tools make you configure and *pay for a second provider* just for memory.
 3. **What infrastructure do they run?** A always-on server (Postgres, Redis, a Rust/Bun daemon, a
-   vector DB) is operational weight — and often cloud-dependent.
+   vector DB) is operational weight: and often cloud-dependent.
 4. **Do they capture coding signals as first-class events?** Corrections, test outcomes, git events,
-   skill upgrades — captured *structurally*, or only as prose an LLM might (or might not) extract?
+   skill upgrades: captured *structurally*, or only as prose an LLM might (or might not) extract?
 
 <pre class="rm-ascii">
            store selectively   no extra key   local, no server   first-class signals
@@ -64,29 +64,29 @@ others          varies          mostly ✗         mostly ✗          ✗ (prob
 <table>
 <thead><tr><th class="rowh">Tool</th><th class="wrap">What it stores</th><th class="wrap">Extra LLM/embed key?</th><th class="wrap">Runs as</th><th class="wrap">First-class coding signals</th><th>License</th></tr></thead>
 <tbody>
-<tr class="me"><td class="rowh">reflect</td><td class="wrap"><strong>selective</strong> learnings; markdown = source of truth</td><td class="wrap"><strong>No</strong> — reuses the agent's own model + local embeddings</td><td class="wrap"><strong>local files</strong> (sqlite + graphml); optional shared Postgres</td><td class="wrap"><strong>Yes</strong> — corrections, tests, tool-loops, git, todos, permissions, contradictions, skill-refresh</td><td>MIT</td></tr>
-<tr><td class="rowh">Hindsight</td><td class="wrap">LLM-extracted facts + mental models</td><td class="wrap">Yes for writes¹</td><td class="wrap">local daemon → Docker (FastAPI+Postgres) → cloud</td><td class="wrap">No — extracted from prose (skill-capture is a logged bug)</td><td>MIT</td></tr>
-<tr><td class="rowh">Mem0</td><td class="wrap">LLM-extracted facts</td><td class="wrap"><strong>Yes</strong> — OpenAI by default at ingest</td><td class="wrap">library → Docker (Postgres+Neo4j); graph = Pro $249/mo</td><td class="wrap">No — hooks, but no correction/git/test capture</td><td>Apache-2.0 + SaaS</td></tr>
-<tr><td class="rowh">ByteRover</td><td class="wrap">curated markdown tree</td><td class="wrap">curation makes its own LLM calls</td><td class="wrap">local files + node daemon; optional cloud sync</td><td class="wrap">No — curation is agent-<em>directed</em>, not passive</td><td>Elastic 2.0 (not OSS)</td></tr>
-<tr><td class="rowh">claude-mem</td><td class="wrap">every tool call → compressed observations</td><td class="wrap"><strong>No</strong> — reuses Claude auth + local embeddings</td><td class="wrap">always-on Bun daemon + optional ChromaDB</td><td class="wrap">No — probabilistic Haiku extraction</td><td>Apache-2.0</td></tr>
-<tr><td class="rowh">agentmemory</td><td class="wrap"><strong>fire-hose</strong> — every tool call, verbatim</td><td class="wrap">optional (value degrades without)</td><td class="wrap">always-on Rust daemon (4 ports)</td><td class="wrap">No — raw events; little structure without LLM</td><td>Apache-2.0</td></tr>
-<tr><td class="rowh">Honcho</td><td class="wrap">user/peer models (theory-of-mind)</td><td class="wrap">Yes (self-host); cloud is per-token</td><td class="wrap">Postgres + Redis + deriver worker; or cloud</td><td class="wrap">No — built for end-user personalization, not coding</td><td>AGPL-3.0</td></tr>
-<tr><td class="rowh">OpenViking</td><td class="wrap">LLM-extracted memories/skills (tiered)</td><td class="wrap"><strong>Yes</strong> — OpenAI/Volcengine by default</td><td class="wrap">Rust+Go+C++ server, always-on</td><td class="wrap">No — git/test/skill not first-class</td><td>AGPL-3.0</td></tr>
+<tr class="me"><td class="rowh">reflect</td><td class="wrap"><strong>selective</strong> learnings; markdown = source of truth</td><td class="wrap"><strong>No</strong>: reuses the agent's own model + local embeddings</td><td class="wrap"><strong>local files</strong> (sqlite + graphml); optional shared Postgres</td><td class="wrap"><strong>Yes</strong>: corrections, tests, tool-loops, git, todos, permissions, contradictions, skill-refresh</td><td>MIT</td></tr>
+<tr><td class="rowh">Hindsight</td><td class="wrap">LLM-extracted facts + mental models</td><td class="wrap">Yes for writes¹</td><td class="wrap">local daemon → Docker (FastAPI+Postgres) → cloud</td><td class="wrap">No: extracted from prose (skill-capture is a logged bug)</td><td>MIT</td></tr>
+<tr><td class="rowh">Mem0</td><td class="wrap">LLM-extracted facts</td><td class="wrap"><strong>Yes</strong>: OpenAI by default at ingest</td><td class="wrap">library → Docker (Postgres+Neo4j); graph = Pro $249/mo</td><td class="wrap">No: hooks, but no correction/git/test capture</td><td>Apache-2.0 + SaaS</td></tr>
+<tr><td class="rowh">ByteRover</td><td class="wrap">curated markdown tree</td><td class="wrap">curation makes its own LLM calls</td><td class="wrap">local files + node daemon; optional cloud sync</td><td class="wrap">No: curation is agent-<em>directed</em>, not passive</td><td>Elastic 2.0 (not OSS)</td></tr>
+<tr><td class="rowh">claude-mem</td><td class="wrap">every tool call → compressed observations</td><td class="wrap"><strong>No</strong>: reuses Claude auth + local embeddings</td><td class="wrap">always-on Bun daemon + optional ChromaDB</td><td class="wrap">No: probabilistic Haiku extraction</td><td>Apache-2.0</td></tr>
+<tr><td class="rowh">agentmemory</td><td class="wrap"><strong>fire-hose</strong>: every tool call, verbatim</td><td class="wrap">optional (value degrades without)</td><td class="wrap">always-on Rust daemon (4 ports)</td><td class="wrap">No: raw events; little structure without LLM</td><td>Apache-2.0</td></tr>
+<tr><td class="rowh">Honcho</td><td class="wrap">user/peer models (theory-of-mind)</td><td class="wrap">Yes (self-host); cloud is per-token</td><td class="wrap">Postgres + Redis + deriver worker; or cloud</td><td class="wrap">No: built for end-user personalization, not coding</td><td>AGPL-3.0</td></tr>
+<tr><td class="rowh">OpenViking</td><td class="wrap">LLM-extracted memories/skills (tiered)</td><td class="wrap"><strong>Yes</strong>: OpenAI/Volcengine by default</td><td class="wrap">Rust+Go+C++ server, always-on</td><td class="wrap">No: git/test/skill not first-class</td><td>AGPL-3.0</td></tr>
 </tbody>
 </table>
 </div>
 
 ➡️ Full scored matrix, token economics, LOCOMO benchmark and the build-vs-adopt critique:
-[Why build, not adopt](/knowledge/reflect-memory/comparison/).
+[Why build, not adopt](/knowledge/reflect-memory/comparison).
 
 ¹ Hindsight's `retain` needs an LLM; its "reuse your Claude subscription" loopback is documented as
-**personal-use-only per Anthropic's terms** — not shippable. See the
+**personal-use-only per Anthropic's terms**: not shippable. See the
 [adopt-vs-build critique](https://github.com/stevengonsalvez/ainb-reflect-memory#why-build-not-adopt).
 
 The pattern: the tools that *don't* need a second key (claude-mem) tend to **store everything and grow
 noisy**; the tools that *do* curate well (Hindsight, Mem0, OpenViking) make you **stand up a server and
 pay a second provider**; and **none** of them capture corrections, test outcomes, git events, or skill
-upgrades as typed signals — they hope an LLM extracts them from the transcript.
+upgrades as typed signals: they hope an LLM extracts them from the transcript.
 
 ## Where reflect fits
 
@@ -98,26 +98,26 @@ the store is dumb, and the signals are typed.**
         ▲              ▲ typed signals              │
         │              │ (corrections, tests,  index (QMD + nano-graphrag)
    harness LLM  ◀── reflect (recall) ◀──── git, skills, contradictions)
-   (capture reuses the agent's OWN model — no extra key, no separate sub)
+   (capture reuses the agent's OWN model: no extra key, no separate sub)
 </pre>
 
 | reflect's answer | to the problem |
 |---|---|
-| **Selective capture** — only signal-bearing moments become learnings; TTL, dedup and contradiction-handling built in | whole-session noise + unbounded growth |
+| **Selective capture**: only signal-bearing moments become learnings; TTL, dedup and contradiction-handling built in | whole-session noise + unbounded growth |
 | **Reuses the agent's own model** (`claude -p`) + a local embedding model | no second API key, no separate subscription, no ToS loophole |
-| **Local files** (QMD sqlite + nano-graphrag graphml) — optional shared Postgres only if you *want* cross-machine | no mandatory server / cloud dependency |
-| **First-class typed signals** — corrections, test pass/fail, tool-loops, git commit/revert, todo completions, permission replies, cross-turn contradictions, idle sweeps, plus auto **skill-refresh** | the gap every other tool leaves to probabilistic extraction |
-| **Cross-harness by design** — Codex writes a learning, a later Claude session reads it | single-harness / MCP-bolted memory |
+| **Local files** (QMD sqlite + nano-graphrag graphml): optional shared Postgres only if you *want* cross-machine | no mandatory server / cloud dependency |
+| **First-class typed signals**: corrections, test pass/fail, tool-loops, git commit/revert, todo completions, permission replies, cross-turn contradictions, idle sweeps, plus auto **skill-refresh** | the gap every other tool leaves to probabilistic extraction |
+| **Cross-harness by design**: Codex writes a learning, a later Claude session reads it | single-harness / MCP-bolted memory |
 | **Markdown source of truth**, volatile signals in a DB sidecar → clean git diffs, reviewable in a PR | opaque DB/vector blobs |
 
 The honest line: on the *no-extra-key* axis alone, claude-mem ties reflect (it also reuses Claude's
-auth). reflect's separation is the **combination** — selective + no-key + local + typed-signals +
-cross-harness + MIT — which no single competitor matches.
+auth). reflect's separation is the **combination**: selective + no-key + local + typed-signals +
+cross-harness + MIT: which no single competitor matches.
 
 ## Next
 
 | Read this | For |
 |---|---|
-| [Construct](/knowledge/reflect-memory/construct/) | the capture → index → recall mental model, and local vs shared (Postgres) backend |
-| [Recall reference](/knowledge/reflect-memory/recall/) | every recall feature with an example and what breaks without it |
-| [Hooks & platform](/knowledge/hooks-and-platform/) | exactly which hook fires what, per harness |
+| [Construct](/knowledge/reflect-memory/construct) | the capture → index → recall mental model, and local vs shared (Postgres) backend |
+| [Recall reference](/knowledge/reflect-memory/recall) | every recall feature with an example and what breaks without it |
+| [Hooks & platform](/knowledge/hooks-and-platform) | exactly which hook fires what, per harness |

--- a/docs/knowledge/reflect-memory/recall.md
+++ b/docs/knowledge/reflect-memory/recall.md
@@ -1,28 +1,28 @@
 ---
-title: "reflect-memory — recall reference (all 57 ports)"
-description: "Every reflect 4.1.0 recall feature as a scannable callout — flag, what it does, an example, and what you'd get without it — plus the full 57-port catalogue."
+title: "reflect-memory: recall reference (all 57 ports)"
+description: "Every reflect 4.1.0 recall feature as a scannable callout: flag, what it does, an example, and what you'd get without it: plus the full 57-port catalogue."
 ---
 
 > "Correct once, never again." This is the reference half of reflect-memory: first one learning's
-> whole journey (the newcomer's mental model), then **every** ported feature as a callout — flag, what
+> whole journey (the newcomer's mental model), then **every** ported feature as a callout: flag, what
 > it does, an example, and the counterfactual: what you'd get if it didn't exist.
 
-For the architecture see [Construct](/knowledge/reflect-memory/construct/); for the problem and the
-landscape comparison see [Problem & fit](/knowledge/reflect-memory/problem-and-fit/) and
-[Why build, not adopt](/knowledge/reflect-memory/comparison/).
+For the architecture see [Construct](/knowledge/reflect-memory/construct); for the problem and the
+landscape comparison see [Problem & fit](/knowledge/reflect-memory/problem-and-fit) and
+[Why build, not adopt](/knowledge/reflect-memory/comparison).
 
 :::note[Examples are illustrative]
 The `reflect search …` examples and their results below are representative, hand-authored to show
-the behaviour — not pasted from a specific live KB run. Every feature is backed by a behavioural
+the behaviour: not pasted from a specific live KB run. Every feature is backed by a behavioural
 proof under [`tests/eval/behavioral/proofs/`](https://github.com/stevengonsalvez/ainb-reflect-memory/tree/main/tests/eval/behavioral/proofs)
 that exercises it with the knob **on and off**.
 :::
 
-## Memory end to end — one learning's journey
+## Memory end to end: one learning's journey
 
 Follow one correction from the moment it happens to the moment it saves you weeks later.
 
-**1 · Capture.** Mid-session you tell the agent: *"no — don't bump the shared `payments.proto`
+**1 · Capture.** Mid-session you tell the agent: *"no: don't bump the shared `payments.proto`
 without regenerating the clients, it broke staging last time."* A `PostToolUse`/`Stop` hook detects
 the correction signal, slices just the relevant dialogue window (not the whole 100k-token transcript),
 and the drain writes a structured learning:
@@ -39,21 +39,21 @@ fix: "Run `make proto-gen` after any .proto edit; CI now gates on it"
 rule: "Never ship a .proto change without regenerated clients"
 ---
 ```
-Alongside it, an entity sidecar records `payments.proto —[prevents]→ staging outage`.
+Alongside it, an entity sidecar records `payments.proto , [prevents]→ staging outage`.
 
 **2 · Index.** `reflect reindex` embeds the note (vector arm), adds its entities + edges to the
 GraphRAG graph (graph arm), and registers it in the BM25 index (QMD arm). It's now reachable three
 different ways.
 
-**3 · Recall — three weeks later, a different session.** A new teammate's agent opens `billing-svc`
+**3 · Recall: three weeks later, a different session.** A new teammate's agent opens `billing-svc`
 and is about to edit `payments.proto`. **SessionStart** fires, builds a query from project + branch
 context, and runs hybrid recall: the **vector arm** matches on meaning, the **BM25 arm** matches the
-literal `payments.proto`, the **graph arm** hops the `prevents` edge — **RRF** fuses the rankings,
+literal `payments.proto`, the **graph arm** hops the `prevents` edge: **RRF** fuses the rankings,
 the **cross-encoder** reranks, the **OOD gate** confirms relevance, the **token budget** packs it in.
 
-Before the agent writes a line, it sees: *"Regenerate gRPC clients after editing payments.proto —
-broke staging last time; run `make proto-gen`."* The mistake never happens twice. That whole chain —
-capture → index → fuse → rerank → gate → inject — is what the 57 ports tune.
+Before the agent writes a line, it sees: *"Regenerate gRPC clients after editing payments.proto , 
+broke staging last time; run `make proto-gen`."* The mistake never happens twice. That whole chain , 
+capture → index → fuse → rerank → gate → inject: is what the 57 ports tune.
 
 ## The 57 ports at a glance
 
@@ -64,17 +64,17 @@ capture → index → fuse → rerank → gate → inject — is what the 57 por
             ─────────────────── scope: R15·A6 · modes: M1·R10·R11 ────────────────
 </pre>
 
-- **Retrieval arms** — R1 R5 R6 R2 R3 R4 → [§ below](#retrieval-arms)
-- **Relevance gates** — R7 R12 → [§ below](#relevance-gates)
-- **Ranking & affinity boosts** — R8 R16 S3 S4 → [§ below](#ranking--affinity-boosts)
-- **Scope: sharding & isolation** — R15 A6 → [§ below](#scope-sharding--isolation)
-- **Recall modes & inject** — M1 R10 R11 M7 M4 O3 A1 R20 → [§ below](#recall-modes--inject)
-- **Caching, dedup & negative-recall** — R9 S7 C1 A3 SG6 S1 → [§ below](#caching-dedup--negative-recall)
+- **Retrieval arms**: R1 R5 R6 R2 R3 R4 → [§ below](#retrieval-arms)
+- **Relevance gates**: R7 R12 → [§ below](#relevance-gates)
+- **Ranking & affinity boosts**: R8 R16 S3 S4 → [§ below](#ranking--affinity-boosts)
+- **Scope: sharding & isolation**: R15 A6 → [§ below](#scope-sharding--isolation)
+- **Recall modes & inject**: M1 R10 R11 M7 M4 O3 A1 R20 → [§ below](#recall-modes--inject)
+- **Caching, dedup & negative-recall**: R9 S7 C1 A3 SG6 S1 → [§ below](#caching-dedup--negative-recall)
 - **Capture · storage · consolidation · team** (the other 29) → [§ below](#the-other-29--capture-storage-consolidation-team)
 
 All 57: **R1–R16 + R20** (17 retrieval/recall), **M1–M8** (8 modes), **S1–S10** (10
 capture/storage), **A1–A6** (6 advanced), **C1–C5** (5 consolidation), **O1–O3** (3 observations),
-**SG1–SG8** (8 signals). (No R17–R19 — the R-series jumps R16 → R20.) ★ = has a
+**SG1–SG8** (8 signals). (No R17–R19: the R-series jumps R16 → R20.) ★ = has a
 [worked example](#worked-examples) below.
 
 ## Retrieval arms
@@ -104,7 +104,7 @@ The parallel signals that find candidates, plus the post-fusion shapers that ord
   </div>
   <div class="rm-card">
     <div class="h"><span class="id">R3 ★</span> MMR diversity · <code>RECALL_MMR</code> (on) / <code>--no-mmr</code></div>
-    <p><span class="lbl">Does</span> Final top-k via Maximal Marginal Relevance — de-clusters near-duplicates. “nginx 502 under load” surfaces the lone “enable keepalive” note past 4 “raise worker_connections” twins.</p>
+    <p><span class="lbl">Does</span> Final top-k via Maximal Marginal Relevance: de-clusters near-duplicates. “nginx 502 under load” surfaces the lone “enable keepalive” note past 4 “raise worker_connections” twins.</p>
     <p class="without"><span class="lbl">Without it</span> Top-k is 4 copies of one idea; the second, correct idea sits at rank 6, never injected.</p>
   </div>
   <div class="rm-card">
@@ -131,12 +131,12 @@ The parallel signals that find candidates, plus the post-fusion shapers that ord
 
 ## Ranking & affinity boosts
 
-Secondary signals that break ties — each bounded so it can nudge, never hijack.
+Secondary signals that break ties: each bounded so it can nudge, never hijack.
 
 <div class="rm-cards two">
   <div class="rm-card">
     <div class="h"><span class="id">R8</span> Bounded multiplicative boosts · <code>RECALL_*_ALPHA</code></div>
-    <p><span class="lbl">Does</span> Each signal applied as <code>1+α·(norm−0.5)</code>, clamped to ±α/2 — recency / confidence / tags / proof break ties only (defaults 0.2/0.2/0.2/0.1).</p>
+    <p><span class="lbl">Does</span> Each signal applied as <code>1+α·(norm−0.5)</code>, clamped to ±α/2: recency / confidence / tags / proof break ties only (defaults 0.2/0.2/0.2/0.1).</p>
     <p class="without"><span class="lbl">Without it</span> Unbounded boosts let “most recent” bury a 2-year-old note that perfectly answers the query.</p>
   </div>
   <div class="rm-card">
@@ -187,7 +187,7 @@ Secondary signals that break ties — each bounded so it can nudge, never hijack
   <div class="rm-card">
     <div class="h"><span class="id">R11</span> Forced-grounding short-circuit · (R10 freshness gate)</div>
     <p><span class="lbl">Does</span> If the tier-1 skill hit is fresh <strong>and</strong> high-confidence, SessionStart emits just that and never spawns the recall subprocess.</p>
-    <p class="without"><span class="lbl">Without it</span> Warm-project boots needlessly spawn the full pipeline — slow and noisy.</p>
+    <p class="without"><span class="lbl">Without it</span> Warm-project boots needlessly spawn the full pipeline: slow and noisy.</p>
   </div>
   <div class="rm-card">
     <div class="h"><span class="id">M7</span> Knowledge-corpus Q&amp;A · <code>reflect corpus build</code></div>
@@ -221,7 +221,7 @@ Secondary signals that break ties — each bounded so it can nudge, never hijack
 <div class="rm-cards two">
   <div class="rm-card">
     <div class="h"><span class="id">R9</span> Fuzzy cache tier · <code>RECALL_FUZZY_CACHE</code> (on)</div>
-    <p><span class="lbl">Does</span> A reworded repeat within the Jaccard threshold (0.85) is served from cache — skips embed+graph+rerank.</p>
+    <p><span class="lbl">Does</span> A reworded repeat within the Jaccard threshold (0.85) is served from cache: skips embed+graph+rerank.</p>
     <p class="without"><span class="lbl">Without it</span> Every rephrasing pays the full retrieval cost; a debugging back-and-forth re-runs it dozens of times.</p>
   </div>
   <div class="rm-card">
@@ -279,7 +279,7 @@ $ reflect search "what's our current API auth"
 ### R7 · OOD gate
 ```
 $ reflect search "totally unrelated topic" --min-overlap 0.3
-∅ ood_gated — top hit overlap 0.08 < 0.3 → injected nothing (no least-bad junk)
+∅ ood_gated: top hit overlap 0.08 < 0.3 → injected nothing (no least-bad junk)
 ```
 
 ### M1 · staged recall
@@ -290,7 +290,7 @@ $ reflect index "tokio panic on shutdown"        # token-capped id+title rows
 $ reflect hydrate a17 c44                          # full bodies only for what you picked
 ```
 
-## The other 29 — capture, storage, consolidation, team
+## The other 29: capture, storage, consolidation, team
 
 Not query-time features, but the plumbing that fills and maintains the KB the recall arms read.
 Listed for completeness so the full 57 are accounted for. (Scroll horizontally.)
@@ -308,7 +308,7 @@ Listed for completeness so the full 57 are accounted for. (Scroll horizontally.)
 <tr><td class="rowh">S5 Belief-revision on ingest</td><td>capture</td><td>always-on</td><td class="wrap">Runs CREATE/UPDATE/DELETE against <code>reflect.db</code> so new learnings revise prior beliefs.</td></tr>
 <tr><td class="rowh">S6 History snapshot on update</td><td>capture</td><td>always-on</td><td class="wrap">Snapshots the prior form into <code>learning_history</code> before mutating a live row.</td></tr>
 <tr><td class="rowh">S8 Doc→chunk→learning grouping</td><td>capture</td><td>always-on</td><td class="wrap">Persists each learning's lineage back to its source transcript + chunk.</td></tr>
-<tr><td class="rowh">S9 Volatile-signals sidecar</td><td>capture</td><td>always-on</td><td class="wrap">Moves churning signals (recall_count, helpful_count…) out of note markdown into a DB sidecar — clean git diffs.</td></tr>
+<tr><td class="rowh">S9 Volatile-signals sidecar</td><td>capture</td><td>always-on</td><td class="wrap">Moves churning signals (recall_count, helpful_count…) out of note markdown into a DB sidecar: clean git diffs.</td></tr>
 <tr><td class="rowh">S10 Write-validate-retry loop</td><td>capture</td><td>always-on (3 tries)</td><td class="wrap">Validates structure + sidecar after write; re-prompts; flags unfixable notes <code>validated: false</code>.</td></tr>
 <tr><td class="rowh">R13 Auto skill-refresh trigger</td><td>capture</td><td>always-on</td><td class="wrap">Flags an existing skill for refresh when a learning it covers lands.</td></tr>
 <tr><td class="rowh">R14 Per-skill staleness signal</td><td>signal</td><td><code>REFLECT_STALENESS_DAYS</code> (30)</td><td class="wrap">Marks a skill <code>is_stale</code> when an in-scope learning changed after its last refresh.</td></tr>
@@ -319,7 +319,7 @@ Listed for completeness so the full 57 are accounted for. (Scroll horizontally.)
 <tr><td class="rowh">SG5 Tool-loop detection</td><td>signal</td><td>always-on</td><td class="wrap">Detects repeated/oscillating tool-call loops as a signal.</td></tr>
 <tr><td class="rowh">SG7 TodoWrite completion signal</td><td>signal</td><td>always-on</td><td class="wrap">Emits a “how I did X” candidate when a todo flips to <code>completed</code>.</td></tr>
 <tr><td class="rowh">SG8 Permission-reply capture</td><td>signal</td><td>always-on</td><td class="wrap">Captures permission-prompt allow/deny replies as policy learnings.</td></tr>
-<tr><td class="rowh">A2 Bitemporal graph edges</td><td>infra</td><td>always-on</td><td class="wrap">Edges carry <code>tcommit</code> / <code>tvalid</code> / <code>tvalid_end</code> — “what was true” vs “what we knew” stay separable.</td></tr>
+<tr><td class="rowh">A2 Bitemporal graph edges</td><td>infra</td><td>always-on</td><td class="wrap">Edges carry <code>tcommit</code> / <code>tvalid</code> / <code>tvalid_end</code>: “what was true” vs “what we knew” stay separable.</td></tr>
 <tr><td class="rowh">A4 Followup-rate diagnostic</td><td>dashboard</td><td><code>RECALL_FOLLOWUP</code> (on)</td><td class="wrap">Logs a recall-quality verdict (did the user immediately re-query differently?) to metrics.</td></tr>
 <tr><td class="rowh">A5 Synthetic compression fallback</td><td>capture</td><td>drain <code>--no-llm</code></td><td class="wrap">Builds a structured learning from heuristics alone when the drain LLM is unavailable.</td></tr>
 <tr><td class="rowh">C2 Auto-consolidation threshold</td><td>consolidation</td><td><code>REFLECT_SYNTHESIS_AUTO_THRESHOLD</code> (30)</td><td class="wrap">Fires the synthesis pass early once learnings-since-last-consolidation cross the threshold.</td></tr>
@@ -336,5 +336,5 @@ Listed for completeness so the full 57 are accounted for. (Scroll horizontally.)
 
 Every feature above is verified by a behavioural proof under
 [`tests/eval/behavioral/proofs/`](https://github.com/stevengonsalvez/ainb-reflect-memory/tree/main/tests/eval/behavioral/proofs)
-(57 `proof_*.py`, one per port). See the [`reflect` CLI reference](/knowledge/reflect-cli/) for how to
+(57 `proof_*.py`, one per port). See the [`reflect` CLI reference](/knowledge/reflect-cli) for how to
 drive recall directly.

--- a/docs/knowledge/reflect-memory/serve.md
+++ b/docs/knowledge/reflect-memory/serve.md
@@ -1,11 +1,11 @@
 ---
 title: "Memory browser (reflect serve)"
-description: "reflect serve — a local, loopback-only web app to browse, search, graph, and curate the reflect knowledge base."
+description: "reflect serve: a local, loopback-only web app to browse, search, graph, and curate the reflect knowledge base."
 ---
 
 `reflect serve` is a local web utility for browsing, searching, and curating the reflect knowledge
-base. It ships with the CLI documented on the [`reflect` CLI reference](/knowledge/reflect-cli/); for
-the engine's recall pipeline see [Recall reference](/knowledge/reflect-memory/recall/).
+base. It ships with the CLI documented on the [`reflect` CLI reference](/knowledge/reflect-cli); for
+the engine's recall pipeline see [Recall reference](/knowledge/reflect-memory/recall).
 
 ```bash
 reflect serve                       # http://127.0.0.1:8377, KB at $GLOBAL_LEARNINGS_PATH or ~/.learnings
@@ -13,7 +13,7 @@ reflect serve --port 8942           # pick a port
 reflect serve --repo /path/to/kb    # browse a specific KB
 ```
 
-To reach it from another device on your tailnet, front it with a proxy — the server itself never
+To reach it from another device on your tailnet, front it with a proxy: the server itself never
 leaves loopback:
 
 ```bash
@@ -22,20 +22,20 @@ tailscale serve --bg --https 8942 http://127.0.0.1:8942
 
 ## What it does
 
-- **Browse** — a faceted memory list (confidence · type · scope · tags/projects), sortable by
+- **Browse**: a faceted memory list (confidence · type · scope · tags/projects), sortable by
   newest, computed recall score, or title.
-- **Search** — lexical BM25 ranking; each result carries a match score and a browse-ordering score
+- **Search**: lexical BM25 ranking; each result carries a match score and a browse-ordering score
   (confidence × recency × tag overlap). This is a browse heuristic, **not** the recall reranker's
-  score — the real reranker (see [R2/R3 in the recall reference](/knowledge/reflect-memory/recall/))
+  score: the real reranker (see [R2/R3 in the recall reference](/knowledge/reflect-memory/recall))
   deliberately dropped exp-decay recency. Full semantic search stays on the `reflect search` CLI.
-- **Graph** — a two-layer force graph of memory and entity nodes; edge widths encode graphml
+- **Graph**: a two-layer force graph of memory and entity nodes; edge widths encode graphml
   relation weights. Toggle the entity layer, drag/pan/zoom, click a memory to open it.
-- **Timeline** — memories grouped chronologically.
-- **Superseded** — `superseded_by` chains rendered newest tip to oldest ancestor.
-- **Curate** — soft-archive/restore (reversible, no hard delete), edit a note's confidence, and
+- **Timeline**: memories grouped chronologically.
+- **Superseded**: `superseded_by` chains rendered newest tip to oldest ancestor.
+- **Curate**: soft-archive/restore (reversible, no hard delete), edit a note's confidence, and
   multi-select memories to queue a group for compression by the `/reflect` consolidate skill
-  (written to a versioned `compress-queue.yaml` — the web app never calls an LLM).
-- **Stats** — confidence/type/scope/tag distributions and engine-op usage counts.
+  (written to a versioned `compress-queue.yaml`: the web app never calls an LLM).
+- **Stats**: confidence/type/scope/tag distributions and engine-op usage counts.
 
 Light and dark themes throughout.
 
@@ -51,22 +51,22 @@ Light and dark themes throughout.
 ## Curation is metadata-only and file-first
 
 Mutations edit the markdown note (the source of truth) and the browser view reloads immediately.
-The nano-graphrag cache used by `reflect search` is **not** rebuilt synchronously — the engine
-only supports a full-batch reindex — so after archiving or editing confidence, run
+The nano-graphrag cache used by `reflect search` is **not** rebuilt synchronously: the engine
+only supports a full-batch reindex: so after archiving or editing confidence, run
 `reflect reindex` to refresh semantic search and the entity graph. The UI hints at this. Note
 bodies stay agent-authored; only metadata is editable here. Postgres backends are read-only in
 this release.
 
 Soft-archive moves the note into an `archived/` sibling directory. This is the browser's own
 reversible delete and is **separate** from the forget sweep's `.forgotten/` directory (see
-[A3 in the recall reference](/knowledge/reflect-memory/recall/)), which the sweep manages with its
+[A3 in the recall reference](/knowledge/reflect-memory/recall)), which the sweep manages with its
 own database accounting. Archiving here does not run the sweep or touch its records.
 
-## Loopback only — no authentication
+## Loopback only: no authentication
 
 Curation is guarded: the server rejects any request whose `Host` isn't loopback (defeats
 DNS-rebinding) and requires an `X-Reflect` header on mutations, so only the same-origin SPA can
-drive them. There is **no auth** — do not bind a public interface. To reach it across your
+drive them. There is **no auth**: do not bind a public interface. To reach it across your
 tailnet, use the `tailscale serve` proxy shown above rather than exposing the port directly.
 
 ## Screenshots

--- a/docs/observability/overview.md
+++ b/docs/observability/overview.md
@@ -1,21 +1,21 @@
 ---
 title: "Observability"
-description: "See what your agents are doing, spending, and running — usage analytics, live process monitoring, causality tracing, and telemetry export to Grafana Cloud."
+description: "See what your agents are doing, spending, and running: usage analytics, live process monitoring, causality tracing, and telemetry export to Grafana Cloud."
 ---
 
-How to see what your agents are doing — what they cost, what's running, why a
+How to see what your agents are doing: what they cost, what's running, why a
 process exists, and how to ship it all to Grafana Cloud.
 
 | Tool | Answers | Surface |
 |------|---------|---------|
-| [Usage analytics (burndown)](../plugins/burndown.md) | "What am I spending — by day, project, model?" | `i` in the TUI · `ainb burndown` |
-| [abtop](../plugins/abtop.md) | "What agent processes are running right now?" | `t` in the TUI · `ainb abtop` |
-| [witr](../plugins/witr.md) | "Why is this process running — what spawned it?" | `w` in the TUI · `ainb witr` |
-| [OpenTelemetry → Grafana Cloud](../reference/otel-grafana.md) | "Ship metrics/logs/traces off-box to dashboards" | `ainb otel setup` |
+| [Usage analytics (burndown)](/plugins/burndown) | "What am I spending: by day, project, model?" | `i` in the TUI · `ainb burndown` |
+| [abtop](/plugins/abtop) | "What agent processes are running right now?" | `t` in the TUI · `ainb abtop` |
+| [witr](/plugins/witr) | "Why is this process running: what spawned it?" | `w` in the TUI · `ainb witr` |
+| [OpenTelemetry → Grafana Cloud](/reference/otel-grafana) | "Ship metrics/logs/traces off-box to dashboards" | `ainb otel setup` |
 
 ## Local vs remote
 
-The first three are **local, in-the-moment** views — open them in the TUI and
+The first three are **local, in-the-moment** views: open them in the TUI and
 read the answer now, no setup. OpenTelemetry is the **off-box, historical**
 path: a local Grafana Alloy collector forwards Claude Code / Codex telemetry to
 Grafana Cloud for cost dashboards, latency percentiles, and trace retention.
@@ -28,5 +28,5 @@ Grafana Cloud for cost dashboards, latency percentiles, and trace retention.
 └──────────────────────────┘     └───────────────────────────────────┘
 ```
 
-Start with the [OpenTelemetry guide](../reference/otel-grafana.md) for the
+Start with the [OpenTelemetry guide](/reference/otel-grafana) for the
 Grafana Cloud setup and example dashboards.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,5 +1,5 @@
 ---
-title: "Plugins — disambiguation"
+title: "Plugins: disambiguation"
 ---
 
 > **Read this first.** The word "plugin" means two different things in this monorepo. Picking the wrong path costs you hours.
@@ -17,27 +17,27 @@ What the rest of this directory documents.
 - **Runtime:** the `ainb` TUI spawns each plugin as a native child process and talks JSON-RPC 2.0 over framed stdio
 - **What they can do:** own a TUI screen, claim a CLI subcommand tree, publish/subscribe to snapshot topics, paint statusline segments
 - **Capability model:** deny-by-default; manifest declares grants for filesystem, network, subprocess, event bus
-- **Reference plugins:** `burndown` (analytics), `session-reader` (data backend), `witr` (process causality, wraps an external binary), and `abtop` (top-for-agents, real-time agent monitor) — all ship in-tree as real subprocess plugins. (Notifications are **not** a plugin — the Inbox + `ainb-notifyd` daemon are host code compiled into `ainb-core`; see [TUI → Inbox & notifications](../tui/inbox-notifications.md).)
+- **Reference plugins:** `burndown` (analytics), `session-reader` (data backend), `witr` (process causality, wraps an external binary), and `abtop` (top-for-agents, real-time agent monitor): all ship in-tree as real subprocess plugins. (Notifications are **not** a plugin: the Inbox + `ainb-notifyd` daemon are host code compiled into `ainb-core`; see [TUI → Inbox & notifications](/tui/inbox-notifications).)
 
 If you want to **add a screen / CLI / dashboard to the TUI**, you want this kind of plugin. Continue to:
-- [overview.md](overview.md) — what a v2 plugin is, conceptually
-- [user-guide.md](user-guide.md) — install, configure, troubleshoot
-- [authoring.md](authoring.md) — write one
-- [spec-v2.md](spec-v2.md) — the wire contract
+- [overview.md](/plugins/overview): what a v2 plugin is, conceptually
+- [user-guide.md](/plugins/user-guide): install, configure, troubleshoot
+- [authoring.md](/plugins/authoring): write one
+- [spec-v2.md](/plugins/spec-v2): the wire contract
 
 ### 2. **Host-agent plugins** (Claude Code / Codex / Copilot plugin systems)
 
 A separate system owned by the host agents themselves. The monorepo ships host-agent plugins under `plugins/<name>/` at the repo root (not inside `ainb-tui/`); `reflect` was **extracted** into its own repo and ships from there:
 
-- **[`reflect`](../toolkit/plugins/reflect.md)** — agent self-improvement + retrieval (skills + SessionStart/PostToolUse/Stop hooks). No longer in this monorepo — it now lives in [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) (plugin under `plugin/`) and is installed from that repo, not via `claude plugin install reflect@agents-in-a-box`.
-- **[`ainb-fleet`](../toolkit/plugins/ainb-fleet.md)** — LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration. `claude plugin install ainb-fleet@agents-in-a-box`
-- **[`ainb-hooks`](../toolkit/plugins/ainb-hooks.md)** — emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../tui/inbox-notifications.md) daemon — host code, not a plugin); wired by `ainb-notifyd install`.
-- **`caveman-stats`** — Claude Code statusline + compaction-survival hooks for upstream `caveman@caveman`.
-- **`illustration`** — mascot-driven illustration skill bundle; no lifecycle hooks.
+- **[`reflect`](/toolkit/plugins/reflect)**: agent self-improvement + retrieval (skills + SessionStart/PostToolUse/Stop hooks). No longer in this monorepo: it now lives in [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) (plugin under `plugin/`) and is installed from that repo, not via `claude plugin install reflect@agents-in-a-box`.
+- **[`ainb-fleet`](/toolkit/plugins/ainb-fleet)**: LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration. `claude plugin install ainb-fleet@agents-in-a-box`
+- **[`ainb-hooks`](/toolkit/plugins/ainb-hooks)**: emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](/tui/inbox-notifications) daemon: host code, not a plugin); wired by `ainb-notifyd install`.
+- **`caveman-stats`**: Claude Code statusline + compaction-survival hooks for upstream `caveman@caveman`.
+- **`illustration`**: mascot-driven illustration skill bundle; no lifecycle hooks.
 
 - **Distribution:** in-monorepo Claude Code plugins go through `.claude-plugin/marketplace.json` at the repo root, which the Claude Code CLI reads (reflect was removed from that marketplace and now ships from ainb-reflect-memory)
 - **Runtime:** host agents load them as skill/hook bundles; the ainb TUI is not involved
-- **Full docs:** [Toolkit → Claude Code plugins](../toolkit/plugins/overview.md) — a page per plugin with how-it-works diagrams
+- **Full docs:** [Toolkit → Claude Code plugins](/toolkit/plugins/overview): a page per plugin with how-it-works diagrams
 
 If you want to **add behaviour to Claude Code itself**, you want a Claude Code plugin. Anthropic's authoritative reference is the [Claude Code plugin docs](https://docs.anthropic.com/en/docs/claude-code); the `plugins/*/` directories here (`ainb-fleet`, `ainb-hooks`) are working examples, and `reflect`'s plugin (in [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) under `plugin/`) is another.
 

--- a/docs/plugins/abtop.md
+++ b/docs/plugins/abtop.md
@@ -1,31 +1,31 @@
 ---
 title: "abtop plugin"
-description: "Integrates the external abtop binary (top-for-agents) as a full-screen ainb screen, CLI, and sidebar entry — real-time monitoring of every AI coding agent on your machine."
+description: "Integrates the external abtop binary (top-for-agents) as a full-screen ainb screen, CLI, and sidebar entry: real-time monitoring of every AI coding agent on your machine."
 ---
 
-`abtop` surfaces real-time AI coding-agent monitoring inside ainb by wrapping the external [`abtop`](https://github.com/graykode/abtop) binary. It is a **subprocess-wrapping** plugin in the same pattern as [`witr`](./witr.md): pressing `t` in ainb hands the full terminal to abtop's own native TUI, returning to ainb on quit — every abtop key works natively, no translation layer.
+`abtop` surfaces real-time AI coding-agent monitoring inside ainb by wrapping the external [`abtop`](https://github.com/graykode/abtop) binary. It is a **subprocess-wrapping** plugin in the same pattern as [`witr`](/plugins/witr): pressing `t` in ainb hands the full terminal to abtop's own native TUI, returning to ainb on quit: every abtop key works natively, no translation layer.
 
-![abtop full journey — sidebar select, first-launch consent, live monitor, return to ainb](../assets/screenshots/abtop-journey.gif)
+![abtop full journey: sidebar select, first-launch consent, live monitor, return to ainb](../assets/screenshots/abtop-journey.gif)
 
 *Press `t` from any ainb screen (or select the `abtop` sidebar tile) to open abtop's live agent-monitor full-screen. First launch shows the rate-limit consent dialog.*
 
 ## What is abtop?
 
-abtop is a `htop`-style TUI that watches every AI coding agent (Claude Code, Codex, and others) running on the machine: token usage, rate-limit headroom, cost burn, active sessions, and hook-triggered status updates. It is maintained by [graykode](https://github.com/graykode/abtop) and is never bundled into ainb — it is detected at runtime.
+abtop is a `htop`-style TUI that watches every AI coding agent (Claude Code, Codex, and others) running on the machine: token usage, rate-limit headroom, cost burn, active sessions, and hook-triggered status updates. It is maintained by [graykode](https://github.com/graykode/abtop) and is never bundled into ainb: it is detected at runtime.
 
 ## How it works
 
-The screen is a **host-embedded foreign TTY**, exactly like witr. abtop's value is its own live interactive monitor — there is no machine-readable wire format for the live view. Pressing `t` (or the sidebar tile 📡) queues `AsyncAction::AttachAbtop`: ainb runs `tmux new-session -A -d -s ainb-abtop "abtop --exit-on-jump"`, suspends its own TUI, and attaches full-screen to abtop's native monitor. When the user quits abtop, ainb resumes. The plugin's `render` method is never invoked for the screen; this wiring lives entirely in `ainb-core`.
+The screen is a **host-embedded foreign TTY**, exactly like witr. abtop's value is its own live interactive monitor: there is no machine-readable wire format for the live view. Pressing `t` (or the sidebar tile 📡) queues `AsyncAction::AttachAbtop`: ainb runs `tmux new-session -A -d -s ainb-abtop "abtop --exit-on-jump"`, suspends its own TUI, and attaches full-screen to abtop's native monitor. When the user quits abtop, ainb resumes. The plugin's `render` method is never invoked for the screen; this wiring lives entirely in `ainb-core`.
 
 The **CLI** path is different: `ainb abtop [args]` execs `abtop --once [args]` directly, inheriting the parent terminal's stdio so abtop's `--once` snapshot prints cleanly (it only emits a one-shot snapshot against a real TTY, then exits). Args are forwarded verbatim, so any flag abtop itself accepts works: `ainb abtop --theme <name>`, etc. (The in-tree `ainb-plugin-abtop` crate also exposes the same surface over `plugin/cli_dispatch` for the plugin harness, but the live `ainb abtop` command is wired directly in `ainb-core`.)
 
-**First-launch consent** — abtop ships an optional `--setup` hook that installs a Claude Code `StatusLine` hook to feed live rate-limit data. On the very first open of the screen, ainb displays a one-time dialog so the user can opt in (or skip) before anything writes to `~/.claude`. ainb never writes `~/.claude` without an explicit "Enable" choice.
+**First-launch consent**: abtop ships an optional `--setup` hook that installs a Claude Code `StatusLine` hook to feed live rate-limit data. On the very first open of the screen, ainb displays a one-time dialog so the user can opt in (or skip) before anything writes to `~/.claude`. ainb never writes `~/.claude` without an explicit "Enable" choice.
 
 ## Capabilities
 
 | Capability | Declared value | Why it is needed |
 |---|---|---|
-| `spawn_subprocess` | `["abtop"]` | Exec `abtop --once` (CLI path) and `abtop --exit-on-jump` (the full-screen handoff). Detection is a `PATH` lookup (`which abtop`) — present/absent only, no version probe and no exec. The list form is per-binary audit metadata. |
+| `spawn_subprocess` | `["abtop"]` | Exec `abtop --once` (CLI path) and `abtop --exit-on-jump` (the full-screen handoff). Detection is a `PATH` lookup (`which abtop`): present/absent only, no version probe and no exec. The list form is per-binary audit metadata. |
 
 All other capabilities (`read_sessions`, `read_claude_logs`, `read_codex_logs`, `write_plugin_data`, `event_bus`, `network`) are left at their deny default.
 
@@ -35,13 +35,13 @@ All other capabilities (`read_sessions`, `read_claude_logs`, `read_codex_logs`, 
 
 Press `t` from any ainb screen, or select the `abtop` / "top-for-agents" entry in the sidebar (shortcut `t`, icon 📡).
 
-ainb suspends and full-screen-attaches to abtop's native TUI running inside a managed tmux session (`ainb-abtop`). Every abtop key works natively — ainb does not intercept or translate them. Press `q` (or abtop's quit binding) to close abtop and return to ainb.
+ainb suspends and full-screen-attaches to abtop's native TUI running inside a managed tmux session (`ainb-abtop`). Every abtop key works natively: ainb does not intercept or translate them. Press `q` (or abtop's quit binding) to close abtop and return to ainb.
 
 If abtop is not on `PATH`, the screen renders an install empty-state with the canonical install command for your platform rather than silently failing.
 
 ### First-launch consent dialog
 
-![abtop first-launch consent — Enable / Just open abtop / Don't ask again](../assets/screenshots/abtop-consent.gif)
+![abtop first-launch consent: Enable / Just open abtop / Don't ask again](../assets/screenshots/abtop-consent.gif)
 
 On the very first time the screen is opened, ainb shows a one-time consent dialog:
 
@@ -67,10 +67,10 @@ Once open, you are in abtop's own interactive TUI. All of abtop's modal keys pas
 | `/` | Filter sessions |
 | `v` | View menu (tree, timeline, panel toggles) |
 | `c` | Config overlay |
-| `?` | Help — abtop's full keybinding list |
+| `?` | Help: abtop's full keybinding list |
 | `q` | Quit abtop, return to ainb |
 
-These are abtop's own keys (verified against the v0.4.7 footer bar), not ainb's — press `?` inside abtop, or see [abtop's docs](https://github.com/graykode/abtop), for the complete reference.
+These are abtop's own keys (verified against the v0.4.7 footer bar), not ainb's: press `?` inside abtop, or see [abtop's docs](https://github.com/graykode/abtop), for the complete reference.
 
 ### CLI (`ainb abtop`)
 
@@ -81,15 +81,15 @@ ainb abtop                     # one-shot status snapshot (runs `abtop --once`)
 ainb abtop --theme <name>      # forwarded verbatim → `abtop --once --theme <name>`
 ```
 
-abtop emits human-readable text only — it has no JSON mode, so there is no `--format json` variant here. Because the command always prepends `--once`, it is for snapshots; the full-screen monitor and the one-time `abtop --setup` hook are reached from the TUI (press `t`), not from `ainb abtop`.
+abtop emits human-readable text only: it has no JSON mode, so there is no `--format json` variant here. Because the command always prepends `--once`, it is for snapshots; the full-screen monitor and the one-time `abtop --setup` hook are reached from the TUI (press `t`), not from `ainb abtop`.
 
 If abtop is not found on `PATH`, the CLI prints an install hint and exits with code 1.
 
 ## Installing abtop
 
-abtop is an external binary maintained by [graykode](https://github.com/graykode/abtop). ainb detects it at runtime — install whichever way fits your environment:
+abtop is an external binary maintained by [graykode](https://github.com/graykode/abtop). ainb detects it at runtime: install whichever way fits your environment:
 
-**macOS (Homebrew — recommended)**
+**macOS (Homebrew: recommended)**
 
 ```sh
 brew install graykode/tap/abtop
@@ -117,4 +117,4 @@ ainb picks up the binary on the next launch; no ainb restart is required within 
 
 ## Source
 
-`crates/ainb-plugin-abtop` — detects the external `abtop` binary, owns the `ainb abtop` CLI via `abtop --once` exec, handles first-launch consent state, and renders the missing/install empty state; the foreign-TTY screen handoff (`t` → `abtop --exit-on-jump`) is wired in `ainb-core`.
+`crates/ainb-plugin-abtop`: detects the external `abtop` binary, owns the `ainb abtop` CLI via `abtop --once` exec, handles first-launch consent state, and renders the missing/install empty state; the foreign-TTY screen handoff (`t` → `abtop --exit-on-jump`) is wired in `ainb-core`.

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -2,7 +2,7 @@
 title: "ainb plugin authoring"
 ---
 
-Developer-facing reference for shipping a v2 plugin. For end-user install/CLI docs see [./user-guide.md](./user-guide.md). For the wire contract see [./spec-v2.md](./spec-v2.md).
+Developer-facing reference for shipping a v2 plugin. For end-user install/CLI docs see [./user-guide.md](/plugins/user-guide). For the wire contract see [./spec-v2.md](/plugins/spec-v2).
 
 ## What you're building
 
@@ -10,15 +10,15 @@ A v2 ainb plugin is a **native executable** that talks JSON-RPC 2.0 to the host 
 
 A plugin can:
 
-- **Own a TUI screen** — implement `Plugin::render` and paint a `WireBuffer` per frame; the host blits it onto the terminal
-- **Own a CLI subcommand tree** — claim a `cli_namespaces` entry in your manifest; the host dispatches `ainb <ns> ...` invocations through `Plugin::cli_dispatch`
-- **Publish snapshots** — push data onto a topic via `HostClient::snapshot_publish`; subscribers (other plugins or the host) get `plugin/handle_event` deliveries
-- **Subscribe to snapshots** — declare `[subscribes].snapshots` in your manifest; the runtime auto-pushes deliveries via `handle_event`
-- **Persist its own state** — write under `~/.agents-in-a-box/plugins/<name>/` (gated by `write_plugin_data`)
-- **Read host-managed state** — sessions, Claude/Codex logs (capability-gated)
-- **Invoke host actions** — call out to host-owned operations via `host/action/invoke`
+- **Own a TUI screen**: implement `Plugin::render` and paint a `WireBuffer` per frame; the host blits it onto the terminal
+- **Own a CLI subcommand tree**: claim a `cli_namespaces` entry in your manifest; the host dispatches `ainb <ns> ...` invocations through `Plugin::cli_dispatch`
+- **Publish snapshots**: push data onto a topic via `HostClient::snapshot_publish`; subscribers (other plugins or the host) get `plugin/handle_event` deliveries
+- **Subscribe to snapshots**: declare `[subscribes].snapshots` in your manifest; the runtime auto-pushes deliveries via `handle_event`
+- **Persist its own state**: write under `~/.agents-in-a-box/plugins/<name>/` (gated by `write_plugin_data`)
+- **Read host-managed state**: sessions, Claude/Codex logs (capability-gated)
+- **Invoke host actions**: call out to host-owned operations via `host/action/invoke`
 
-The bundled `ainb-plugin-burndown` is the canonical reference: owns the Analytics screen, the `ainb usage` CLI tree, and a statusline segment. `ainb-plugin-session-reader` is the canonical pure-publisher example. `ainb-plugin-witr` is the canonical **subprocess-wrapping** example: it declares `spawn_subprocess`, detects an external binary (`witr`) on `PATH`, gates on a version check, and execs `witr --json <target>` to back its `ainb witr` CLI + `/witr` slash (its *screen* is a host-embedded `witr -i` TTY, not a `WireBuffer` render) — the template for surfacing any external tool as a plugin without vendoring its code. Each has a dedicated page under [Plugins → In-tree plugins](./overview.md#reference-plugins).
+The bundled `ainb-plugin-burndown` is the canonical reference: owns the Analytics screen, the `ainb usage` CLI tree, and a statusline segment. `ainb-plugin-session-reader` is the canonical pure-publisher example. `ainb-plugin-witr` is the canonical **subprocess-wrapping** example: it declares `spawn_subprocess`, detects an external binary (`witr`) on `PATH`, gates on a version check, and execs `witr --json <target>` to back its `ainb witr` CLI + `/witr` slash (its *screen* is a host-embedded `witr -i` TTY, not a `WireBuffer` render): the template for surfacing any external tool as a plugin without vendoring its code. Each has a dedicated page under [Plugins → In-tree plugins](/plugins/overview#reference-plugins).
 
 ## Scaffold
 
@@ -53,7 +53,7 @@ ainb-plugin-types-sessions = { path = "../ainb-plugin-types-sessions" }
 
 async-trait = "0.1"                             # required for #[async_trait] on Plugin
 
-# Common workspace deps — pull what you need:
+# Common workspace deps: pull what you need:
 tokio       = { workspace = true, features = ["macros", "rt-multi-thread", "io-std"] }
 serde       = { workspace = true, features = ["derive"] }
 serde_json  = { workspace = true }
@@ -62,7 +62,7 @@ anyhow      = { workspace = true }
 ratatui     = { workspace = true, default-features = false }
 ```
 
-Crate type is a normal Rust `lib` + `bin`. **Not** `cdylib` — that was v1.
+Crate type is a normal Rust `lib` + `bin`. **Not** `cdylib`: that was v1.
 
 The plugin crate sits inside the parent workspace; no separate `[workspace.exclude]` ceremony is needed.
 
@@ -93,11 +93,11 @@ spawn          = "lazy"
 idle_reap_secs = 600
 ```
 
-See [v2.md §1](./spec-v2.md#1-manifest) for the full schema and capability semantics.
+See [v2.md §1](/plugins/spec-v2#1-manifest) for the full schema and capability semantics.
 
 ## Implementing the `Plugin` trait
 
-The crate is named `ainb-plugin-sdk-rust` for `Cargo.toml`, but its `[lib].name` is `ainb_plugin_sdk` — that's the path you `use` from Rust code. The trait surface uses ergonomic types (`WireBuffer`, `CliOutput`); the SDK marshals to and from the wire types documented in [`v2.md`](./spec-v2.md) on your behalf.
+The crate is named `ainb-plugin-sdk-rust` for `Cargo.toml`, but its `[lib].name` is `ainb_plugin_sdk`: that's the path you `use` from Rust code. The trait surface uses ergonomic types (`WireBuffer`, `CliOutput`); the SDK marshals to and from the wire types documented in [`v2.md`](/plugins/spec-v2) on your behalf.
 
 `src/lib.rs`:
 
@@ -178,17 +178,17 @@ The SDK handles Content-Length framing, JSON-RPC envelope encode/decode, method 
 |---|---|---|
 | `manifest()` | required (no default) | At construction; SDK reads it once for `plugin/init` |
 | `render` | required (no default) | Host requests a paint of the screen at the given viewport size |
-| `on_init` | optional (default no-op) | Right after `plugin/init` — open files, kick subscriptions, publish bootstrap. `granted_capabilities` lets you refuse to start with `SdkError::plugin(...)` if a required cap was withheld |
+| `on_init` | optional (default no-op) | Right after `plugin/init`: open files, kick subscriptions, publish bootstrap. `granted_capabilities` lets you refuse to start with `SdkError::plugin(...)` if a required cap was withheld |
 | `handle_key` | optional (default no-op) | A keystroke landed on a screen this plugin owns; preempts `handle_event` |
-| `handle_event` | optional (default no-op) | A subscribed snapshot was published — `params.topic` + `params.payload` |
+| `handle_event` | optional (default no-op) | A subscribed snapshot was published: `params.topic` + `params.payload` |
 | `cli_dispatch` | optional (default `exit 2`) | `ainb <namespace> ...` was invoked; namespace + argv are passed by reference |
 | `on_shutdown` | optional (default no-op) | Host is reaping the plugin; flush state and return |
 
 Pure-publisher plugins (no screen) can satisfy `render` with `Ok(WireBuffer::new(0, 0))` since the host never requests a paint for a plugin that doesn't declare any screens.
 
-Both `handle_key` and `handle_event` are **notifications** — the plugin dispatcher serialises them inline on the read loop to preserve chunk ordering and multi-key sequence semantics.
+Both `handle_key` and `handle_event` are **notifications**: the plugin dispatcher serialises them inline on the read loop to preserve chunk ordering and multi-key sequence semantics.
 
-## `HostClient` — calling back into the host
+## `HostClient`: calling back into the host
 
 ```rust
 host.log_info("…").await;                                  // notification
@@ -224,7 +224,7 @@ Bump the wire types crate's `WIRE_VERSION` whenever you change the chunk shape. 
 # From the workspace root (ainb-tui/).
 cargo build -p ainb-plugin-mything
 
-# Stage every plugin into dist/plugins/<id>/ — this is what the dev TUI
+# Stage every plugin into dist/plugins/<id>/: this is what the dev TUI
 # loads from. On macOS, also re-signs the binary (Cargo's link-time
 # signature is path-bound and gets invalidated by the copy step; without
 # re-signing, AMFI SIGKILLs at exec with no stderr).
@@ -234,7 +234,7 @@ just stage-plugins
 cargo run --bin ainb -- tui
 ```
 
-Add an entry for your plugin to `scripts/build-plugins.sh` if it doesn't already enumerate every plugin crate (the current script iterates a hard-coded list — extend it).
+Add an entry for your plugin to `scripts/build-plugins.sh` if it doesn't already enumerate every plugin crate (the current script iterates a hard-coded list: extend it).
 
 Staged layout:
 
@@ -251,7 +251,7 @@ The host discovers plugins by walking `dist/plugins/<id>/manifest.toml` at start
 ### Logs
 
 ```bash
-# Host JSONL log — includes plugin host.log calls AND plugin stderr drain.
+# Host JSONL log: includes plugin host.log calls AND plugin stderr drain.
 tail -f ~/.agents-in-a-box/logs/agents-in-a-box-*.jsonl | jq .
 
 # Enable trace-level for a specific plugin crate:
@@ -289,11 +289,11 @@ async fn render_paints_header_cell() {
 }
 ```
 
-### Conformance — `ainb-plugin-cts-v2`
+### Conformance: `ainb-plugin-cts-v2`
 
 The CTS runs your built binary through 14 host-impersonation axes. Tests sit in `crates/ainb-plugin-cts-v2/tests/axes.rs`; each axis spawns the plugin under a synthetic host driver and asserts wire-level behaviour. Add a per-axis canary plugin under `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/main.rs` if your plugin tests a path no canary covers yet.
 
-### Tripwires — end-to-end TUI tests
+### Tripwires: end-to-end TUI tests
 
 Tripwire tests in `crates/ainb-core/tests/tripwire_*.rs` drive the real `ainb tui` binary in detached tmux, send keystrokes, capture the pane, and assert on rendered output. They're the only tests that catch "plugin compiled but doesn't render". See `.claude/skills/tmux-ui-tripwire/SKILL.md` for the pattern.
 
@@ -303,13 +303,13 @@ Minimum coverage: one tripwire that proves your plugin's screen renders somethin
 
 ## Distribution
 
-Currently in-tree only. Marketplace install (`ainb plugin install <name>`) targets the v1 catalog schema and will be refreshed for v2 — TBD.
+Currently in-tree only. Marketplace install (`ainb plugin install <name>`) targets the v1 catalog schema and will be refreshed for v2: TBD.
 
 ## Pitfalls
 
 - **Don't forget to stage.** `cargo build -p ainb-plugin-mything` writes to `target/debug/` but the host loads from `dist/plugins/mything/mything`. Run `just stage-plugins` after every rebuild.
 - **macOS AMFI.** Any copied/moved binary needs re-signing or it gets SIGKILL'd silently at exec. `just stage-plugins` handles it; don't skip.
 - **Wire-version drift.** When you change the on-wire shape of a snapshot event, bump `WIRE_VERSION` in the types crate. Subscribers will latch `schema_mismatch` until they rebuild against the new constant.
-- **FIFO ordering.** The plugin SDK dispatches `plugin/handle_event` notifications inline on its read loop precisely so that chunked publishes apply in order. Don't try to spawn background tasks to process events — you'll re-order them.
+- **FIFO ordering.** The plugin SDK dispatches `plugin/handle_event` notifications inline on its read loop precisely so that chunked publishes apply in order. Don't try to spawn background tasks to process events: you'll re-order them.
 - **Capability default is deny.** Forget to add `network = true` to your manifest and `host.action_invoke("fetch", ...)` returns `RpcError { code: -32001 }`. Always grep the host log for `capability denied` first when debugging a stuck call.
 - **Idle reap.** `lifecycle.idle_reap_secs = 600` means the host will SIGTERM your plugin after 10 minutes of no requests. Set `0` to disable, or implement a periodic self-publish if the plugin needs to stay warm.

--- a/docs/plugins/burndown.md
+++ b/docs/plugins/burndown.md
@@ -1,25 +1,25 @@
 ---
 title: "burndown plugin"
-description: "Owns the Analytics screen and the ainb usage CLI — renders usage data published by session-reader over the event bus."
+description: "Owns the Analytics screen and the ainb usage CLI: renders usage data published by session-reader over the event bus."
 ---
 
-`burndown` is the in-tree **screen-owner** reference plugin: it paints the full Analytics dashboard and owns the `ainb usage` CLI tree. It is also the consumer half of the event-bus **publish/subscribe** pattern — it does not scan any session files itself, it renders the snapshots `session-reader` publishes.
+`burndown` is the in-tree **screen-owner** reference plugin: it paints the full Analytics dashboard and owns the `ainb usage` CLI tree. It is also the consumer half of the event-bus **publish/subscribe** pattern: it does not scan any session files itself, it renders the snapshots `session-reader` publishes.
 
 ![The burndown Analytics dashboard inside ainb](../assets/screenshots/burndown-dashboard.png)
 
-*Press `i` in ainb to open the Analytics dashboard — cost/token burndown, per-project and per-model breakdowns, a live session ticker, and optimization hints.*
+*Press `i` in ainb to open the Analytics dashboard: cost/token burndown, per-project and per-model breakdowns, a live session ticker, and optimization hints.*
 
 ## How it works
 
-![burndown plugin — how it works](../assets/diagrams/burndown.svg)
+![burndown plugin: how it works](../assets/diagrams/burndown.svg)
 
-`burndown` is **eager-spawned** (manifest `[lifecycle].spawn = "eager"`). On `plugin/init` it subscribes to `sessions.usage_data` and `sessions.scan_progress`, then publishes an empty payload on `sessions.refresh_request` to kick `session-reader` into a fresh scan with the subscription already on the wire — closing the race where chunk 0 of an in-flight publish would otherwise be missed.
+`burndown` is **eager-spawned** (manifest `[lifecycle].spawn = "eager"`). On `plugin/init` it subscribes to `sessions.usage_data` and `sessions.scan_progress`, then publishes an empty payload on `sessions.refresh_request` to kick `session-reader` into a fresh scan with the subscription already on the wire: closing the race where chunk 0 of an in-flight publish would otherwise be missed.
 
 `session-reader` scans `~/.claude/projects/**` and `~/.codex/sessions/**` and publishes the aggregated usage to the host event bus. The host delivers each publish to `burndown` as a `plugin/handle_event` call on the subscribed topic. Large snapshots arrive **chunked**: chunk 0 carries the bounded aggregates, follow-on chunks extend the `calls` / `sessions` / `shell_commands` tails, and the `is_final` chunk assembles the accumulator into the live `UsageData` (a wire-version mismatch latches a schema-upgrade hint instead). Progress ticks on `sessions.scan_progress` drive the "Scanning sessions… N/M" skeleton until real data lands.
 
-For the **Analytics screen**, the host sends `plugin/render` with a `Viewport`; `burndown` paints a ratatui `Buffer`, converts it to a sparse `WireBuffer` cell stream, and the host blits it each frame. Filtering (`analyze_turns` + per-day/project/model rollups) is memoised in a one-deep cache keyed on `(data_generation, filters+period+provider)` so idle re-renders are O(1). Keystrokes arrive via `plugin/handle_key` — most mutate local UI state (period `1`–`5`/`m`/`q`/`a`, provider `←`/`→`/`p`, panel focus `Tab`, zoom `z`, drill-down `Enter`); `r` re-publishes `sessions.refresh_request` and `F` publishes `sessions.flush_cache_request`.
+For the **Analytics screen**, the host sends `plugin/render` with a `Viewport`; `burndown` paints a ratatui `Buffer`, converts it to a sparse `WireBuffer` cell stream, and the host blits it each frame. Filtering (`analyze_turns` + per-day/project/model rollups) is memoised in a one-deep cache keyed on `(data_generation, filters+period+provider)` so idle re-renders are O(1). Keystrokes arrive via `plugin/handle_key`: most mutate local UI state (period `1`–`5`/`m`/`q`/`a`, provider `←`/`→`/`p`, panel focus `Tab`, zoom `z`, drill-down `Enter`); `r` re-publishes `sessions.refresh_request` and `F` publishes `sessions.flush_cache_request`.
 
-For the **CLI**, the host routes `ainb usage …` through `plugin/cli_dispatch`. `burndown` strips the host-level `--format` flag, re-parses the rest with clap, and runs the report against its latest in-memory snapshot — capturing the legacy report writer's stdout into the JSON-RPC reply. If no snapshot has arrived yet it returns the "install session-reader" hint and the host CLI shim retries until the deadline.
+For the **CLI**, the host routes `ainb usage …` through `plugin/cli_dispatch`. `burndown` strips the host-level `--format` flag, re-parses the rest with clap, and runs the report against its latest in-memory snapshot: capturing the legacy report writer's stdout into the JSON-RPC reply. If no snapshot has arrived yet it returns the "install session-reader" hint and the host CLI shim retries until the deadline.
 
 ## Capabilities
 
@@ -29,25 +29,25 @@ Declared in `plugin.toml` `[capabilities]` (everything not listed defaults to de
 | --- | --- |
 | `read_sessions` | Read access to `~/.agents-in-a-box/sessions/**`. |
 | `write_plugin_data` | Persist plugin-local config (model aliases, display currency) under the plugin data dir. |
-| `event_bus` | Exposes `host/snapshot/get` + `host/snapshot/publish` + `host/log` on the reverse channel — required to subscribe to `sessions.usage_data` and publish `sessions.refresh_request`. |
+| `event_bus` | Exposes `host/snapshot/get` + `host/snapshot/publish` + `host/log` on the reverse channel: required to subscribe to `sessions.usage_data` and publish `sessions.refresh_request`. |
 
-It does **not** declare `read_claude_logs`, `read_codex_logs`, `spawn_subprocess`, or `network` — burndown no longer scans logs itself; `session-reader` owns the data plane.
+It does **not** declare `read_claude_logs`, `read_codex_logs`, `spawn_subprocess`, or `network`: burndown no longer scans logs itself; `session-reader` owns the data plane.
 
 ## Using it
 
-- **Screen** — the manifest provides the `analytics` screen. Open it from the host's screen navigation; you get the full analytics dashboard (per-day / per-project / per-model panels, drill-down chips, provider filter). In-screen keys: `1`–`5` / `m` / `q` / `a` (period), `←` `→` / `p` (provider), `Tab` / `Shift+Tab` (panel focus), `z` (zoom), `Enter` (drill-down chip), `X` (exclude chip), `C` (clear chips), `Backspace` (pop chip / exit zoom), `k` (scroll up), `r` (refresh), `F` (flush cache + rescan). `Esc` is host-reserved for navigate-back.
-- **CLI namespace** — provides `cli_namespaces = ["usage"]`, dispatched as `ainb usage <subcommand>`:
-  - `ainb usage report` — compact burndown report
+- **Screen**: the manifest provides the `analytics` screen. Open it from the host's screen navigation; you get the full analytics dashboard (per-day / per-project / per-model panels, drill-down chips, provider filter). In-screen keys: `1`–`5` / `m` / `q` / `a` (period), `←` `→` / `p` (provider), `Tab` / `Shift+Tab` (panel focus), `z` (zoom), `Enter` (drill-down chip), `X` (exclude chip), `C` (clear chips), `Backspace` (pop chip / exit zoom), `k` (scroll up), `r` (refresh), `F` (flush cache + rescan). `Esc` is host-reserved for navigate-back.
+- **CLI namespace**: provides `cli_namespaces = ["usage"]`, dispatched as `ainb usage <subcommand>`:
+  - `ainb usage report`: compact burndown report
   - `ainb usage today` / `ainb usage month` / `ainb usage status`
-  - `ainb usage models [--by-task]` — per-model rollup or model × activity matrix
-  - `ainb usage export` — CSV / JSON export
+  - `ainb usage models [--by-task]`: per-model rollup or model × activity matrix
+  - `ainb usage export`: CSV / JSON export
   - `ainb usage optimize` / `ainb usage compare` / `ainb usage yield`
-  - `ainb usage plan …` / `ainb usage currency …` / `ainb usage model-alias …` — config subtrees
+  - `ainb usage plan …` / `ainb usage currency …` / `ainb usage model-alias …`: config subtrees
   - `ainb usage cache info` / `ainb usage cache clear`
   - The host-level `--format <text|json|csv>` flag is honoured on report subcommands.
-- **Slash commands** — provides `/usage` and `/burndown`.
-- **Snapshot topics** — provides no published topics (`provides.snapshots = []`). It **subscribes** to `sessions.usage_data` (the data plane) and `sessions.scan_progress` (skeleton ticks), and **publishes** the control topics `sessions.refresh_request` and `sessions.flush_cache_request` to drive `session-reader`.
+- **Slash commands**: provides `/usage` and `/burndown`.
+- **Snapshot topics**: provides no published topics (`provides.snapshots = []`). It **subscribes** to `sessions.usage_data` (the data plane) and `sessions.scan_progress` (skeleton ticks), and **publishes** the control topics `sessions.refresh_request` and `sessions.flush_cache_request` to drive `session-reader`.
 
 ## Source
 
-`crates/ainb-plugin-burndown` — the screen-owner reference plugin: renders the Analytics dashboard from `session-reader`'s published snapshots and serves the `ainb usage` CLI. Diagram generated via /fireworks-tech-graph.
+`crates/ainb-plugin-burndown`: the screen-owner reference plugin: renders the Analytics dashboard from `session-reader`'s published snapshots and serves the `ainb usage` CLI. Diagram generated via /fireworks-tech-graph.

--- a/docs/plugins/changelog.md
+++ b/docs/plugins/changelog.md
@@ -9,13 +9,13 @@ Tracks how the plugin contract (`./spec-v2.md`) evolves.
 - **Adding** a manifest field, JSON-RPC method, capability flag, or wire-type field with `#[serde(default)]` stays inside the current contract version. Existing plugins keep passing `ainb-plugin-cts-v2`.
 - **Renaming**, **removing**, or **changing the signature** of any method or field is a breaking change. The contract bumps (`v2 → v3`); `ainb-plugin-cts-v<n+1>` ships alongside, and the previous CTS stays supported until the host drops every plugin still pinned to the older contract.
 - The runtime's `ABI_VERSION` integer in `crates/ainb-plugin-runtime/src/plugin_task.rs` is the wire-level handshake version stamped on `plugin/init`. Bump only when the contract version bumps.
-- Snapshot wire types (e.g. `ainb-plugin-types-sessions`) carry their own `WIRE_VERSION` constants — those evolve independently from the contract version.
+- Snapshot wire types (e.g. `ainb-plugin-types-sessions`) carry their own `WIRE_VERSION` constants: those evolve independently from the contract version.
 
-## v2 — 2026-05-14
+## v2: 2026-05-14
 
 Subprocess plugin contract. Plugins are native executables exchanging JSON-RPC 2.0 over LSP-style Content-Length framed stdio. Replaces the v1 wasm contract entirely.
 
-Surface area (full reference in [v2.md](./spec-v2.md)):
+Surface area (full reference in [v2.md](/plugins/spec-v2)):
 
 - **Six host → plugin methods**: `plugin/init`, `plugin/shutdown`, `plugin/render`, `plugin/handle_event`, `plugin/handle_key`, `plugin/cli_dispatch`.
 - **Eight plugin → host methods**: `host/snapshot/get`, `host/snapshot/publish`, `host/snapshot/subscribe`, `host/action/invoke`, `host/log`, `host/fs/read_dir`, `host/fs/read_file`, `host/network/fetch`.
@@ -26,8 +26,8 @@ Surface area (full reference in [v2.md](./spec-v2.md)):
 - **Chunked publishes**: `WIRE_VERSION` + `chunk_index` + `is_final` ordering contract; subscribers MUST drop follow-on chunks that arrived without chunk 0.
 - **Priority key channel** (2026-05-15): host runtime drains `plugin/handle_key` notifications ahead of `plugin/handle_event` to prevent FIFO starvation during chunked publishes.
 
-`ainb-plugin-cts-v2` ships with 21 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (`ainb witr` CLI + `/witr` slash wrapping the external `witr` binary via `spawn_subprocess`; its process-causality screen is a host-embedded `witr -i` TTY). See [Plugins → In-tree plugins](./overview.md#reference-plugins) for per-plugin pages.
+`ainb-plugin-cts-v2` ships with 21 conformance axes. In-tree dogfood plugins: `burndown` (analytics screen + `ainb usage` CLI), `session-reader` (chunked usage_data publisher), and `witr` (`ainb witr` CLI + `/witr` slash wrapping the external `witr` binary via `spawn_subprocess`; its process-causality screen is a host-embedded `witr -i` TTY). See [Plugins → In-tree plugins](/plugins/overview#reference-plugins) for per-plugin pages.
 
-## v1 — historical, removed 2026-05-15
+## v1: historical, removed 2026-05-15
 
 Earlier contract using `wasm32-wasip1` cdylibs + a wasmi host runtime + linker-omitted host-fn imports for capability gating. Replaced by v2 (subprocess) because the wasm sandbox added implementation cost without buying any safety property the OS process boundary doesn't already provide for ainb's threat model. The v1 spec lived at `./spec-v1.md`; no in-tree plugins targeted it long enough to require a deprecation path.

--- a/docs/plugins/learnings.md
+++ b/docs/plugins/learnings.md
@@ -1,30 +1,30 @@
 ---
 title: "learnings plugin"
-description: "Browse, search and graph your reflect knowledge base inside ainb — the read-only TUI front-end to the ~/.learnings memory the reflect plugin builds."
+description: "Browse, search and graph your reflect knowledge base inside ainb: the read-only TUI front-end to the ~/.learnings memory the reflect plugin builds."
 ---
 
-`learnings` is the in-tree **memory browser** plugin: it is the read-only TUI window onto the knowledge base that the [`reflect`](../toolkit/plugins/reflect.md) plugin captures and indexes. Where `reflect` is the *write* side — it watches your Claude Code sessions, captures corrections as learning notes, and dual-indexes them — `learnings` is the *read* side: a Browse / Search / Graph explorer over that same `~/.learnings` store, with no data plane of its own. Open it in ainb with `m`, or from any agent with the `/recall` / `/memory` slash commands.
+`learnings` is the in-tree **memory browser** plugin: it is the read-only TUI window onto the knowledge base that the [`reflect`](/toolkit/plugins/reflect) plugin captures and indexes. Where `reflect` is the *write* side: it watches your Claude Code sessions, captures corrections as learning notes, and dual-indexes them: `learnings` is the *read* side: a Browse / Search / Graph explorer over that same `~/.learnings` store, with no data plane of its own. Open it in ainb with `m`, or from any agent with the `/recall` / `/memory` slash commands.
 
-![The learnings Browse tab — the reflect KB listed by id, scope/conf/category/source/project filter chips, and confidence column](../assets/screenshots/learnings-browse.png)
+![The learnings Browse tab: the reflect KB listed by id, scope/conf/category/source/project filter chips, and confidence column](../assets/screenshots/learnings-browse.png)
 
 *Press `m` in ainb to open the learnings screen. Browse lists every note in the KB with its confidence; `f` cycles the filter chips, `Tab`/`/`/`g` switch panes.*
 
 ## What it is a view of
 
-`learnings` is, in the words of its own manifest, *"a read-only browser over the reflect knowledge base."* It never writes learnings and never re-indexes — it reads the artifacts `reflect` (and the `reflect-kb` CLI) produce and renders them three ways. It is the natural companion to the [reflect plugin](../toolkit/plugins/reflect.md) and the [`reflect` CLI](../knowledge/reflect-cli.md): reflect's `correct once, never again` loop fills the store; `learnings` lets you actually *see* what's in it.
+`learnings` is, in the words of its own manifest, *"a read-only browser over the reflect knowledge base."* It never writes learnings and never re-indexes: it reads the artifacts `reflect` (and the `reflect-kb` CLI) produce and renders them three ways. It is the natural companion to the [reflect plugin](/toolkit/plugins/reflect) and the [`reflect` CLI](/knowledge/reflect-cli): reflect's `correct once, never again` loop fills the store; `learnings` lets you actually *see* what's in it.
 
 ### The memory file system it reads
 
-The knowledge base is a plain directory tree — the canonical root is `~/.learnings/` (the legacy `~/.claude/global-learnings/` root is still read as a fallback). `learnings` reads three kinds of artifact directly off disk, plus one through a CLI:
+The knowledge base is a plain directory tree: the canonical root is `~/.learnings/` (the legacy `~/.claude/global-learnings/` root is still read as a fallback). `learnings` reads three kinds of artifact directly off disk, plus one through a CLI:
 
 | Artifact | Path (default) | What `learnings` does with it |
 | --- | --- | --- |
 | **Markdown learning notes** | `~/.learnings/documents/learnings/*.md` | The Browse list + the Detail read-pane. Each note carries YAML front-matter (`title`, `category`, `scope`, `confidence`, `key_insight`, `tags`, `provenance`) and a Markdown body. |
 | **Entity sidecars** | `*.entities.yaml` next to each note | The **typed graph**. Each sidecar declares `entities` (name / type / description) and `relationships` (`source`, `target`, `type` ∈ `solves` / `caused_by` / `causes` / `requires` / `relates_to`, `strength`). These typed edges are what the Graph tab draws. |
-| **nano-graphrag cache** | `~/.learnings/nano_graphrag_cache/` | `graph_chunk_entity_relation.graphml` (the GraphRAG entity graph) and `kv_store_community_reports.json` (the community clusters) — the source for the community-cluster view. |
-| **QMD index** | `~/.cache/qmd/index.sqlite`, collection `learnings` | The Search tab. `learnings` shells the [`qmd`](https://github.com/stevengonsalvez/agents-in-a-box) binary against this index for fast lexical/semantic recall — it does not parse the sqlite itself. |
+| **nano-graphrag cache** | `~/.learnings/nano_graphrag_cache/` | `graph_chunk_entity_relation.graphml` (the GraphRAG entity graph) and `kv_store_community_reports.json` (the community clusters): the source for the community-cluster view. |
+| **QMD index** | `~/.cache/qmd/index.sqlite`, collection `learnings` | The Search tab. `learnings` shells the [`qmd`](https://github.com/stevengonsalvez/agents-in-a-box) binary against this index for fast lexical/semantic recall: it does not parse the sqlite itself. |
 
-> **Compatibility, in one line:** if `reflect` (or `reflect reindex`) built it, `learnings` can view it. The plugin reads the **exact** layout the reflect plugin's `recall.py` / synthesis scripts and the `reflect-kb` CLI write — Markdown notes + `.entities.yaml` sidecars + the nano-graphrag graphml/community cache + the qmd index. Because `reflect:ingest` harvests memory from **every** agent (Claude, Codex, Copilot, Gemini) into that one unified store, `learnings` ends up being a single pane over all of them.
+> **Compatibility, in one line:** if `reflect` (or `reflect reindex`) built it, `learnings` can view it. The plugin reads the **exact** layout the reflect plugin's `recall.py` / synthesis scripts and the `reflect-kb` CLI write: Markdown notes + `.entities.yaml` sidecars + the nano-graphrag graphml/community cache + the qmd index. Because `reflect:ingest` harvests memory from **every** agent (Claude, Codex, Copilot, Gemini) into that one unified store, `learnings` ends up being a single pane over all of them.
 
 ### How it lines up with reflect
 
@@ -39,23 +39,23 @@ The knowledge base is a plain directory tree — the canonical root is `~/.learn
    Claude/Codex/Copilot/… ──┘    graphrag)         ▲ read-only, no re-index
 ```
 
-Reflect owns capture + indexing (and auto-recall back into the agent's context). `learnings` is the human-facing viewer of the same files — so the two share a store but never a write path. Set up reflect first (`ainb reflect bootstrap`); `learnings` then has something to show.
+Reflect owns capture + indexing (and auto-recall back into the agent's context). `learnings` is the human-facing viewer of the same files: so the two share a store but never a write path. Set up reflect first (`ainb reflect bootstrap`); `learnings` then has something to show.
 
 ## The three views
 
-`learnings` is a tabbed shell — `Tab` cycles **Browse → Search → Graph**, and `g` jumps straight to the Graph tab from anywhere.
+`learnings` is a tabbed shell: `Tab` cycles **Browse → Search → Graph**, and `g` jumps straight to the Graph tab from anywhere.
 
-### Browse — the notes
+### Browse: the notes
 
 The Browse tab (above) lists every note by id with its confidence, and a row of filter chips (`scope` / `conf` / `category` / `source` / `project`). `f` activates the chips, `↑↓` move, `⏎` opens the Detail read-pane (title, key insight, the Markdown body, the entity + relationship lists, and provenance), `Backspace` closes it.
 
-### Search — qmd recall
+### Search: qmd recall
 
-![The Search tab — a live query box that recalls from the qmd index](../assets/screenshots/learnings-search.png)
+![The Search tab: a live query box that recalls from the qmd index](../assets/screenshots/learnings-search.png)
 
-`/` (from any tab) focuses the Search query box; type a query and `⏎` runs a hybrid lexical/semantic search against the qmd index, listing ranked hits you can open into Detail. This is the same recall surface the reflect hooks use automatically at session start — here you drive it by hand.
+`/` (from any tab) focuses the Search query box; type a query and `⏎` runs a hybrid lexical/semantic search against the qmd index, listing ranked hits you can open into Detail. This is the same recall surface the reflect hooks use automatically at session start: here you drive it by hand.
 
-### Graph — see how memories connect
+### Graph: see how memories connect
 
 The Graph tab is where the typed `entities.yaml` relationships come alive. **`g`** focuses it; it has three renderings.
 
@@ -63,17 +63,17 @@ The Graph tab is where the typed `entities.yaml` relationships come alive. **`g`
 
 Three, each a different lens on the same typed entity graph:
 
-**1 · Entity neighbourhood (text)** — the default. Pick an entity from the list and see its typed outgoing edges as `<entity> --<rel_type>--> <neighbour>` lines, aggregated across every note's `relationships[]`.
+**1 · Entity neighbourhood (text)**: the default. Pick an entity from the list and see its typed outgoing edges as `<entity> --<rel_type>--> <neighbour>` lines, aggregated across every note's `relationships[]`.
 
-![The Graph tab entity-neighbourhood view — typed edges like audit-after-rebase --solves--> stale plan execution](../assets/screenshots/learnings-graph-neighbourhood.png)
+![The Graph tab entity-neighbourhood view: typed edges like audit-after-rebase --solves--> stale plan execution](../assets/screenshots/learnings-graph-neighbourhood.png)
 
-**2 · Community clusters** — press **`c`** to toggle to the nano-graphrag community view: one row per detected cluster (`title` + member count + impact rating), read from `kv_store_community_reports.json`. This is the GraphRAG "communities" lens — groups of entities that co-occur across many learnings.
+**2 · Community clusters**: press **`c`** to toggle to the nano-graphrag community view: one row per detected cluster (`title` + member count + impact rating), read from `kv_store_community_reports.json`. This is the GraphRAG "communities" lens: groups of entities that co-occur across many learnings.
 
-![The Graph tab community-cluster view — nano-graphrag community reports](../assets/screenshots/learnings-community.png)
+![The Graph tab community-cluster view: nano-graphrag community reports](../assets/screenshots/learnings-community.png)
 
-**3 · Radial ego local-graph (the map)** — press **`v`** to swap the text neighbourhood for a spatial, Obsidian-style local graph drawn on the character grid. The list-selected entity sits at the centre; its typed neighbours fan out on a ring as boxed `[entity]` nodes, joined by ASCII edges with **arrowheads** on directed relationships and **colour-coded type labels** (`solves` green, `caused_by`/`causes` red, `requires` blue, `relates_to` grey with no arrowhead). It is fully **deterministic** — no physics, no random layout — so the same KB always draws the same map.
+**3 · Radial ego local-graph (the map)**: press **`v`** to swap the text neighbourhood for a spatial, Obsidian-style local graph drawn on the character grid. The list-selected entity sits at the centre; its typed neighbours fan out on a ring as boxed `[entity]` nodes, joined by ASCII edges with **arrowheads** on directed relationships and **colour-coded type labels** (`solves` green, `caused_by`/`causes` red, `requires` blue, `relates_to` grey with no arrowhead). It is fully **deterministic**: no physics, no random layout: so the same KB always draws the same map.
 
-![Radial map journey — open, graph, v to map, navigate, recentre, hops, back](../assets/screenshots/learnings-map-journey.gif)
+![Radial map journey: open, graph, v to map, navigate, recentre, hops, back](../assets/screenshots/learnings-map-journey.gif)
 
 *`m` → `g` → `v` opens the radial map; `↓`+`⏎` recentres on a neighbour; `h` widens the hop; `Backspace` returns to the neighbourhood.*
 
@@ -81,17 +81,17 @@ The map is an **ego / local** graph: centre + 1 hop by default (toggle to 2 with
 
 | Centred on one entity | After `⏎` recentre on a neighbour |
 | --- | --- |
-| ![Map centred on audit-after-rebase, ↑ solves edge](../assets/screenshots/learnings-map-centre.png) | ![Map recentred on stale plan execution — green solves + red caused_by, ↓ arrowheads](../assets/screenshots/learnings-map-recentred.png) |
+| ![Map centred on audit-after-rebase, ↑ solves edge](../assets/screenshots/learnings-map-centre.png) | ![Map recentred on stale plan execution: green solves + red caused_by, ↓ arrowheads](../assets/screenshots/learnings-map-recentred.png) |
 
 For a hot, highly-connected entity the 15-node cap keeps the ring legible and offers `[+N more]`; `e` expands it to the full set:
 
-![Hub overflow — 15 nodes on the ring plus a +3 more node, then e expands to all 18](../assets/screenshots/learnings-map-overflow.gif)
+![Hub overflow: 15 nodes on the ring plus a +3 more node, then e expands to all 18](../assets/screenshots/learnings-map-overflow.gif)
 
 | Capped: `nodes:15 (+3)` | Expanded with `e`: `nodes:18` |
 | --- | --- |
-| ![A hub with 15 neighbours on the ring and a +3 more overflow node](../assets/screenshots/learnings-map-overflow-cap.png) | ![The same hub after pressing e — all 18 neighbours shown](../assets/screenshots/learnings-map-expanded.png) |
+| ![A hub with 15 neighbours on the ring and a +3 more overflow node](../assets/screenshots/learnings-map-overflow-cap.png) | ![The same hub after pressing e: all 18 neighbours shown](../assets/screenshots/learnings-map-expanded.png) |
 
-**Not (yet) rendered:** a full-graph (whole-KB, non-ego) view and force-directed physics are deliberately out of scope for v1 — the radial ego layout was chosen precisely because it is cheap and deterministic.
+**Not (yet) rendered:** a full-graph (whole-KB, non-ego) view and force-directed physics are deliberately out of scope for v1: the radial ego layout was chosen precisely because it is cheap and deterministic.
 
 ### Graph keymap
 
@@ -102,7 +102,7 @@ For a hot, highly-connected entity the 15-node cap keeps the ring legible and of
 | `c` | toggle entity neighbourhood ⇄ community clusters |
 | `v` | cycle the view: neighbourhood → **radial map** → neighbourhood |
 | `↑ ↓ ← →` (in map) | move across rings (↑↓) / orbit within a ring (←→) |
-| `⏎` / mouse click (in map) | recentre on the selected / clicked node — animated |
+| `⏎` / mouse click (in map) | recentre on the selected / clicked node: animated |
 | `h` (in map) | toggle hop depth 1 ↔ 2 |
 | `e` (in map) | expand the `[+N more]` overflow node |
 | `o` (in map) | open the learnings behind the entity (a picker if more than one → Detail) |
@@ -110,7 +110,7 @@ For a hot, highly-connected entity the 15-node cap keeps the ring legible and of
 
 ## How it works
 
-`learnings` is **lazy-spawned** (manifest `[lifecycle].spawn = "lazy"`) — it stays dormant until you open the screen or type `/recall` / `/memory`. On `plugin/init` the host injects the resolved `[plugins.learnings]` config; the plugin scans `learnings_dir` for `*.md` notes (+ their `.entities.yaml` sidecars), aggregates every note's `relationships[]` into a typed adjacency keyed by entity name, and lazily reads the `graph_cache` community json the first time you reach the Graph tab. The Graph map is a pure pipeline — extract the ego subgraph → deterministic radial layout → render boxes/edges/arrowheads/labels — so it renders the same tokens every run. Search shells `qmd` against the configured index; selecting a hit opens the same Detail pane Browse uses.
+`learnings` is **lazy-spawned** (manifest `[lifecycle].spawn = "lazy"`): it stays dormant until you open the screen or type `/recall` / `/memory`. On `plugin/init` the host injects the resolved `[plugins.learnings]` config; the plugin scans `learnings_dir` for `*.md` notes (+ their `.entities.yaml` sidecars), aggregates every note's `relationships[]` into a typed adjacency keyed by entity name, and lazily reads the `graph_cache` community json the first time you reach the Graph tab. The Graph map is a pure pipeline: extract the ego subgraph → deterministic radial layout → render boxes/edges/arrowheads/labels: so it renders the same tokens every run. Search shells `qmd` against the configured index; selecting a hit opens the same Detail pane Browse uses.
 
 ## Capabilities
 
@@ -118,12 +118,12 @@ Declared in `manifest.toml` `[capabilities]` (everything not listed defaults to 
 
 | Capability | Why it is needed |
 | --- | --- |
-| `read_paths = ["~/.learnings", "~/.cache/qmd"]` | Path-scoped fs read envelope — the plugin may read the KB notes/sidecars, the nano-graphrag cache, and the qmd index, and nothing else. |
+| `read_paths = ["~/.learnings", "~/.cache/qmd"]` | Path-scoped fs read envelope: the plugin may read the KB notes/sidecars, the nano-graphrag cache, and the qmd index, and nothing else. |
 | `spawn_subprocess = ["qmd", "learnings"]` | Semantic search shells `qmd`; graph-expanded search may shell `learnings`. |
 | `write_plugin_data` | Persist plugin-local UI state under the plugin data dir. |
 | `event_bus` | Exposes the snapshot/event reverse channel for refresh. |
 
-It declares **no** `cli_namespaces` — `learnings` is TUI-only.
+It declares **no** `cli_namespaces`: `learnings` is TUI-only.
 
 ## Configuration
 
@@ -140,11 +140,11 @@ Point these at any directory that follows the same reflect-KB layout to browse a
 
 ## Using it
 
-- **Screen** — provides the `learnings` screen. Open it with `m` (or `/recall` / `/memory`). `Tab` cycles Browse → Search → Graph; `/` jumps to Search; `g` jumps to the Graph tab.
-- **Slash commands** — `/recall` and `/memory` both open the learnings screen from any agent context.
+- **Screen**: provides the `learnings` screen. Open it with `m` (or `/recall` / `/memory`). `Tab` cycles Browse → Search → Graph; `/` jumps to Search; `g` jumps to the Graph tab.
+- **Slash commands**: `/recall` and `/memory` both open the learnings screen from any agent context.
 
 ## Related
 
-- [reflect plugin](../toolkit/plugins/reflect.md) — the capture + indexing side that *builds* the KB `learnings` views.
-- [reflect CLI (`reflect-kb`)](../knowledge/reflect-cli.md) — the `add` / `reindex` / `search` data layer.
-- [Plugin architecture overview](./overview.md) — how ainb's v2 subprocess plugins work.
+- [reflect plugin](/toolkit/plugins/reflect): the capture + indexing side that *builds* the KB `learnings` views.
+- [reflect CLI (`reflect-kb`)](/knowledge/reflect-cli): the `add` / `reindex` / `search` data layer.
+- [Plugin architecture overview](/plugins/overview): how ainb's v2 subprocess plugins work.

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -1,10 +1,10 @@
 ---
-title: "ainb v2 plugins — overview"
+title: "ainb v2 plugins: overview"
 ---
 
-What a v2 subprocess plugin is, conceptually. New here? Read [README.md](./README.md) first — it disambiguates from Claude Code plugins.
+What a v2 subprocess plugin is, conceptually. New here? Read [README.md](/plugins/readme) first: it disambiguates from Claude Code plugins.
 
-For the user CLI flow, jump to [user-guide.md](./user-guide.md). To write one, [authoring.md](./authoring.md). For the wire contract, [spec-v2.md](./spec-v2.md).
+For the user CLI flow, jump to [user-guide.md](/plugins/user-guide). To write one, [authoring.md](/plugins/authoring). For the wire contract, [spec-v2.md](/plugins/spec-v2).
 
 ## What is a plugin?
 
@@ -16,37 +16,37 @@ Plugins only see the host capabilities they declare in their manifest, and they 
 
 ![ainb v2 plugin architecture: the host and its runtime, the JSON-RPC method sets on each side of the wire, the six in-tree plugins, and the two ways a plugin can draw](../assets/diagrams/plugin-architecture.svg)
 
-The host (`ainb-core`) spawns each plugin as a child process and drives it over **JSON-RPC 2.0 / Content-Length-framed stdio**. Host→plugin methods: `plugin/init` (with the granted capabilities), `plugin/render` (host sends a `Viewport`, plugin returns a `WireBuffer`), `plugin/handle_key`, `plugin/handle_event`, `plugin/cli_dispatch`, `plugin/shutdown`. Plugin→host (reverse) calls: `host/snapshot/publish` + `host/snapshot/subscribe` (the **event bus**) and `host/action/invoke`. The `ainb-plugin-runtime` enforces capabilities — an ungranted host-fn call comes back as JSON-RPC `-32001` (`CAPABILITY_DENIED`).
+The host (`ainb-core`) spawns each plugin as a child process and drives it over **JSON-RPC 2.0 / Content-Length-framed stdio**. Host→plugin methods: `plugin/init` (with the granted capabilities), `plugin/render` (host sends a `Viewport`, plugin returns a `WireBuffer`), `plugin/handle_key`, `plugin/handle_event`, `plugin/cli_dispatch`, `plugin/shutdown`. Plugin→host (reverse) calls: `host/snapshot/publish` + `host/snapshot/subscribe` (the **event bus**) and `host/action/invoke`. The `ainb-plugin-runtime` enforces capabilities: an ungranted host-fn call comes back as JSON-RPC `-32001` (`CAPABILITY_DENIED`).
 
 ### Two ways a plugin screen renders
 
-- **In-process `WireBuffer`** — the host owns the terminal; the plugin paints a sparse cell grid the host blits each frame. Integrated and themeable. This is how **`burndown`** draws the Analytics dashboard.
-- **Host-embedded foreign TTY** — for an interactive program that has no machine-readable render (only its own TUI), the host *suspends* and hands the whole terminal to the external binary, resuming when it exits — the same mechanism ainb uses to attach to agent sessions. This is how **`witr`** opens its all-process browser (`witr -i`): there's no JSON for witr's live process list, so pressing `w` runs `tmux new-session -A -d -s ainb-witr "witr -i"` and attaches full-screen.
+- **In-process `WireBuffer`**: the host owns the terminal; the plugin paints a sparse cell grid the host blits each frame. Integrated and themeable. This is how **`burndown`** draws the Analytics dashboard.
+- **Host-embedded foreign TTY**: for an interactive program that has no machine-readable render (only its own TUI), the host *suspends* and hands the whole terminal to the external binary, resuming when it exits: the same mechanism ainb uses to attach to agent sessions. This is how **`witr`** opens its all-process browser (`witr -i`): there's no JSON for witr's live process list, so pressing `w` runs `tmux new-session -A -d -s ainb-witr "witr -i"` and attaches full-screen.
 
 ## What a plugin can own
 
-- **A TUI screen** — implement `Plugin::render` and paint a `WireBuffer` per frame; the host blits it onto the terminal.
-- **A CLI subcommand tree** — claim a `cli_namespaces` entry in your manifest; the host dispatches `ainb <ns> ...` invocations through `Plugin::cli_dispatch`.
-- **Snapshot topics (publish/subscribe)** — push data on a topic via `HostClient::snapshot_publish`; subscribers (other plugins or the host) get `plugin/handle_event` deliveries.
-- **A statusline segment** — own a slice of the persistent status bar.
-- **Its own state** — write under `~/.agents-in-a-box/plugins/<name>/` (gated by `write_plugin_data`).
-- **Host actions** — invoke host-owned operations via `host/action/invoke` (gated by capability).
+- **A TUI screen**: implement `Plugin::render` and paint a `WireBuffer` per frame; the host blits it onto the terminal.
+- **A CLI subcommand tree**: claim a `cli_namespaces` entry in your manifest; the host dispatches `ainb <ns> ...` invocations through `Plugin::cli_dispatch`.
+- **Snapshot topics (publish/subscribe)**: push data on a topic via `HostClient::snapshot_publish`; subscribers (other plugins or the host) get `plugin/handle_event` deliveries.
+- **A statusline segment**: own a slice of the persistent status bar.
+- **Its own state**: write under `~/.agents-in-a-box/plugins/<name>/` (gated by `write_plugin_data`).
+- **Host actions**: invoke host-owned operations via `host/action/invoke` (gated by capability).
 
 ## Reference plugins
 
 Four plugins ship in-tree as the canonical examples:
 
-- **[`burndown`](./burndown.md)** — screen-owner reference. Owns the Analytics screen (renders a ratatui dashboard into a `WireBuffer` each frame) and the `ainb usage` CLI tree; subscribes to `sessions.usage_data` from `session-reader`.
-- **[`session-reader`](./session-reader.md)** — pure-publisher reference. No screen. Scans `~/.claude/projects/**`, `~/.codex/sessions/**` (and more) and chunk-publishes usage snapshots on `sessions.usage_data` for `burndown` to render.
-- **[`witr`](./witr.md)** — subprocess-wrapper reference. The `ainb witr <target>` CLI + `/witr` slash run `witr --json <target>` and parse the ancestry JSON; its **screen** is a host-embedded foreign TTY (`w` hands the terminal to `witr -i` — see [the two render paths](#two-ways-a-plugin-screen-renders)). Declares `spawn_subprocess` + `event_bus`.
-- **[`learnings`](./learnings.md)** — read-only-browser reference. A path-scoped fs reader + `qmd` subprocess: it browses, searches and **graphs** the [`reflect`](../toolkit/plugins/reflect.md) knowledge base under `~/.learnings` (Markdown notes + `.entities.yaml` sidecars + the nano-graphrag cache + the qmd index). Opens with `m` / `/recall` / `/memory`; its Graph tab renders an entity neighbourhood, community clusters, and a deterministic radial ego local-graph. Declares `read_paths` + `spawn_subprocess` + `event_bus`.
-- **[`abtop`](./abtop.md)** — subprocess-wrapper plugin for `abtop` (top-for-agents). The `ainb abtop` CLI execs `abtop --once`; pressing `t` attaches the terminal full-screen to `abtop --exit-on-jump` (same foreign-TTY hand-off pattern as witr). First launch shows a one-time rate-limit `--setup` consent dialog. Declares `spawn_subprocess` only.
+- **[`burndown`](/plugins/burndown)**: screen-owner reference. Owns the Analytics screen (renders a ratatui dashboard into a `WireBuffer` each frame) and the `ainb usage` CLI tree; subscribes to `sessions.usage_data` from `session-reader`.
+- **[`session-reader`](/plugins/session-reader)**: pure-publisher reference. No screen. Scans `~/.claude/projects/**`, `~/.codex/sessions/**` (and more) and chunk-publishes usage snapshots on `sessions.usage_data` for `burndown` to render.
+- **[`witr`](/plugins/witr)**: subprocess-wrapper reference. The `ainb witr <target>` CLI + `/witr` slash run `witr --json <target>` and parse the ancestry JSON; its **screen** is a host-embedded foreign TTY (`w` hands the terminal to `witr -i`: see [the two render paths](#two-ways-a-plugin-screen-renders)). Declares `spawn_subprocess` + `event_bus`.
+- **[`learnings`](/plugins/learnings)**: read-only-browser reference. A path-scoped fs reader + `qmd` subprocess: it browses, searches and **graphs** the [`reflect`](/toolkit/plugins/reflect) knowledge base under `~/.learnings` (Markdown notes + `.entities.yaml` sidecars + the nano-graphrag cache + the qmd index). Opens with `m` / `/recall` / `/memory`; its Graph tab renders an entity neighbourhood, community clusters, and a deterministic radial ego local-graph. Declares `read_paths` + `spawn_subprocess` + `event_bus`.
+- **[`abtop`](/plugins/abtop)**: subprocess-wrapper plugin for `abtop` (top-for-agents). The `ainb abtop` CLI execs `abtop --once`; pressing `t` attaches the terminal full-screen to `abtop --exit-on-jump` (same foreign-TTY hand-off pattern as witr). First launch shows a one-time rate-limit `--setup` consent dialog. Declares `spawn_subprocess` only.
 
 Each links to its own page with a `/fireworks-tech-graph` diagram of how it works.
 
-> **Not a plugin:** the Inbox screen + `ainb-notifyd` daemon are sometimes mistaken for an in-tree plugin (the crate is named `ainb-plugin-notifyd`). They are **host code compiled into `ainb-core`** — no manifest, no JSON-RPC, no capability gate. They're documented under [TUI → Inbox & notifications](../tui/inbox-notifications.md), not here.
+> **Not a plugin:** the Inbox screen + `ainb-notifyd` daemon are sometimes mistaken for an in-tree plugin (the crate is named `ainb-plugin-notifyd`). They are **host code compiled into `ainb-core`**: no manifest, no JSON-RPC, no capability gate. They're documented under [TUI → Inbox & notifications](/tui/inbox-notifications), not here.
 
-![Burndown plugin — full analytics dashboard](../assets/screenshots/burndown.png)
+![Burndown plugin: full analytics dashboard](../assets/screenshots/burndown.png)
 
 *The burndown plugin rendering the full analytics dashboard against real `~/.claude/projects` data.*
 
@@ -70,7 +70,7 @@ dist/plugins/
     └── manifest.toml
 ```
 
-(`notifyd` is **not** here — it's a daemon compiled into `ainb-core`, not a staged subprocess plugin; see [TUI → Inbox & notifications](../tui/inbox-notifications.md).)
+(`notifyd` is **not** here: it's a daemon compiled into `ainb-core`, not a staged subprocess plugin; see [TUI → Inbox & notifications](/tui/inbox-notifications).)
 
 That layout is what `just stage-plugins` produces from in-tree crates, and what the host walks on startup. The `AINB_PLUGIN_ROOT` env var overrides it (defaults to `<workspace-root>/dist/plugins`).
 
@@ -93,14 +93,14 @@ network             = []       # bool or hostname allow-list
 
 Default for every flag is **deny** (`false` / `[]`). The runtime rejects host-fn calls against a capability the manifest doesn't grant with JSON-RPC error code `-32001` (`CAPABILITY_DENIED`).
 
-Full semantics: [spec-v2.md §1](./spec-v2.md#1-manifest) and [spec-v2.md §9](./spec-v2.md#9-capability-gates).
+Full semantics: [spec-v2.md §1](/plugins/spec-v2#1-manifest) and [spec-v2.md §9](/plugins/spec-v2#9-capability-gates).
 
 ## Versus the deprecated v1 wasm contract
 
-v1 used `wasm32-wasip1` cdylibs in a wasmi host runtime with linker-omitted host-fn imports for capability gating. v2 dropped wasm entirely — a normal `cargo build` binary, native code, OS-process boundary. The wasm sandbox added implementation cost without buying any safety property the OS process boundary doesn't already provide for ainb's threat model.
+v1 used `wasm32-wasip1` cdylibs in a wasmi host runtime with linker-omitted host-fn imports for capability gating. v2 dropped wasm entirely: a normal `cargo build` binary, native code, OS-process boundary. The wasm sandbox added implementation cost without buying any safety property the OS process boundary doesn't already provide for ainb's threat model.
 
 ## Next steps
 
-- **End user?** [user-guide.md](./user-guide.md) — every `ainb plugin` command.
-- **Building a plugin?** [authoring.md](./authoring.md) — Rust SDK, scaffolding, debugging.
-- **Implementing a host?** [spec-v2.md](./spec-v2.md) — the wire contract.
+- **End user?** [user-guide.md](/plugins/user-guide): every `ainb plugin` command.
+- **Building a plugin?** [authoring.md](/plugins/authoring): Rust SDK, scaffolding, debugging.
+- **Implementing a host?** [spec-v2.md](/plugins/spec-v2): the wire contract.

--- a/docs/plugins/session-reader.md
+++ b/docs/plugins/session-reader.md
@@ -1,21 +1,21 @@
 ---
 title: "session-reader plugin"
-description: "Pure-publisher reference plugin — scans per-provider session logs and chunk-publishes a UsageData snapshot on the event bus."
+description: "Pure-publisher reference plugin: scans per-provider session logs and chunk-publishes a UsageData snapshot on the event bus."
 ---
 
-A pure data-plane plugin: it owns **no screen and no CLI namespace**. It walks the per-provider session-log directories, aggregates a `UsageData` snapshot, and chunk-publishes it on the `sessions.usage_data` topic for downstream consumers (`burndown`, and the host) to render. It is the canonical **publisher** example — the inverse of a screen-owning plugin, exercising only the event bus, log-read, and plugin-data capabilities.
+A pure data-plane plugin: it owns **no screen and no CLI namespace**. It walks the per-provider session-log directories, aggregates a `UsageData` snapshot, and chunk-publishes it on the `sessions.usage_data` topic for downstream consumers (`burndown`, and the host) to render. It is the canonical **publisher** example: the inverse of a screen-owning plugin, exercising only the event bus, log-read, and plugin-data capabilities.
 
 ## How it works
 
-![session-reader plugin — how it works](../assets/diagrams/session-reader.svg)
+![session-reader plugin: how it works](../assets/diagrams/session-reader.svg)
 
-The plugin never paints anything — its `Plugin::render` returns an empty `0×0` `WireBuffer` and the host's render path tolerates that. On `plugin/init` it does *not* publish; instead it subscribes (`host/snapshot/subscribe`) to two trigger topics and then sits idle. Publishing on startup would race the consumer's own subscription and lose chunks, so the design is strictly pull: a consumer asks, the plugin answers.
+The plugin never paints anything: its `Plugin::render` returns an empty `0×0` `WireBuffer` and the host's render path tolerates that. On `plugin/init` it does *not* publish; instead it subscribes (`host/snapshot/subscribe`) to two trigger topics and then sits idle. Publishing on startup would race the consumer's own subscription and lose chunks, so the design is strictly pull: a consumer asks, the plugin answers.
 
-When a `plugin/handle_event` for `sessions.refresh_request` arrives, the plugin scans the four provider roots (`~/.claude/projects/**`, `~/.codex/sessions/**`, `~/.gemini/sessions`, `~/.config/github-copilot/sessions`, plus Cursor) on a blocking task, parses each file, and aggregates a `UsageData` snapshot. Parses are cached in a SQLite file under the plugin's own data dir — files whose `(mtime, size)` are unchanged short-circuit, so a warm rescan is cheap. While the cold scan runs it streams per-file progress on `sessions.scan_progress` so `burndown` can render a "Scanning sessions…" line.
+When a `plugin/handle_event` for `sessions.refresh_request` arrives, the plugin scans the four provider roots (`~/.claude/projects/**`, `~/.codex/sessions/**`, `~/.gemini/sessions`, `~/.config/github-copilot/sessions`, plus Cursor) on a blocking task, parses each file, and aggregates a `UsageData` snapshot. Parses are cached in a SQLite file under the plugin's own data dir: files whose `(mtime, size)` are unchanged short-circuit, so a warm rescan is cheap. While the cold scan runs it streams per-file progress on `sessions.scan_progress` so `burndown` can render a "Scanning sessions…" line.
 
 The aggregated `UsageData` is then split by `chunk_usage_data` into one or more msgpack envelopes, each kept under ~2 MiB so the post-base64 JSON-RPC body stays well under the host framer's 16 MiB cap. Chunk 0 carries the bounded aggregates; follow-on chunks carry slices of the unbounded tail vecs (`calls`, `sessions`, `shell_commands`); the last chunk is flagged `is_final`. Each chunk is pushed via `host/snapshot/publish` on `sessions.usage_data`.
 
-The host's event bus stores the latest publish per topic and fans `plugin/handle_event` deliveries to subscribers (`burndown`); the host itself can also pull the stored snapshot via `host/snapshot/get`. The `sessions.flush_cache_request` topic is the recovery escape hatch — it wipes the parse cache and forces a cold rescan (driven by `burndown`'s `F` key).
+The host's event bus stores the latest publish per topic and fans `plugin/handle_event` deliveries to subscribers (`burndown`); the host itself can also pull the stored snapshot via `host/snapshot/get`. The `sessions.flush_cache_request` topic is the recovery escape hatch: it wipes the parse cache and forces a cold rescan (driven by `burndown`'s `F` key).
 
 ## Capabilities
 
@@ -32,14 +32,14 @@ These are the exact `[capabilities]` from `manifest.toml`. Every flag defaults t
 
 ## Using it
 
-There is **nothing to open and nothing to type** — by design. The plugin provides no screen, no slash command, and no `ainb <ns> ...` CLI namespace. You interact with it only indirectly, through the topics it publishes and subscribes:
+There is **nothing to open and nothing to type**: by design. The plugin provides no screen, no slash command, and no `ainb <ns> ...` CLI namespace. You interact with it only indirectly, through the topics it publishes and subscribes:
 
-- **Publishes** (`[provides] snapshots`): `sessions.usage_data` — the chunked `UsageData` snapshot consumed by `burndown` (and the host). It also publishes `sessions.scan_progress` while a cold scan is in flight.
-- **Subscribes** (`[subscribes] snapshots`): `sessions.refresh_request` (any publisher forces a re-scan + re-publish) and `sessions.flush_cache_request` (wipe the parse cache, then cold re-scan — backing `burndown`'s `F` key).
+- **Publishes** (`[provides] snapshots`): `sessions.usage_data`: the chunked `UsageData` snapshot consumed by `burndown` (and the host). It also publishes `sessions.scan_progress` while a cold scan is in flight.
+- **Subscribes** (`[subscribes] snapshots`): `sessions.refresh_request` (any publisher forces a re-scan + re-publish) and `sessions.flush_cache_request` (wipe the parse cache, then cold re-scan: backing `burndown`'s `F` key).
 - **Lifecycle**: declared `spawn = "eager"` so the first snapshot is ready before `burndown` asks; idle-reaped after 600s.
 
-To see its output, open the **Analytics** screen owned by `burndown` (or run `ainb usage`) — that screen renders the snapshot this plugin produces.
+To see its output, open the **Analytics** screen owned by `burndown` (or run `ainb usage`): that screen renders the snapshot this plugin produces.
 
 ## Source
 
-`crates/ainb-plugin-session-reader` — the data backend for ainb's usage analytics: scans provider session logs, caches parses, and chunk-publishes the `UsageData` snapshot. Diagram generated via /fireworks-tech-graph.
+`crates/ainb-plugin-session-reader`: the data backend for ainb's usage analytics: scans provider session logs, caches parses, and chunk-publishes the `UsageData` snapshot. Diagram generated via /fireworks-tech-graph.

--- a/docs/plugins/spec-v2.md
+++ b/docs/plugins/spec-v2.md
@@ -1,10 +1,10 @@
 ---
-title: "ainb plugin contract — v2 (subprocess)"
+title: "ainb plugin contract: v2 (subprocess)"
 ---
 
 **Status:** stable.
 **Host versions covered:** `2.x.y` (additive minor bumps stay in v2).
-**Successor:** tracked in [CHANGELOG.md](./changelog.md). A new contract version (`v3`) ships only when an existing signature changes incompatibly.
+**Successor:** tracked in [CHANGELOG.md](/plugins/changelog). A new contract version (`v3`) ships only when an existing signature changes incompatibly.
 
 A plugin **conforms to v2** if it satisfies every MUST clause below. The `ainb-plugin-cts-v2` crate is the executable form of this document; a plugin author runs it via `cargo test` to get a per-axis pass/fail report.
 
@@ -67,7 +67,7 @@ idle_reap_secs = 600         # 0 disables reaping
 - `version` parses as semver; `abi_version` is an integer
 - The manifest sits at `dist/plugins/<name>/manifest.toml` on disk
 
-**Capability semantics.** `CapabilityGrant` accepts two forms: `true|false` (boolean grant) and `["host1", "host2"]` (allow-list grant; e.g. `network = ["api.openai.com"]`). The host evaluates `is_granted()` at request dispatch — denied capabilities return JSON-RPC error code `-32001` (CAPABILITY_DENIED).
+**Capability semantics.** `CapabilityGrant` accepts two forms: `true|false` (boolean grant) and `["host1", "host2"]` (allow-list grant; e.g. `network = ["api.openai.com"]`). The host evaluates `is_granted()` at request dispatch: denied capabilities return JSON-RPC error code `-32001` (CAPABILITY_DENIED).
 
 **Subscriptions.** `[subscribes].snapshots` is the declarative subscription path: the runtime auto-pushes `plugin/handle_event` for every publish on listed topics, with no imperative subscribe call required at startup. Plugins may also call `host/snapshot/subscribe` at runtime for the same effect.
 
@@ -80,7 +80,7 @@ The wire is LSP-style Content-Length framing.
 ```text
 Content-Length: <decimal-bytes>\r\n
 \r\n
-<body bytes — exactly Content-Length>
+<body bytes: exactly Content-Length>
 ```
 
 Constraints (from `ainb-plugin-protocol::framing`):
@@ -93,14 +93,14 @@ The body is a single JSON-RPC 2.0 envelope.
 
 ## 3. JSON-RPC dialect
 
-Standard JSON-RPC 2.0 (`{"jsonrpc":"2.0", ...}`). Requests carry an `id`; notifications omit it. The plugin process is the server for `plugin/*` methods AND the client for `host/*` methods — it multiplexes both directions on its stdio.
+Standard JSON-RPC 2.0 (`{"jsonrpc":"2.0", ...}`). Requests carry an `id`; notifications omit it. The plugin process is the server for `plugin/*` methods AND the client for `host/*` methods: it multiplexes both directions on its stdio.
 
 **Error codes:**
 
 | Code | Constant | Meaning |
 |---|---|---|
-| `-32601` | `METHOD_NOT_FOUND` | JSON-RPC 2.0 — unknown method |
-| `-32602` | `INVALID_PARAMS` | JSON-RPC 2.0 — params couldn't be deserialised |
+| `-32601` | `METHOD_NOT_FOUND` | JSON-RPC 2.0: unknown method |
+| `-32602` | `INVALID_PARAMS` | JSON-RPC 2.0: params couldn't be deserialised |
 | `-32001` | `CAPABILITY_DENIED` | Plugin requested a host action its manifest doesn't grant |
 | `-32002` | `ACTION_TIMEOUT` | `host/action/invoke` exceeded caller-supplied timeout |
 | `-32003` | `MANIFEST_VALIDATION` | Manifest schema validation failed at init |
@@ -124,8 +124,8 @@ Wire shape:
 | `plugin/init` | Request | `PluginInitParams` | `PluginInitResult` |
 | `plugin/shutdown` | Request | `PluginShutdownParams` | `PluginShutdownResult` |
 | `plugin/render` | Request | `RenderParams` | `RenderResult` (contains `WireBuffer`) |
-| `plugin/handle_event` | Notification | `HandleEventParams` | — |
-| `plugin/handle_key` | Notification | `HandleKeyParams` | — |
+| `plugin/handle_event` | Notification | `HandleEventParams` |: |
+| `plugin/handle_key` | Notification | `HandleKeyParams` |: |
 | `plugin/cli_dispatch` | Request | `CliDispatchParams` | `CliDispatchResult` |
 
 `plugin/init` MUST be the first method called; the plugin MUST reply with its decoded manifest + its declared ABI version. `plugin/shutdown` is the last method; the plugin SHOULD exit within the host's shutdown grace window (currently 5 s).
@@ -152,10 +152,10 @@ plugin: exit 0
 | Method | Kind | Request | Response |
 |---|---|---|---|
 | `host/snapshot/get` | Request | `SnapshotGetParams` | `SnapshotGetResult` |
-| `host/snapshot/publish` | Notification | `SnapshotPublishParams` | — |
+| `host/snapshot/publish` | Notification | `SnapshotPublishParams` |: |
 | `host/snapshot/subscribe` | Request | `SnapshotSubscribeParams` | `SnapshotSubscribeResult` |
 | `host/action/invoke` | Request (with timeout) | `ActionInvokeParams` | `ActionInvokeResult` |
-| `host/log` | Notification | `LogParams` | — |
+| `host/log` | Notification | `LogParams` |: |
 | `host/fs/read_dir` | Request | `FsReadDirParams` | `FsReadDirResult` |
 | `host/fs/read_file` | Request | `FsReadFileParams` | `FsReadFileResult` |
 | `host/network/fetch` | Request | `NetworkFetchParams` | `NetworkFetchResult` |
@@ -248,7 +248,7 @@ Contract:
 - a single-chunk publish has `chunk_index = 0, is_final = true`
 - chunk size target is implementation-defined; current `session-reader` uses ~2 MiB msgpack so the encoded frame stays under ~2.7 MiB after base64 inflation
 
-Subscribers MUST drop a follow-on chunk (index > 0) for which they never observed a chunk 0 — partial data without aggregates is worse than no data. A subsequent chunk 0 discards any in-flight accumulator.
+Subscribers MUST drop a follow-on chunk (index > 0) for which they never observed a chunk 0: partial data without aggregates is worse than no data. A subsequent chunk 0 discards any in-flight accumulator.
 
 ## 7. Lifecycle states
 
@@ -282,7 +282,7 @@ The runtime's per-plugin task transitions:
 | `read_codex_logs` | `host/fs/*` under `~/.codex/sessions/**` |
 | `write_plugin_data` | Any write under `~/.agents-in-a-box/plugins/<name>/` |
 | `event_bus` | All `host/snapshot/*` methods |
-| `network` | `host/network/fetch` — boolean gate, optionally restricted to listed hostnames |
+| `network` | `host/network/fetch`: boolean gate, optionally restricted to listed hostnames |
 | `spawn_subprocess` | Any host action that exec's a child on the plugin's behalf |
 
 Denied capability → `RpcError { code: -32001, message: "capability denied: <cap>" }`.
@@ -293,7 +293,7 @@ Denied capability → `RpcError { code: -32001, message: "capability denied: <ca
 
 Plugins MUST pass every axis their manifest's capability + provides surface implies. Axes for surface a plugin doesn't expose are skipped.
 
-> **Author tooling.** Two crates back this: `ainb-plugin-cts-v2` is the subprocess conformance runner described above (canary plugins + host-side `tests/axes.rs`), and `ainb-plugin-testkit` is an in-process harness that drives a `Plugin` trait impl over a `tokio::io::DuplexStream` pair — exercising the full JSON-RPC + Content-Length framing path without spawning a subprocess or staging a binary on disk. Use `testkit` for fast unit-style assertions while authoring; use `cts-v2` for the authoritative per-axis pass/fail gate.
+> **Author tooling.** Two crates back this: `ainb-plugin-cts-v2` is the subprocess conformance runner described above (canary plugins + host-side `tests/axes.rs`), and `ainb-plugin-testkit` is an in-process harness that drives a `Plugin` trait impl over a `tokio::io::DuplexStream` pair: exercising the full JSON-RPC + Content-Length framing path without spawning a subprocess or staging a binary on disk. Use `testkit` for fast unit-style assertions while authoring; use `cts-v2` for the authoritative per-axis pass/fail gate.
 
 ## 11. Stability promise
 

--- a/docs/plugins/user-guide.md
+++ b/docs/plugins/user-guide.md
@@ -2,7 +2,7 @@
 title: "Plugin user guide"
 ---
 
-User-facing reference for the `ainb plugin` family of commands. New to plugins? Read [overview.md](./overview.md) first. Writing one? [authoring.md](./authoring.md). Wire contract: [spec-v2.md](./spec-v2.md).
+User-facing reference for the `ainb plugin` family of commands. New to plugins? Read [overview.md](/plugins/overview) first. Writing one? [authoring.md](/plugins/authoring). Wire contract: [spec-v2.md](/plugins/spec-v2).
 
 ## Status of the install / marketplace flow
 
@@ -18,7 +18,7 @@ just stage-plugins
 ./target/debug/ainb tui
 ```
 
-`AINB_DISABLE_PLUGINS=1 ainb tui` boots the host with the runtime disabled — useful when bisecting a plugin-induced regression.
+`AINB_DISABLE_PLUGINS=1 ainb tui` boots the host with the runtime disabled: useful when bisecting a plugin-induced regression.
 
 ## Commands that work today
 
@@ -85,9 +85,9 @@ network             = []       # bool or hostname allow-list
 
 Default for every flag is **deny** (`false` / `[]`). The runtime rejects host-fn calls against a capability the manifest doesn't grant with JSON-RPC error code `-32001` (`CAPABILITY_DENIED`).
 
-When the install flow returns, capability prompts will reappear at install time. Until then, capabilities are read straight from the on-disk manifest at runtime discovery — there is no separate `installed.toml` lockfile in the subprocess world.
+When the install flow returns, capability prompts will reappear at install time. Until then, capabilities are read straight from the on-disk manifest at runtime discovery: there is no separate `installed.toml` lockfile in the subprocess world.
 
-See [./spec-v2.md §1](./spec-v2.md#1-manifest) for full semantics.
+See [./spec-v2.md §1](/plugins/spec-v2#1-manifest) for full semantics.
 
 ## Configuration
 
@@ -97,9 +97,9 @@ The host supports four knobs for selecting which plugins load, evaluated in this
 
 | Knob | Where | Behavior |
 |---|---|---|
-| `AINB_DISABLE_PLUGINS=1` | env | Kill switch — skip discovery entirely. Runtime comes up plugin-free. |
-| `AINB_ONLY_PLUGINS=a,b` | env | Allowlist — load ONLY the named plugins; everything else skipped. |
-| `AINB_DISABLE_PLUGIN=a,b` | env | Denylist — load everything EXCEPT the named plugins. Ignored when `AINB_ONLY_PLUGINS` is set. |
+| `AINB_DISABLE_PLUGINS=1` | env | Kill switch: skip discovery entirely. Runtime comes up plugin-free. |
+| `AINB_ONLY_PLUGINS=a,b` | env | Allowlist: load ONLY the named plugins; everything else skipped. |
+| `AINB_DISABLE_PLUGIN=a,b` | env | Denylist: load everything EXCEPT the named plugins. Ignored when `AINB_ONLY_PLUGINS` is set. |
 | `[plugins].enabled = [...]` | `config.toml` | Persistent allowlist. Same shape as `AINB_ONLY_PLUGINS` but survives across runs. Env vars override config. |
 | `[plugins].disabled = [...]` | `config.toml` | Persistent denylist. Ignored when `[plugins].enabled` is non-empty. |
 
@@ -115,7 +115,7 @@ AINB_DISABLE_PLUGIN=burndown ainb tui
 # Load only session-reader (useful for a headless data pipeline).
 AINB_ONLY_PLUGINS=session-reader ainb tui
 
-# Multiple names — comma-separated, whitespace tolerated.
+# Multiple names: comma-separated, whitespace tolerated.
 AINB_ONLY_PLUGINS="burndown, session-reader" ainb tui
 ```
 
@@ -123,7 +123,7 @@ Persistent config (`~/.agents-in-a-box/config/config.toml`):
 
 ```toml
 [plugins]
-# Either list (or neither) — when both are set, `enabled` wins.
+# Either list (or neither): when both are set, `enabled` wins.
 enabled = ["session-reader"]
 # disabled = ["burndown"]
 ```
@@ -148,10 +148,10 @@ Redirects every host-managed path (`logs/`, `plugins/<name>/`, `sessions/`) unde
 
 ## Troubleshooting
 
-- **"the marketplace + installer flow is being re-cut against the subprocess ABI 2.0"** — install flow not yet ported. Use in-tree crates + `just stage-plugins` until Phase 7c lands.
-- **`ainb plugin list` returns "(no plugins registered)"** — the runtime found no manifests under `dist/plugins/`. Did you run `just stage-plugins`? Is `AINB_PLUGIN_ROOT` pointing at the right directory?
-- **Plugin exits 137 in <1 ms on macOS, no stderr** — AMFI silent-kill. The binary's codesign got invalidated by a copy. Re-run `just stage-plugins`.
-- **Analytics shows "plugin: rendering…" but never updates** — the burndown plugin crashed or session-reader never published. Run `ainb plugin watch burndown` AND `ainb plugin tail session-reader --level debug` in two terminals to see which one failed.
-- **`schema_mismatch` banner on Analytics** — the publisher and subscriber disagree on `WIRE_VERSION`. Rebuild both plugins from the same checkout (`cargo build --workspace` + `just stage-plugins`).
-- **Keystrokes feel sluggish during burndown refresh** — should be fixed by the priority-key channel landed 2026-05-15 (PR #125). If you see it on a build older than that, rebase onto `feat/plugin`.
-- **Capability errors (`-32001`)** — the plugin asked for a host action its manifest doesn't grant. The host JSONL log entry includes which capability and which method.
+- **"the marketplace + installer flow is being re-cut against the subprocess ABI 2.0"**: install flow not yet ported. Use in-tree crates + `just stage-plugins` until Phase 7c lands.
+- **`ainb plugin list` returns "(no plugins registered)"**: the runtime found no manifests under `dist/plugins/`. Did you run `just stage-plugins`? Is `AINB_PLUGIN_ROOT` pointing at the right directory?
+- **Plugin exits 137 in <1 ms on macOS, no stderr**: AMFI silent-kill. The binary's codesign got invalidated by a copy. Re-run `just stage-plugins`.
+- **Analytics shows "plugin: rendering…" but never updates**: the burndown plugin crashed or session-reader never published. Run `ainb plugin watch burndown` AND `ainb plugin tail session-reader --level debug` in two terminals to see which one failed.
+- **`schema_mismatch` banner on Analytics**: the publisher and subscriber disagree on `WIRE_VERSION`. Rebuild both plugins from the same checkout (`cargo build --workspace` + `just stage-plugins`).
+- **Keystrokes feel sluggish during burndown refresh**: should be fixed by the priority-key channel landed 2026-05-15 (PR #125). If you see it on a build older than that, rebase onto `feat/plugin`.
+- **Capability errors (`-32001`)**: the plugin asked for a host action its manifest doesn't grant. The host JSONL log entry includes which capability and which method.

--- a/docs/plugins/witr.md
+++ b/docs/plugins/witr.md
@@ -3,23 +3,23 @@ title: "witr plugin"
 description: "Wraps the external witr binary to surface process-causality tracing as an ainb screen, CLI, and slash command."
 ---
 
-`witr` surfaces process-causality tracing inside ainb by wrapping the external [`witr`](https://github.com/pranshuparmar/witr) binary (>= 0.3.2 on `PATH`). It is the canonical **subprocess-wrapping** reference — and it exemplifies *two* integration patterns at once: a host-embedded **foreign TTY** for its interactive screen, and a `spawn_subprocess` **exec-and-parse** flow for its CLI and slash command.
+`witr` surfaces process-causality tracing inside ainb by wrapping the external [`witr`](https://github.com/pranshuparmar/witr) binary (>= 0.3.2 on `PATH`). It is the canonical **subprocess-wrapping** reference: and it exemplifies *two* integration patterns at once: a host-embedded **foreign TTY** for its interactive screen, and a `spawn_subprocess` **exec-and-parse** flow for its CLI and slash command.
 
 ![witr's interactive process browser embedded in ainb](../assets/screenshots/witr-browser.png)
 
-*Press `w` in ainb to open witr's interactive browser full-screen — a sortable all-process list with a live ancestry pane.*
+*Press `w` in ainb to open witr's interactive browser full-screen: a sortable all-process list with a live ancestry pane.*
 
 ## How it works
 
-![witr plugin — how it works](../assets/diagrams/witr.svg)
+![witr plugin: how it works](../assets/diagrams/witr.svg)
 
-There is no single render path here — witr is two surfaces fused onto one external binary, and the diagram shows them as two lanes.
+There is no single render path here: witr is two surfaces fused onto one external binary, and the diagram shows them as two lanes.
 
-**The screen is not a `WireBuffer`.** witr's value is its own interactive all-process browser (sortable process list + ancestry pane), which has no machine-readable render — it lives only in `witr -i`. So pressing `w` (or the sidebar tile) does a host-level handoff, not a `plugin/render` call. The host (`ainb-core`) emits `AppEvent::GoToWitr`, which queues `AsyncAction::AttachWitr`: ainb runs `tmux new-session -A -d -s ainb-witr "witr -i"`, suspends its own TUI, and attaches full-screen to witr's native interactive browser — the same suspend/attach/resume mechanism ainb uses to embed agent sessions. When the user quits witr, ainb resumes. This wiring lives entirely in `ainb-core`; the plugin's `render` is never invoked for the screen.
+**The screen is not a `WireBuffer`.** witr's value is its own interactive all-process browser (sortable process list + ancestry pane), which has no machine-readable render: it lives only in `witr -i`. So pressing `w` (or the sidebar tile) does a host-level handoff, not a `plugin/render` call. The host (`ainb-core`) emits `AppEvent::GoToWitr`, which queues `AsyncAction::AttachWitr`: ainb runs `tmux new-session -A -d -s ainb-witr "witr -i"`, suspends its own TUI, and attaches full-screen to witr's native interactive browser: the same suspend/attach/resume mechanism ainb uses to embed agent sessions. When the user quits witr, ainb resumes. This wiring lives entirely in `ainb-core`; the plugin's `render` is never invoked for the screen.
 
-**The CLI and slash run `witr --json` and parse it.** `ainb witr <target>` is routed by the host to the plugin's `plugin/cli_dispatch` (namespace `witr`); `/witr <target>` reaches `handle_slash`. Both call the plugin's single `scan()` authority, which execs `witr --json <target>` under the `spawn_subprocess` capability (argv array, no shell; bounded by a 5s timeout) and decodes stdout into a typed `WitrSnapshot`. The decode tolerates two real witr quirks: witr exits non-zero to signal that *warnings* are present even when it printed a complete, valid JSON snapshot — so a successful parse wins regardless of exit code — and Go's `encoding/json` marshals empty slices/maps as `null`, which is mapped back to empty collections. From the snapshot, the CLI emits text / `--tree` / `--warnings` / canonical `--format json`, while the slash opens a detail overlay.
+**The CLI and slash run `witr --json` and parse it.** `ainb witr <target>` is routed by the host to the plugin's `plugin/cli_dispatch` (namespace `witr`); `/witr <target>` reaches `handle_slash`. Both call the plugin's single `scan()` authority, which execs `witr --json <target>` under the `spawn_subprocess` capability (argv array, no shell; bounded by a 5s timeout) and decodes stdout into a typed `WitrSnapshot`. The decode tolerates two real witr quirks: witr exits non-zero to signal that *warnings* are present even when it printed a complete, valid JSON snapshot: so a successful parse wins regardless of exit code: and Go's `encoding/json` marshals empty slices/maps as `null`, which is mapped back to empty collections. From the snapshot, the CLI emits text / `--tree` / `--warnings` / canonical `--format json`, while the slash opens a detail overlay.
 
-**Fresh scans publish on the event bus.** When a scan runs from a live host channel (the TUI refresh path), the parsed snapshot is published to the `witr.snapshot` topic via `host/snapshot/publish`, msgpack-encoded and byte-deterministic. The one-shot `ainb witr` CLI invocation passes no host channel — there are no bus subscribers during a single CLI run — so the publish is skipped there.
+**Fresh scans publish on the event bus.** When a scan runs from a live host channel (the TUI refresh path), the parsed snapshot is published to the `witr.snapshot` topic via `host/snapshot/publish`, msgpack-encoded and byte-deterministic. The one-shot `ainb witr` CLI invocation passes no host channel: there are no bus subscribers during a single CLI run: so the publish is skipped there.
 
 ## Capabilities
 
@@ -32,17 +32,17 @@ These are the exact non-default capabilities declared in `manifest.toml`. Every 
 
 ## Using it
 
-- **Screen** — open it by pressing `w` from the home surface or selecting the witr sidebar tile. Instead of a plugin-rendered screen, ainb hands the terminal to witr's native `witr -i` interactive browser full-screen (sortable all-process list + ancestry pane); quit witr to return to ainb. If witr is missing or below 0.3.2, the plugin renders an install/upgrade empty state instead.
-- **CLI** (`cli_namespaces = ["witr"]`) — `ainb witr` execs the wrapped binary and renders the parsed snapshot:
-  - `ainb witr nginx` — trace a process by name (positional; witr fuzzy-matches)
-  - `ainb witr --pid 1234`, `ainb witr --port 5432`, `ainb witr --file /var/run/x.lock`, `ainb witr --container redis` — typed targets
-  - `ainb witr nginx --tree` — ancestry chain as an indented tree
-  - `ainb witr --port 5432 --warnings` — just the warnings list
-  - `ainb witr --pid 1234 --format json` — canonical JSON re-emit of the snapshot
-  - `ainb witr nginx --short` — raw `witr <target>` passthrough (no JSON re-parse; cannot be combined with `--format json`)
-- **Slash command** (`/witr`) — `/witr <target>` scans the target and opens a focused detail overlay over the current screen.
-- **Published topic** — `witr.snapshot` (msgpack-encoded `WitrSnapshot`), emitted on each fresh scan from a live host channel. The plugin subscribes to nothing.
+- **Screen**: open it by pressing `w` from the home surface or selecting the witr sidebar tile. Instead of a plugin-rendered screen, ainb hands the terminal to witr's native `witr -i` interactive browser full-screen (sortable all-process list + ancestry pane); quit witr to return to ainb. If witr is missing or below 0.3.2, the plugin renders an install/upgrade empty state instead.
+- **CLI** (`cli_namespaces = ["witr"]`): `ainb witr` execs the wrapped binary and renders the parsed snapshot:
+  - `ainb witr nginx`: trace a process by name (positional; witr fuzzy-matches)
+  - `ainb witr --pid 1234`, `ainb witr --port 5432`, `ainb witr --file /var/run/x.lock`, `ainb witr --container redis`: typed targets
+  - `ainb witr nginx --tree`: ancestry chain as an indented tree
+  - `ainb witr --port 5432 --warnings`: just the warnings list
+  - `ainb witr --pid 1234 --format json`: canonical JSON re-emit of the snapshot
+  - `ainb witr nginx --short`: raw `witr <target>` passthrough (no JSON re-parse; cannot be combined with `--format json`)
+- **Slash command** (`/witr`): `/witr <target>` scans the target and opens a focused detail overlay over the current screen.
+- **Published topic**: `witr.snapshot` (msgpack-encoded `WitrSnapshot`), emitted on each fresh scan from a live host channel. The plugin subscribes to nothing.
 
 ## Source
 
-`crates/ainb-plugin-witr` — detects the external `witr` binary, owns the `ainb witr` CLI + `/witr` slash via `witr --json` exec-and-parse, publishes `witr.snapshot`, and renders the missing/outdated empty state; the foreign-TTY screen handoff (`w` → `witr -i`) is wired in `ainb-core`. Diagram generated via /fireworks-tech-graph.
+`crates/ainb-plugin-witr`: detects the external `witr` binary, owns the `ainb witr` CLI + `/witr` slash via `witr --json` exec-and-parse, publishes `witr.snapshot`, and renders the missing/outdated empty state; the foreign-TTY screen handoff (`w` → `witr -i`) is wired in `ainb-core`. Diagram generated via /fireworks-tech-graph.

--- a/docs/product/architecture.md
+++ b/docs/product/architecture.md
@@ -4,7 +4,7 @@ title: "Whole-system architecture"
 
 How the four components of agents-in-a-box fit together.
 
-> For component-level deep dives, see [TUI architecture](../tui/architecture.md), [plugin spec v2](../plugins/spec-v2.md), and [knowledge system overview](../knowledge/overview.md).
+> For component-level deep dives, see [TUI architecture](/tui/architecture), [plugin spec v2](/plugins/spec-v2), and [knowledge system overview](/knowledge/overview).
 
 ---
 
@@ -12,7 +12,7 @@ How the four components of agents-in-a-box fit together.
 
 ![agents-in-a-box ecosystem architecture: the ainb TUI host, the v2 plugin host and its six in-tree plugins, the nine daemons the TUI supervises, the separate toolkit and reflect-memory repos, and how it is distributed](../assets/diagrams/ecosystem-architecture.svg)
 
-Solid arrows are data/control flow, dashed arrows are writes and feedback, clay is fleet prompt delivery, and olive is the learning loop. The small hops where lines cross are jump-overs — the lines do not connect.
+Solid arrows are data/control flow, dashed arrows are writes and feedback, clay is fleet prompt delivery, and olive is the learning loop. The small hops where lines cross are jump-overs: the lines do not connect.
 
 ---
 
@@ -162,7 +162,7 @@ dist/plugins/<name>/            staged plugin binaries (built from in-tree
 | Boundary | Contract |
 |---|---|
 | TUI ↔ AI provider | None. The TUI spawns the provider CLI in a tmux PTY and reads/writes the pane. |
-| TUI ↔ plugin | [Plugin spec v2](../plugins/spec-v2.md) — framed JSON-RPC over stdio. |
+| TUI ↔ plugin | [Plugin spec v2](/plugins/spec-v2): framed JSON-RPC over stdio. |
 | TUI ↔ ainb-toolkit | None at runtime. ainb-toolkit is deployed ahead of time to `~/.<tool>/`; the TUI doesn't read it. ainb pins a release of `stevengonsalvez/ainb-toolkit` and the skill manager syncs from it. |
 | Plugin ↔ Plugin | Snapshot bus (publish/subscribe) brokered by the TUI host. See spec §6. |
 | reflect-kb ↔ anyone | CLI only. No library API. |
@@ -171,7 +171,7 @@ dist/plugins/<name>/            staged plugin binaries (built from in-tree
 
 ## See also
 
-- [TUI architecture (deeper)](../tui/architecture.md)
-- [Plugin wire spec](../plugins/spec-v2.md)
-- [Toolkit overview](../toolkit/overview.md)
-- [Knowledge system overview](../knowledge/overview.md)
+- [TUI architecture (deeper)](/tui/architecture)
+- [Plugin wire spec](/plugins/spec-v2)
+- [Toolkit overview](/toolkit/overview)
+- [Knowledge system overview](/knowledge/overview)

--- a/docs/product/value.md
+++ b/docs/product/value.md
@@ -30,7 +30,7 @@ One coding agent is a chat window. Five agents is an operations problem. `ainb` 
 
 ## Next steps
 
-- [Overview](what-is-ainb.md): monorepo architecture and component breakdown
-- [Install](../tui/install.md): installation methods
-- [Quickstart](../tui/quickstart.md): launch your first session in 60 seconds
-- [Concepts](concepts.md): workspaces, worktrees, and attention
+- [Overview](/product/what-is-ainb): monorepo architecture and component breakdown
+- [Install](/tui/install): installation methods
+- [Quickstart](/tui/quickstart): launch your first session in 60 seconds
+- [Concepts](/product/concepts): workspaces, worktrees, and attention

--- a/docs/product/what-is-ainb.md
+++ b/docs/product/what-is-ainb.md
@@ -75,8 +75,8 @@ Each component is independently useful. You can use ainb-toolkit without ever op
 
 ## Where to go next
 
-- [Install ainb](../tui/install.md)
-- [Quickstart](../tui/quickstart.md): first session in 60 seconds
-- [Concepts](concepts.md): workspaces, worktrees, and sessions
-- [Keyboard shortcuts](../tui/keyboard-shortcuts.md)
-- [CLI reference](../tui/cli.md)
+- [Install ainb](/tui/install)
+- [Quickstart](/tui/quickstart): first session in 60 seconds
+- [Concepts](/product/concepts): workspaces, worktrees, and sessions
+- [Keyboard shortcuts](/tui/keyboard-shortcuts)
+- [CLI reference](/tui/cli)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -6,7 +6,7 @@ Where to find the architecture documentation, by depth.
 
 ## Start here
 
-[**Whole-system architecture**](../product/architecture.md) is the page you
+[**Whole-system architecture**](/product/architecture) is the page you
 probably want. It carries the ecosystem diagram, the box diagram, the data and
 control flow walkthroughs, the on-disk layout and the boundary contracts
 between components.
@@ -15,11 +15,11 @@ between components.
 
 | Component | Page |
 |---|---|
-| The TUI host: crates, threading, render loop | [TUI architecture](../tui/architecture.md) |
-| The v2 plugin ABI: wire format, capabilities, conformance | [Plugin spec v2](../plugins/spec-v2.md) |
-| Hangar: the managed-agents control plane | [Hangar architecture](../hangar/architecture.md) |
-| Knowledge capture and recall | [Knowledge system overview](../knowledge/overview.md) |
-| Which repo holds what | [Repositories](repositories.md) |
+| The TUI host: crates, threading, render loop | [TUI architecture](/tui/architecture) |
+| The v2 plugin ABI: wire format, capabilities, conformance | [Plugin spec v2](/plugins/spec-v2) |
+| Hangar: the managed-agents control plane | [Hangar architecture](/hangar/architecture) |
+| Knowledge capture and recall | [Knowledge system overview](/knowledge/overview) |
+| Which repo holds what | [Repositories](/reference/repositories) |
 
 ## Diagrams
 
@@ -38,5 +38,5 @@ check them against the rendered diagram.
 
 ## See also
 
-- [Docs hub](../README.md)
-- [Glossary](glossary.md)
+- [Docs hub](/readme)
+- [Glossary](/reference/glossary)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -6,65 +6,65 @@ Definitions for the terms that recur across the agents-in-a-box docs. Where a te
 
 ## Agents, sessions, worktrees
 
-**Agent** — an AI coding harness instance (Claude Code, Codex CLI, GitHub Copilot, Gemini). agents-in-a-box is harness-agnostic: skills, agents, and plugins are deployed to each harness's config directory.
+**Agent**: an AI coding harness instance (Claude Code, Codex CLI, GitHub Copilot, Gemini). agents-in-a-box is harness-agnostic: skills, agents, and plugins are deployed to each harness's config directory.
 
-**Session** — a single conversation/run of an agent against a project. The TUI lists, attaches to, and recovers sessions; session logs are walked per-provider by the `session-reader` plugin.
+**Session**: a single conversation/run of an agent against a project. The TUI lists, attaches to, and recovers sessions; session logs are walked per-provider by the `session-reader` plugin.
 
-**Worktree** — a git worktree giving a task its own isolated checkout and branch (architecture: worktree-per-task). Lets multiple agents work in parallel without colliding on the same working tree.
+**Worktree**: a git worktree giving a task its own isolated checkout and branch (architecture: worktree-per-task). Lets multiple agents work in parallel without colliding on the same working tree.
 
 ## Plugins
 
-**Plugin (v2, subprocess)** — an ainb plugin that conforms to the [v2 contract](../plugins/spec-v2.md): a native executable spawned by the host as a child process, exchanging **JSON-RPC 2.0** over framed stdio (stdin = requests from host, stdout = responses + reverse-calls, stderr = host log output). Governed by capability grants in its manifest.
+**Plugin (v2, subprocess)**: an ainb plugin that conforms to the [v2 contract](/plugins/spec-v2): a native executable spawned by the host as a child process, exchanging **JSON-RPC 2.0** over framed stdio (stdin = requests from host, stdout = responses + reverse-calls, stderr = host log output). Governed by capability grants in its manifest.
 
-**Claude Code plugin** — a *different* concept: a Claude Code harness extension (e.g. the `reflect` plugin) that bundles skills, hooks, and adapters and is installed with `claude plugin install`. It does not implement the ainb v2 subprocess contract; the two senses of "plugin" are unrelated.
+**Claude Code plugin**: a *different* concept: a Claude Code harness extension (e.g. the `reflect` plugin) that bundles skills, hooks, and adapters and is installed with `claude plugin install`. It does not implement the ainb v2 subprocess contract; the two senses of "plugin" are unrelated.
 
 ## Toolkit units
 
-**Skill** — a structured workflow invoked by slash command (e.g. `/commit`, `/plan`), shared across harnesses from `skills/` in the [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo.
+**Skill**: a structured workflow invoked by slash command (e.g. `/commit`, `/plan`), shared across harnesses from `skills/` in the [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo.
 
-**Agent (toolkit)** — a specialised sub-agent definition (e.g. `code-reviewer`, `distinguished-engineer`) from `agents/` in the [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo, delegated to for focused work.
+**Agent (toolkit)**: a specialised sub-agent definition (e.g. `code-reviewer`, `distinguished-engineer`) from `agents/` in the [`stevengonsalvez/ainb-toolkit`](https://github.com/stevengonsalvez/ainb-toolkit) repo, delegated to for focused work.
 
-**Workflow** — a multi-phase orchestration that chains skills (plan → implement → validate) under a structured delivery process.
+**Workflow**: a multi-phase orchestration that chains skills (plan → implement → validate) under a structured delivery process.
 
 ## Knowledge base
 
-**QMD** — the vector / semantic search engine of the knowledge base; answers "what matches?" via embedding similarity (BM25 + vector hybrid).
+**QMD**: the vector / semantic search engine of the knowledge base; answers "what matches?" via embedding similarity (BM25 + vector hybrid).
 
-**GraphRAG** — the graph search engine; answers "what's connected?" by traversing the entity-relationship graph. Built with `nano-graphrag` using a passthrough LLM that consumes pre-extracted entity sidecars (no external LLM calls during indexing).
+**GraphRAG**: the graph search engine; answers "what's connected?" by traversing the entity-relationship graph. Built with `nano-graphrag` using a passthrough LLM that consumes pre-extracted entity sidecars (no external LLM calls during indexing).
 
-**Sidecar** — an `.entities.yaml` file sitting next to a knowledge document (`doc.md` + `doc.entities.yaml`). It carries the pre-extracted entities and relationships that feed GraphRAG indexing directly.
+**Sidecar**: an `.entities.yaml` file sitting next to a knowledge document (`doc.md` + `doc.entities.yaml`). It carries the pre-extracted entities and relationships that feed GraphRAG indexing directly.
 
-**Community report** — a GraphRAG-generated summary of a cluster (community) of related entities, used to answer higher-level questions about a connected region of the graph.
+**Community report**: a GraphRAG-generated summary of a cluster (community) of related entities, used to answer higher-level questions about a connected region of the graph.
 
 ## Terminal & tmux
 
-**tmux** — terminal multiplexer used to run persistent, detachable agent and dev-server sessions. Sessions survive disconnects and are reattached with `tmux attach -t <session>`.
+**tmux**: terminal multiplexer used to run persistent, detachable agent and dev-server sessions. Sessions survive disconnects and are reattached with `tmux attach -t <session>`.
 
-**PTY** — pseudo-terminal; the kernel device pair that lets the TUI and tmux drive a child process as if it had a real terminal (handles resize, raw input, ANSI output).
+**PTY**: pseudo-terminal; the kernel device pair that lets the TUI and tmux drive a child process as if it had a real terminal (handles resize, raw input, ANSI output).
 
-**Pane** — a single rectangular split inside a tmux window running one shell/process.
+**Pane**: a single rectangular split inside a tmux window running one shell/process.
 
-**Window** — a full-screen tab within a tmux session; a window contains one or more panes.
+**Window**: a full-screen tab within a tmux session; a window contains one or more panes.
 
 ## Plugin contract & runtime
 
-**ABI** — Application Binary Interface; the host/plugin runtime contract version. A v2 plugin declares `abi_version = 2` in its manifest and must match the host's `ABI_VERSION` (currently `2`). See [spec-v2 §5.4](../plugins/spec-v2.md).
+**ABI**: Application Binary Interface; the host/plugin runtime contract version. A v2 plugin declares `abi_version = 2` in its manifest and must match the host's `ABI_VERSION` (currently `2`). See [spec-v2 §5.4](/plugins/spec-v2).
 
-**Wire version** — the schema version of a snapshot/event type. Plugin types crates (e.g. `ainb-plugin-types-sessions`) carry a `pub const WIRE_VERSION: u32` (currently `3`); subscribers must check `event.version == WIRE_VERSION` and reject mismatches gracefully rather than panicking.
+**Wire version**: the schema version of a snapshot/event type. Plugin types crates (e.g. `ainb-plugin-types-sessions`) carry a `pub const WIRE_VERSION: u32` (currently `3`); subscribers must check `event.version == WIRE_VERSION` and reject mismatches gracefully rather than panicking.
 
-**CTS (Conformance Test Suite)** — the executable form of the plugin spec. `ainb-plugin-cts-v2` covers **21 axes** (manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot get-after-publish, snapshot subscribe, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, event-stream subscribe, managed-subprocess spawn, unix-socket dial, secret-store get, mouse forwarding, read_paths config, redraw hint). A plugin author runs it via `cargo test` for a per-axis pass/fail report.
+**CTS (Conformance Test Suite)**: the executable form of the plugin spec. `ainb-plugin-cts-v2` covers **21 axes** (manifest round-trip, framing, method dispatch, capability gating, render determinism, snapshot get-after-publish, snapshot subscribe, action timeout, log filtering, fs path guard, graceful shutdown, crash recovery, quarantine, CLI dispatch capture, event-stream subscribe, managed-subprocess spawn, unix-socket dial, secret-store get, mouse forwarding, read_paths config, redraw hint). A plugin author runs it via `cargo test` for a per-axis pass/fail report.
 
-**Canary** — a minimal plugin written to exercise exactly one CTS axis, living at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/`.
+**Canary**: a minimal plugin written to exercise exactly one CTS axis, living at `crates/ainb-plugin-cts-v2/tests/canaries/<axis>/`.
 
-**`cts-v2`** — the `ainb-plugin-cts-v2` crate: the host-side conformance test runner (21 axes) plus its canary plugins.
+**`cts-v2`**: the `ainb-plugin-cts-v2` crate: the host-side conformance test runner (21 axes) plus its canary plugins.
 
-**`testkit`** — the `ainb-plugin-testkit` crate: an in-process test harness for plugin authors. A plugin author hands their `Plugin` impl to testkit to exercise it without spawning a real subprocess.
+**`testkit`**: the `ainb-plugin-testkit` crate: an in-process test harness for plugin authors. A plugin author hands their `Plugin` impl to testkit to exercise it without spawning a real subprocess.
 
-**`notifyd`** — the `ainb-plugin-notifyd` crate: the ainb-owned notification daemon. Listens on a Unix domain socket at `~/.agents-in-a-box/notify.sock` and is one of the in-tree v2 reference plugins (alongside `burndown` for analytics and `session-reader` for the session data backend).
+**`notifyd`**: the `ainb-plugin-notifyd` crate: the ainb-owned notification daemon. Listens on a Unix domain socket at `~/.agents-in-a-box/notify.sock` and is one of the in-tree v2 reference plugins (alongside `burndown` for analytics and `session-reader` for the session data backend).
 
 ## See also
 
-- [Architecture](./architecture.md)
-- [Plugin contract — v2](../plugins/spec-v2.md)
-- [Knowledge base overview](../knowledge/overview.md)
-- [Docs hub](../README.md)
+- [Architecture](/reference/architecture)
+- [Plugin contract: v2](/plugins/spec-v2)
+- [Knowledge base overview](/knowledge/overview)
+- [Docs hub](/readme)

--- a/docs/reference/otel-grafana.md
+++ b/docs/reference/otel-grafana.md
@@ -25,7 +25,7 @@ both the `ainb` CLI and the first-run TUI onboarding wizard.
 
 > The three Grafana values come from one screen: **Connections → OpenTelemetry
 > (OTLP)** in your Grafana Cloud stack. The "Instance ID" there is the Basic-auth
-> username — it is NOT your org id.
+> username: it is NOT your org id.
 
 Example of the three values (yours differ by region/stack):
 
@@ -36,7 +36,7 @@ API token      glc_eyJ...        (scope: metrics + logs + traces write)
 ```
 
 > The OTLP endpoint is the **remote** Grafana Cloud URL Alloy ships to (ends in
-> `/otlp`) — **not** the local `http://localhost:4318` that Claude Code points at.
+> `/otlp`): **not** the local `http://localhost:4318` that Claude Code points at.
 > That local hop is wired automatically; you only supply the remote endpoint here.
 
 ## Setup (CLI)
@@ -53,7 +53,7 @@ ainb otel start            # (re)start Alloy in its tmux session
 2. Prompt for the three Grafana Cloud values (or read them from
    `GRAFANA_OTLP_ENDPOINT` / `GRAFANA_INSTANCE_ID` / `GRAFANA_API_TOKEN` env
    vars if set).
-3. Write `~/.agents-in-a-box/otel/grafana-cloud.env` (mode `0600` — secrets).
+3. Write `~/.agents-in-a-box/otel/grafana-cloud.env` (mode `0600`: secrets).
 4. Ensure the generic, non-secret OTEL keys are in `~/.claude/settings.json`.
 5. Wire your shell rc to `source` the env file (backed up to `<rc>.bak`).
 6. Offer to `brew install` Alloy if missing, then start it in tmux.
@@ -64,7 +64,7 @@ The onboarding wizard has an optional **Telemetry** step. Fill the three fields
 (Tab to move between them) and press Enter to set up, or press Enter with the
 fields empty to skip. Re-run later any time with `ainb otel setup`.
 
-The TUI does not `brew install` Alloy — if it's missing the config is still
+The TUI does not `brew install` Alloy: if it's missing the config is still
 written; finish with `ainb otel setup` or `brew install grafana/grafana/alloy`
 then `ainb otel start`.
 
@@ -72,8 +72,8 @@ then `ainb otel start`.
 
 | File | Contents | Secret? |
 |------|----------|---------|
-| `~/.claude/settings.json` (`env`) | Generic OTEL flags (exporter/protocol/intervals/log toggles) | **No** — this file syncs to a public repo, so nothing machine-specific or secret goes here |
-| `~/.agents-in-a-box/otel/grafana-cloud.env` | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES` (host.name), `GRAFANA_*` creds | **Yes** — `0600`, never committed, sourced by your shell + read by Alloy |
+| `~/.claude/settings.json` (`env`) | Generic OTEL flags (exporter/protocol/intervals/log toggles) | **No**: this file syncs to a public repo, so nothing machine-specific or secret goes here |
+| `~/.agents-in-a-box/otel/grafana-cloud.env` | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES` (host.name), `GRAFANA_*` creds | **Yes**: `0600`, never committed, sourced by your shell + read by Alloy |
 | `~/.agents-in-a-box/otel/config.alloy` | Alloy OTLP fan-in pipeline (Delta→Cumulative for Mimir) | No |
 | `~/.agents-in-a-box/otel/dashboards/*.json` | Grafana dashboards to import (Claude Code + Codex) | No |
 
@@ -97,14 +97,14 @@ the data.
 `~/.agents-in-a-box/otel/dashboards/`. Import them in Grafana Cloud
 (**Dashboards → New → Import**) to land these views.
 
-**Claude Code — Usage & Cost** — total cost/tokens, sessions, active time, cost
+**Claude Code: Usage & Cost**: total cost/tokens, sessions, active time, cost
 rate by model, tokens by type, cost by skill, cost-by-model share, plus recent
 traces and prompt text.
 
-![Claude Code Usage & Cost Grafana dashboard — cost, tokens, sessions, cost by model and by skill](../assets/screenshots/otel-grafana-claude-dashboard.png)
+![Claude Code Usage & Cost Grafana dashboard: cost, tokens, sessions, cost by model and by skill](../assets/screenshots/otel-grafana-claude-dashboard.png)
 
-**Codex CLI — Usage & Telemetry** — total tokens, conversation turns, tool/hook
+**Codex CLI: Usage & Telemetry**: total tokens, conversation turns, tool/hook
 runs, WebSocket requests, tokens-per-turn and turn-latency p95, MCP tool-list
 latency, and the full `codex_*` series catalog.
 
-![Codex CLI Usage & Telemetry Grafana dashboard — tokens, turns, tool/hook runs, latency p95, series catalog](../assets/screenshots/otel-grafana-codex-dashboard.png)
+![Codex CLI Usage & Telemetry Grafana dashboard: tokens, turns, tool/hook runs, latency p95, series catalog](../assets/screenshots/otel-grafana-codex-dashboard.png)

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -10,9 +10,9 @@ in its own public repo; the `ainb` tool consumes both as external sources.
 
 | Repo | What it holds | Consumed how |
 |---|---|---|
-| **[stevengonsalvez/agents-in-a-box](https://github.com/stevengonsalvez/agents-in-a-box)** | The `ainb` TUI/CLI unit manager (Rust workspace under `ainb-tui/`), the v2 JSON-RPC plugin system, and this documentation site. | — |
+| **[stevengonsalvez/agents-in-a-box](https://github.com/stevengonsalvez/agents-in-a-box)** | The `ainb` TUI/CLI unit manager (Rust workspace under `ainb-tui/`), the v2 JSON-RPC plugin system, and this documentation site. |: |
 | **[stevengonsalvez/ainb-toolkit](https://github.com/stevengonsalvez/ainb-toolkit)** | The canonical home for the curated **skills** (`skills/`), **agents** (`agents/`), **workflows** (`workflows/`), **utilities** (`utilities/`), per-tool rule layouts, the `external-dependencies.yaml` manifest, the legacy `bootstrap.js` installer, and the generated `catalog.yaml`. Flattened at the repo root. | `ainb` browses + installs from it as a pinned external source; the agents-in-a-box release CI clones a pinned tag of it to generate the curated `catalog-index.json` release asset. |
-| **[stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory)** | The `reflect` long-term-memory system — the Python retrieval/GraphRAG engine (at the repo root) plus its Claude plugin (under `plugin/`). Extracted out of agents-in-a-box into its own public repo. | Engine installs via `uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'`; the plugin ships from the repo's `plugin/` dir; `ainb reflect bootstrap` installs the engine from that URL. |
+| **[stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory)** | The `reflect` long-term-memory system: the Python retrieval/GraphRAG engine (at the repo root) plus its Claude plugin (under `plugin/`). Extracted out of agents-in-a-box into its own public repo. | Engine installs via `uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'`; the plugin ships from the repo's `plugin/` dir; `ainb reflect bootstrap` installs the engine from that URL. |
 
 ## How they fit together
 
@@ -27,14 +27,14 @@ in its own public repo; the `ainb` tool consumes both as external sources.
                                                                     └──────────────────────────┘
 ```
 
-- **Browsing & installing skills** — `ainb skill browse "" --catalog ainb` reads
+- **Browsing & installing skills**: `ainb skill browse "" --catalog ainb` reads
   the `catalog-index.json` published as an agents-in-a-box release asset. Each
   owned entry's install URI is `gh:stevengonsalvez/ainb-toolkit@<tag>/skills/<name>`,
   pinning the ainb-toolkit ref the catalog was generated from.
-- **Authoring a skill or agent** — open a PR against **ainb-toolkit**, then
+- **Authoring a skill or agent**: open a PR against **ainb-toolkit**, then
   regenerate its catalog with `bash bin/generate-catalog.sh`.
 - **The reflect long-term-memory system was extracted to its own repo,
-  [`stevengonsalvez/ainb-reflect-memory`](https://github.com/stevengonsalvez/ainb-reflect-memory)** —
+  [`stevengonsalvez/ainb-reflect-memory`](https://github.com/stevengonsalvez/ainb-reflect-memory)** , 
   the retrieval/GraphRAG engine sits at that repo's root and its Claude plugin
   under `plugin/`. It is no longer in agents-in-a-box's marketplace; the engine
   installs via

--- a/docs/skill-manager/browse.md
+++ b/docs/skill-manager/browse.md
@@ -3,7 +3,7 @@ title: Catalog browse
 description: Search the skills catalog and install from the TUI or CLI.
 ---
 
-> Browse a remote skill catalog (skills.sh) before installing — the
+> Browse a remote skill catalog (skills.sh) before installing: the
 > single biggest UX gap vs other skill managers. See
 > `.agents/plans/skill-manager-v1.3-tdd.md` (bead `ai-a20`) for the full
 > spec this document summarises.
@@ -13,7 +13,7 @@ description: Search the skills catalog and install from the TUI or CLI.
 Before v1.3 you had to know a unit's exact `gh:owner/repo@ref/path` URI
 before `ainb skill install` could touch it. Browse closes that gap: a
 ranked, searchable view of a remote catalog, with one-key install from
-the SkillManager TUI. **Results are ephemeral** — there is no SQLite, no
+the SkillManager TUI. **Results are ephemeral**: there is no SQLite, no
 cache file; a search returns a `Vec<CatalogHit>` that the caller renders
 and (on install) routes through the existing install flow.
 
@@ -56,12 +56,12 @@ type → the query buffer (Enter searches)
 ↑↓   → select a result (Results mode)
 Enter→ install the selected hit (source add + skill install)
 /    → back to Query mode to refine
-Esc  → close (results discarded — ephemeral)
+Esc  → close (results discarded: ephemeral)
 ```
 
 Enter on a result routes the hit's `install_uri` through the existing
 install flow exactly like the CLI: derive the source URI, `ainb source
-add` it (idempotent — "already exists" is fine), then `ainb skill install
+add` it (idempotent: "already exists" is fine), then `ainb skill install
 <uri> --yes`. On success the modal closes and the Units table reloads.
 
 ## API key (optional)
@@ -73,7 +73,7 @@ this order (first hit wins):
 |-------|--------|
 | 1 | `AINB_SKILLS_API_KEY` environment variable |
 | 2 | `[skills].api_key` in `~/.agents-in-a-box/config/config.toml` |
-| 3 | none — search is attempted unauthenticated |
+| 3 | none: search is attempted unauthenticated |
 
 ```toml
 # ~/.agents-in-a-box/config/config.toml
@@ -81,7 +81,7 @@ this order (first hit wins):
 api_key = "sk-your-skills-sh-key"
 ```
 
-The key travels in an `Authorization: Bearer <key>` header — it is
+The key travels in an `Authorization: Bearer <key>` header: it is
 **never** placed in the request URL. When skills.sh returns `401`/`403`
 the backend surfaces `CatalogError::AuthRequired` with the message
 *"set AINB_SKILLS_API_KEY or [skills].api_key in config.toml"*.
@@ -92,9 +92,9 @@ These keep the **live binary** offline (CI never hits skills.sh):
 
 | Env var | Effect |
 |---------|--------|
-| `AINB_CATALOG_MOCK=1` | `search()` returns canned hits — no socket, no reqwest client. The `[b]` TUI tripwire sets this. |
+| `AINB_CATALOG_MOCK=1` | `search()` returns canned hits: no socket, no reqwest client. The `[b]` TUI tripwire sets this. |
 | `AINB_SKILLS_API_BASE=<url>` | Reroute the catalog base host at a local stub (e.g. a `wiremock` server). |
-| `AINB_CATALOG_MOCK_INSTALL_URI=<uri>` | Replace the top canned hit's `install_uri` — a tripwire points it at a local `git:file://…` bare remote so `[b] → Enter` install fetches locally. |
+| `AINB_CATALOG_MOCK_INSTALL_URI=<uri>` | Replace the top canned hit's `install_uri`: a tripwire points it at a local `git:file://…` bare remote so `[b] → Enter` install fetches locally. |
 
 Because the TUI builds the backend on the tokio event-loop thread, the
 `reqwest::blocking::Client` is built **lazily** inside the network branch
@@ -108,5 +108,5 @@ binary against the Full-tier sandbox via tmux: `m → b → type query →
 Enter (results) → Enter (install)`. It sets `AINB_CATALOG_MOCK=1` and
 points `AINB_CATALOG_MOCK_INSTALL_URI` at a second local bare remote
 seeded with `browse-demo-skill`, then asserts the manifest gains that
-source and `lock.yaml` records the deployed unit — **zero network**.
+source and `lock.yaml` records the deployed unit: **zero network**.
 Skips cleanly when `tmux` is unavailable.

--- a/docs/skill-manager/check.md
+++ b/docs/skill-manager/check.md
@@ -12,7 +12,7 @@ description: Detect units that have drifted ahead of or behind their upstream so
 
 Locked units pin a source SHA, but the upstream repo keeps moving.
 Before v1.2 there was no surface that said *"the version you
-installed is 4 commits behind"* — users had to run `ainb skill
+installed is 4 commits behind"*: users had to run `ainb skill
 update --check` per-source. Drift detection replaces that with a
 single CLI + an always-on column in the SkillManager TUI.
 
@@ -85,16 +85,16 @@ The Detail pane shows the commit count under the active unit (for
 `mpsc::unbounded_channel`). Results land in `drift_cache` on the
 next `AppState::tick`. The table renders `…` placeholders until
 results arrive, so the screen stays interactive. A second
-`GoToSkillManager` while a poll is in flight coalesces — the second
+`GoToSkillManager` while a poll is in flight coalesces: the second
 request is a no-op until the first lands.
 
 ## Acceptance tripwires
 
-- `drift::` unit tests (14) — every variant reachable through the
+- `drift::` unit tests (14): every variant reachable through the
   Mock backend; backend errors propagate.
-- `skill_check_tests` (4) — tabular + JSON + `--source` scoping +
+- `skill_check_tests` (4): tabular + JSON + `--source` scoping +
   empty-lockfile path.
-- `tripwire_core_skill_manager_drift_column` (5) — every glyph +
+- `tripwire_core_skill_manager_drift_column` (5): every glyph +
   colour combination rendered.
-- `tripwire_core_skill_manager_drift_background_poll` (2) — async
+- `tripwire_core_skill_manager_drift_background_poll` (2): async
   fetch lands in `drift_cache`; second start coalesces.

--- a/docs/skill-manager/discovery.md
+++ b/docs/skill-manager/discovery.md
@@ -5,7 +5,7 @@ description: Detect existing skills, agents, commands and marketplace plugins on
 
 > Read-only adoption flow for users with pre-populated tool homes
 > and Claude-Code-installed marketplace plugins. Layers on top of
-> the v1 skill-manager — see `ainb-tui/plans/skill-manager/spec.md`
+> the v1 skill-manager: see `ainb-tui/plans/skill-manager/spec.md`
 > for v1 mechanics, and
 > `.agents/goals/ainb-skill-manager-v1.1-discovery-spec.md` for the
 > full v1.1 spec this document summarises.
@@ -32,9 +32,9 @@ import. Nothing is written without explicit user consent.
 
 ```text
 DiscoveryWalker (read-only)
-├── class_a   — marketplace plugins from ~/.claude/plugins/cache/
-├── class_b   — legacy external-dependencies.yaml matcher (opt-in)
-└── class_c   — orphan SKILL.md units in ~/.<tool>/skills/, etc.
+├── class_a  : marketplace plugins from ~/.claude/plugins/cache/
+├── class_b  : legacy external-dependencies.yaml matcher (opt-in)
+└── class_c  : orphan SKILL.md units in ~/.<tool>/skills/, etc.
                 across all 9 adapter tools
               ↓
 Reconciler (pure fn)
@@ -48,13 +48,13 @@ SkillManager TUI
 └── [Enter] import all · [d] details · [s] skip
 ```
 
-All three walkers are **pure** — they never write, never panic on
+All three walkers are **pure**: they never write, never panic on
 malformed input, and tolerate any subset of the layout being
 missing (best-effort discovery).
 
 ## The three walker classes
 
-### Class A — marketplace plugins
+### Class A: marketplace plugins
 
 Source: `ainb-cli/src/discovery/class_a.rs`.
 
@@ -65,7 +65,7 @@ directory and every `agents/<name>.md` file as a
 
 ```text
 ~/.claude/plugins/
-├── known_marketplaces.json     # registry — when present, marketplace
+├── known_marketplaces.json     # registry: when present, marketplace
 │                               # names are real; when absent every
 │                               # marketplace is labelled "unknown"
 └── cache/
@@ -88,7 +88,7 @@ DiscoveredMarketplaceUnit {
 }
 ```
 
-### Class B — legacy YAML matcher (opt-in)
+### Class B: legacy YAML matcher (opt-in)
 
 The legacy `external-dependencies.yaml` matcher was only ever enabled via the
 `--legacy-yaml=<path>` flag on the now-removed `ainb migrate --discover`
@@ -99,12 +99,12 @@ discovered units against the legacy bootstrap manifest, so users
 mid-cutover from `bootstrap.js` can adopt their units as
 `gh:<repo>@<ref>` URIs instead of `local:`.
 
-Never auto-runs — the bootstrap.js era is over and surfacing its
+Never auto-runs: the bootstrap.js era is over and surfacing its
 metadata by default would rot `ainb`. The flag preserves the
 migration path for the dwindling set of users still on the old
 flow.
 
-### Class C — orphan units across 9 tool homes
+### Class C: orphan units across 9 tool homes
 
 Source: `ainb-cli/src/discovery/class_c.rs`.
 
@@ -151,7 +151,7 @@ A SKILL.md (or flat `.md`) is treated as "parseable" when:
 
 `frontmatter_valid = true` reports that the YAML block existed
 AND parsed. It does NOT require both `name` and `kind` to be
-populated — name-only and kind-only frontmatter are valid. The
+populated: name-only and kind-only frontmatter are valid. The
 walker never aborts on a single malformed unit; the malformed one
 falls back to directory name + kind=skill.
 
@@ -159,10 +159,10 @@ falls back to directory name + kind=skill.
 
 `tripwire perf_budget_under_500ms_for_100_units` asserts the
 class-C walker completes a 100-unit fixture in under 500ms on a
-debug build. Class-A walks file-system-bound but small layouts —
+debug build. Class-A walks file-system-bound but small layouts , 
 empirically <100ms for a full Claude Code plugin cache.
 
-## Reconciler — URI synthesis + conflict detection
+## Reconciler: URI synthesis + conflict detection
 
 Source: `ainb-cli/src/discovery/reconcile.rs`. Pure fn:
 
@@ -190,7 +190,7 @@ fn reconcile(walker_out: &WalkerOutput) -> ManifestPatch
 
 The reconciler indexes class-C orphans by `(tool, name)` then
 walks the class-A output looking for collisions. The default is
-**orphan wins** — the user's hand-edited files take precedence —
+**orphan wins**: the user's hand-edited files take precedence , 
 which the `[s]` keybind in the TUI Units panel can flip per-unit.
 
 | Scenario                                                  | Default                                                              |
@@ -230,13 +230,13 @@ maybe_show_discovery_banner(state, ainb_home, walker)
 
 The banner flips to `Visible` when ALL three conditions hold:
 
-1. `manifest.units.is_empty()` — the user hasn't yet adopted
+1. `manifest.units.is_empty()`: the user hasn't yet adopted
    anything.
-2. `<ainb_home>/.discovery-skipped` marker absent — the user has
+2. `<ainb_home>/.discovery-skipped` marker absent: the user has
    not previously pressed `[s]`.
 3. Walker output has at least one candidate.
 
-Subsequent re-opens of SkillManager are **idempotent** — if the
+Subsequent re-opens of SkillManager are **idempotent**: if the
 banner is already `Visible`, the trigger is a no-op so the user
 sees the same counts they did first time. Per spec §Edge cases:
 "Banner appears but user navigates away before pressing Enter →
@@ -245,7 +245,7 @@ Banner re-appears next open until dismissed via [s]."
 ### Banner overlay
 
 ```text
-┌ Detected existing units — import them? ┐
+┌ Detected existing units: import them? ┐
 │ Marketplace plugins:                 3 │
 │ Orphan units:                        9 │
 │                                        │
@@ -271,16 +271,16 @@ Counts come from `compute_counts(&WalkerOutput)`:
 
 | Key      | Action                                                                            |
 |----------|-----------------------------------------------------------------------------------|
-| `Enter`  | `apply_discovery_import` — calls `reconcile()` on the cached walker output, merges the patch into `<ainb_home>/manifest.yaml`, refreshes the Sources / Units / Detail panels in place, and dismisses the banner. |
-| `d`      | `toggle_discovery_details` — flips between the compact `Visible` and expanded `Details` rendering. |
-| `s`      | `apply_discovery_skip` — writes `<ainb_home>/.discovery-skipped`, dismisses the banner, and clears the cached walker output. |
+| `Enter`  | `apply_discovery_import`: calls `reconcile()` on the cached walker output, merges the patch into `<ainb_home>/manifest.yaml`, refreshes the Sources / Units / Detail panels in place, and dismisses the banner. |
+| `d`      | `toggle_discovery_details`: flips between the compact `Visible` and expanded `Details` rendering. |
+| `s`      | `apply_discovery_skip`: writes `<ainb_home>/.discovery-skipped`, dismisses the banner, and clears the cached walker output. |
 | `Esc`/`q`| Returns to Home without touching the banner state. The banner re-appears next time SkillManager opens. |
 
 ### Persistence
 
 - **Import** writes the new sources + units to
   `<ainb_home>/manifest.yaml` and dismisses the banner. No
-  separate skip-marker is written — the import is the "yes"
+  separate skip-marker is written: the import is the "yes"
   answer.
 - **Skip** writes a zero-byte `<ainb_home>/.discovery-skipped`
   marker file. Future opens skip the trigger entirely until the

--- a/docs/skill-manager/guide.mdx
+++ b/docs/skill-manager/guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: Skill manager — guide
+title: "Skill manager: guide"
 description: User guide, demos, and internals for the ainb skill manager, with recordings of every action.
 tableOfContents: false
 ---

--- a/docs/skill-manager/promote.md
+++ b/docs/skill-manager/promote.md
@@ -5,23 +5,23 @@ description: Turn a local orphan skill into a git-backed source with `ainb skill
 
 > One-shot command that turns a hand-edited orphan into a
 > git-backed source. Bridges the gap between adopting a `local:`
-> unit and tracking it as upstream — without forcing the user
+> unit and tracking it as upstream: without forcing the user
 > through `skill-creator` + manual `git init` / `git push`.
 >
 > Full design: spec
 > `.agents/goals/ainb-skill-manager-v1.1-discovery-spec.md`
-> §`ainb skill promote` — Detailed Design.
+> §`ainb skill promote`: Detailed Design.
 
 ## What promote does
 
 After discovery imports an orphan as
 `local:~/.claude/skills@head/my-skill`, the unit is tracked but
 the source of truth is still a single file under the user's home
-directory — fragile, machine-local, and impossible to share or
+directory: fragile, machine-local, and impossible to share or
 version. `ainb skill promote` migrates that file into a git repo
 the user controls, commits + pushes it, and rewrites the manifest
 URI from `local:` to `gh:user/repo@<branch>/skills/<name>`. The
-on-disk file at `~/.claude/skills/my-skill/` stays where it is —
+on-disk file at `~/.claude/skills/my-skill/` stays where it is , 
 that's the deployed instance now, with the git repo as upstream.
 
 `ainb skill update my-skill` thereafter pulls upstream and
@@ -51,16 +51,16 @@ Options:
 These were settled before implementation began and should not be
 revisited without re-opening the spec interview:
 
-1. **Clone location** — persistent cache at
+1. **Clone location**: persistent cache at
    `~/.agents-in-a-box/promote-cache/<user>/<repo>/`. Cloned once,
    reused on subsequent promotes against the same repo (`git pull
    --ff-only`). Survives across runs. No automatic cache eviction
    (manual: `rm -rf ~/.agents-in-a-box/promote-cache/`).
-2. **Push strategy** — direct push to the repo's default branch,
+2. **Push strategy**: direct push to the repo's default branch,
    resolved via `gh repo view --json defaultBranchRef`. No PR
    creation in v1.1. Users who want a PR push to a feature branch
    manually post-promote.
-3. **Post-promote local-copy handling** — keep
+3. **Post-promote local-copy handling**: keep
    `~/.<tool>/skills/<name>/` files in place. Rewrite the manifest
    URI to `gh:user/repo@<branch>/skills/<name>`. Register the
    existing local files as the deployed instance in the lockfile:
@@ -71,7 +71,7 @@ revisited without re-opening the spec interview:
    ```
    Future `ainb skill update` pulls upstream, compares hashes,
    no-ops if unchanged.
-4. **`gh` dependency** — hard requirement. Pre-flight runs `gh
+4. **`gh` dependency**: hard requirement. Pre-flight runs `gh
    auth status` and bails fast with an exact remediation command
    if it fails.
 
@@ -147,21 +147,21 @@ it does not happen at all.
 
 ## Out of scope for v1.1 (deferred to v1.2)
 
-The following are explicitly deferred — please do NOT add them as
+The following are explicitly deferred: please do NOT add them as
 follow-up beads under the v1.1 epic without re-opening the spec
 interview:
 
-- **`--pr` flag** — open a PR via `gh pr create` instead of
+- **`--pr` flag**: open a PR via `gh pr create` instead of
   pushing directly to the default branch.
-- **`--new-repo` flag** — create the target repo via `gh repo
+- **`--new-repo` flag**: create the target repo via `gh repo
   create` if it doesn't exist.
-- **`--workdir` flag** — promote into a named branch in the cache
+- **`--workdir` flag**: promote into a named branch in the cache
   for manual PR follow-up.
-- **`ainb skill pull`** — bidirectional sync from a promoted
+- **`ainb skill pull`**: bidirectional sync from a promoted
   upstream back to the local copy. v1.1 promote is one-shot.
-- **Multi-unit promote** — loop manually for now
+- **Multi-unit promote**: loop manually for now
   (`for u in a b c; do ainb skill promote $u --to ...; done`).
-- **`--clean-cache` flag** — explicit eviction of
+- **`--clean-cache` flag**: explicit eviction of
   `~/.agents-in-a-box/promote-cache/`. Manual `rm -rf` works.
 
 ## Open questions (tracked for v1.2 design)
@@ -177,7 +177,7 @@ interview:
 
 - Spec: `.agents/goals/ainb-skill-manager-v1.1-discovery-spec.md`
 - Discovery flow (the input to promote):
-  [`docs/skill-manager/discovery.md`](./discovery.md)
+  [`docs/skill-manager/discovery.md`](/skill-manager/discovery)
 - v1 skill-manager CLI surface:
   `ainb-tui/plans/skill-manager/spec.md` §8 (`source`, `skill`,
   `migrate`, `doctor`, `usage`).

--- a/docs/skill-manager/sandbox-testing.md
+++ b/docs/skill-manager/sandbox-testing.md
@@ -1,9 +1,9 @@
 ---
 title: Sandbox testing
-description: Run the skill manager against a throwaway sandbox home — never your real ~/.claude.
+description: "Run the skill manager against a throwaway sandbox home: never your real ~/.claude."
 ---
 
-> Reproducible test harness for the SkillManager — drives the TUI +
+> Reproducible test harness for the SkillManager: drives the TUI +
 > CLI against a seeded fake `~/.claude` / `~/.codex` without touching
 > your real tool homes. Two surfaces from one design: a Rust fixture
 > for in-process integration tests, plus a bash script for manual TUI
@@ -46,7 +46,7 @@ a fixture that:
 ```
 
 The two paths share design (same seeded skills, same env-var set,
-same bare-remote shape) but not code — the Rust API uses
+same bare-remote shape) but not code: the Rust API uses
 `tempfile::tempdir()` for parallel-safe tests; the bash script
 writes to a stable cache path so a developer can leave the sandbox
 in place between TUI sessions.
@@ -62,7 +62,7 @@ in place between TUI sessions.
 `Full` (~2s) is for tripwires that need multi-tool coverage,
 conflict-flip exercises, or the upcoming provenance matcher.
 
-## Manual workflow (just — recommended)
+## Manual workflow (just: recommended)
 
 `brew install just`, then from the worktree root:
 
@@ -77,10 +77,10 @@ just --list skill-manager               # list every recipe
 
 All env vars (`HOME`, `AINB_HOME`, `AINB_TOOL_HOME_*`,
 `GIT_TERMINAL_PROMPT`, `GIT_ASKPASS`) are set inside the justfile
-itself — no `source env.sh` step. Override the sandbox root with
+itself: no `source env.sh` step. Override the sandbox root with
 `AINB_SANDBOX_ROOT=/tmp/foo just skill-manager up`.
 
-## Manual workflow (raw bash — no just)
+## Manual workflow (raw bash: no just)
 
 ```bash
 # 1. Build a sandbox (default ~/.cache/ainb-sandbox, default Minimal)
@@ -89,7 +89,7 @@ scripts/skill-manager-sandbox.sh up
 # 2. Arm the env
 source ~/.cache/ainb-sandbox/env.sh
 
-# 3. Launch ainb — press [m] to enter SkillManager
+# 3. Launch ainb: press [m] to enter SkillManager
 ./target/debug/ainb
 
 # 4. Or drive the CLI
@@ -115,7 +115,7 @@ scripts/skill-manager-sandbox.sh down
 - `--root /` refused (would clobber the filesystem).
 - `--root $HOME` refused (would clobber the user's real home).
 - `down` refuses any directory that lacks the `.ainb-sandbox-marker`
-  sentinel file — protection against accidentally wiping a wrong
+  sentinel file: protection against accidentally wiping a wrong
   path.
 - `down` on a missing root is a no-op (exit 0).
 
@@ -158,13 +158,13 @@ fn my_skill_manager_test() {
 ```
 
 `SandboxLayout::env_vars()` returns the env-var pairs the bash
-launcher writes to `env.sh` — identical contract.
+launcher writes to `env.sh`: identical contract.
 
 ## Test coverage matrix
 
 | Journey                                    | Covered by                                                                                                |
 |--------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| Fixture itself builds correctly            | `crates/ainb-skill-core/tests/sandbox_fixture_smoke.rs` — 5 tests across both tiers                       |
+| Fixture itself builds correctly            | `crates/ainb-skill-core/tests/sandbox_fixture_smoke.rs`: 5 tests across both tiers                       |
 | Refuse to seed at `$HOME`                  | `sandbox_fixture_smoke::refuses_to_seed_into_real_home`                                                   |
 | Idempotent rebuild                         | `sandbox_fixture_smoke::rebuild_into_existing_root_is_idempotent`                                         |
 | env_vars contract                          | `sandbox_fixture_smoke::env_vars_round_trip_paths`                                                        |
@@ -172,7 +172,7 @@ launcher writes to `env.sh` — identical contract.
 | Drift InSync/Outdated round-trip vs bare   | `crates/ainb-skill-core/tests/drift_tests_integration.rs`                                                 |
 | TestBackend render of SkillsScreenData     | `crates/ainb-core/tests/tripwire_core_skill_manager_sandbox_loads.rs`                                     |
 | Live tmux: press `m`, see SkillManager     | `crates/ainb-core/tests/tripwire_core_skill_manager_sandbox_e2e.rs`                                       |
-| Bash `up`/`down` safety guards (rm -rf belts) | `crates/ainb-core/tests/sandbox_script_safety_guards.rs` — 4 tests against the real script               |
+| Bash `up`/`down` safety guards (rm -rf belts) | `crates/ainb-core/tests/sandbox_script_safety_guards.rs`: 4 tests against the real script               |
 
 ## Prod-binary isolation
 
@@ -200,7 +200,7 @@ explicit `--features` flag is a self-dev-dep in
 ainb-skill-core = { path = ".", features = ["test-fixtures"] }
 ```
 
-Cargo treats this as a separate dependency edge — tests see the
+Cargo treats this as a separate dependency edge: tests see the
 fixture, production builds don't. `ainb-core` adopts the same
 pattern in its own dev-deps so the SkillManager tripwires can
 consume the fixture.

--- a/docs/skill-manager/sync.md
+++ b/docs/skill-manager/sync.md
@@ -5,7 +5,7 @@ description: Bidirectional sync between deployed units and their source repos.
 
 > Bidirectional reconciliation between a unit's deployed copies on
 > tool homes and the source-of-truth in its declared repo. Layers
-> on top of v1 (install / update) and the v1.1 promote flow — see
+> on top of v1 (install / update) and the v1.1 promote flow: see
 > `docs/skill-manager/promote.md` for the one-way promote path and
 > `.agents/goals/ainb-skill-manager-v1.2-rollup-plan.md` §D for the
 > full v1.2 spec this document summarises.
@@ -15,7 +15,7 @@ description: Bidirectional sync between deployed units and their source repos.
 `ainb skill install` and `ainb skill update` are one-way fetches:
 the repo wins. But users routinely tweak a deployed skill in their
 tool home (a typo, a clearer prompt) and want that improvement to
-land back in the source repo — and they want the reverse, too:
+land back in the source repo: and they want the reverse, too:
 pulling teammate edits down into every tool home in one shot. Sync
 is the one command that handles both directions; the planner
 decides which.
@@ -38,7 +38,7 @@ SyncPlanner       ─▶  inspect home vs repo per unit (pure)
 
 `ainb_skill_core::sync::plan_sync(source, mappings, units) -> Vec<SyncAction>`
 where each `SyncAction { unit_name, direction: ToRepo | ToHome |
-NoOp, reason }`. Pure — uses `LockedUnit.sha` (deployed git ref) +
+NoOp, reason }`. Pure: uses `LockedUnit.sha` (deployed git ref) +
 mtime fallback when refs are absent. The `reason` field carries a
 human-readable explanation that the CLI surfaces in `--dry-run`.
 
@@ -59,7 +59,7 @@ trait (kept inside `ainb-skill-core` to avoid a dep cycle with
 2. `git add --` the changed file.
 3. `git commit -m "sync: <unit-name>"` with a placeholder identity
    when global git config has none (matches the promote flow).
-4. `git push -- origin <ref>` — gated by
+4. `git push -- origin <ref>`: gated by
    `AINB_SYNC_SKIP_PUSH=1` so tripwires exercise the local-commit
    path without configuring a real remote.
 
@@ -88,7 +88,7 @@ without expanding every one. Existing five test callsites use
 otherwise it fires `AppEvent::SkillManagerSync` and runs the same
 flow as the CLI for the focused unit. The help-bar `[s]` legend
 reads `sync`. The conflict-peer check reads the manifest from
-`$AINB_HOME/manifest.yaml` on the hot keystroke path — sub-millisecond
+`$AINB_HOME/manifest.yaml` on the hot keystroke path: sub-millisecond
 on typical manifests; a `selected_unit_has_conflict_peer` cache is
 the documented follow-up if profiling ever flags it.
 
@@ -103,10 +103,10 @@ a named tripwire.
 
 ## Acceptance tripwires
 
-- `sync_to_home_tests`, `sync_to_repo_tests` — executor smoke tests
+- `sync_to_home_tests`, `sync_to_repo_tests`: executor smoke tests
   with mocked fetchers (4 + 4).
-- `skill_sync_roundtrip_tests` — full CLI roundtrip: edit home →
+- `skill_sync_roundtrip_tests`: full CLI roundtrip: edit home →
   `ainb skill sync` → assert cache repo has new commit; reverse
   edit → sync → assert home file matches (2).
-- `skill_manager_sync_keybind_tests` — `[s]` routing (3).
-- `auto_infer_gh_layout_tests` — bootstrap-fallback confirmation (6).
+- `skill_manager_sync_keybind_tests`: `[s]` routing (3).
+- `auto_infer_gh_layout_tests`: bootstrap-fallback confirmation (6).

--- a/docs/skill-manager/usage.md
+++ b/docs/skill-manager/usage.md
@@ -5,14 +5,14 @@ description: How the skill manager records and surfaces per-unit usage.
 
 > Per-unit invocation counts + last-used timestamps surfaced in the
 > SkillManager Detail pane. Layers on top of v1 (manifest +
-> lockfile) — see `ainb-tui/plans/skill-manager/spec.md` for v1
+> lockfile): see `ainb-tui/plans/skill-manager/spec.md` for v1
 > mechanics, and `.agents/goals/ainb-skill-manager-v1.2-rollup-plan.md`
 > §B for the full v1.2 spec this document summarises.
 
 ## Why usage tracking exists
 
 Before v1.2 the Detail pane showed only the unit URI and its
-deployed paths — useful for verifying *what* is installed but
+deployed paths: useful for verifying *what* is installed but
 silent on *whether you actually use it*. v1.2 adds a lockfile-side
 counter that the SkillManager can render at a glance, so users can
 prune skills they have not invoked in months and recognise the ones
@@ -51,7 +51,7 @@ units:
       invocations: 12                          # u64, default 0
 ```
 
-Legacy v1 lockfiles without `usage` parse cleanly — the field is
+Legacy v1 lockfiles without `usage` parse cleanly: the field is
 `serde(default, skip_serializing_if = "UsageRecord::is_empty")`, so
 roundtrip byte-stability is preserved.
 
@@ -74,7 +74,7 @@ ainb skill usage --verbose        # print per-unit counts as they land
 For each targeted unit, the subcommand walks every tool the unit is
 deployed to, sums `detect_invocations` results (keeping the most
 recent timestamp across tools), and writes the aggregate to the
-lockfile. Idempotent — running twice on a quiet system produces the
+lockfile. Idempotent: running twice on a quiet system produces the
 same lockfile.
 
 ## Detail pane render (B.4)
@@ -88,7 +88,7 @@ Usage: 12 invocations · last used 3h ago
 ```
 
 The "time-ago" string is computed against `chrono::Utc::now()` (no
-chrono dep added at the `ainb-skill-core` crate boundary — the
+chrono dep added at the `ainb-skill-core` crate boundary: the
 timestamp is stored as a string and parsed at the render layer).
 Unparseable timestamps fall back to the raw value.
 

--- a/docs/toolkit/agents.md
+++ b/docs/toolkit/agents.md
@@ -31,4 +31,4 @@ access, and area of expertise.
 
 ## See also
 
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/toolkit/bootstrap.md
+++ b/docs/toolkit/bootstrap.md
@@ -66,5 +66,5 @@ Read-only. Checks every applicable manifest entry has its `SKILL.md` at the expe
 
 ## See also
 
-- [Toolkit overview](overview.md)
-- [Docs hub](../README.md)
+- [Toolkit overview](/toolkit/overview)
+- [Docs hub](/readme)

--- a/docs/toolkit/overview.md
+++ b/docs/toolkit/overview.md
@@ -9,8 +9,8 @@ repo, where it is **flattened** at the repo root: skills at `skills/`, agents at
 `agents/`, workflows at `workflows/`, utilities at `utilities/`, plus
 `bootstrap.js`, `external-dependencies.yaml`, and `catalog.yaml`. `ainb`
 consumes it as a pinned external source. The paths shown below use the legacy
-`toolkit/packages/` form for continuity — in ainb-toolkit they live without the
-`toolkit/packages/` prefix. See [Repositories](/reference/repositories/) for how
+`toolkit/packages/` form for continuity: in ainb-toolkit they live without the
+`toolkit/packages/` prefix. See [Repositories](/reference/repositories) for how
 the two repos fit together.
 :::
 
@@ -26,7 +26,7 @@ One canonical source tree, many AI tools. Author a skill, agent, or workflow onc
 | `packages/workflows/single-agent/` | Guided plan -> implement -> validate flows |
 | `packages/knowledge/` | Knowledge/docs templates |
 
-The `reflect` Claude Code plugin and its companion knowledge-base CLI were extracted into their own repo, [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) — the CLI flattened at that repo's root, the plugin under `plugin/`. They are no longer in this monorepo (or under `toolkit/packages/`). The reflect/recall CLI is installed via `uv tool install` (`uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'`) by `bootstrap.js`.
+The `reflect` Claude Code plugin and its companion knowledge-base CLI were extracted into their own repo, [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory): the CLI flattened at that repo's root, the plugin under `plugin/`. They are no longer in this monorepo (or under `toolkit/packages/`). The reflect/recall CLI is installed via `uv tool install` (`uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'`) by `bootstrap.js`.
 
 ## Supported tools
 
@@ -54,7 +54,7 @@ node bootstrap.js --tool=claude-code-4.5   # one tool
 node bootstrap.js --tool=claude-code-4.5 --verify   # read-only parity check
 ```
 
-Each target gets its own home-dir population; repeat per tool. See [Bootstrap engine](bootstrap.md) for the deploy mechanics.
+Each target gets its own home-dir population; repeat per tool. See [Bootstrap engine](/toolkit/bootstrap) for the deploy mechanics.
 
 ## External dependencies
 
@@ -72,7 +72,7 @@ Artifacts land under `specs/<feature-branch>/`.
 
 ## See also
 
-- [Bootstrap engine](bootstrap.md)
-- [Skills](skills.md)
-- [Agents](agents.md)
-- [Docs hub](../README.md)
+- [Bootstrap engine](/toolkit/bootstrap)
+- [Skills](/toolkit/skills)
+- [Agents](/toolkit/agents)
+- [Docs hub](/readme)

--- a/docs/toolkit/plugins/ainb-fleet.md
+++ b/docs/toolkit/plugins/ainb-fleet.md
@@ -3,21 +3,21 @@ title: "ainb-fleet"
 description: "Claude Code skill bundle that teaches agents to drive the `ainb fleet` multi-session orchestration subcommands."
 ---
 
-`ainb-fleet` (v0.1.0) is a **Claude Code plugin** — loaded by Claude Code itself, not by the ainb TUI — that ships a bundle of LLM-facing skills teaching an agent how to use the `ainb fleet ...` orchestration subcommands: broadcasting a prompt to many sessions, ack-gated step sequences, surfacing blocked sessions ("needs"), an auto-continue daemon, and a fleet standup. The orchestration logic itself lives in the `ainb` Rust binary; this plugin is purely the teaching layer that points the agent at the right command for the job. It replaces the deprecated `popa` plugin, whose Node code is gone.
+`ainb-fleet` (v0.1.0) is a **Claude Code plugin**: loaded by Claude Code itself, not by the ainb TUI: that ships a bundle of LLM-facing skills teaching an agent how to use the `ainb fleet ...` orchestration subcommands: broadcasting a prompt to many sessions, ack-gated step sequences, surfacing blocked sessions ("needs"), an auto-continue daemon, and a fleet standup. The orchestration logic itself lives in the `ainb` Rust binary; this plugin is purely the teaching layer that points the agent at the right command for the job. It replaces the deprecated `popa` plugin, whose Node code is gone.
 
 ## How it works
 
-![ainb-fleet — how it works](../../assets/diagrams/ainb-fleet.svg)
+![ainb-fleet: how it works](../../assets/diagrams/ainb-fleet.svg)
 
-This plugin registers **no hooks, no commands, and no agents** — it is a pure skill bundle. When you invoke one of its colon-namespaced skills (`/ainb-fleet:standup`, `/ainb-fleet:broadcast`, etc.), the skill teaches the agent the exact `ainb fleet ...` invocation to shell out to. All the real work — discovering sessions, reading transcripts, routing writes — happens inside the `ainb` Rust binary.
+This plugin registers **no hooks, no commands, and no agents**: it is a pure skill bundle. When you invoke one of its colon-namespaced skills (`/ainb-fleet:standup`, `/ainb-fleet:broadcast`, etc.), the skill teaches the agent the exact `ainb fleet ...` invocation to shell out to. All the real work: discovering sessions, reading transcripts, routing writes: happens inside the `ainb` Rust binary.
 
-The fleet engine discovers sessions from three sources — every session `ainb` has spawned, sessions registered with the claude-peers broker (`~/.claude-peers.db`), and background-job dirs under `~/.claude/jobs/` — then merges and dedupes them by `cwd`. Reads go through the source of truth (JSONL transcripts plus tmux pane buffers); writes go out peers-first via the broker when a peer is registered, falling back to `tmux send-keys` literal mode otherwise.
+The fleet engine discovers sessions from three sources: every session `ainb` has spawned, sessions registered with the claude-peers broker (`~/.claude-peers.db`), and background-job dirs under `~/.claude/jobs/`: then merges and dedupes them by `cwd`. Reads go through the source of truth (JSONL transcripts plus tmux pane buffers); writes go out peers-first via the broker when a peer is registered, falling back to `tmux send-keys` literal mode otherwise.
 
 The bundle has a top-level router skill (`ainb-fleet`) that maps the five verbs to their focused sub-skills, plus a workflow-backed variant of `needs`. The `fleet-needs` skill runs the deterministic `hangar` workflow (verb=`needs`: discover → enrich → prioritize → render-ready cards), then renders a "Jarvis HUD" of every blocked session and fires an `AskUserQuestion` per session so the user can answer the whole fleet in one batch; answers are routed back to each target's tmux pane.
 
 The daemon skill describes a long-running watcher that scans each session's recent pane buffer every 5 seconds and auto-sends `continue` to any session whose buffer matches a known API-error regex (`rate_limited`, `overloaded_error`, `internal_server_error`, `request_timeout`, `socket_hang_up`, `fetch_failed`, `connection_reset`), deduping on `(session_id, pattern, match-context)` so it fires once per error.
 
-**ATC (Air Traffic Control)** is the persistent orchestrating brain that ties the verbs together on a schedule with a policy. `ainb fleet atc setup <name>` provisions `~/.agents-in-a-box/atc/<name>/` — a generated `CLAUDE.md` policy, a `meta.json` config, seeded `state.json` / `task-log.md` durable memory, and an installed OS-timer heartbeat (launchd `StartInterval` on macOS, a systemd `--user` timer on Linux) — then spawns a real `ainb run` Claude session reading that policy. Every N minutes (default 15) the timer runs `ainb fleet atc heartbeat <name>`, which builds a compact `[HEARTBEAT]` nudge from the **LLM-free** `ainb fleet needs --format json` read and tmux-sends it into the session, so ATC spends tokens only deciding. The policy is conservative and **escalate-on-uncertainty**: it auto-clears the safe cases (confident ASK → `broadcast`; ERR → `continue`, capped at 3 per session) and escalates the rest to the phone bridge, never auto-running destructive actions. ATC is **poll-mode** — it needs no hook/inbox plumbing and works against the existing fleet verbs today; the plumbing track is a drop-in event-driven enhancement. For managed fleets ATC **supersedes** the `daemon` skill, absorbing its auto-`continue` job with the retry cap the daemon lacks. `status` / `list` / `repair` / `teardown` round out the lifecycle; teardown idempotently removes the timer and session, and `repair <name>` re-asserts a broken heartbeat scheduler by rebuilding the OS timer unit against the current `PATH` / `$AINB_BIN` without touching `meta.json`, `CLAUDE.md`, the hooks, or the session (`--dry-run` writes nothing and is never greener than a real run: it previews the conservative local-timer path and reports the daemon fields as `null`, because whether the daemon would take the heartbeat depends on registration succeeding, which a read-only preview cannot determine).
+**ATC (Air Traffic Control)** is the persistent orchestrating brain that ties the verbs together on a schedule with a policy. `ainb fleet atc setup <name>` provisions `~/.agents-in-a-box/atc/<name>/`: a generated `CLAUDE.md` policy, a `meta.json` config, seeded `state.json` / `task-log.md` durable memory, and an installed OS-timer heartbeat (launchd `StartInterval` on macOS, a systemd `--user` timer on Linux): then spawns a real `ainb run` Claude session reading that policy. Every N minutes (default 15) the timer runs `ainb fleet atc heartbeat <name>`, which builds a compact `[HEARTBEAT]` nudge from the **LLM-free** `ainb fleet needs --format json` read and tmux-sends it into the session, so ATC spends tokens only deciding. The policy is conservative and **escalate-on-uncertainty**: it auto-clears the safe cases (confident ASK → `broadcast`; ERR → `continue`, capped at 3 per session) and escalates the rest to the phone bridge, never auto-running destructive actions. ATC is **poll-mode**: it needs no hook/inbox plumbing and works against the existing fleet verbs today; the plumbing track is a drop-in event-driven enhancement. For managed fleets ATC **supersedes** the `daemon` skill, absorbing its auto-`continue` job with the retry cap the daemon lacks. `status` / `list` / `repair` / `teardown` round out the lifecycle; teardown idempotently removes the timer and session, and `repair <name>` re-asserts a broken heartbeat scheduler by rebuilding the OS timer unit against the current `PATH` / `$AINB_BIN` without touching `meta.json`, `CLAUDE.md`, the hooks, or the session (`--dry-run` writes nothing and is never greener than a real run: it previews the conservative local-timer path and reports the daemon fields as `null`, because whether the daemon would take the heartbeat depends on registration succeeding, which a read-only preview cannot determine).
 
 ## What it provides
 
@@ -25,15 +25,15 @@ The daemon skill describes a long-running watcher that scans each session's rece
 
 | Skill | Purpose |
 |---|---|
-| `ainb-fleet` | Overview / router — at-a-glance map of the five fleet verbs, discovery sources, and global flags |
+| `ainb-fleet` | Overview / router: at-a-glance map of the five fleet verbs, discovery sources, and global flags |
 | `ainb-fleet:ainb-spawn` | Spawn contract for `ainb run`: the two legal shapes (repo root plus `--worktree --create-branch`, or an existing worktree passed bare), the flag-by-flag rationale, the trap table (bare checkout, empty `--parent`, unset `--parent` eating the next token), and the post-spawn verify loop |
 | `ainb-fleet:standup` | List every claude session on the host, merged + deduped across ainb · peers broker · bg jobs |
 | `ainb-fleet:broadcast` | Fan one prompt out to selected sessions (requires `--all`, `--filter <regex>`, or `--cwd <substring>`) |
 | `ainb-fleet:sequence` | Send ordered multi-step prompts, ack-gated between steps via JSONL turn-end detection |
-| `ainb-fleet:needs` | Center control panel — enumerate sessions blocked on ASK / ERR / IDLE / WAIT signals, render the Jarvis HUD |
-| `ainb-fleet:fleet-needs` | Workflow-backed `needs` — runs the `hangar` workflow, renders the HUD, fires `AskUserQuestion`, routes answers back |
+| `ainb-fleet:needs` | Center control panel: enumerate sessions blocked on ASK / ERR / IDLE / WAIT signals, render the Jarvis HUD |
+| `ainb-fleet:fleet-needs` | Workflow-backed `needs`: runs the `hangar` workflow, renders the HUD, fires `AskUserQuestion`, routes answers back |
 | `ainb-fleet:cost` | Per-session / model / day / group USD spend rollups sourced from burndown, plus `config.toml` budget caps that fire notifyd alerts |
-| `ainb-fleet:atc` | **Air Traffic Control** — provision / inspect / tear down the persistent fleet brain that watches on a heartbeat, auto-clears safe sessions, and escalates the rest to your phone |
+| `ainb-fleet:atc` | **Air Traffic Control**: provision / inspect / tear down the persistent fleet brain that watches on a heartbeat, auto-clears safe sessions, and escalates the rest to your phone |
 | `ainb-fleet:daemon` | Background watcher that auto-`continue`s sessions matching an API-error regex (**superseded by ATC** for managed fleets) |
 
 ### Workflow
@@ -44,7 +44,7 @@ The daemon skill describes a long-running watcher that scans each session's rece
 
 ### Hooks / Commands / Agents
 
-None — this plugin registers no lifecycle hooks, slash commands, or sub-agents.
+None: this plugin registers no lifecycle hooks, slash commands, or sub-agents.
 
 ## Install
 
@@ -52,17 +52,17 @@ None — this plugin registers no lifecycle hooks, slash commands, or sub-agents
 claude plugin install ainb-fleet@agents-in-a-box
 ```
 
-The plugin is published via this repo's root `.claude-plugin/marketplace.json` (marketplace name `agents-in-a-box`). It requires the `ainb` binary on `PATH` to do any real work — the skills shell out to `ainb fleet ...`.
+The plugin is published via this repo's root `.claude-plugin/marketplace.json` (marketplace name `agents-in-a-box`). It requires the `ainb` binary on `PATH` to do any real work: the skills shell out to `ainb fleet ...`.
 
 ## Using it
 
 - **Get a fleet roster:** `/ainb-fleet:standup` (add `--format json` to pipe into `jq`).
-- **Apply one instruction everywhere:** `/ainb-fleet:broadcast` — e.g. `ainb fleet broadcast "/clear" --filter "shotclubhouse"`. A targeting flag is mandatory to prevent accidental fan-out.
-- **Run an ordered cycle:** `/ainb-fleet:sequence` — e.g. disconnect → reconnect → verify, waiting for each step's assistant turn-end before the next.
+- **Apply one instruction everywhere:** `/ainb-fleet:broadcast`: e.g. `ainb fleet broadcast "/clear" --filter "shotclubhouse"`. A targeting flag is mandatory to prevent accidental fan-out.
+- **Run an ordered cycle:** `/ainb-fleet:sequence`: e.g. disconnect → reconnect → verify, waiting for each step's assistant turn-end before the next.
 - **See what wants your attention:** `/ainb-fleet:needs` (or `/ainb-fleet:fleet-needs` when `CLAUDE_CODE_WORKFLOWS=1`) renders a HUD of every blocked session and lets you answer them in one `AskUserQuestion` batch.
-- **Unattended fleet supervision:** `/ainb-fleet:atc` (`ainb fleet atc setup <name>`) stands up the persistent brain — it watches the whole fleet on a heartbeat, clears the safe/blocked sessions itself, and pings your phone only for the calls that genuinely need you. Supersedes the daemon for managed fleets.
+- **Unattended fleet supervision:** `/ainb-fleet:atc` (`ainb fleet atc setup <name>`) stands up the persistent brain: it watches the whole fleet on a heartbeat, clears the safe/blocked sessions itself, and pings your phone only for the calls that genuinely need you. Supersedes the daemon for managed fleets.
 - **Unattended error recovery (one-off):** `/ainb-fleet:daemon` runs a watcher that auto-`continue`s sessions hitting transient API errors (run via `nohup ... &` for real background use). For ongoing supervision prefer ATC, which adds a retry cap.
 
 ## Source
 
-`plugins/ainb-fleet/` — a Claude Code skill bundle (8 skills + the `hangar` workflow) teaching agents to drive the `ainb fleet` Rust subcommands; the ATC skill pairs with the `ainb fleet atc` provisioning verbs in the Rust binary. Diagram generated via /fireworks-tech-graph.
+`plugins/ainb-fleet/`: a Claude Code skill bundle (8 skills + the `hangar` workflow) teaching agents to drive the `ainb fleet` Rust subcommands; the ATC skill pairs with the `ainb fleet atc` provisioning verbs in the Rust binary. Diagram generated via /fireworks-tech-graph.

--- a/docs/toolkit/plugins/ainb-hooks.md
+++ b/docs/toolkit/plugins/ainb-hooks.md
@@ -7,7 +7,7 @@ description: "Claude Code / Codex / Copilot plugin that emits session lifecycle 
 
 ## How it works
 
-![ainb-hooks — how it works](../../assets/diagrams/ainb-hooks.svg)
+![ainb-hooks: how it works](../../assets/diagrams/ainb-hooks.svg)
 
 The plugin's `.claude-plugin/plugin.json` registers every documented Claude lifecycle hook with `AINB_AGENT=claude ${CLAUDE_PLUGIN_ROOT}/hooks/notify.sh`. Codex registers every documented CLI hook via `codex/hooks.json` with `AINB_AGENT=codex`; Copilot remains `copilot/hooks.json` with `AINB_AGENT=copilot`. Each hook has a 5-second timeout so a slow delivery never stalls the agent.
 
@@ -21,7 +21,7 @@ Downstream, `ainb-notifyd` persists envelopes to a SQLite `notifications.db` and
 
 ## What it provides
 
-This plugin ships only hooks plus the shared `notify.sh` script — no skills, commands, or agents.
+This plugin ships only hooks plus the shared `notify.sh` script: no skills, commands, or agents.
 
 ### Hooks
 
@@ -32,7 +32,7 @@ Claude and Codex retain every documented hook in Hangar. Inbox handling remains 
 | Claude Code | all 30 documented hooks | full lifecycle and workload record | durable projection source |
 | Codex CLI | all 11 documented CLI hooks | full lifecycle and workload record | durable projection source |
 | GitHub Copilot CLI | `notification` | Agent notifications and permission prompts | the agent is blocked on you |
-| GitHub Copilot CLI | `agentStop` | Agent turn / session stops | the agent finished — come back |
+| GitHub Copilot CLI | `agentStop` | Agent turn / session stops | the agent finished: come back |
 
 Telemetry stays out of the inbox because the daemon drops non-user-facing events on arrival.
 
@@ -43,11 +43,11 @@ Telemetry stays out of the inbox because the daemon drops non-user-facing events
 | `.claude-plugin/plugin.json` | Claude Code plugin manifest (`hooks` block, name, version) |
 | `codex/hooks.json` | Codex `~/.codex/hooks.json` merge template (`__AINB_HOOK_SCRIPT__` placeholder) |
 | `copilot/hooks.json` | Copilot `~/.copilot/hooks/ainb.json` drop-in template |
-| `hooks/notify.sh` | Universal hook script — normalizes the payload and delivers it to the socket |
+| `hooks/notify.sh` | Universal hook script: normalizes the payload and delivers it to the socket |
 
 ## Install
 
-`ainb-hooks` is published in the `agents-in-a-box` plugin marketplace, but you don't install it by hand — the `ainb-notifyd` binary's installer wires it for the chosen agents and manages the notifyd lifecycle:
+`ainb-hooks` is published in the `agents-in-a-box` plugin marketplace, but you don't install it by hand: the `ainb-notifyd` binary's installer wires it for the chosen agents and manages the notifyd lifecycle:
 
 ```bash
 ainb-notifyd install --claude --codex --copilot
@@ -55,7 +55,7 @@ ainb-notifyd status
 ainb-notifyd uninstall --all
 ```
 
-For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring the `agents-in-a-box` marketplace is known, then `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" counts as success) — so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex**, it merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block, extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh`, and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path. For **Copilot**, it writes `copilot/hooks.json` as a standalone drop-in at `~/.copilot/hooks/ainb.json`. The install method is recorded in `~/.agents-in-a-box/install.json` so uninstall is fully reversible (`claude plugin uninstall` for Claude, managed-block removal for Codex, drop-in deletion for Copilot).
+For **Claude**, the installer shells out to the `claude` plugin CLI: ensuring the `agents-in-a-box` marketplace is known, then `claude plugin install ainb-hooks@agents-in-a-box` (idempotent; "already installed" counts as success): so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex**, it merges `codex/hooks.json` into `~/.codex/hooks.json` as a managed block, extracts `notify.sh` to `~/.agents-in-a-box/hooks/notify.sh`, and rewrites the `__AINB_HOOK_SCRIPT__` placeholder to that absolute path. For **Copilot**, it writes `copilot/hooks.json` as a standalone drop-in at `~/.copilot/hooks/ainb.json`. The install method is recorded in `~/.agents-in-a-box/install.json` so uninstall is fully reversible (`claude plugin uninstall` for Claude, managed-block removal for Codex, drop-in deletion for Copilot).
 
 > The plugin's README recommends a higher-level `ainb hooks install` wrapper; that `ainb hooks` CLI is planned but not yet on `main`, so use `ainb-notifyd install` (above) today.
 
@@ -68,4 +68,4 @@ For **Claude**, the installer shells out to the `claude` plugin CLI — ensuring
 
 ## Source
 
-`plugins/ainb-hooks/` — a thin hook plugin: a manifest plus one `notify.sh` normalizer shared by Claude Code and Codex. Diagram generated via /fireworks-tech-graph.
+`plugins/ainb-hooks/`: a thin hook plugin: a manifest plus one `notify.sh` normalizer shared by Claude Code and Codex. Diagram generated via /fireworks-tech-graph.

--- a/docs/toolkit/plugins/overview.md
+++ b/docs/toolkit/plugins/overview.md
@@ -3,7 +3,7 @@ title: "Claude Code plugins"
 description: "The host-agent plugins this repo ships or documents: reflect, ainb-fleet, ainb-hooks, caveman-stats, and illustration."
 ---
 
-These are **host-agent plugins** — bundles of skills, hooks, and commands that Claude Code, Codex, or Copilot load. They are a different system from [ainb v2 plugins](../../plugins/overview.md), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](../../plugins/README.md) first.
+These are **host-agent plugins**: bundles of skills, hooks, and commands that Claude Code, Codex, or Copilot load. They are a different system from [ainb v2 plugins](/plugins/overview), which are subprocess plugins for the **ainb TUI**. If you're unsure which you want, read the [plugins disambiguation](/plugins/readme) first.
 
 The repo publishes the in-tree Claude Code plugins through `.claude-plugin/marketplace.json` at the repo root; the source lives under `plugins/<name>/`. Add the marketplace, then install:
 
@@ -11,20 +11,20 @@ The repo publishes the in-tree Claude Code plugins through `.claude-plugin/marke
 claude plugin marketplace add https://github.com/stevengonsalvez/agents-in-a-box.git
 claude plugin install ainb-fleet@agents-in-a-box
 
-# (or `stevengonsalvez/agents-in-a-box` shorthand if you have GitHub SSH keys set up —
+# (or `stevengonsalvez/agents-in-a-box` shorthand if you have GitHub SSH keys set up , 
 #  the shorthand resolves to SSH and fails with "Host key verification failed" otherwise)
 ```
 
-> `reflect` is no longer in this marketplace — it was extracted to [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) and ships from that repo's `plugin/` dir (or run `ainb reflect bootstrap`).
+> `reflect` is no longer in this marketplace: it was extracted to [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) and ships from that repo's `plugin/` dir (or run `ainb reflect bootstrap`).
 
 ## The plugins
 
 | Plugin | What it does | Install |
 |---|---|---|
-| [reflect](./reflect.md) | Agent self-improvement + retrieval — captures learnings and auto-injects relevant prior ones at session start. **(extracted → [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory))** | `ainb reflect bootstrap` |
-| [ainb-fleet](./ainb-fleet.md) | LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration (broadcast, sequence, needs, daemon). | `claude plugin install ainb-fleet@agents-in-a-box` |
-| [ainb-hooks](./ainb-hooks.md) | Emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](../../tui/inbox-notifications.md) daemon — host code, not a plugin). | `ainb-notifyd install --claude --codex --copilot` |
-| `caveman-stats` | Lifecycle hooks for caveman mode: statusline token-savings suffix and compaction survival. **Claude-only** — the hook *events* exist in all three harnesses (see matrix), but the code reads Claude session JSONL (`CLAUDE_CONFIG_DIR`) and writes the Claude statusline suffix, and no Codex/Copilot statusline consumes it. | `claude plugin install caveman-stats@agents-in-a-box` |
+| [reflect](/toolkit/plugins/reflect) | Agent self-improvement + retrieval: captures learnings and auto-injects relevant prior ones at session start. **(extracted → [ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory))** | `ainb reflect bootstrap` |
+| [ainb-fleet](/toolkit/plugins/ainb-fleet) | LLM-facing skill bundle teaching agents to drive `ainb fleet …` multi-session orchestration (broadcast, sequence, needs, daemon). | `claude plugin install ainb-fleet@agents-in-a-box` |
+| [ainb-hooks](/toolkit/plugins/ainb-hooks) | Emits Claude Code / Codex / Copilot lifecycle events to the ainb notification inbox (consumed by the [Inbox & notifications](/tui/inbox-notifications) daemon: host code, not a plugin). | `ainb-notifyd install --claude --codex --copilot` |
+| `caveman-stats` | Lifecycle hooks for caveman mode: statusline token-savings suffix and compaction survival. **Claude-only**: the hook *events* exist in all three harnesses (see matrix), but the code reads Claude session JSONL (`CLAUDE_CONFIG_DIR`) and writes the Claude statusline suffix, and no Codex/Copilot statusline consumes it. | `claude plugin install caveman-stats@agents-in-a-box` |
 | `illustration` | Mascot-driven illustration skill bundle; no lifecycle hooks. | `claude plugin install illustration@agents-in-a-box` |
 
 ## Hook parity target

--- a/docs/toolkit/plugins/reflect.md
+++ b/docs/toolkit/plugins/reflect.md
@@ -3,17 +3,17 @@ title: "reflect"
 description: "Claude Code plugin for agent self-improvement: captures corrections as learnings, indexes them, and auto-recalls the relevant ones into every new session."
 ---
 
-`reflect` is a **Claude Code plugin** — it is loaded by Claude Code (Anthropic's plugin system: skills + hooks + commands), not by the ainb TUI. It captures the corrections and design decisions you make in a session as structured learnings, indexes them into a hybrid GraphRAG + BM25 knowledge base, and auto-injects the most relevant prior learnings into every new session. Philosophy: *correct once, never again; recall everything next time.* Current version: **5.2.5** (the ref pinned in `.claude-plugin/marketplace.json`).
+`reflect` is a **Claude Code plugin**: it is loaded by Claude Code (Anthropic's plugin system: skills + hooks + commands), not by the ainb TUI. It captures the corrections and design decisions you make in a session as structured learnings, indexes them into a hybrid GraphRAG + BM25 knowledge base, and auto-injects the most relevant prior learnings into every new session. Philosophy: *correct once, never again; recall everything next time.* Current version: **5.2.5** (the ref pinned in `.claude-plugin/marketplace.json`).
 
 ## How it works
 
-![reflect — how it works](../../assets/diagrams/reflect.svg)
+![reflect: how it works](../../assets/diagrams/reflect.svg)
 
-The plugin manifest registers five lifecycle hooks. **`SessionStart`** runs two commands: `session_start_recall.py` builds a query from the session's cwd, branch, and recent commits and injects the top-3 reranked learnings as `additionalContext`; and `reflect-drain-bg.sh` launches a detached background drainer that processes any reflections queued from prior sessions. **`UserPromptSubmit`** re-runs recall using the actual prompt as a sharper query (with per-session dedupe), and also completes the mini-learning capture — if a tool just failed and the prompt looks like a correction, it writes a low-confidence learning straight to disk without spending an LLM call.
+The plugin manifest registers five lifecycle hooks. **`SessionStart`** runs two commands: `session_start_recall.py` builds a query from the session's cwd, branch, and recent commits and injects the top-3 reranked learnings as `additionalContext`; and `reflect-drain-bg.sh` launches a detached background drainer that processes any reflections queued from prior sessions. **`UserPromptSubmit`** re-runs recall using the actual prompt as a sharper query (with per-session dedupe), and also completes the mini-learning capture: if a tool just failed and the prompt looks like a correction, it writes a low-confidence learning straight to disk without spending an LLM call.
 
-**`PostToolUse`** is the first half of that cheap capture path: when a tool call fails, it arms a watcher so the next `UserPromptSubmit` can detect a correction. **`Stop`** enqueues short sessions (that ended before compaction) for asynchronous reflection, and **`PreCompact`** enqueues long sessions when Claude Code compacts the conversation — both feed the same `~/.reflect/pending_reflections.jsonl` queue, deduped by `session_id`.
+**`PostToolUse`** is the first half of that cheap capture path: when a tool call fails, it arms a watcher so the next `UserPromptSubmit` can detect a correction. **`Stop`** enqueues short sessions (that ended before compaction) for asynchronous reflection, and **`PreCompact`** enqueues long sessions when Claude Code compacts the conversation: both feed the same `~/.reflect/pending_reflections.jsonl` queue, deduped by `session_id`.
 
-Capture and indexing run through the sub-skills. `/reflect` scans a conversation, classifies corrections vs. successes, and writes a Markdown learning note plus a YAML entity sidecar (people, files, libraries, decisions). The background drainer replays queued transcripts through the same `/reflect` skill headlessly. Everything is dual-indexed into **reflect-kb** — nano-graphrag for semantic + entity-graph search and qmd for fast BM25 lexical search — both running locally.
+Capture and indexing run through the sub-skills. `/reflect` scans a conversation, classifies corrections vs. successes, and writes a Markdown learning note plus a YAML entity sidecar (people, files, libraries, decisions). The background drainer replays queued transcripts through the same `/reflect` skill headlessly. Everything is dual-indexed into **reflect-kb**: nano-graphrag for semantic + entity-graph search and qmd for fast BM25 lexical search: both running locally.
 
 Retrieval closes the loop: `/reflect:recall` (the same engine the SessionStart and UserPromptSubmit hooks call automatically) runs hybrid search, reranks by confidence × recency × tag overlap, and surfaces the strongest learnings back into the agent's context before the first token is generated.
 
@@ -23,12 +23,12 @@ Retrieval closes the loop: `/reflect:recall` (the same engine the SessionStart a
 
 | Skill | Purpose |
 |-------|---------|
-| `reflect` | Full conversation scan — detect behavioral corrections and knowledge signals, classify them, write a learning note with an entity sidecar for GraphRAG indexing |
+| `reflect` | Full conversation scan: detect behavioral corrections and knowledge signals, classify them, write a learning note with an entity sidecar for GraphRAG indexing |
 | `reflect:recall` | Retrieve relevant prior learnings from the global KB via hybrid vector + graph search, reranked by confidence, recency, and tag overlap (also runs automatically at SessionStart / UserPromptSubmit) |
-| `reflect:ingest` | The global knowledge indexer — harvest ALL memory sources across tools (Claude, Codex, Copilot, Gemini) into the unified GraphRAG + qmd KB, archiving originals and generating entity sidecars |
-| `reflect:consolidate` | Project-level memory consolidation — merge orphaned worktree memory dirs into a single `.agents/MEMORY.md` (deduplicates and sections; does not index into the global KB) |
-| `reflect:errors-ack` | Triage and acknowledge entries in the reflect errors sink (`~/.reflect/errors.json`) — drain poison, parser crashes, ingest failures, hook timeouts; invoked from the statusline ⚠N badge |
-| `reflect-status` | Read-only metrics — pending reviews, sidecar coverage, GraphRAG health; can approve/reject pending low-confidence items |
+| `reflect:ingest` | The global knowledge indexer: harvest ALL memory sources across tools (Claude, Codex, Copilot, Gemini) into the unified GraphRAG + qmd KB, archiving originals and generating entity sidecars |
+| `reflect:consolidate` | Project-level memory consolidation: merge orphaned worktree memory dirs into a single `.agents/MEMORY.md` (deduplicates and sections; does not index into the global KB) |
+| `reflect:errors-ack` | Triage and acknowledge entries in the reflect errors sink (`~/.reflect/errors.json`): drain poison, parser crashes, ingest failures, hook timeouts; invoked from the statusline ⚠N badge |
+| `reflect-status` | Read-only metrics: pending reviews, sidecar coverage, GraphRAG health; can approve/reject pending low-confidence items |
 
 ### Hooks (registered in `plugin.json`)
 
@@ -42,22 +42,22 @@ Retrieval closes the loop: `/reflect:recall` (the same engine the SessionStart a
 
 ## Install
 
-Reflect is two layers: the plugin (hooks + skills) and the `reflect-kb` CLI (recall/search + qmd + nano-graphrag). Both now ship from the standalone [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) repo (the CLI flattened at the repo root, the plugin under `plugin/`) — they are no longer in the agents-in-a-box monorepo, so `claude plugin install reflect@agents-in-a-box` no longer resolves. The one-step path uses `ainb`:
+Reflect is two layers: the plugin (hooks + skills) and the `reflect-kb` CLI (recall/search + qmd + nano-graphrag). Both now ship from the standalone [stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) repo (the CLI flattened at the repo root, the plugin under `plugin/`): they are no longer in the agents-in-a-box monorepo, so `claude plugin install reflect@agents-in-a-box` no longer resolves. The one-step path uses `ainb`:
 
 ```bash
-# 1. CLI engine (recall/search + qmd + nano-graphrag) — no subdirectory:
+# 1. CLI engine (recall/search + qmd + nano-graphrag): no subdirectory:
 uv tool install --upgrade 'git+https://github.com/stevengonsalvez/ainb-reflect-memory.git[graph]'
 
-# 2. plugin: skills + hooks — install NATIVELY per harness from the new repo's
+# 2. plugin: skills + hooks: install NATIVELY per harness from the new repo's
 #    plugin/ dir (distinct manifests, no conflict). Install per your harness's
 #    plugin runtime / the adapters under plugin/adapters/ (see the repo README).
 
-# 3. everything else in one shot — `ainb reflect bootstrap` auto-installs the
+# 3. everything else in one shot: `ainb reflect bootstrap` auto-installs the
 #    reflect-kb[graph] engine via uv (from the new repo URL above) and prints
 #    any missing system tools (bash>=4, coreutils, jq) for you to run
 ainb reflect bootstrap
 
-# 4. verify — dependency check classified by what needs each tool
+# 4. verify: dependency check classified by what needs each tool
 ainb doctor
 ```
 
@@ -65,7 +65,7 @@ ainb doctor
 
 ### One plugin dir, three native installs
 
-All three harnesses have native plugin runtimes, and the new repo's `plugin/` dir is a valid plugin for each — the manifests live at distinct paths and reference distinct hooks files, so they coexist without conflict:
+All three harnesses have native plugin runtimes, and the new repo's `plugin/` dir is a valid plugin for each: the manifests live at distinct paths and reference distinct hooks files, so they coexist without conflict:
 
 | Harness | Manifest | Hooks file | Hook shape | Install |
 |---|---|---|---|---|
@@ -76,31 +76,31 @@ All three harnesses have native plugin runtimes, and the new repo's `plugin/` di
 (All paths above are relative to the new repo's `plugin/` directory.) Shared (read-only) across all three: `skills/`, `hooks/` scripts, `scripts/`. No default-discovery hooks file (`hooks.json` / `hooks/hooks.json`) exists, so no harness auto-loads the wrong-format file.
 
 Hook status per harness:
-- **Claude Code**: hooks registered via `.claude-plugin/plugin.json` — fully auto-wired when the plugin is installed.
+- **Claude Code**: hooks registered via `.claude-plugin/plugin.json`: fully auto-wired when the plugin is installed.
 - **GitHub Copilot**: `plugin.json` `hooks` field is scaffolded for future use; Copilot's plugin system currently installs skills only (hooks listed as "coming soon" in the `github/copilot-plugins` marketplace). Hooks are wired via the Python adapter (`adapters/copilot/copilot_adapter.py install`), which writes `~/.copilot/hooks/reflect.json` with the correct `version:1` camelCase format. Once Copilot ships hook support, the `copilot-hooks.json` and `${PLUGIN_ROOT}` will be used automatically.
-- **OpenAI Codex**: hooks registered via `.codex-plugin/plugin.json` — auto-wired on install.
+- **OpenAI Codex**: hooks registered via `.codex-plugin/plugin.json`: auto-wired on install.
 
 Copilot does not auto-inject `sessionStart` `additionalContext` into the model context in headless `-p` mode, so on Copilot recall is surfaced via manual `/recall`.
 
 ## Using it
 
 - **Mostly automatic.** Once installed, the SessionStart hook fires `recall` at the start of every new session and surfaces relevant prior learnings before you type. UserPromptSubmit sharpens that with the actual prompt on each turn.
-- **Capture happens for free.** Failed tool calls + correction-shaped follow-ups become low-cost mini-learnings, and short / compacted sessions are queued and drained in the background — no manual step required.
-- **`/reflect`** — run it explicitly to scan the current conversation and write a learning note when you want to capture something deliberately.
-- **`/reflect:recall "<anything>"`** — query the knowledge base on demand.
-- **`/reflect:ingest`** — periodically bulk-index existing memories from any tool into the global KB.
-- **`/reflect:consolidate`** — merge scattered worktree memory dirs into one project `.agents/MEMORY.md`.
-- **`/reflect-status`** — view pipeline metrics, pending reviews, and KB health; approve/reject low-confidence items.
-- **`/reflect:errors-ack`** — triage the errors sink when the statusline shows a ⚠N badge.
+- **Capture happens for free.** Failed tool calls + correction-shaped follow-ups become low-cost mini-learnings, and short / compacted sessions are queued and drained in the background: no manual step required.
+- **`/reflect`**: run it explicitly to scan the current conversation and write a learning note when you want to capture something deliberately.
+- **`/reflect:recall "<anything>"`**: query the knowledge base on demand.
+- **`/reflect:ingest`**: periodically bulk-index existing memories from any tool into the global KB.
+- **`/reflect:consolidate`**: merge scattered worktree memory dirs into one project `.agents/MEMORY.md`.
+- **`/reflect-status`**: view pipeline metrics, pending reviews, and KB health; approve/reject low-confidence items.
+- **`/reflect:errors-ack`**: triage the errors sink when the statusline shows a ⚠N badge.
 
 ## Memory browser
 
 The knowledge base this plugin captures into and recalls from can also be browsed, searched, and
-curated from a local web app — `reflect serve`, part of the `reflect-kb` engine. It reads the same
+curated from a local web app: `reflect serve`, part of the `reflect-kb` engine. It reads the same
 markdown KB the plugin writes to, so archiving or editing confidence there is visible on the next
 recall (after a `reflect reindex`). See the
-[memory browser guide](/knowledge/reflect-memory/serve/) for how to run it.
+[memory browser guide](/knowledge/reflect-memory/serve) for how to run it.
 
 ## Source
 
-[stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory) — Claude Code plugin (skills + lifecycle hooks, under `plugin/`) backed by the `reflect-kb` GraphRAG + qmd library (flattened at the repo root). Extracted out of the agents-in-a-box monorepo into its own repo. Diagram generated via /fireworks-tech-graph.
+[stevengonsalvez/ainb-reflect-memory](https://github.com/stevengonsalvez/ainb-reflect-memory): Claude Code plugin (skills + lifecycle hooks, under `plugin/`) backed by the `reflect-kb` GraphRAG + qmd library (flattened at the repo root). Extracted out of the agents-in-a-box monorepo into its own repo. Diagram generated via /fireworks-tech-graph.

--- a/docs/toolkit/skills.md
+++ b/docs/toolkit/skills.md
@@ -54,4 +54,4 @@ Not yet folded into the grouped lists above: `claude-langfuse` `explain-to-me` `
 
 ## See also
 
-- [Docs hub](../README.md)
+- [Docs hub](/readme)

--- a/docs/tui/architecture.md
+++ b/docs/tui/architecture.md
@@ -112,7 +112,7 @@ crates/ainb-core/src/
 
 ## Plugin runtime
 
-`ainb-plugin-runtime` is the host-side supervisor that loads v2 plugins as native subprocess binaries speaking JSON-RPC over stdio (the `ainb-plugin-protocol` types). Authors build against `ainb-plugin-sdk-rust` and validate with `ainb-plugin-testkit` and the `ainb-plugin-cts-v2` conformance suite. The three in-tree reference plugins — `burndown` (analytics), `notifyd` (notifications), and `session-reader` (data backend) — double as worked examples. Install and inspect plugins via `ainb plugin install|list|lint|watch|tail` (see the [CLI reference](cli.md)).
+`ainb-plugin-runtime` is the host-side supervisor that loads v2 plugins as native subprocess binaries speaking JSON-RPC over stdio (the `ainb-plugin-protocol` types). Authors build against `ainb-plugin-sdk-rust` and validate with `ainb-plugin-testkit` and the `ainb-plugin-cts-v2` conformance suite. The three in-tree reference plugins: `burndown` (analytics), `notifyd` (notifications), and `session-reader` (data backend): double as worked examples. Install and inspect plugins via `ainb plugin install|list|lint|watch|tail` (see the [CLI reference](/tui/cli)).
 
 ## Style guide
 
@@ -122,13 +122,13 @@ Components follow the shared palette in `.claude/skills/tui-screen/SKILL.md`: co
 
 Tests live under `crates/ainb-core/tests/`:
 
-- **Unit + model tests** — `test_app_state.rs`, `test_events.rs`, `test_session_model.rs`, etc.
-- **Behavioral** — `behavioral.rs` and the `behavioral/` suite.
-- **E2E PTY** — `e2e_pty_tests.rs`, `interactive_mode_tests.rs` (real PTY drive).
-- **Tripwires** — `tripwire_*.rs` tmux-driven end-to-end screen assertions (burndown, inbox, crash recovery, new-session, …).
+- **Unit + model tests**: `test_app_state.rs`, `test_events.rs`, `test_session_model.rs`, etc.
+- **Behavioral**: `behavioral.rs` and the `behavioral/` suite.
+- **E2E PTY**: `e2e_pty_tests.rs`, `interactive_mode_tests.rs` (real PTY drive).
+- **Tripwires**: `tripwire_*.rs` tmux-driven end-to-end screen assertions (burndown, inbox, crash recovery, new-session, …).
 
 ## See also
 
-- [Overview](overview.md)
-- [Keyboard shortcuts](keyboard-shortcuts.md)
-- [Docs hub](../README.md)
+- [Overview](/tui/overview)
+- [Keyboard shortcuts](/tui/keyboard-shortcuts)
+- [Docs hub](/readme)

--- a/docs/tui/attach.md
+++ b/docs/tui/attach.md
@@ -65,6 +65,6 @@ Use in-pane attach for quick interventions: answering prompts, confirming comman
 
 ## Next steps
 
-- [Starting a new session](start-session.md): wizard configuration options
-- [Code review diff](code-review.md): inspect file diffs before attaching
-- [Keyboard shortcuts](keyboard-shortcuts.md): all navigation bindings
+- [Starting a new session](/tui/start-session): wizard configuration options
+- [Code review diff](/tui/code-review): inspect file diffs before attaching
+- [Keyboard shortcuts](/tui/keyboard-shortcuts): all navigation bindings

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "ainb CLI Reference"
-description: "Full multi-hierarchy reference for every ainb subcommand — generated from the binary's --help."
+description: "Full multi-hierarchy reference for every ainb subcommand: generated from the binary's --help."
 ---
 
 `ainb` is both an interactive terminal UI and a scriptable, headless CLI. Every
@@ -9,7 +9,7 @@ output, so humans drive it from the dashboard and agents drive it from shell
 scripts. Run `ainb` with no arguments to launch the TUI; use any subcommand
 below for non-interactive work.
 
-> **Generated — do not edit by hand.** This page is produced from the live
+> **Generated: do not edit by hand.** This page is produced from the live
 > binary by [`ainb-tui/scripts/gen-cli-reference.sh`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/ainb-tui/scripts/gen-cli-reference.sh),
 > which walks `ainb <cmd> --help` for every command. CI fails if it drifts, so
 > the output of `ainb --help` stays the source of truth. To update: run the
@@ -20,13 +20,13 @@ below for non-interactive work.
 | Flag | Description |
 |------|-------------|
 | `--format <text\|json\|csv\|markdown>` | Output format for any command (default `text`). `json` is the machine-readable form for scripting/agents. |
-| `-h, --help` | Print help for the command (recursive — works at every level). |
+| `-h, --help` | Print help for the command (recursive: works at every level). |
 | `-V, --version` | Print the build identity (commit + date), or `-V` for the bare semver. |
 
 ## Reading this reference
 
 Each command shows its description followed by the verbatim `ainb <cmd> --help`
-output — including its arguments, flags, and an `EXAMPLES:` block. Groups
+output: including its arguments, flags, and an `EXAMPLES:` block. Groups
 (`config`, `git`, `usage`, `fleet`, `hangar`, …) nest their subcommands as
 sub-sections; recursive help (`ainb <group> <sub> --help`) works for every
 node. The page's right-hand "On this page" panel is the full command tree.
@@ -94,7 +94,7 @@ Options:
       --dangerously-skip-permissions   Skip permission prompts (dangerous!)
       --name <NAME>                    Custom tmux session name (NOT an attach/status/kill handle)
   -i, --interactive                    Run in interactive mode (spawn tmux and attach)
-      --parent <PARENT>                Parent session id — links this session to an orchestrator (e.g. ATC) so its completions route to the parent's durable inbox (event-driven plumbing). Exported into the session as `AINB_PARENT_SESSION`
+      --parent <PARENT>                Parent session id: links this session to an orchestrator (e.g. ATC) so its completions route to the parent's durable inbox (event-driven plumbing). Exported into the session as `AINB_PARENT_SESSION`
   -h, --help                           Print help
 
 EXAMPLES:
@@ -943,10 +943,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -976,10 +976,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1009,10 +1009,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1042,10 +1042,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1075,10 +1075,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -o, --output <OUTPUT>      Output file or directory
   -h, --help                 Print help
 ```
@@ -1131,10 +1131,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1256,10 +1256,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1289,10 +1289,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1322,10 +1322,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1355,10 +1355,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1438,21 +1438,21 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
       --by-task              Emit a per-model × per-activity-category matrix instead of the flat per-model rollup. Rows = model, columns = activity category, cell = (calls, tokens, cost)
   -h, --help                 Print help
 ```
 
 ## `ainb claudecode`
 
-Claude Code-specific commands (statusline, etc.). Provider-namespaced — other providers grow their own.
+Claude Code-specific commands (statusline, etc.). Provider-namespaced: other providers grow their own.
 
 ```console
 $ ainb claudecode --help
-Claude Code-specific commands (statusline, etc.). Provider-namespaced — other providers grow their own.
+Claude Code-specific commands (statusline, etc.). Provider-namespaced: other providers grow their own.
 
 Usage: ainb claudecode [OPTIONS] <COMMAND>
 
@@ -1489,11 +1489,11 @@ Options:
 
 ## `ainb codex`
 
-Codex-specific commands (statusline, etc.). Provider-namespaced — the Codex analog of `claudecode`.
+Codex-specific commands (statusline, etc.). Provider-namespaced: the Codex analog of `claudecode`.
 
 ```console
 $ ainb codex --help
-Codex-specific commands (statusline, etc.). Provider-namespaced — the Codex analog of `claudecode`.
+Codex-specific commands (statusline, etc.). Provider-namespaced: the Codex analog of `claudecode`.
 
 Usage: ainb codex [OPTIONS] <COMMAND>
 
@@ -1718,7 +1718,7 @@ Options:
       --format <format>   Output format [default: text] [possible values: text, json, csv, markdown]
       --listen <ADDR>     Address to bind (default: web.listen, or 127.0.0.1:8420; non-loopback needs --token)
       --token <SECRET>    Bearer token required on every /api/* route (enables non-loopback bind)
-      --insecure-bind     Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface — the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
+      --insecure-bind     Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface: the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
       --read-only         Viewer-only: disable the live terminal write surface (the WS terminal is refused with 403)
       --no-read-only      Serve the write surface for this run, overriding web.read_only
       --no-insecure-bind  Refuse an unauthenticated non-loopback bind for this run, overriding web.insecure_bind
@@ -2059,13 +2059,13 @@ Commands:
   confirm        Guardrail confirm cards: copilot tool calls held for a human
   activity       The append-only copilot activity feed
   sequence       Ordered prompts with ack between steps
-  needs          Center control panel — sessions blocked on input / errors / idle / waiting
+  needs          Center control panel: sessions blocked on input / errors / idle / waiting
   archived       Sessions the daemon retired out of the live roster (still browsable)
   cost           Per-session / model / day / group spend rollups + budget caps
   daemon         DEPRECATED, superseded by `ainb fleet atc`: auto-continues API errors without ATC's per-session retry cap
   daemons        Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
   runtime        Install the standalone Fleet daemon and provider hooks
-  atc            Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
+  atc            Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
   bridge         Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
   enrich-cache   Content-addressed enrich cache (the producer's write path)
   help           Print this message or the help of the given subcommand(s)
@@ -2233,7 +2233,7 @@ Usage: ainb fleet standup [OPTIONS]
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --text             Force text output even with --format json
-      --no-enrich        Skip AI enrichment — 0-token output (env AINB_FLEET_ENRICH=0)
+      --no-enrich        Skip AI enrichment: 0-token output (env AINB_FLEET_ENRICH=0)
   -h, --help             Print help
 ```
 
@@ -2695,18 +2695,18 @@ Options:
 
 ### `ainb fleet needs`
 
-Center control panel — sessions blocked on input / errors / idle / waiting
+Center control panel: sessions blocked on input / errors / idle / waiting
 
 ```console
 $ ainb fleet needs --help
-Center control panel — sessions blocked on input / errors / idle / waiting
+Center control panel: sessions blocked on input / errors / idle / waiting
 
 Usage: ainb fleet needs [OPTIONS]
 
 Options:
       --format <format>      Output format [default: text] [possible values: text, json, csv, markdown]
       --idle-min <idle-min>  Minutes of assistant silence before flagging IDLE (default 5, env AINB_FLEET_IDLE_MIN)
-      --no-enrich            Skip AI enrichment — 0-token HUD (env AINB_FLEET_ENRICH=0)
+      --no-enrich            Skip AI enrichment: 0-token HUD (env AINB_FLEET_ENRICH=0)
   -h, --help                 Print help
 ```
 
@@ -2824,11 +2824,11 @@ Options:
 
 ### `ainb fleet atc`
 
-Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
+Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
 
 ```console
 $ ainb fleet atc --help
-Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
+Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
 
 Usage: ainb fleet atc [OPTIONS] <COMMAND>
 
@@ -3932,7 +3932,7 @@ Run the shared MCP pool daemon (foreground).
 $ ainb mcp daemon --help
 Run the shared MCP pool daemon (foreground).
 
-You rarely run this directly — `ainb run` and the TUI overlay's import auto-start it detached. There is exactly ONE daemon per user, keyed by the control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, so N sessions share ONE child process per server. A second start is a no-op — it detects the live socket (or loses the bind race) and exits.
+You rarely run this directly: `ainb run` and the TUI overlay's import auto-start it detached. There is exactly ONE daemon per user, keyed by the control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, so N sessions share ONE child process per server. A second start is a no-op: it detects the live socket (or loses the bind race) and exits.
 
 Lifecycle: servers spawn lazily on first attach; a server's child is reaped [mcp_pool].idle_grace_secs after its last client detaches (default 300); and the whole daemon exits after [mcp_pool].daemon_idle_grace_secs with no clients anywhere (default 900, 0 = never) so an unused or orphaned pool can't linger.
 
@@ -4051,7 +4051,7 @@ Commands:
   run        Run the daemon in the foreground (default)
   stop       Stop a running daemon via its PID file
   reap       Kill orphan / wedged notifyd processes, sparing the live owner
-  restart    Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+  restart    Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
   install    Install the ainb-hooks hook
   uninstall  Uninstall the ainb-hooks hook
   status     Report install + daemon status
@@ -4116,11 +4116,11 @@ Options:
 
 ### `ainb notifyd restart`
 
-Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
 
 ```console
 $ ainb notifyd restart --help
-Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
+Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
 
 Usage: ainb notifyd restart [OPTIONS]
 
@@ -4270,7 +4270,7 @@ Commands:
   unsubscribe  Unsubscribe an actor from an issue's notifications. Idempotent
   subscribers  List who watches an issue, with the reason each one was subscribed
   react        Add, remove, or list an issue's emoji reactions
-  why          Explain why an issue did (or did not) dispatch — its admission history
+  why          Explain why an issue did (or did not) dispatch: its admission history
   timeline     Show one issue's activity timeline: state changes, assignments, comments
   property     Set or clear one of the workspace's custom properties on an issue
   meta         Read and write an issue's agent metadata scratch bag
@@ -4315,7 +4315,7 @@ Options:
           When set, the issue's assignee is the agent and a `queued` task is enqueued for the agent's runtime, so the daemon's claim loop picks it up, materialises the agent's attached skills (P6.4), and dispatches the provider. The created task id is printed alongside the issue id.
 
       --priority <PRIORITY>
-          Urgency: 0..3 mapping P3..P0 — HIGHER = MORE URGENT (default 0).
+          Urgency: 0..3 mapping P3..P0: HIGHER = MORE URGENT (default 0).
           
           Stamped onto BOTH the created issue and (when `--assign` enqueues one) the task: the daemon's claim loop drains `priority DESC, created_at, id` (reference ordering parity), so a higher value jumps the queue while equal priorities stay FIFO.
           
@@ -4337,12 +4337,12 @@ Options:
           Persisted as the issue's ordered acceptance-criteria list (migration 0048, multica parity); rendered on the detail card's `Acceptance:` block.
 
       --context-ref <CONTEXT_REFS>
-          A context reference — URL / `owner/repo#123` / note (repeatable).
+          A context reference: URL / `owner/repo#123` / note (repeatable).
           
           Persisted as the issue's ordered context-reference list (migration 0048, multica parity); rendered on the detail card's `Context:` block.
 
       --repo <REPO>
-          The repo the run executes in: an absolute checkout path, the literal `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`) — a remote is cloned once into the shared clone cache and the local path persisted, exactly like the board card-create path (migration 0032/0042)
+          The repo the run executes in: an absolute checkout path, the literal `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`): a remote is cloned once into the shared clone cache and the local path persisted, exactly like the board card-create path (migration 0032/0042)
 
       --source-branch <SOURCE_BRANCH>
           The SOURCE branch the run branches FROM (migration 0042); omitted uses the repo's default branch. Persisted on the issue AND the enqueued task
@@ -4363,7 +4363,7 @@ Options:
       --origin-type <ORIGIN_TYPE>
           Provenance of this issue: `autopilot` | `comment_mention` | `manual` (migration 0056, multica parity #21).
           
-          Defaults to `$HANGAR_ORIGIN_TYPE` — the daemon injects it into a dispatched agent's environment, so an issue an agent creates mid-run is attributable back to the comment / autopilot that asked for it. With neither flag nor env, a create is stamped `manual`.
+          Defaults to `$HANGAR_ORIGIN_TYPE`: the daemon injects it into a dispatched agent's environment, so an issue an agent creates mid-run is attributable back to the comment / autopilot that asked for it. With neither flag nor env, a create is stamped `manual`.
 
       --origin-id <ORIGIN_ID>
           The provenance id: the autopilot id for `autopilot`, the comment id for `comment_mention`. REQUIRED for every kind except `manual`.
@@ -4449,7 +4449,7 @@ Options:
           [possible values: text, json, csv, markdown]
 
       --state <STATE>
-          New lifecycle state — one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`; omitted leaves it
+          New lifecycle state: one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`; omitted leaves it
 
       --assign <ASSIGN>
           Reassign the issue to an agent (`agent.id`); omitted leaves the assignee.
@@ -4492,7 +4492,7 @@ Arguments:
 
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
-      --state <STATE>          The lifecycle state applied to EVERY id — one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`
+      --state <STATE>          The lifecycle state applied to EVERY id: one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`
       --workspace <WORKSPACE>  Workspace slug the issues belong to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -4661,11 +4661,11 @@ Options:
 
 #### `ainb hangar issue why`
 
-Explain why an issue did (or did not) dispatch — its admission history
+Explain why an issue did (or did not) dispatch: its admission history
 
 ```console
 $ ainb hangar issue why --help
-Explain why an issue did (or did not) dispatch — its admission history
+Explain why an issue did (or did not) dispatch: its admission history
 
 Usage: ainb hangar issue why [OPTIONS] <ID>
 
@@ -4694,7 +4694,7 @@ Arguments:
 
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
-      --limit <LIMIT>          How many entries to show — the newest window, printed oldest-first [default: 200]
+      --limit <LIMIT>          How many entries to show: the newest window, printed oldest-first [default: 200]
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -4844,7 +4844,7 @@ Walk the mapping table and repair Hangar <-> bd drift
 Usage: ainb hangar beads reconcile [OPTIONS]
 
 Options:
-      --dry-run          Diff only — report drift without writing either side
+      --dry-run          Diff only: report drift without writing either side
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --label <LABEL>    Restrict to bd issues carrying this label (repeatable)
       --json             Emit the reconcile report as JSON instead of a summary line
@@ -5111,8 +5111,8 @@ Manage personal access tokens
 Usage: ainb hangar auth token [OPTIONS] <COMMAND>
 
 Commands:
-  create  Mint a new PAT. Prints the plaintext **once** — it is never recoverable
-  list    List this user's PATs (id, scope, timestamps — never the plaintext)
+  create  Mint a new PAT. Prints the plaintext **once**: it is never recoverable
+  list    List this user's PATs (id, scope, timestamps: never the plaintext)
   revoke  Revoke a PAT by id
   help    Print this message or the help of the given subcommand(s)
 
@@ -5420,7 +5420,7 @@ Options:
       --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
       --description <DESCRIPTION>    Optional short blurb rendered beside the agent (≤255 characters)
       --avatar <AVATAR>              Optional avatar token (e.g. `emoji:🦊`); omitted mints a random emoji
-      --service-tier <SERVICE_TIER>  Optional Codex service tier (e.g. `priority`); omitted inherits the local Codex config. Stored + surfaced only — no dispatch-time override yet
+      --service-tier <SERVICE_TIER>  Optional Codex service tier (e.g. `priority`); omitted inherits the local Codex config. Stored + surfaced only: no dispatch-time override yet
       --workspace <WORKSPACE>        Workspace slug to create the agent in. Defaults to the bootstrapped `default` workspace (created if absent)
   -h, --help                         Print help
 ```
@@ -5467,7 +5467,7 @@ Options:
       --clear-mcp                    Clear the MCP config; omitted leaves it
       --thinking <THINKING>          New thinking level (e.g. `low`/`medium`/`high`); omitted leaves it. Mutually exclusive with `--clear-thinking`
       --clear-thinking               Clear the thinking level; omitted leaves it
-      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history — prefer `--env-stdin` / `--env-file` for secrets
+      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history: prefer `--env-stdin` / `--env-file` for secrets
       --env-stdin                    Read the whole env map from STDIN as a JSON object of string→string, keeping secrets off argv; `{}` clears it and empty input is an ERROR, not a clear
       --env-file <ENV_FILE>          Read the whole env map from a FILE as a JSON object of string→string (same contract as `--env-stdin`)
       --token-budget <TOKEN_BUDGET>  New token budget (rtk/headroom, migration 0042); omitted leaves it. Mutually exclusive with `--clear-token-budget`
@@ -5497,7 +5497,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
-      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner: the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -5517,7 +5517,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
-      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner: the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -5628,7 +5628,7 @@ Commands:
   list      List the workspace's members (email + role)
   set-role  Change a member's role (`owner` / `admin` / `member`)
   remove    Remove a member from the workspace (the user row survives)
-  invite    Invite an email to join (pending until accepted — parity #18)
+  invite    Invite an email to join (pending until accepted: parity #18)
   invites   List the workspace's live pending invitations
   accept    Accept an invitation addressed to you (this is what adds the member)
   decline   Decline an invitation addressed to you (no member is created)
@@ -5750,11 +5750,11 @@ Options:
 
 #### `ainb hangar member invite`
 
-Invite an email to join (pending until accepted — parity #18)
+Invite an email to join (pending until accepted: parity #18)
 
 ```console
 $ ainb hangar member invite --help
-Invite an email to join (pending until accepted — parity #18)
+Invite an email to join (pending until accepted: parity #18)
 
 Usage: ainb hangar member invite [OPTIONS] --email <EMAIL>
 
@@ -5769,7 +5769,7 @@ Options:
           [possible values: text, json, csv, markdown]
 
       --role <ROLE>
-          The role the invitee will hold on accept: `admin` or `member` (default `member`). `owner` parses but is rejected — ownership is transferred, never invited
+          The role the invitee will hold on accept: `admin` or `member` (default `member`). `owner` parses but is rejected: ownership is transferred, never invited
 
           Possible values:
           - owner:  Full administrative control; a workspace must always keep one
@@ -5872,7 +5872,7 @@ Create squads, manage membership, and view squad status + leader
 Usage: ainb hangar squad [OPTIONS] <COMMAND>
 
 Commands:
-  list           List the workspace's squads (name, leader, members) — the status view
+  list           List the workspace's squads (name, leader, members): the status view
   create         Create a squad with a leader actor-ref (`agent:<id>` / `member:<id>`)
   add-member     Add a member actor to a squad (`agent:<id>` / `member:<id>`)
   remove-member  Remove a member actor from a squad (`agent:<id>` / `member:<id>`)
@@ -5891,11 +5891,11 @@ Options:
 
 #### `ainb hangar squad list`
 
-List the workspace's squads (name, leader, members) — the status view
+List the workspace's squads (name, leader, members): the status view
 
 ```console
 $ ainb hangar squad list --help
-List the workspace's squads (name, leader, members) — the status view
+List the workspace's squads (name, leader, members): the status view
 
 Usage: ainb hangar squad list [OPTIONS]
 
@@ -5989,7 +5989,7 @@ Options:
       --priority <PRIORITY>    Claim urgency (0..3, higher = more urgent). Defaults to `0` (routine) [default: 0]
       --fanout                 Dispatch through the squad. Enqueues the card into the first role-gated pipeline column, where ONE eligible agent takes it (no longer one run per member)
       --redundant <N>          Deliberately run this issue N times in parallel on up to N distinct squad agents, all stamped with one shared `run_group`. Omitted or `1` is a single owner
-      --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner — the ordinary single-operator assign, which the gate always admits
+      --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner: the ordinary single-operator assign, which the gate always admits
       --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -6118,7 +6118,7 @@ Commands:
   webhook       Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
   deliveries    List the autopilot's recent webhook deliveries (audit log)
   collaborator  Manage the rule's explicit WRITE-GRANT set (multica parity #27)
-  subscriber    Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+  subscriber    Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
   access        Open or restrict who may WRITE this rule (multica parity #27)
   help          Print this message or the help of the given subcommand(s)
 
@@ -6148,7 +6148,7 @@ Options:
           Name, unique within the workspace
 
       --cron <CRON>
-          Cron expression (UTC, 5-field) — validated before insert
+          Cron expression (UTC, 5-field): validated before insert
 
       --agent <AGENT>
           Agent id to dispatch to at each tick (`agent.id`)
@@ -6181,7 +6181,7 @@ Options:
           [default: skip]
 
       --as-user <AS_USER>
-          The ACCOUNTABLE HUMAN for this rule (`user.id` or email). Recorded on rule-version v1, which creation writes in the same transaction. Omitted defaults to the local human (`member:me`) — a CLI create always has a human at the keyboard
+          The ACCOUNTABLE HUMAN for this rule (`user.id` or email). Recorded on rule-version v1, which creation writes in the same transaction. Omitted defaults to the local human (`member:me`): a CLI create always has a human at the keyboard
 
       --workspace <WORKSPACE>
           Workspace slug to create in. Defaults to the bootstrapped `default`
@@ -6273,7 +6273,7 @@ Options:
           New display name (cosmetic on its own)
 
       --cron <CRON>
-          New cron expression (UTC, 5-field) — revalidated before any write
+          New cron expression (UTC, 5-field): revalidated before any write
 
       --agent <AGENT>
           Re-target the rule at a different agent (`agent.id`)
@@ -6303,7 +6303,7 @@ Options:
           - replace: Supersede the in-flight run and fire fresh
 
       --as-user <AS_USER>
-          The ACCOUNTABLE HUMAN for this edit (`user.id` or email) — the name recorded on the minted rule version. Defaults to the local human (`member:me`)
+          The ACCOUNTABLE HUMAN for this edit (`user.id` or email): the name recorded on the minted rule version. Defaults to the local human (`member:me`)
 
       --workspace <WORKSPACE>
           Workspace slug the autopilot belongs to. Defaults to `default`
@@ -6363,7 +6363,7 @@ Options:
           [default: manual]
 
       --as-user <AS_USER>
-          The human firing it (`user.id` or email). A `manual` run attributes to this human (`direct_human`) — them, not the rule's owner. An `api` run stays UNATTENDED (`rule_owner`), matching multica. Defaults to the local human (`member:me`)
+          The human firing it (`user.id` or email). A `manual` run attributes to this human (`direct_human`): them, not the rule's owner. An `api` run stays UNATTENDED (`rule_owner`), matching multica. Defaults to the local human (`member:me`)
 
       --workspace <WORKSPACE>
           Workspace slug the autopilot belongs to. Defaults to `default`
@@ -6480,11 +6480,11 @@ Options:
 
 #### `ainb hangar autopilot subscriber`
 
-Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
 
 ```console
 $ ainb hangar autopilot subscriber --help
-Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
+Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
 
 Usage: ainb hangar autopilot subscriber [OPTIONS] <COMMAND>
 
@@ -6512,7 +6512,7 @@ Usage: ainb hangar autopilot access [OPTIONS] --id <ID> --mode <MODE>
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --id <ID>                The autopilot id (`autopilot.id`)
-      --mode <MODE>            `open` (any actor in the workspace may write — the default and every pre-0064 rule) or `restricted` (owner / workspace owner+admin / an explicit `editor` collaborator only)
+      --mode <MODE>            `open` (any actor in the workspace may write: the default and every pre-0064 rule) or `restricted` (owner / workspace owner+admin / an explicit `editor` collaborator only)
       --as-user <AS_USER>      The acting human (write gate subject + rule-version attribution)
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
@@ -6597,7 +6597,7 @@ Options:
       --repo-whitelist <REPO_WHITELIST>
           Set the repo whitelist as a comma-separated list of `owner/name` slugs (e.g. `org/api,org/web`). The empty string sets a configured-but-empty whitelist (allows nothing); use `--clear-repo-whitelist` to remove the gate
       --clear-repo-whitelist
-          Unset the repo whitelist (no gate — every repo allowed)
+          Unset the repo whitelist (no gate: every repo allowed)
       --workspace <WORKSPACE>
           Workspace slug to configure. Defaults to the bootstrapped `default` workspace
   -h, --help
@@ -6770,7 +6770,7 @@ Options:
       --issue <ISSUE>          Issue id (ULID) to comment on
       --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
       --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
-      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
+      --parent <PARENT>        The comment this one replies to: drives the reply-parent fallback and multica's parent-mention inheritance
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -6790,7 +6790,7 @@ Options:
       --issue <ISSUE>          Issue id (ULID) to comment on
       --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
       --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
-      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
+      --parent <PARENT>        The comment this one replies to: drives the reply-parent fallback and multica's parent-mention inheritance
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -7105,7 +7105,7 @@ Options:
 
 The skill-manager commands (`skill`, `source`, `search`, `migrate`) are
 intercepted before clap and routed to the unit manager; they are documented in
-their own section under [Skill manager](../skill-manager/guide) and surfaced in
+their own section under [Skill manager](/skill-manager/guide) and surfaced in
 `ainb --help` under "SKILL MANAGER". Run `ainb skill --help` for the full verb
 list.
 
@@ -7114,10 +7114,10 @@ list.
 A few commands are hidden from `ainb --help` because they are internal
 daemon/hook entrypoints rather than everyday verbs. Run `<cmd> --help` for each:
 
-- `ainb notifyd <run|stop|install|uninstall|status|list>` — the ainb-hooks
+- `ainb notifyd <run|stop|install|uninstall|status|list>`: the ainb-hooks
   notification daemon. `ainb notifyd list [--format json]` reads persisted
   notifications headlessly; the TUI Inbox is the interactive view.
-- `ainb statusline` — legacy Claude Code statusline alias (prefer
+- `ainb statusline`: legacy Claude Code statusline alias (prefer
   `ainb claudecode statusline`).
 
 ## Exit codes

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "ainb CLI Reference"
-description: "Full multi-hierarchy reference for every ainb subcommand: generated from the binary's --help."
+description: "Full multi-hierarchy reference for every ainb subcommand — generated from the binary's --help."
 ---
 
 `ainb` is both an interactive terminal UI and a scriptable, headless CLI. Every
@@ -9,7 +9,7 @@ output, so humans drive it from the dashboard and agents drive it from shell
 scripts. Run `ainb` with no arguments to launch the TUI; use any subcommand
 below for non-interactive work.
 
-> **Generated: do not edit by hand.** This page is produced from the live
+> **Generated — do not edit by hand.** This page is produced from the live
 > binary by [`ainb-tui/scripts/gen-cli-reference.sh`](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/ainb-tui/scripts/gen-cli-reference.sh),
 > which walks `ainb <cmd> --help` for every command. CI fails if it drifts, so
 > the output of `ainb --help` stays the source of truth. To update: run the
@@ -20,13 +20,13 @@ below for non-interactive work.
 | Flag | Description |
 |------|-------------|
 | `--format <text\|json\|csv\|markdown>` | Output format for any command (default `text`). `json` is the machine-readable form for scripting/agents. |
-| `-h, --help` | Print help for the command (recursive: works at every level). |
+| `-h, --help` | Print help for the command (recursive — works at every level). |
 | `-V, --version` | Print the build identity (commit + date), or `-V` for the bare semver. |
 
 ## Reading this reference
 
 Each command shows its description followed by the verbatim `ainb <cmd> --help`
-output: including its arguments, flags, and an `EXAMPLES:` block. Groups
+output — including its arguments, flags, and an `EXAMPLES:` block. Groups
 (`config`, `git`, `usage`, `fleet`, `hangar`, …) nest their subcommands as
 sub-sections; recursive help (`ainb <group> <sub> --help`) works for every
 node. The page's right-hand "On this page" panel is the full command tree.
@@ -94,7 +94,7 @@ Options:
       --dangerously-skip-permissions   Skip permission prompts (dangerous!)
       --name <NAME>                    Custom tmux session name (NOT an attach/status/kill handle)
   -i, --interactive                    Run in interactive mode (spawn tmux and attach)
-      --parent <PARENT>                Parent session id: links this session to an orchestrator (e.g. ATC) so its completions route to the parent's durable inbox (event-driven plumbing). Exported into the session as `AINB_PARENT_SESSION`
+      --parent <PARENT>                Parent session id — links this session to an orchestrator (e.g. ATC) so its completions route to the parent's durable inbox (event-driven plumbing). Exported into the session as `AINB_PARENT_SESSION`
   -h, --help                           Print help
 
 EXAMPLES:
@@ -943,10 +943,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -976,10 +976,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1009,10 +1009,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1042,10 +1042,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1075,10 +1075,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -o, --output <OUTPUT>      Output file or directory
   -h, --help                 Print help
 ```
@@ -1131,10 +1131,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1256,10 +1256,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1289,10 +1289,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1322,10 +1322,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1355,10 +1355,10 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
   -h, --help                 Print help
 ```
 
@@ -1438,21 +1438,21 @@ Options:
       --hard                 Hard refresh: wipe the parse cache and stable rollup, then rebuild everything from source before reporting. CPU-heavy on large histories; the flag itself is the explicit opt-in (no interactive prompt, safe for pipes/scripts)
       --project <PROJECT>    Drill into a single project (exact match). Repeatable
       --model <MODEL>        Drill into a single model (exact match). Repeatable
-      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc.: see ActivityCategory::label). Repeatable
+      --activity <ACTIVITY>  Drill into one activity category (Coding, Conversation, Git, etc. — see ActivityCategory::label). Repeatable
       --session <SESSION>    Drill into a single session id. Repeatable
       --branch <BRANCH>      Drill into a single git branch (exact match against `gitBranch` on Claude turns). Repeatable. Codex turns have no recorded branch and are excluded by any non-empty `--branch` filter
-      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap": emit every row [default: 8]
+      --top <TOP>            Cap the long By-Project / By-Activity / By-Model tables at N rows (default 8 mirrors the historical hard-coded slice). Applies to report, today, month, and export subcommands across every format. 0 means "no cap" — emit every row [default: 8]
       --by-task              Emit a per-model × per-activity-category matrix instead of the flat per-model rollup. Rows = model, columns = activity category, cell = (calls, tokens, cost)
   -h, --help                 Print help
 ```
 
 ## `ainb claudecode`
 
-Claude Code-specific commands (statusline, etc.). Provider-namespaced: other providers grow their own.
+Claude Code-specific commands (statusline, etc.). Provider-namespaced — other providers grow their own.
 
 ```console
 $ ainb claudecode --help
-Claude Code-specific commands (statusline, etc.). Provider-namespaced: other providers grow their own.
+Claude Code-specific commands (statusline, etc.). Provider-namespaced — other providers grow their own.
 
 Usage: ainb claudecode [OPTIONS] <COMMAND>
 
@@ -1489,11 +1489,11 @@ Options:
 
 ## `ainb codex`
 
-Codex-specific commands (statusline, etc.). Provider-namespaced: the Codex analog of `claudecode`.
+Codex-specific commands (statusline, etc.). Provider-namespaced — the Codex analog of `claudecode`.
 
 ```console
 $ ainb codex --help
-Codex-specific commands (statusline, etc.). Provider-namespaced: the Codex analog of `claudecode`.
+Codex-specific commands (statusline, etc.). Provider-namespaced — the Codex analog of `claudecode`.
 
 Usage: ainb codex [OPTIONS] <COMMAND>
 
@@ -1718,7 +1718,7 @@ Options:
       --format <format>   Output format [default: text] [possible values: text, json, csv, markdown]
       --listen <ADDR>     Address to bind (default: web.listen, or 127.0.0.1:8420; non-loopback needs --token)
       --token <SECRET>    Bearer token required on every /api/* route (enables non-loopback bind)
-      --insecure-bind     Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface: the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
+      --insecure-bind     Allow a non-loopback bind with no token. DANGEROUS: an unauthenticated bind exposes a control surface — the live WS terminal is interactive shell access to every fleet session. Only honored with --read-only (terminal disabled); otherwise refused. Use --token instead to expose the write surface safely
       --read-only         Viewer-only: disable the live terminal write surface (the WS terminal is refused with 403)
       --no-read-only      Serve the write surface for this run, overriding web.read_only
       --no-insecure-bind  Refuse an unauthenticated non-loopback bind for this run, overriding web.insecure_bind
@@ -2059,13 +2059,13 @@ Commands:
   confirm        Guardrail confirm cards: copilot tool calls held for a human
   activity       The append-only copilot activity feed
   sequence       Ordered prompts with ack between steps
-  needs          Center control panel: sessions blocked on input / errors / idle / waiting
+  needs          Center control panel — sessions blocked on input / errors / idle / waiting
   archived       Sessions the daemon retired out of the live roster (still browsable)
   cost           Per-session / model / day / group spend rollups + budget caps
   daemon         DEPRECATED, superseded by `ainb fleet atc`: auto-continues API errors without ATC's per-session retry cap
   daemons        Unified runtime health of every long-running daemon (phone bridge / notifyd / ATC / fleet daemon)
   runtime        Install the standalone Fleet daemon and provider hooks
-  atc            Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
+  atc            Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
   bridge         Native phone bridge (Telegram + Slack): relay messages two-way to ainb sessions
   enrich-cache   Content-addressed enrich cache (the producer's write path)
   help           Print this message or the help of the given subcommand(s)
@@ -2233,7 +2233,7 @@ Usage: ainb fleet standup [OPTIONS]
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --text             Force text output even with --format json
-      --no-enrich        Skip AI enrichment: 0-token output (env AINB_FLEET_ENRICH=0)
+      --no-enrich        Skip AI enrichment — 0-token output (env AINB_FLEET_ENRICH=0)
   -h, --help             Print help
 ```
 
@@ -2695,18 +2695,18 @@ Options:
 
 ### `ainb fleet needs`
 
-Center control panel: sessions blocked on input / errors / idle / waiting
+Center control panel — sessions blocked on input / errors / idle / waiting
 
 ```console
 $ ainb fleet needs --help
-Center control panel: sessions blocked on input / errors / idle / waiting
+Center control panel — sessions blocked on input / errors / idle / waiting
 
 Usage: ainb fleet needs [OPTIONS]
 
 Options:
       --format <format>      Output format [default: text] [possible values: text, json, csv, markdown]
       --idle-min <idle-min>  Minutes of assistant silence before flagging IDLE (default 5, env AINB_FLEET_IDLE_MIN)
-      --no-enrich            Skip AI enrichment: 0-token HUD (env AINB_FLEET_ENRICH=0)
+      --no-enrich            Skip AI enrichment — 0-token HUD (env AINB_FLEET_ENRICH=0)
   -h, --help                 Print help
 ```
 
@@ -2824,11 +2824,11 @@ Options:
 
 ### `ainb fleet atc`
 
-Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
+Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
 
 ```console
 $ ainb fleet atc --help
-Air Traffic Control: the persistent fleet brain (setup / status / list / repair / teardown)
+Air Traffic Control — the persistent fleet brain (setup / status / list / repair / teardown)
 
 Usage: ainb fleet atc [OPTIONS] <COMMAND>
 
@@ -3932,7 +3932,7 @@ Run the shared MCP pool daemon (foreground).
 $ ainb mcp daemon --help
 Run the shared MCP pool daemon (foreground).
 
-You rarely run this directly: `ainb run` and the TUI overlay's import auto-start it detached. There is exactly ONE daemon per user, keyed by the control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, so N sessions share ONE child process per server. A second start is a no-op: it detects the live socket (or loses the bind race) and exits.
+You rarely run this directly — `ainb run` and the TUI overlay's import auto-start it detached. There is exactly ONE daemon per user, keyed by the control socket at ~/.agents-in-a-box/mcp/sockets/control.sock: every `ainb` instance (and Codex/Copilot sessions wired via `ainb mcp install`) shares it, so N sessions share ONE child process per server. A second start is a no-op — it detects the live socket (or loses the bind race) and exits.
 
 Lifecycle: servers spawn lazily on first attach; a server's child is reaped [mcp_pool].idle_grace_secs after its last client detaches (default 300); and the whole daemon exits after [mcp_pool].daemon_idle_grace_secs with no clients anywhere (default 900, 0 = never) so an unused or orphaned pool can't linger.
 
@@ -4051,7 +4051,7 @@ Commands:
   run        Run the daemon in the foreground (default)
   stop       Stop a running daemon via its PID file
   reap       Kill orphan / wedged notifyd processes, sparing the live owner
-  restart    Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
+  restart    Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
   install    Install the ainb-hooks hook
   uninstall  Uninstall the ainb-hooks hook
   status     Report install + daemon status
@@ -4116,11 +4116,11 @@ Options:
 
 ### `ainb notifyd restart`
 
-Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
+Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
 
 ```console
 $ ainb notifyd restart --help
-Stop, reap, and respawn the daemon: the single resume/repair command for a dead or wedged approve socket
+Stop, reap, and respawn the daemon — the single resume/repair command for a dead or wedged approve socket
 
 Usage: ainb notifyd restart [OPTIONS]
 
@@ -4270,7 +4270,7 @@ Commands:
   unsubscribe  Unsubscribe an actor from an issue's notifications. Idempotent
   subscribers  List who watches an issue, with the reason each one was subscribed
   react        Add, remove, or list an issue's emoji reactions
-  why          Explain why an issue did (or did not) dispatch: its admission history
+  why          Explain why an issue did (or did not) dispatch — its admission history
   timeline     Show one issue's activity timeline: state changes, assignments, comments
   property     Set or clear one of the workspace's custom properties on an issue
   meta         Read and write an issue's agent metadata scratch bag
@@ -4315,7 +4315,7 @@ Options:
           When set, the issue's assignee is the agent and a `queued` task is enqueued for the agent's runtime, so the daemon's claim loop picks it up, materialises the agent's attached skills (P6.4), and dispatches the provider. The created task id is printed alongside the issue id.
 
       --priority <PRIORITY>
-          Urgency: 0..3 mapping P3..P0: HIGHER = MORE URGENT (default 0).
+          Urgency: 0..3 mapping P3..P0 — HIGHER = MORE URGENT (default 0).
           
           Stamped onto BOTH the created issue and (when `--assign` enqueues one) the task: the daemon's claim loop drains `priority DESC, created_at, id` (reference ordering parity), so a higher value jumps the queue while equal priorities stay FIFO.
           
@@ -4337,12 +4337,12 @@ Options:
           Persisted as the issue's ordered acceptance-criteria list (migration 0048, multica parity); rendered on the detail card's `Acceptance:` block.
 
       --context-ref <CONTEXT_REFS>
-          A context reference: URL / `owner/repo#123` / note (repeatable).
+          A context reference — URL / `owner/repo#123` / note (repeatable).
           
           Persisted as the issue's ordered context-reference list (migration 0048, multica parity); rendered on the detail card's `Context:` block.
 
       --repo <REPO>
-          The repo the run executes in: an absolute checkout path, the literal `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`): a remote is cloned once into the shared clone cache and the local path persisted, exactly like the board card-create path (migration 0032/0042)
+          The repo the run executes in: an absolute checkout path, the literal `scratch`, or a REMOTE (`owner/repo`, a full URL, or `git@…`) — a remote is cloned once into the shared clone cache and the local path persisted, exactly like the board card-create path (migration 0032/0042)
 
       --source-branch <SOURCE_BRANCH>
           The SOURCE branch the run branches FROM (migration 0042); omitted uses the repo's default branch. Persisted on the issue AND the enqueued task
@@ -4363,7 +4363,7 @@ Options:
       --origin-type <ORIGIN_TYPE>
           Provenance of this issue: `autopilot` | `comment_mention` | `manual` (migration 0056, multica parity #21).
           
-          Defaults to `$HANGAR_ORIGIN_TYPE`: the daemon injects it into a dispatched agent's environment, so an issue an agent creates mid-run is attributable back to the comment / autopilot that asked for it. With neither flag nor env, a create is stamped `manual`.
+          Defaults to `$HANGAR_ORIGIN_TYPE` — the daemon injects it into a dispatched agent's environment, so an issue an agent creates mid-run is attributable back to the comment / autopilot that asked for it. With neither flag nor env, a create is stamped `manual`.
 
       --origin-id <ORIGIN_ID>
           The provenance id: the autopilot id for `autopilot`, the comment id for `comment_mention`. REQUIRED for every kind except `manual`.
@@ -4449,7 +4449,7 @@ Options:
           [possible values: text, json, csv, markdown]
 
       --state <STATE>
-          New lifecycle state: one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`; omitted leaves it
+          New lifecycle state — one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`; omitted leaves it
 
       --assign <ASSIGN>
           Reassign the issue to an agent (`agent.id`); omitted leaves the assignee.
@@ -4492,7 +4492,7 @@ Arguments:
 
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
-      --state <STATE>          The lifecycle state applied to EVERY id: one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`
+      --state <STATE>          The lifecycle state applied to EVERY id — one of `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`
       --workspace <WORKSPACE>  Workspace slug the issues belong to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -4661,11 +4661,11 @@ Options:
 
 #### `ainb hangar issue why`
 
-Explain why an issue did (or did not) dispatch: its admission history
+Explain why an issue did (or did not) dispatch — its admission history
 
 ```console
 $ ainb hangar issue why --help
-Explain why an issue did (or did not) dispatch: its admission history
+Explain why an issue did (or did not) dispatch — its admission history
 
 Usage: ainb hangar issue why [OPTIONS] <ID>
 
@@ -4694,7 +4694,7 @@ Arguments:
 
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
-      --limit <LIMIT>          How many entries to show: the newest window, printed oldest-first [default: 200]
+      --limit <LIMIT>          How many entries to show — the newest window, printed oldest-first [default: 200]
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -4844,7 +4844,7 @@ Walk the mapping table and repair Hangar <-> bd drift
 Usage: ainb hangar beads reconcile [OPTIONS]
 
 Options:
-      --dry-run          Diff only: report drift without writing either side
+      --dry-run          Diff only — report drift without writing either side
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
       --label <LABEL>    Restrict to bd issues carrying this label (repeatable)
       --json             Emit the reconcile report as JSON instead of a summary line
@@ -5111,8 +5111,8 @@ Manage personal access tokens
 Usage: ainb hangar auth token [OPTIONS] <COMMAND>
 
 Commands:
-  create  Mint a new PAT. Prints the plaintext **once**: it is never recoverable
-  list    List this user's PATs (id, scope, timestamps: never the plaintext)
+  create  Mint a new PAT. Prints the plaintext **once** — it is never recoverable
+  list    List this user's PATs (id, scope, timestamps — never the plaintext)
   revoke  Revoke a PAT by id
   help    Print this message or the help of the given subcommand(s)
 
@@ -5420,7 +5420,7 @@ Options:
       --instructions <INSTRUCTIONS>  Optional instructions / system prompt for the agent
       --description <DESCRIPTION>    Optional short blurb rendered beside the agent (≤255 characters)
       --avatar <AVATAR>              Optional avatar token (e.g. `emoji:🦊`); omitted mints a random emoji
-      --service-tier <SERVICE_TIER>  Optional Codex service tier (e.g. `priority`); omitted inherits the local Codex config. Stored + surfaced only: no dispatch-time override yet
+      --service-tier <SERVICE_TIER>  Optional Codex service tier (e.g. `priority`); omitted inherits the local Codex config. Stored + surfaced only — no dispatch-time override yet
       --workspace <WORKSPACE>        Workspace slug to create the agent in. Defaults to the bootstrapped `default` workspace (created if absent)
   -h, --help                         Print help
 ```
@@ -5467,7 +5467,7 @@ Options:
       --clear-mcp                    Clear the MCP config; omitted leaves it
       --thinking <THINKING>          New thinking level (e.g. `low`/`medium`/`high`); omitted leaves it. Mutually exclusive with `--clear-thinking`
       --clear-thinking               Clear the thinking level; omitted leaves it
-      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history: prefer `--env-stdin` / `--env-file` for secrets
+      --env <ENV>                    A `KEY=VALUE` env var for the agent (repeatable; ANY `--env` REPLACES the whole map). Visible in `ps` / shell history — prefer `--env-stdin` / `--env-file` for secrets
       --env-stdin                    Read the whole env map from STDIN as a JSON object of string→string, keeping secrets off argv; `{}` clears it and empty input is an ERROR, not a clear
       --env-file <ENV_FILE>          Read the whole env map from a FILE as a JSON object of string→string (same contract as `--env-stdin`)
       --token-budget <TOKEN_BUDGET>  New token budget (rtk/headroom, migration 0042); omitted leaves it. Mutually exclusive with `--clear-token-budget`
@@ -5497,7 +5497,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
-      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner: the ordinary single-operator archive
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -5517,7 +5517,7 @@ Arguments:
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --workspace <WORKSPACE>  Workspace slug the agent belongs to. Defaults to the bootstrapped `default` workspace
-      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner: the ordinary single-operator archive
+      --by <BY>                The `user.id` recorded as the archiving actor (migration 0052). Omitted defaults to the workspace owner — the ordinary single-operator archive
   -h, --help                   Print help
 ```
 
@@ -5628,7 +5628,7 @@ Commands:
   list      List the workspace's members (email + role)
   set-role  Change a member's role (`owner` / `admin` / `member`)
   remove    Remove a member from the workspace (the user row survives)
-  invite    Invite an email to join (pending until accepted: parity #18)
+  invite    Invite an email to join (pending until accepted — parity #18)
   invites   List the workspace's live pending invitations
   accept    Accept an invitation addressed to you (this is what adds the member)
   decline   Decline an invitation addressed to you (no member is created)
@@ -5750,11 +5750,11 @@ Options:
 
 #### `ainb hangar member invite`
 
-Invite an email to join (pending until accepted: parity #18)
+Invite an email to join (pending until accepted — parity #18)
 
 ```console
 $ ainb hangar member invite --help
-Invite an email to join (pending until accepted: parity #18)
+Invite an email to join (pending until accepted — parity #18)
 
 Usage: ainb hangar member invite [OPTIONS] --email <EMAIL>
 
@@ -5769,7 +5769,7 @@ Options:
           [possible values: text, json, csv, markdown]
 
       --role <ROLE>
-          The role the invitee will hold on accept: `admin` or `member` (default `member`). `owner` parses but is rejected: ownership is transferred, never invited
+          The role the invitee will hold on accept: `admin` or `member` (default `member`). `owner` parses but is rejected — ownership is transferred, never invited
 
           Possible values:
           - owner:  Full administrative control; a workspace must always keep one
@@ -5872,7 +5872,7 @@ Create squads, manage membership, and view squad status + leader
 Usage: ainb hangar squad [OPTIONS] <COMMAND>
 
 Commands:
-  list           List the workspace's squads (name, leader, members): the status view
+  list           List the workspace's squads (name, leader, members) — the status view
   create         Create a squad with a leader actor-ref (`agent:<id>` / `member:<id>`)
   add-member     Add a member actor to a squad (`agent:<id>` / `member:<id>`)
   remove-member  Remove a member actor from a squad (`agent:<id>` / `member:<id>`)
@@ -5891,11 +5891,11 @@ Options:
 
 #### `ainb hangar squad list`
 
-List the workspace's squads (name, leader, members): the status view
+List the workspace's squads (name, leader, members) — the status view
 
 ```console
 $ ainb hangar squad list --help
-List the workspace's squads (name, leader, members): the status view
+List the workspace's squads (name, leader, members) — the status view
 
 Usage: ainb hangar squad list [OPTIONS]
 
@@ -5989,7 +5989,7 @@ Options:
       --priority <PRIORITY>    Claim urgency (0..3, higher = more urgent). Defaults to `0` (routine) [default: 0]
       --fanout                 Dispatch through the squad. Enqueues the card into the first role-gated pipeline column, where ONE eligible agent takes it (no longer one run per member)
       --redundant <N>          Deliberately run this issue N times in parallel on up to N distinct squad agents, all stamped with one shared `run_group`. Omitted or `1` is a single owner
-      --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner: the ordinary single-operator assign, which the gate always admits
+      --invoker <INVOKER>      The user the invocation-permission gate judges this assignment by (a user id or an email). Omitted defaults to the workspace owner — the ordinary single-operator assign, which the gate always admits
       --workspace <WORKSPACE>  Workspace slug the squad belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -6118,7 +6118,7 @@ Commands:
   webhook       Configure the HTTP webhook trigger (enable/disable, rotate secret, filter)
   deliveries    List the autopilot's recent webhook deliveries (audit log)
   collaborator  Manage the rule's explicit WRITE-GRANT set (multica parity #27)
-  subscriber    Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
+  subscriber    Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
   access        Open or restrict who may WRITE this rule (multica parity #27)
   help          Print this message or the help of the given subcommand(s)
 
@@ -6148,7 +6148,7 @@ Options:
           Name, unique within the workspace
 
       --cron <CRON>
-          Cron expression (UTC, 5-field): validated before insert
+          Cron expression (UTC, 5-field) — validated before insert
 
       --agent <AGENT>
           Agent id to dispatch to at each tick (`agent.id`)
@@ -6181,7 +6181,7 @@ Options:
           [default: skip]
 
       --as-user <AS_USER>
-          The ACCOUNTABLE HUMAN for this rule (`user.id` or email). Recorded on rule-version v1, which creation writes in the same transaction. Omitted defaults to the local human (`member:me`): a CLI create always has a human at the keyboard
+          The ACCOUNTABLE HUMAN for this rule (`user.id` or email). Recorded on rule-version v1, which creation writes in the same transaction. Omitted defaults to the local human (`member:me`) — a CLI create always has a human at the keyboard
 
       --workspace <WORKSPACE>
           Workspace slug to create in. Defaults to the bootstrapped `default`
@@ -6273,7 +6273,7 @@ Options:
           New display name (cosmetic on its own)
 
       --cron <CRON>
-          New cron expression (UTC, 5-field): revalidated before any write
+          New cron expression (UTC, 5-field) — revalidated before any write
 
       --agent <AGENT>
           Re-target the rule at a different agent (`agent.id`)
@@ -6303,7 +6303,7 @@ Options:
           - replace: Supersede the in-flight run and fire fresh
 
       --as-user <AS_USER>
-          The ACCOUNTABLE HUMAN for this edit (`user.id` or email): the name recorded on the minted rule version. Defaults to the local human (`member:me`)
+          The ACCOUNTABLE HUMAN for this edit (`user.id` or email) — the name recorded on the minted rule version. Defaults to the local human (`member:me`)
 
       --workspace <WORKSPACE>
           Workspace slug the autopilot belongs to. Defaults to `default`
@@ -6363,7 +6363,7 @@ Options:
           [default: manual]
 
       --as-user <AS_USER>
-          The human firing it (`user.id` or email). A `manual` run attributes to this human (`direct_human`): them, not the rule's owner. An `api` run stays UNATTENDED (`rule_owner`), matching multica. Defaults to the local human (`member:me`)
+          The human firing it (`user.id` or email). A `manual` run attributes to this human (`direct_human`) — them, not the rule's owner. An `api` run stays UNATTENDED (`rule_owner`), matching multica. Defaults to the local human (`member:me`)
 
       --workspace <WORKSPACE>
           Workspace slug the autopilot belongs to. Defaults to `default`
@@ -6480,11 +6480,11 @@ Options:
 
 #### `ainb hangar autopilot subscriber`
 
-Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
+Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
 
 ```console
 $ ainb hangar autopilot subscriber --help
-Manage the rule's STANDING subscriber list: every issue the rule spawns auto-subscribes it (multica parity #27)
+Manage the rule's STANDING subscriber list — every issue the rule spawns auto-subscribes it (multica parity #27)
 
 Usage: ainb hangar autopilot subscriber [OPTIONS] <COMMAND>
 
@@ -6512,7 +6512,7 @@ Usage: ainb hangar autopilot access [OPTIONS] --id <ID> --mode <MODE>
 Options:
       --format <format>        Output format [default: text] [possible values: text, json, csv, markdown]
       --id <ID>                The autopilot id (`autopilot.id`)
-      --mode <MODE>            `open` (any actor in the workspace may write: the default and every pre-0064 rule) or `restricted` (owner / workspace owner+admin / an explicit `editor` collaborator only)
+      --mode <MODE>            `open` (any actor in the workspace may write — the default and every pre-0064 rule) or `restricted` (owner / workspace owner+admin / an explicit `editor` collaborator only)
       --as-user <AS_USER>      The acting human (write gate subject + rule-version attribution)
       --workspace <WORKSPACE>  Workspace slug the autopilot belongs to. Defaults to `default`
   -h, --help                   Print help
@@ -6597,7 +6597,7 @@ Options:
       --repo-whitelist <REPO_WHITELIST>
           Set the repo whitelist as a comma-separated list of `owner/name` slugs (e.g. `org/api,org/web`). The empty string sets a configured-but-empty whitelist (allows nothing); use `--clear-repo-whitelist` to remove the gate
       --clear-repo-whitelist
-          Unset the repo whitelist (no gate: every repo allowed)
+          Unset the repo whitelist (no gate — every repo allowed)
       --workspace <WORKSPACE>
           Workspace slug to configure. Defaults to the bootstrapped `default` workspace
   -h, --help
@@ -6770,7 +6770,7 @@ Options:
       --issue <ISSUE>          Issue id (ULID) to comment on
       --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
       --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
-      --parent <PARENT>        The comment this one replies to: drives the reply-parent fallback and multica's parent-mention inheritance
+      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -6790,7 +6790,7 @@ Options:
       --issue <ISSUE>          Issue id (ULID) to comment on
       --body <BODY>            The comment body. `@handle` and `[@Label](mention://type/id)` both route
       --author <AUTHOR>        The author as a canonical actor-ref. `member:me` is the local operator, which the invocation gate resolves to the workspace owner [default: member:me]
-      --parent <PARENT>        The comment this one replies to: drives the reply-parent fallback and multica's parent-mention inheritance
+      --parent <PARENT>        The comment this one replies to — drives the reply-parent fallback and multica's parent-mention inheritance
       --workspace <WORKSPACE>  Workspace slug the issue belongs to. Defaults to the bootstrapped `default` workspace
   -h, --help                   Print help
 ```
@@ -7105,7 +7105,7 @@ Options:
 
 The skill-manager commands (`skill`, `source`, `search`, `migrate`) are
 intercepted before clap and routed to the unit manager; they are documented in
-their own section under [Skill manager](/skill-manager/guide) and surfaced in
+their own section under [Skill manager](../skill-manager/guide) and surfaced in
 `ainb --help` under "SKILL MANAGER". Run `ainb skill --help` for the full verb
 list.
 
@@ -7114,10 +7114,10 @@ list.
 A few commands are hidden from `ainb --help` because they are internal
 daemon/hook entrypoints rather than everyday verbs. Run `<cmd> --help` for each:
 
-- `ainb notifyd <run|stop|install|uninstall|status|list>`: the ainb-hooks
+- `ainb notifyd <run|stop|install|uninstall|status|list>` — the ainb-hooks
   notification daemon. `ainb notifyd list [--format json]` reads persisted
   notifications headlessly; the TUI Inbox is the interactive view.
-- `ainb statusline`: legacy Claude Code statusline alias (prefer
+- `ainb statusline` — legacy Claude Code statusline alias (prefer
   `ainb claudecode statusline`).
 
 ## Exit codes

--- a/docs/tui/code-review.md
+++ b/docs/tui/code-review.md
@@ -54,6 +54,6 @@ ainb diff-review ./path     # review another directory or worktree
 
 ## Next steps
 
-- [Overview](overview.md): all TUI screens and shortcuts
-- [Attaching to sessions](attach.md): inspect running agent tmux sessions
-- [CLI reference](cli.md): command-line flags for diff-review
+- [Overview](/tui/overview): all TUI screens and shortcuts
+- [Attaching to sessions](/tui/attach): inspect running agent tmux sessions
+- [CLI reference](/tui/cli): command-line flags for diff-review

--- a/docs/tui/daemons.mdx
+++ b/docs/tui/daemons.mdx
@@ -1,29 +1,29 @@
 ---
 title: "Daemons overlay"
-description: "Press d in the ainb TUI to open the Daemons overlay — every ainb-managed background daemon and socket in one place: the shared MCP pool, the Headroom compression proxy, the notifyd notification daemon with its approve socket, plus the R restart lever that repairs a dead approve socket."
+description: "Press d in the ainb TUI to open the Daemons overlay: every ainb-managed background daemon and socket in one place: the shared MCP pool, the Headroom compression proxy, the notifyd notification daemon with its approve socket, plus the R restart lever that repairs a dead approve socket."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-ainb runs a few background daemons on your behalf — the shared MCP server pool, the Headroom compression proxy, and the `notifyd` notification daemon that also serves the permission approve socket. Rather than make you hunt for them with `ps`, every ainb-managed daemon and socket shows up in one place: press **`d`** from anywhere in the TUI to open the **Daemons** overlay.
+ainb runs a few background daemons on your behalf: the shared MCP server pool, the Headroom compression proxy, and the `notifyd` notification daemon that also serves the permission approve socket. Rather than make you hunt for them with `ps`, every ainb-managed daemon and socket shows up in one place: press **`d`** from anywhere in the TUI to open the **Daemons** overlay.
 
 ![ainb TUI Daemons overlay showing the shared MCP pool row as down and the Headroom proxy on port 8787 as up with a saved-tokens count and a watched marker, plus the consuming-sessions line; r refreshes and esc closes](../assets/screenshots/daemons-overlay.gif)
 
-*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](token-optimization.mdx) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `R` restarts notifyd; `Esc` closes.*
+*The overlay lists each daemon with a live status dot, and for the Headroom proxy: its port (`:8787`), the tokens it has saved so far (the same figure as the [Savings tab](/tui/token-optimization) and `ainb usage savings`), and which sessions are routed through it. `r` refreshes; `R` restarts notifyd; `Esc` closes.*
 
 ## What's on it
 
-- **MCP pool** — the shared `ainb mcp daemon` that spawns each MCP server once behind a unix socket. See [Shared MCP pool](mcp-pool.mdx).
-- **Headroom proxy** — the ainb-managed compression proxy. Its row carries the live saved-token count and a **`watched`** marker when the in-loop watchdog is keeping it alive for a routed session.
-- **notifyd processes** — every running `ainb-notifyd` process, one line each, with its pid and health class. Orphaned or wedged strays are counted with a `· N to clean up (run \`ainb notifyd reap\`)` hint. notifyd owns the [Inbox](inbox-notifications.md) socket **and** the **approve socket** (`~/.agents-in-a-box/approve.sock`) that the synchronous permission round-trip blocks on.
+- **MCP pool**: the shared `ainb mcp daemon` that spawns each MCP server once behind a unix socket. See [Shared MCP pool](/tui/mcp-pool).
+- **Headroom proxy**: the ainb-managed compression proxy. Its row carries the live saved-token count and a **`watched`** marker when the in-loop watchdog is keeping it alive for a routed session.
+- **notifyd processes**: every running `ainb-notifyd` process, one line each, with its pid and health class. Orphaned or wedged strays are counted with a `· N to clean up (run \`ainb notifyd reap\`)` hint. notifyd owns the [Inbox](/tui/inbox-notifications) socket **and** the **approve socket** (`~/.agents-in-a-box/approve.sock`) that the synchronous permission round-trip blocks on.
 
 <Aside type="note">
-The Headroom watchdog isn't a separate process — it's an in-loop tick (~10 s) that re-ensures the proxy if a routed session is live but the proxy has died. Because it belongs to the Headroom proxy, it's surfaced as the `watched` attribute on that row rather than as its own daemon. Every ainb-managed daemon and socket lives on this screen — that's the invariant.
+The Headroom watchdog isn't a separate process: it's an in-loop tick (~10 s) that re-ensures the proxy if a routed session is live but the proxy has died. Because it belongs to the Headroom proxy, it's surfaced as the `watched` attribute on that row rather than as its own daemon. Every ainb-managed daemon and socket lives on this screen: that's the invariant.
 </Aside>
 
 ## The restart lever (`R`)
 
-The overlay is mostly for observing, but notifyd gets one deliberate control: **`R` restarts notifyd** — stop the owner, reap strays, respawn, and wait for the approve socket to bind. This is the **single resume/repair command** for a dead or wedged approve socket, and it is safe to run while permission prompts are mid-wait: a blocked `PermissionRequest` hook re-dials the socket every 500 ms until its deadline, so every still-waiting prompt re-registers itself the moment the fresh daemon binds. One restart repairs the socket *and* resumes the pending prompts — no hook is lost.
+The overlay is mostly for observing, but notifyd gets one deliberate control: **`R` restarts notifyd**: stop the owner, reap strays, respawn, and wait for the approve socket to bind. This is the **single resume/repair command** for a dead or wedged approve socket, and it is safe to run while permission prompts are mid-wait: a blocked `PermissionRequest` hook re-dials the socket every 500 ms until its deadline, so every still-waiting prompt re-registers itself the moment the fresh daemon binds. One restart repairs the socket *and* resumes the pending prompts: no hook is lost.
 
 The outcome (`stopped · reaped · spawned pid · socket bound`) is shown as a transient status line under the notifyd header, and the daemon list re-scans automatically so the new pid appears.
 
@@ -36,7 +36,7 @@ ainb notifyd restart --format json    # machine-readable outcome
 
 ## The full health view
 
-The overlay is the quick glance; `ainb fleet daemons` is the full table — every daemon with state, pid, uptime, last activity, and a health reason. The **approve broker** appears as its own row there: it rides notifyd's process (no pid of its own), so its liveness is the socket accepting a connection, and its health reason carries the live pending-waiter count (`serving — 2 pending requests`) so you can see blocked hooks at a glance.
+The overlay is the quick glance; `ainb fleet daemons` is the full table: every daemon with state, pid, uptime, last activity, and a health reason. The **approve broker** appears as its own row there: it rides notifyd's process (no pid of its own), so its liveness is the socket accepting a connection, and its health reason carries the live pending-waiter count (`serving: 2 pending requests`) so you can see blocked hooks at a glance.
 
 ```bash
 ainb fleet daemons                    # unified daemon health table
@@ -56,7 +56,7 @@ ainb notifyd reap      # kill orphan/wedged notifyd strays, sparing the live own
 
 ## See also
 
-- [Inbox & notifications](inbox-notifications.md) — the daemon behind the notifyd rows, and the permission approve/deny round-trip.
-- [Token optimisation — Headroom & RTK](token-optimization.mdx) — the proxy this overlay watches.
-- [Shared MCP pool](mcp-pool.mdx) — the other daemon on this screen.
-- [Keyboard shortcuts](keyboard-shortcuts.md).
+- [Inbox & notifications](/tui/inbox-notifications): the daemon behind the notifyd rows, and the permission approve/deny round-trip.
+- [Token optimisation: Headroom & RTK](/tui/token-optimization): the proxy this overlay watches.
+- [Shared MCP pool](/tui/mcp-pool): the other daemon on this screen.
+- [Keyboard shortcuts](/tui/keyboard-shortcuts).

--- a/docs/tui/faq.md
+++ b/docs/tui/faq.md
@@ -63,7 +63,7 @@ Then reload: `tmux source-file ~/.tmux.conf`
 
 ### How do I copy/paste in tmux?
 
-See the [Clipboard Setup section in ainb-tui/CLAUDE.md](../../ainb-tui/CLAUDE.md#clipboard-setup) for full details.
+See the [Clipboard Setup section in ainb-tui/CLAUDE.md](https://github.com/stevengonsalvez/agents-in-a-box/blob/main/ainb-tui/CLAUDE.md#clipboard-setup) for full details.
 
 **Quick reference:**
 

--- a/docs/tui/fleet-cost.md
+++ b/docs/tui/fleet-cost.md
@@ -6,7 +6,7 @@ description: "Per-session / model / day / group spend rollups + budget caps for 
 `ainb fleet cost` surfaces ainb's existing cost tracking as fleet-shaped
 spend rollups, plus configurable budget caps that fire notifyd alerts.
 
-ainb already prices every provider call — `cost_usd` is recorded on each
+ainb already prices every provider call: `cost_usd` is recorded on each
 `ProviderCall` / `TokenBucket` and aggregated by the **burndown** plugin
 (the same data behind `ainb usage`). This verb does **not** re-price
 anything: it fetches burndown's `usage report --format json` payload live
@@ -23,7 +23,7 @@ ainb --format json fleet cost                    # JSON
 ainb --format json fleet cost --period week      # today | week | 30days | month | all
 ```
 
-`--format` is a global flag — it precedes `fleet`. `--period` (default
+`--format` is a global flag: it precedes `fleet`. `--period` (default
 `month`) scopes the reporting window: the burndown plugin date-bounds its
 call set and re-aggregates every rollup, so a narrower period returns less
 spend. `all` reports lifetime totals.
@@ -74,7 +74,7 @@ A breach is delivered through the existing **notifyd** substrate: a valid
 `Envelope` is written to `~/.agents-in-a-box/notify.sock` with raw event
 `Notification:budget_exceeded`. It classifies as `AlertKind::WaitingOnUser`,
 passes notifyd's user-facing filter, and lands as a row in
-`notifications.db` — the same path idle/permission prompts take. No new
+`notifications.db`: the same path idle/permission prompts take. No new
 alert kind is introduced. Delivery is best-effort: if the socket is
 unreachable the report still prints, with a warning on stderr.
 
@@ -91,5 +91,5 @@ unreachable the report still prints, with a warning on stderr.
   `~/.claude/projects`; subsequent calls hit the cache and return sub-second.
 - Requires the burndown plugin (`ainb plugin install burndown`), the same
   dependency `ainb usage` has.
-- To change pricing or the spend plan, use `ainb usage plan ...` — this verb
+- To change pricing or the spend plan, use `ainb usage plan ...`: this verb
   consumes ainb's pricing, it does not own it.

--- a/docs/tui/inbox-notifications.md
+++ b/docs/tui/inbox-notifications.md
@@ -3,33 +3,33 @@ title: "Inbox & notifications"
 description: "How ainb captures host-agent hook events into the Inbox and the per-session [!]/[?]/[✓] status markers, via the ainb-notifyd daemon. Host code, not a plugin."
 ---
 
-The **Inbox** screen, the per-session **status markers** (`[!]` / `[?]` / `[✓]`), and the **`ainb-notifyd`** daemon are all part of the `ainb` host binary — **not** an ainb plugin. This page is the single reference for how notifications work: the daemon captures Claude Code / Codex / Copilot lifecycle hook events into SQLite, and `ainb-tui` renders them two ways — the Inbox screen (full history) and a live per-session marker (the one row glyph that tells you a session needs you).
+The **Inbox** screen, the per-session **status markers** (`[!]` / `[?]` / `[✓]`), and the **`ainb-notifyd`** daemon are all part of the `ainb` host binary: **not** an ainb plugin. This page is the single reference for how notifications work: the daemon captures Claude Code / Codex / Copilot lifecycle hook events into SQLite, and `ainb-tui` renders them two ways: the Inbox screen (full history) and a live per-session marker (the one row glyph that tells you a session needs you).
 
 > **Agent support.** Claude Code is the primary, most-tested path (registered through the `claude` plugin CLI). Codex is wired via `~/.codex/hooks.json`; Copilot is wired via `~/.copilot/hooks/ainb.json`. Their user-facing events flow into the Inbox and mark matching sessions (`[✓]` / `[?]` / `[!]`), though Claude remains the better-exercised integration.
 
-> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins — `burndown`, `session-reader`, `witr` — which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](../toolkit/plugins/ainb-hooks.md), and that is a plugin of the *host agent* (Claude Code / Codex / Copilot), installed into their config dirs — not a plugin of `ainb`.
+> **Why it's not a plugin.** The crate is *named* `ainb-plugin-notifyd` (it lives alongside the example plugin crates), but it has no `manifest.toml`, no JSON-RPC boundary, and is never spawned as a subprocess. `ainb-core` links it as an ordinary Rust path-dependency and compiles it straight into the host. Contrast with the real v2 subprocess plugins: `burndown`, `session-reader`, `witr`: which run as spawned child processes over stdio JSON-RPC and are governed by the capability gate. The **only** plugin in this feature is [`ainb-hooks`](/toolkit/plugins/ainb-hooks), and that is a plugin of the *host agent* (Claude Code / Codex / Copilot), installed into their config dirs: not a plugin of `ainb`.
 
 ![The Inbox screen in ainb-tui](../assets/screenshots/notifyd-inbox.png)
 
-*Press `b` in ainb to open the Inbox — captured Claude Code / Codex / Copilot lifecycle events with a list + detail pane, agent filter, and per-session unread counts.*
+*Press `b` in ainb to open the Inbox: captured Claude Code / Codex / Copilot lifecycle events with a list + detail pane, agent filter, and per-session unread counts.*
 
 ## How it works
 
-![Inbox & notifications — how it works](../assets/diagrams/notifyd.svg)
+![Inbox & notifications: how it works](../assets/diagrams/notifyd.svg)
 
-The capture path starts outside ainb, in a thin bash hook (`notify.sh`). For **Claude Code** it is registered through the plugin marketplace — `ainb notifyd install` shells out to `claude plugin install ainb-hooks@agents-in-a-box`, so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex** a managed block is merged into `~/.codex/hooks.json` pointing at the canonical `~/.agents-in-a-box/hooks/notify.sh`. For **Copilot**, `ainb-notifyd` writes a standalone drop-in at `~/.copilot/hooks/ainb.json`. Only the **actionable** lifecycle events are registered — Claude uses `Notification` (idle / awaiting-input + permission prompts), Codex uses `PermissionRequest` (approval prompts), Copilot uses `notification`, and all three have a turn-finished hook (`Stop` / `agentStop`). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
+The capture path starts outside ainb, in a thin bash hook (`notify.sh`). For **Claude Code** it is registered through the plugin marketplace: `ainb notifyd install` shells out to `claude plugin install ainb-hooks@agents-in-a-box`, so Claude resolves and runs the plugin's bundled `notify.sh`. For **Codex** a managed block is merged into `~/.codex/hooks.json` pointing at the canonical `~/.agents-in-a-box/hooks/notify.sh`. For **Copilot**, `ainb-notifyd` writes a standalone drop-in at `~/.copilot/hooks/ainb.json`. Only the **actionable** lifecycle events are registered: Claude uses `Notification` (idle / awaiting-input + permission prompts), Codex uses `PermissionRequest` (approval prompts), Copilot uses `notification`, and all three have a turn-finished hook (`Stop` / `agentStop`). When one fires, the script normalizes the payload into a JSON `Envelope` (`protocol_version`, `agent`, `raw_event`, `session_id`, `cwd`, `project`, `ts`, `payload`) and writes one newline-terminated line to the Unix socket at `~/.agents-in-a-box/notify.sock`. If the socket is absent it lazy-spawns the daemon; if delivery still fails it appends the envelope to `notify.fallback.jsonl`. The hook always exits `0` so a delivery failure never blocks the agent.
 
-Telemetry events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`) are deliberately **not** hooked — `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
+Telemetry events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, `SubagentStop`) are deliberately **not** hooked: `PostToolUse` alone fires dozens of times per turn and would bury the signal. So the inbox only ever contains things that need you.
 
-`ainb-notifyd` is a tokio accept-loop daemon. On startup it replays (and clears) any queued `notify.fallback.jsonl`, then binds the `0600` socket and writes a PID file. Each accepted connection is parsed into an `Envelope` and checked against `is_user_facing`: non-actionable events (telemetry like `SessionStart` / `PostToolUse`) are **dropped before persistence** — a defensive second filter on top of the trimmed hook registration, so a stale install never accumulates noise either. User-facing events (`Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, approval/wait events, etc.) are persisted via `insert_and_prune` and emitted as a native OS notification, debounced per `(session_id, raw_event)` on a 60s window.
+`ainb-notifyd` is a tokio accept-loop daemon. On startup it replays (and clears) any queued `notify.fallback.jsonl`, then binds the `0600` socket and writes a PID file. Each accepted connection is parsed into an `Envelope` and checked against `is_user_facing`: non-actionable events (telemetry like `SessionStart` / `PostToolUse`) are **dropped before persistence**: a defensive second filter on top of the trimmed hook registration, so a stale install never accumulates noise either. User-facing events (`Stop`, `Notification`, `PermissionRequest`, `agent-turn-complete`, approval/wait events, etc.) are persisted via `insert_and_prune` and emitted as a native OS notification, debounced per `(session_id, raw_event)` on a 60s window.
 
-Storage is a dedicated SQLite database, `~/.agents-in-a-box/notifications.db`, opened in WAL mode so the daemon (writer) and TUI (reader) never block each other. It is intentionally separate from `session-reader`'s `usage.db` — different lifecycles, independent migrations. A retention sweep runs on every insert (default: prune rows older than 7 days, cap the table at 10,000 rows, oldest first).
+Storage is a dedicated SQLite database, `~/.agents-in-a-box/notifications.db`, opened in WAL mode so the daemon (writer) and TUI (reader) never block each other. It is intentionally separate from `session-reader`'s `usage.db`: different lifecycles, independent migrations. A retention sweep runs on every insert (default: prune rows older than 7 days, cap the table at 10,000 rows, oldest first).
 
-The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. Separately, the Sessions screen reads recent store events to draw a live per-session **status marker** (`[!]` / `[?]` / `[✓]`) on each session row — see [Per-session status markers](#per-session-status-markers) below. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly — there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
+The render side lives in `ainb-core`. The **Inbox** screen (`components/inbox.rs`) holds a long-lived `Store` handle and re-queries SQLite on every render tick (cheap with WAL + `LIMIT 200`). It paints a two-pane list + detail view, and supports mark-read, dismiss, dismiss-all-visible, an archived toggle, and an agent filter. Separately, the Sessions screen reads recent store events to draw a live per-session **status marker** (`[!]` / `[?]` / `[✓]`) on each session row: see [Per-session status markers](#per-session-status-markers) below. Because `notifyd` is in-tree, it reaches the filesystem, the socket, and the OS notifier directly: there is no JSON-RPC boundary, no `plugin/render` / `plugin/cli_dispatch`, and no `host/snapshot/publish`.
 
 ## Per-session status markers
 
-The Inbox is the full history; the **status marker** is the at-a-glance signal. Every session row in the Sessions screen shows one marker (or nothing), recomputed from the same hook events so you can see across the whole fleet which sessions need you without opening the Inbox. It is **sparse by design** — a session with no pending event shows nothing.
+The Inbox is the full history; the **status marker** is the at-a-glance signal. Every session row in the Sessions screen shows one marker (or nothing), recomputed from the same hook events so you can see across the whole fleet which sessions need you without opening the Inbox. It is **sparse by design**: a session with no pending event shows nothing.
 
 ![Per-session status markers in the session list](../assets/screenshots/session-status-markers.png)
 
@@ -41,36 +41,36 @@ The agents register the same intent, but not the same raw hook names. The mappin
 
 | Hook fired | Marker | Means | Shows until |
 |------------|--------|-------|-------------|
-| `Notification` | `[?]` amber | awaiting input — asked a question, needs permission, or the prompt sat idle (~60s) | the agent resumes generating · you attach · a newer `Stop` supersedes it — **no TTL** |
-| `Stop` | `[✓]` green | turn finished — over to you | **5-minute TTL** · the agent resumes · you attach · a newer event |
-| `PermissionRequest` | `[!]` red | blocked on tool approval | the agent resumes · attach. Fires only on sessions with the **fleet plumbing** hook set installed (fleet-managed sessions register `PermissionRequest` there); the plain notifyd install folds permission into `Notification`, which reads as `[?]`. On fleet sessions this hook also *blocks* for a live approve/deny — see [Permission approve/deny round-trip](#permission-approvedeny-round-trip) |
-| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry — not hooked by the notifyd install (fleet plumbing registers `SessionStart`/`UserPromptSubmit` to drive the fleet panel's `STARTING`/`RUNNING` states) | — |
+| `Notification` | `[?]` amber | awaiting input: asked a question, needs permission, or the prompt sat idle (~60s) | the agent resumes generating · you attach · a newer `Stop` supersedes it: **no TTL** |
+| `Stop` | `[✓]` green | turn finished: over to you | **5-minute TTL** · the agent resumes · you attach · a newer event |
+| `PermissionRequest` | `[!]` red | blocked on tool approval | the agent resumes · attach. Fires only on sessions with the **fleet plumbing** hook set installed (fleet-managed sessions register `PermissionRequest` there); the plain notifyd install folds permission into `Notification`, which reads as `[?]`. On fleet sessions this hook also *blocks* for a live approve/deny: see [Permission approve/deny round-trip](#permission-approvedeny-round-trip) |
+| `SessionStart` · `UserPromptSubmit` · `PostToolUse` · `PreCompact` | *(none)* | telemetry: not hooked by the notifyd install (fleet plumbing registers `SessionStart`/`UserPromptSubmit` to drive the fleet panel's `STARTING`/`RUNNING` states) |: |
 
 ### Codex
 
 | Hook fired | Marker | Means | Shows until |
 |------------|--------|-------|-------------|
-| *(none — Codex has no `Notification` hook)* | `[?]` amber | awaiting input | **not shown today** — Codex permission prompts use `PermissionRequest`; turn completion uses `Stop` |
+| *(none: Codex has no `Notification` hook)* | `[?]` amber | awaiting input | **not shown today**: Codex permission prompts use `PermissionRequest`; turn completion uses `Stop` |
 | `Stop` (aliases `agent-turn-complete`, `task_complete`) | `[✓]` green | turn finished | **5-minute TTL** · resumes · attach |
 | `PermissionRequest` | `[!]` red | blocked on exec/patch approval | clears when the agent resumes · attach |
-| `SessionStart` · `UserPromptSubmit` · `PreToolUse` · `PostToolUse` · `PreCompact` · `PostCompact` · `SubagentStart` · `SubagentStop` | *(none)* | telemetry — not hooked | — |
+| `SessionStart` · `UserPromptSubmit` · `PreToolUse` · `PostToolUse` · `PreCompact` · `PostCompact` · `SubagentStart` · `SubagentStop` | *(none)* | telemetry: not hooked |: |
 
 ### GitHub Copilot CLI
 
 | Hook fired | Marker | Means | Shows until |
 |------------|--------|-------|-------------|
-| `notification` | `[?]` amber | awaiting input or permission prompt | the agent resumes · you attach · a newer `agentStop` supersedes it — **no TTL** |
+| `notification` | `[?]` amber | awaiting input or permission prompt | the agent resumes · you attach · a newer `agentStop` supersedes it: **no TTL** |
 | `agentStop` | `[✓]` green | turn finished | **5-minute TTL** · resumes · attach |
 
 While a session is **actively generating**, the marker is suppressed (the busy state covers it). The marker recomputes every **~5 s** (the preview-refresh tick), so every appear/clear lands on that cadence rather than instantly.
 
-**Does it clear when I answer?** Yes — answering a session (typing a prompt, or approving a permission) makes the agent start responding, and the marker clears on the next ~5 s refresh once it does. It clears via *the agent resuming*, not the keystroke itself, so there's a ≤5 s window between hitting enter and the marker disappearing. **Attaching** to a session clears it immediately and advances a per-session baseline to "now", so it won't re-mark until *new* activity arrives after you look away.
+**Does it clear when I answer?** Yes: answering a session (typing a prompt, or approving a permission) makes the agent start responding, and the marker clears on the next ~5 s refresh once it does. It clears via *the agent resuming*, not the keystroke itself, so there's a ≤5 s window between hitting enter and the marker disappearing. **Attaching** to a session clears it immediately and advances a per-session baseline to "now", so it won't re-mark until *new* activity arrives after you look away.
 
-Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Only events within a rolling **6-hour window** count — so opening ainb immediately surfaces sessions that were already waiting before you launched it (the `[✓]` TTL keeps long-finished turns from piling up, so only genuinely-pending `[?]` / `[!]` survive).
+Markers are matched to sessions by **working directory + agent**: each hook event carries the `cwd` it fired in, joined to the ainb session whose `workspace_path` matches (trailing-slash tolerant). Only events within a rolling **6-hour window** count: so opening ainb immediately surfaces sessions that were already waiting before you launched it (the `[✓]` TTL keeps long-finished turns from piling up, so only genuinely-pending `[?]` / `[!]` survive).
 
 ## Permission approve/deny round-trip
 
-Fleet-managed Claude sessions get a **synchronous, first-class permission gate**: when Claude fires a `PermissionRequest` hook, the hook process *blocks* on notifyd's approve socket until a human approves or denies it — from the fleet panel, the CLI, or not at all (timeout ⇒ deny). The answer flows straight back to Claude as the hook's `hookSpecificOutput` permission decision, so approving in the TUI is exactly as authoritative as pressing `y` in the Claude session itself.
+Fleet-managed Claude sessions get a **synchronous, first-class permission gate**: when Claude fires a `PermissionRequest` hook, the hook process *blocks* on notifyd's approve socket until a human approves or denies it: from the fleet panel, the CLI, or not at all (timeout ⇒ deny). The answer flows straight back to Claude as the hook's `hookSpecificOutput` permission decision, so approving in the TUI is exactly as authoritative as pressing `y` in the Claude session itself.
 
 ```
 ┌────────┐ PermissionRequest ┌───────────┐  AWAIT   ┌────────────────┐
@@ -87,54 +87,54 @@ Fleet-managed Claude sessions get a **synchronous, first-class permission gate**
                                                  └──────────────────┘
 ```
 
-- **Fleet panel (TUI)** — press `f` on the home screen. A session blocked on approval shows the gold **`APRV`** badge (a freshly booting one shows blue **`STRT`**); select the row and press **`y`** to approve or **`n`** to deny.
-- **CLI** — `ainb fleet approve` with no argument lists the sessions currently waiting (with tool, context, and wait time; `--format json` for scripting). `ainb fleet approve <session-id>` / `ainb fleet deny <session-id> [--reason "…"]` delivers the decision; a no-waiter miss exits non-zero.
+- **Fleet panel (TUI)**: press `f` on the home screen. A session blocked on approval shows the gold **`APRV`** badge (a freshly booting one shows blue **`STRT`**); select the row and press **`y`** to approve or **`n`** to deny.
+- **CLI**: `ainb fleet approve` with no argument lists the sessions currently waiting (with tool, context, and wait time; `--format json` for scripting). `ainb fleet approve <session-id>` / `ainb fleet deny <session-id> [--reason "…"]` delivers the decision; a no-waiter miss exits non-zero.
 
-### Fault tolerance — no hook is ever lost
+### Fault tolerance: no hook is ever lost
 
 The waiting side is built to survive every failure mode without silently green-lighting a tool call:
 
-- **Timeout ladder** — the broker holds an AWAIT for up to 600 s; the waiting hook re-dials until 640 s; Claude's own hook timeout is registered at 660 s. Each layer answers before the one above kills it, and an unanswered wait falls back to **deny** — never auto-approve.
-- **Dead or restarted socket** — the blocked hook re-dials `approve.sock` every 500 ms until its deadline. If notifyd dies mid-wait, the prompt isn't lost: the moment a fresh daemon binds the socket, every still-waiting hook re-registers itself.
-- **Single resume/repair command** — `ainb notifyd restart` (CLI) or **`R`** in the [Daemons overlay](daemons.mdx) stops the owner, reaps strays, respawns, and waits for `approve.sock` to bind. Because of the re-dial loop, that one command repairs the socket *and* resumes every pending prompt.
-- **Observability** — the approve broker is a first-class row in `ainb fleet daemons`, with the live pending-waiter count in its health reason (`serving — 2 pending requests`), and notifyd's processes are listed in the `d` overlay.
+- **Timeout ladder**: the broker holds an AWAIT for up to 600 s; the waiting hook re-dials until 640 s; Claude's own hook timeout is registered at 660 s. Each layer answers before the one above kills it, and an unanswered wait falls back to **deny**: never auto-approve.
+- **Dead or restarted socket**: the blocked hook re-dials `approve.sock` every 500 ms until its deadline. If notifyd dies mid-wait, the prompt isn't lost: the moment a fresh daemon binds the socket, every still-waiting hook re-registers itself.
+- **Single resume/repair command**: `ainb notifyd restart` (CLI) or **`R`** in the [Daemons overlay](/tui/daemons) stops the owner, reaps strays, respawns, and waits for `approve.sock` to bind. Because of the re-dial loop, that one command repairs the socket *and* resumes every pending prompt.
+- **Observability**: the approve broker is a first-class row in `ainb fleet daemons`, with the live pending-waiter count in its health reason (`serving: 2 pending requests`), and notifyd's processes are listed in the `d` overlay.
 
 ## Host resources it touches
 
-Because this is host code, there is **no manifest and no capability declaration** — the capability gate that governs subprocess plugins does not apply. It reaches the filesystem, the socket, and the OS notifier directly. For reference, the host-side resources it touches are:
+Because this is host code, there is **no manifest and no capability declaration**: the capability gate that governs subprocess plugins does not apply. It reaches the filesystem, the socket, and the OS notifier directly. For reference, the host-side resources it touches are:
 
 | Resource | Why it is needed |
 |----------|------------------|
 | `~/.agents-in-a-box/notifications.db` (SQLite, read+write) | Persist captured envelopes; back the Inbox list and the unread badge. |
 | `~/.agents-in-a-box/notify.sock` (Unix socket, `0600`) | Receive envelopes from the `ainb-hooks` script. |
 | `~/.agents-in-a-box/notify.pid`, `notify.fallback.jsonl` | Single-instance guard; recover events queued while the daemon was down. |
-| `~/.agents-in-a-box/approve.sock` (Unix socket, `0600`) | The **approve broker** — blocked `PermissionRequest` hooks park here awaiting a human approve/deny from the fleet panel or CLI. Rides notifyd's process; visible as its own row in `ainb fleet daemons`. |
-| `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.copilot/hooks/ainb.json`, `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents — Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block, Copilot via a standalone drop-in. |
+| `~/.agents-in-a-box/approve.sock` (Unix socket, `0600`) | The **approve broker**: blocked `PermissionRequest` hooks park here awaiting a human approve/deny from the fleet panel or CLI. Rides notifyd's process; visible as its own row in `ainb fleet daemons`. |
+| `claude` CLI (subprocess), `~/.codex/hooks.json` (read+write), `~/.copilot/hooks/ainb.json`, `~/.agents-in-a-box/hooks/notify.sh` | The `install` / `uninstall` verbs wire the hook into the host agents: Claude via `claude plugin install/uninstall`, Codex via a managed `hooks.json` block, Copilot via a standalone drop-in. |
 | `osascript` / `notify-send` (subprocess) | Emit the native OS notification for user-facing events. |
 
 ## Using it
 
-![The home screen — Inbox in the sidebar](../assets/screenshots/home-inbox-sidebar.png)
+![The home screen: Inbox in the sidebar](../assets/screenshots/home-inbox-sidebar.png)
 
-*The Inbox is a first-class home-screen surface — `b` from anywhere, or `Enter` on the sidebar tile.*
+*The Inbox is a first-class home-screen surface: `b` from anywhere, or `Enter` on the sidebar tile.*
 
-- **Discoverability surfaces** — three places advertise the Inbox so users don't have to memorise a hidden shortcut:
-  - The home screen sidebar lists `📥 Inbox  [b]` between Sessions and Recovery — press `Enter` on the tile, or `b` globally, to open it. (`b` for "in-**B**ox" — picked to avoid the case-pair confusion between `i` Stats and the earlier `I` Inbox binding.)
+- **Discoverability surfaces**: three places advertise the Inbox so users don't have to memorise a hidden shortcut:
+  - The home screen sidebar lists `📥 Inbox  [b]` between Sessions and Recovery: press `Enter` on the tile, or `b` globally, to open it. (`b` for "in-**B**ox": picked to avoid the case-pair confusion between `i` Stats and the earlier `I` Inbox binding.)
   - The bottom menu bar (every split-pane screen) always shows `b inbox`. When the store has unread + non-dismissed events the hint becomes `● N · b inbox`, so the global unread count is visible even when the Inbox screen is closed.
-  - The Sessions screen renders a live **status marker** (`[!]` / `[?]` / `[✓]`) on the row of any session with a pending hook event, matched by `cwd` ↔ `workspace_path`. This is the primary surface — notifications are tied to the session that produced them, not a separate destination. See [Per-session status markers](#per-session-status-markers).
-- **Inbox screen** — press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex → copilot), `r` force refresh, `q`/`Esc` back.
-- **cwd-based correlation (jump-to-tmux)** — every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
-- **Daemon + installer CLI** — the verbs live both on the standalone `ainb-notifyd` binary and as the **`ainb notifyd …` subcommand** on the main `ainb` binary (both delegate to the identical `ainb_plugin_notifyd` functions, so they can never diverge). The alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd` — the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
-  - `ainb-notifyd run` (or `ainb notifyd run` / bare `ainb notifyd`) — run the daemon in the foreground. The hook script lazy-spawns `ainb notifyd` when the socket is missing; if `ainb` is on `PATH` the daemon auto-starts and the event is delivered live (no fallback file).
-  - `ainb-notifyd install --claude --codex --copilot` (or `--all`) — install the `ainb-hooks` hook for the chosen agents.
-  - `ainb-notifyd uninstall --claude --codex --copilot` (or `--all`) — reverse the install; preserves user-authored Codex hooks and other Copilot hook files.
-  - `ainb-notifyd status` — report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness. `--format json` emits `{agents, daemon: {pid, running}}` for scripting.
-  - `ainb-notifyd stop` — send `SIGTERM` to a running daemon via its PID file.
-  - `ainb-notifyd restart` — stop the owner, reap strays, respawn, and wait for the approve socket to bind: the **single resume/repair command** for a dead or wedged approve socket (see the [round-trip section](#permission-approvedeny-round-trip) for why waiting prompts survive it).
-  - `ainb-notifyd reap` — kill orphaned/wedged notifyd strays, sparing the live owner.
-  - Every verb accepts `--format` (default `text`) for scripting — e.g. `ainb notifyd status --format json`. The host form takes `text|json|csv|markdown`; the standalone `ainb-notifyd` binary takes `text|json`.
-- **Snapshot topics** — none. `notifyd` does not publish or subscribe on the event bus; the Inbox reads SQLite directly. There is no slash command.
+  - The Sessions screen renders a live **status marker** (`[!]` / `[?]` / `[✓]`) on the row of any session with a pending hook event, matched by `cwd` ↔ `workspace_path`. This is the primary surface: notifications are tied to the session that produced them, not a separate destination. See [Per-session status markers](#per-session-status-markers).
+- **Inbox screen**: press **`b`** from anywhere on the home screen, or `Enter` on the `📥 Inbox` sidebar tile. You get a two-pane list + detail view of captured events. Keys inside the Inbox: `↑`/`↓` (or `k`/`j`) move, `PageUp`/`PageDown` jump 10 rows, `Enter` open + mark read **and jump to the matching session's tmux pane** (via the cwd correlation below), `d` dismiss selected, `Shift+C` dismiss every visible row, `a` toggle archived (dismissed) rows, `p` cycle the agent filter (all → claude → codex → copilot), `r` force refresh, `q`/`Esc` back.
+- **cwd-based correlation (jump-to-tmux)**: every envelope carries the agent's `cwd` at hook-fire time, and every ainb `Session` carries a `workspace_path`. When the user presses `Enter` on an Inbox row, notifyd resolves the row's `cwd` to the first ainb workspace whose path matches (exact or `workspace_path/`-prefix to cover worktree subdirs), picks a session in that workspace, and queues an `AttachToOtherTmux` action with that session's `tmux_session_name`. There is no shared session-id namespace between the host agents' `session_id` strings and ainb's `Session.id` `Uuid`; the cwd is the bridge.
+- **Daemon + installer CLI**: the verbs live both on the standalone `ainb-notifyd` binary and as the **`ainb notifyd …` subcommand** on the main `ainb` binary (both delegate to the identical `ainb_plugin_notifyd` functions, so they can never diverge). The alias exists because `notify.sh`'s lazy-spawn invokes `ainb notifyd`: the host binary is the one guaranteed to be on `PATH` after a normal install. Verbs (both forms work):
+  - `ainb-notifyd run` (or `ainb notifyd run` / bare `ainb notifyd`): run the daemon in the foreground. The hook script lazy-spawns `ainb notifyd` when the socket is missing; if `ainb` is on `PATH` the daemon auto-starts and the event is delivered live (no fallback file).
+  - `ainb-notifyd install --claude --codex --copilot` (or `--all`): install the `ainb-hooks` hook for the chosen agents.
+  - `ainb-notifyd uninstall --claude --codex --copilot` (or `--all`): reverse the install; preserves user-authored Codex hooks and other Copilot hook files.
+  - `ainb-notifyd status`: report per-agent install state, hook-script health, socket liveness, last event, and daemon PID liveness. `--format json` emits `{agents, daemon: {pid, running}}` for scripting.
+  - `ainb-notifyd stop`: send `SIGTERM` to a running daemon via its PID file.
+  - `ainb-notifyd restart`: stop the owner, reap strays, respawn, and wait for the approve socket to bind: the **single resume/repair command** for a dead or wedged approve socket (see the [round-trip section](#permission-approvedeny-round-trip) for why waiting prompts survive it).
+  - `ainb-notifyd reap`: kill orphaned/wedged notifyd strays, sparing the live owner.
+  - Every verb accepts `--format` (default `text`) for scripting: e.g. `ainb notifyd status --format json`. The host form takes `text|json|csv|markdown`; the standalone `ainb-notifyd` binary takes `text|json`.
+- **Snapshot topics**: none. `notifyd` does not publish or subscribe on the event bus; the Inbox reads SQLite directly. There is no slash command.
 
 ## Source
 
-`crates/ainb-plugin-notifyd` — in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store` (`recent_since` backs the markers), event→marker classification (`classify_attention`), the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic (Claude via the `claude` CLI). The Inbox screen lives in `crates/ainb-core/src/components/inbox.rs`; the per-session marker logic (`attention_for_session` / `refresh_attention_markers`) lives in `crates/ainb-core/src/app/state.rs`. Diagram generated via /fireworks-tech-graph.
+`crates/ainb-plugin-notifyd`: in-tree library + `ainb-notifyd` daemon binary: envelope wire format, the SQLite `Store` (`recent_since` backs the markers), event→marker classification (`classify_attention`), the tokio listener, OS-notify dispatch, and the `ainb-hooks` install/uninstall logic (Claude via the `claude` CLI). The Inbox screen lives in `crates/ainb-core/src/components/inbox.rs`; the per-session marker logic (`attention_for_session` / `refresh_attention_markers`) lives in `crates/ainb-core/src/app/state.rs`. Diagram generated via /fireworks-tech-graph.

--- a/docs/tui/keyboard-shortcuts.md
+++ b/docs/tui/keyboard-shortcuts.md
@@ -42,8 +42,8 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 | Key | Action |
 |-----|--------|
 | `n` | New session (local or remote) |
-| `a` | [Attach](attach.md) full-screen (TUI suspends; `Ctrl+B` `d` detaches) |
-| `A` | [In-pane attach](attach.md) — the preview pane becomes a live embedded tmux client (`Ctrl+Q` releases) |
+| `a` | [Attach](/tui/attach) full-screen (TUI suspends; `Ctrl+B` `d` detaches) |
+| `A` | [In-pane attach](/tui/attach): the preview pane becomes a live embedded tmux client (`Ctrl+Q` releases) |
 | `B` | Toggle the sessions sidebar |
 | `e` | Restart stopped session |
 | `u` | Re-authenticate credentials |
@@ -71,7 +71,7 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 | Key | Action |
 |-----|--------|
 | `r` | Refresh |
-| `R` | Restart notifyd — the single resume/repair command for a dead approve socket |
+| `R` | Restart notifyd: the single resume/repair command for a dead approve socket |
 | `Esc` / `q` / `d` | Close |
 
 ## Recovery screen
@@ -85,7 +85,7 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 
 | Key | Action |
 |-----|--------|
-| `g` | Open the [Code Review](code-review.md) diff for the selected session |
+| `g` | Open the [Code Review](/tui/code-review) diff for the selected session |
 | `p` | Commit & push |
 
 ### Within the Code Review diff
@@ -93,17 +93,30 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 | Key | Action |
 |-----|--------|
 | `↑` / `↓` | Move across the file tree (file → scroll body) |
-| `j` / `k` | Scroll the diff body |
-| `n` / `N` | Next / previous hunk (`Hunk x/y` counter) |
-| `Space` / `Enter` | Toggle a folder, or collapse/expand a file's diff block |
-| `e` / `E` | Expand / collapse all folders |
-| `z` | Reveal more context at the nearest gap |
-| `[` / `]` | Previous / next file |
-| Mouse | Wheel scrolls the diff; click a tree row to select/toggle |
-| `Tab` | Cycle Review → Commits → Markdown |
-| `Esc` / `q` | Back |
+| `←` / `→` | Switch between file tree and diff view |
+| `Tab` | Toggle focus between file tree and diff view |
+| `Space` | Expand / collapse current file |
+| `e` | Expand all files |
+| `c` | Collapse all files |
+| `n` / `N` | Next / previous hunk |
+| `[` / `]` | Next / previous file |
+| `w` | Toggle word-level diff emphasis |
+| `b` | Toggle blame view |
+| `s` | Toggle side-by-side vs inline view |
+| `Enter` | Open current file in editor |
+| `Esc` / `q` | Exit diff viewer |
 
-> The same surface is available standalone: `ainb diff-review [path]`.
+## Command-line flags
+
+| Key / Flag | Action |
+|------------|--------|
+| `ainb --worktree` | Force worktree isolation for new session |
+| `ainb --create-branch <name>` | Create and switch to new branch in worktree |
+| `ainb --repo <path>` | Target specific repository path |
+| `ainb --remote-repo <url>` | Clone and open remote repository |
+| `ainb --tool <claude\|codex>` | Select agent provider explicitly |
+| `ainb --list` | List active sessions and exit |
+| `ainb --kill <name>` | Terminate named session |
 
 ## Usage / Stats screen
 
@@ -128,6 +141,6 @@ Keys verified against the in-app help overlay (`?`) and the event handlers in `c
 
 ## See also
 
-- [Overview](overview.md)
-- [CLI reference](cli.md)
-- [Docs hub](../README.md)
+- [Overview](/tui/overview)
+- [CLI reference](/tui/cli)
+- [Docs hub](/readme)

--- a/docs/tui/mcp-pool.mdx
+++ b/docs/tui/mcp-pool.mdx
@@ -1,37 +1,37 @@
 ---
 title: "Shared MCP pool"
-description: "ainb runs one MCP server process per server name, shared across every host session over a unix socket — so a swarm of Claude/Codex/Copilot sessions stops spawning a node/bun process per session per MCP. Configure with [mcp_pool], import from .mcp.json, install for other agent CLIs."
+description: "ainb runs one MCP server process per server name, shared across every host session over a unix socket: so a swarm of Claude/Codex/Copilot sessions stops spawning a node/bun process per session per MCP. Configure with [mcp_pool], import from .mcp.json, install for other agent CLIs."
 ---
 
 import { Tabs, TabItem, Steps, Card, CardGrid, Aside } from '@astrojs/starlight/components';
 
 Every Claude Code session normally spawns its **own** node/bun process for each configured MCP server. Run a swarm of sessions and that multiplies into dozens of processes hogging CPU and RAM ([anthropics/claude-code#45880](https://github.com/anthropics/claude-code/issues/45880) reports kernel panics from 510 node processes). The **shared MCP pool** fixes this: a standalone `ainb mcp daemon` spawns each MCP server **once** behind a unix socket, and every session attaches through a tiny `ainb mcp proxy` stdio shim. N sessions, one backend process.
 
-![ainb shared MCP pool — a project with only a .mcp.json (context7 via npx); ainb mcp import makes it poolable; the daemon starts; two independent sessions attach and both get real context7 tools; ainb mcp status shows clients: 2 sharing one child_pid; the process group proof shows a single shared context7 server for both sessions](../assets/screenshots/mcp-pool.gif)
+![ainb shared MCP pool: a project with only a .mcp.json (context7 via npx); ainb mcp import makes it poolable; the daemon starts; two independent sessions attach and both get real context7 tools; ainb mcp status shows clients: 2 sharing one child_pid; the process group proof shows a single shared context7 server for both sessions](../assets/screenshots/mcp-pool.gif)
 
-*Two sessions attach to a real context7 server and both receive its tools (`resolve-library-id`, `query-docs`). `ainb mcp status` reports `clients: 2` against one `child_pid` — a single shared process group. Without the pool, those two sessions would spawn two separate context7 servers.*
+*Two sessions attach to a real context7 server and both receive its tools (`resolve-library-id`, `query-docs`). `ainb mcp status` reports `clients: 2` against one `child_pid`: a single shared process group. Without the pool, those two sessions would spawn two separate context7 servers.*
 
 <CardGrid>
   <Card title="510 processes" icon="warning">
-    node procs that kernel-panicked a Mac — [claude-code#45880](https://github.com/anthropics/claude-code/issues/45880).
+    node procs that kernel-panicked a Mac: [claude-code#45880](https://github.com/anthropics/claude-code/issues/45880).
   </Card>
   <Card title="80% fewer" icon="approve-check">
     processes measured by the community shared-proxy workaround (7 sessions × 5 servers).
   </Card>
   <Card title="11/11 green" icon="rocket">
-    live e2e assertions pass — `scripts/validate-mcp-pool.sh`.
+    live e2e assertions pass: `scripts/validate-mcp-pool.sh`.
   </Card>
 </CardGrid>
 
 ## The problem: MCP process explosion
 
-MCP's stdio transport is one-client-only by design — the client launches the server as a subprocess and owns its stdin/stdout pipe. So every session that wants a server spawns its own copy. Multiply by a swarm of worktree sessions and the math gets ugly fast: Anthropic issue `claude-code#45880` reports 15 sessions × 34 servers demanding up to 510 node processes — enough to trigger hardware-watchdog kernel panics. The community workaround (a shared HTTP proxy) measured an 80% process / 77% memory reduction. ainb bakes that win in natively, no extra runtime.
+MCP's stdio transport is one-client-only by design: the client launches the server as a subprocess and owns its stdin/stdout pipe. So every session that wants a server spawns its own copy. Multiply by a swarm of worktree sessions and the math gets ugly fast: Anthropic issue `claude-code#45880` reports 15 sessions × 34 servers demanding up to 510 node processes: enough to trigger hardware-watchdog kernel panics. The community workaround (a shared HTTP proxy) measured an 80% process / 77% memory reduction. ainb bakes that win in natively, no extra runtime.
 
 ## Quick start
 
 <Steps>
 
-1. The pool is **on by default** — there's nothing to enable for a basic setup.
+1. The pool is **on by default**: there's nothing to enable for a basic setup.
 
 2. Point at any project that has MCP servers in its `.mcp.json` (or in ainb config), then start a session as usual:
 
@@ -49,15 +49,15 @@ MCP's stdio transport is one-client-only by design — the client launches the s
 
 </Steps>
 
-## Walkthrough — from scratch
+## Walkthrough: from scratch
 
 The full journey in one recording: a project whose only MCP config is a plain `.mcp.json`, made poolable with `ainb mcp import`, two sessions attaching to a **real** context7 server, and the proof that both share **one** backend process.
 
-![Shared MCP pool walkthrough — Step 1: a project with a .mcp.json declaring context7 over npx. Step 2: ainb mcp import --user imports it into ainb config. Step 3: the pool daemon starts. Step 4: session-1 and session-2 each attach via ainb mcp proxy and both receive context7's tools (resolve-library-id, query-docs) from the same real server. Step 5: ainb mcp status reports clients: 2 against one child_pid in state running. Step 6: the process group listing shows one npm-exec + node pair — a single shared context7 server. Summary: 2 sessions, 1 shared context7 server; without the pool that would be 2 servers and ~4 node processes.](../assets/screenshots/mcp-pool-journey.gif)
+![Shared MCP pool walkthrough: Step 1: a project with a .mcp.json declaring context7 over npx. Step 2: ainb mcp import --user imports it into ainb config. Step 3: the pool daemon starts. Step 4: session-1 and session-2 each attach via ainb mcp proxy and both receive context7's tools (resolve-library-id, query-docs) from the same real server. Step 5: ainb mcp status reports clients: 2 against one child_pid in state running. Step 6: the process group listing shows one npm-exec + node pair: a single shared context7 server. Summary: 2 sessions, 1 shared context7 server; without the pool that would be 2 servers and ~4 node processes.](../assets/screenshots/mcp-pool-journey.gif)
 
 *Every command in the recording is one you'd run yourself. Reproduce it with `scripts/mcp-pool-journey.sh` (real context7, isolated `$HOME`, no Claude auth needed).*
 
-## Wire it up — per agent
+## Wire it up: per agent
 
 The shim is just a stdio command, so any agent CLI can funnel into the same backend processes. Claude is automatic; Codex and Copilot need one wiring command.
 
@@ -65,7 +65,7 @@ The shim is just a stdio command, so any agent CLI can funnel into the same back
 
 <TabItem label="Claude">
 
-Zero-config — the pool is wired automatically when you `ainb run`.
+Zero-config: the pool is wired automatically when you `ainb run`.
 
 <Steps>
 
@@ -103,7 +103,7 @@ Codex reads a global MCP config, so wire it once.
 
    This adds shim entries to `~/.codex/config.toml` pointing at the pool sockets.
 
-2. Make sure the daemon is up — any ainb Claude session starts it, or run it yourself:
+2. Make sure the daemon is up: any ainb Claude session starts it, or run it yourself:
 
    ```bash
    ainb mcp daemon &
@@ -135,7 +135,7 @@ Same one-time wiring for GitHub Copilot CLI.
    ainb mcp daemon &
    ```
 
-3. Start Copilot — its MCP servers now attach to the shared pool.
+3. Start Copilot: its MCP servers now attach to the shared pool.
 
 </Steps>
 
@@ -147,7 +147,7 @@ Wire both at once with `ainb mcp install --codex --copilot`. A Codex session, a 
 
 ## Configure the pool
 
-Pool settings and per-server opt-out live in `config.toml` (user-level `~/.agents-in-a-box/config/config.toml`, or per-repo `.ainb/config.toml`), or in the TUI under **Configuration → MCP Pool**. You usually don't have to hand-write any of this — see the **.mcp.json** and **import** tabs.
+Pool settings and per-server opt-out live in `config.toml` (user-level `~/.agents-in-a-box/config/config.toml`, or per-repo `.ainb/config.toml`), or in the TUI under **Configuration → MCP Pool**. You usually don't have to hand-write any of this: see the **.mcp.json** and **import** tabs.
 
 <Tabs syncKey="config">
 
@@ -185,7 +185,7 @@ You don't have to declare servers in ainb config at all. A project whose only MC
 }
 ```
 
-`ainb run` auto-imports the stdio entry, registers it with the daemon, and rewrites `.mcp.json` to point at the shim. Remote (`http`/`sse`) entries are left alone — there's no local process to pool.
+`ainb run` auto-imports the stdio entry, registers it with the daemon, and rewrites `.mcp.json` to point at the shim. Remote (`http`/`sse`) entries are left alone: there's no local process to pool.
 
 </TabItem>
 
@@ -229,27 +229,27 @@ ainb mcp status
 
 ## Monitor the pool
 
-Open the **MCP** entry in the home sidebar (or press `p` for *pool*) for a live overlay of what's served right now — and **which sessions share each backend process**.
+Open the **MCP** entry in the home sidebar (or press `p` for *pool*) for a live overlay of what's served right now: and **which sessions share each backend process**.
 
-![ainb MCP pool overlay — a popup titled "MCP Pool — 1 server · 1 shared" over the home screen; a table row shows context7, state running, Shared ✓×2 in green, Sessions "api-session, web-session", a PID, spawn count, and uptime; the sidebar shows the 🧬 MCP entry; the help bar reads "↑↓ select · s stop server · X stop pool · r refresh · esc close · refreshed 2s ago"](../assets/screenshots/mcp-overlay.gif)
+![ainb MCP pool overlay: a popup titled "MCP Pool: 1 server · 1 shared" over the home screen; a table row shows context7, state running, Shared ✓×2 in green, Sessions "api-session, web-session", a PID, spawn count, and uptime; the sidebar shows the 🧬 MCP entry; the help bar reads "↑↓ select · s stop server · X stop pool · r refresh · esc close · refreshed 2s ago"](../assets/screenshots/mcp-overlay.gif)
 
-*Two sessions sharing one context7 process — the overlay names them (`api-session`, `web-session`) against a single `pid`. The session label is the ainb session name, passed through the shim's `--session` flag.*
+*Two sessions sharing one context7 process: the overlay names them (`api-session`, `web-session`) against a single `pid`. The session label is the ainb session name, passed through the shim's `--session` flag.*
 
 What the table shows per server: **state** (running / grace / idle / failed), **shared** (`✓ ×N` when more than one session is attached), the **session names**, the backend **pid**, **spawn count**, and **uptime**.
 
 Actions:
 
-- **`i` — import**: pulls stdio servers from your Claude user scope (`~/.claude.json`) — plus the launch directory's `.mcp.json` if there is one — into the **global user config** (`~/.agents-in-a-box/config/config.toml`), then makes them show up in the table right away: if the pool daemon is running they're registered with it; if it isn't, **import starts it** (the daemon loads every configured server on boot), so you never get an "imported ✓" with an empty table. The overlay is a *global* pool view (it isn't bound to any worktree), so import targets the user config — the one config read from anywhere; per-worktree `.mcp.json` servers are already auto-imported at session create. Import is additive: existing entries are never overwritten, and servers whose command doesn't resolve on the host are skipped. The result (`▸ imported … · started pool`) shows in a line above the help bar.
-- **`s` — stop server** (confirmed): reaps the selected server's process; attached sessions reconnect and the next attach respawns it.
-- **`X` — stop pool** (confirmed): shuts the whole daemon down; every session falls back to its own MCP processes.
+- **`i`: import**: pulls stdio servers from your Claude user scope (`~/.claude.json`): plus the launch directory's `.mcp.json` if there is one: into the **global user config** (`~/.agents-in-a-box/config/config.toml`), then makes them show up in the table right away: if the pool daemon is running they're registered with it; if it isn't, **import starts it** (the daemon loads every configured server on boot), so you never get an "imported ✓" with an empty table. The overlay is a *global* pool view (it isn't bound to any worktree), so import targets the user config: the one config read from anywhere; per-worktree `.mcp.json` servers are already auto-imported at session create. Import is additive: existing entries are never overwritten, and servers whose command doesn't resolve on the host are skipped. The result (`▸ imported … · started pool`) shows in a line above the help bar.
+- **`s`: stop server** (confirmed): reaps the selected server's process; attached sessions reconnect and the next attach respawns it.
+- **`X`: stop pool** (confirmed): shuts the whole daemon down; every session falls back to its own MCP processes.
 - **`r`** refreshes on demand; **`esc`** / **`q`** closes.
 
-![ainb MCP pool overlay import — the overlay open over the home screen; pressing `i` imports a server into the user config, a "▸ imported context7 → …/.agents-in-a-box/config/config.toml" result line appears above the help bar, and the context7 row shows in the table; the help bar reads "↑↓ select · s stop server · X stop pool · i import · r refresh · esc close"](../assets/screenshots/mcp-import.gif)
+![ainb MCP pool overlay import: the overlay open over the home screen; pressing `i` imports a server into the user config, a "▸ imported context7 → …/.agents-in-a-box/config/config.toml" result line appears above the help bar, and the context7 row shows in the table; the help bar reads "↑↓ select · s stop server · X stop pool · i import · r refresh · esc close"](../assets/screenshots/mcp-import.gif)
 
-*Press `i` in the overlay to bring servers in from `.mcp.json` without dropping to a shell — it writes the config and registers them live.*
+*Press `i` in the overlay to bring servers in from `.mcp.json` without dropping to a shell: it writes the config and registers them live.*
 
 <Aside type="tip" title="It costs nothing when closed">
-The overlay is lazy by design. It fetches the daemon's status **once on open**, then (while open) auto-refreshes every `monitor_refresh_secs` (default `2`; set `0` for on-open + manual only). The control-socket read runs off-thread, so the TUI never blocks; and when the overlay is closed, **nothing polls** — there is no background monitor. Configure under `[mcp_pool]`:
+The overlay is lazy by design. It fetches the daemon's status **once on open**, then (while open) auto-refreshes every `monitor_refresh_secs` (default `2`; set `0` for on-open + manual only). The control-socket read runs off-thread, so the TUI never blocks; and when the overlay is closed, **nothing polls**: there is no background monitor. Configure under `[mcp_pool]`:
 
 ```toml
 [mcp_pool]
@@ -269,7 +269,7 @@ A tool call fans in: many stdio shims, one socket, one child.
 
 <Steps>
 
-1. **A session attaches.** At session create, `ainb run` ensures the daemon is up, then rewrites the worktree's `.mcp.json` so each pooled server's entry becomes the shim (`ainb mcp proxy <socket>`). When the agent launches that "server", it's really launching the shim — a line-framed stdio↔socket bridge with exponential-backoff reconnect, so a daemon blip recovers in seconds.
+1. **A session attaches.** At session create, `ainb run` ensures the daemon is up, then rewrites the worktree's `.mcp.json` so each pooled server's entry becomes the shim (`ainb mcp proxy <socket>`). When the agent launches that "server", it's really launching the shim: a line-framed stdio↔socket bridge with exponential-backoff reconnect, so a daemon blip recovers in seconds.
 
 2. **The daemon lazy-spawns the real server.** The first client to connect triggers the one-and-only spawn of the actual MCP command (e.g. `npx -y @upstash/context7-mcp`), in its own process group so npx/uvx grandchildren die with it. Restarts are rate-limited.
 
@@ -279,11 +279,11 @@ A tool call fans in: many stdio shims, one socket, one child.
 
 </Steps>
 
-If anything fails — daemon down, server not on PATH — the session silently falls back to spawning its own MCP, so a session never fails to start because of the pool. Host/tmux sessions only; Docker sessions keep their per-container MCP init.
+If anything fails: daemon down, server not on PATH: the session silently falls back to spawning its own MCP, so a session never fails to start because of the pool. Host/tmux sessions only; Docker sessions keep their per-container MCP init.
 
-## One daemon per machine — lifecycle &amp; scaling
+## One daemon per machine: lifecycle &amp; scaling
 
-**Running several `ainb` windows does *not* start several daemons.** There is exactly **one daemon per user**, keyed by the control socket at `~/.agents-in-a-box/mcp/sockets/control.sock`. Every `ainb` instance — and every Codex/Copilot session wired with `ainb mcp install` — discovers and shares that one daemon, which in turn keeps one child process per server. Ten windows all using context7 = **one** `context7` process, not ten.
+**Running several `ainb` windows does *not* start several daemons.** There is exactly **one daemon per user**, keyed by the control socket at `~/.agents-in-a-box/mcp/sockets/control.sock`. Every `ainb` instance: and every Codex/Copilot session wired with `ainb mcp install`: discovers and shares that one daemon, which in turn keeps one child process per server. Ten windows all using context7 = **one** `context7` process, not ten.
 
 The singleton is enforced by two independent guards, so even a dead heat collapses to one survivor:
 
@@ -291,11 +291,11 @@ The singleton is enforced by two independent guards, so even a dead heat collaps
 
 1. **Discover before spawn.** Before starting a daemon, `ensure_daemon()` (what `ainb run` and the overlay's import call) connects to the control socket and `ping`s it. If it answers, nothing is spawned.
 
-2. **Exclusive bind.** If a daemon *is* spawned, it re-checks the socket and then `bind()`s it — an OS-exclusive operation. If two instances race past step 1 simultaneously, the first binds and the second's bind fails, so it logs and exits. A crashed daemon's stale socket fails the liveness `connect` and is cleaned up automatically, so a fresh start is never blocked.
+2. **Exclusive bind.** If a daemon *is* spawned, it re-checks the socket and then `bind()`s it: an OS-exclusive operation. If two instances race past step 1 simultaneously, the first binds and the second's bind fails, so it logs and exits. A crashed daemon's stale socket fails the liveness `connect` and is cleaned up automatically, so a fresh start is never blocked.
 
 </Steps>
 
-Scope is **per `$HOME`**: same user → same daemon. (Sandboxes with a custom `$HOME` get their own pool — that's how the test harnesses stay isolated.)
+Scope is **per `$HOME`**: same user → same daemon. (Sandboxes with a custom `$HOME` get their own pool: that's how the test harnesses stay isolated.)
 
 ### What it costs at rest
 
@@ -303,11 +303,11 @@ Scope is **per `$HOME`**: same user → same daemon. (Sandboxes with a custom `$
 |---|---|
 | **Lazy spawn** | At daemon start only lightweight listener tasks exist; the child process spawns on **first attach**. An idle pool is essentially free. |
 | **Refcounted sharing** | N session shims → **1 child** per server. The win scales with how many sessions you run. |
-| **Per-server reap** | `idle_grace_secs` (default 300) after the last client detaches, the **child** is killed but the listener stays — the next attach respawns it. |
-| **Daemon self-shutdown** | `daemon_idle_grace_secs` (default 900; `0` = never) with **zero** clients anywhere, the **whole daemon** exits and removes its sockets. `ainb run` / import restart it on demand, so an unused — or orphaned — pool never lingers. |
+| **Per-server reap** | `idle_grace_secs` (default 300) after the last client detaches, the **child** is killed but the listener stays: the next attach respawns it. |
+| **Daemon self-shutdown** | `daemon_idle_grace_secs` (default 900; `0` = never) with **zero** clients anywhere, the **whole daemon** exits and removes its sockets. `ainb run` / import restart it on demand, so an unused: or orphaned: pool never lingers. |
 
 <Aside type="tip" title="Why the daemon can exit on its own">
-The daemon is spawned detached so it survives the TUI closing — useful for a persistent pool, but it means a daemon whose `$HOME`/sandbox was deleted would otherwise run forever. `daemon_idle_grace_secs` closes that: no clients for the grace window → clean exit. Because startup is lazy and cheap, the next session just brings it back.
+The daemon is spawned detached so it survives the TUI closing: useful for a persistent pool, but it means a daemon whose `$HOME`/sandbox was deleted would otherwise run forever. `daemon_idle_grace_secs` closes that: no clients for the grace window → clean exit. Because startup is lazy and cheap, the next session just brings it back.
 </Aside>
 
 ## The hard parts the mux had to solve
@@ -315,23 +315,23 @@ The daemon is spawned detached so it survives the TUI closing — useful for a p
 A naive byte-pipe (the agent-deck approach this started from) leaks state across sessions. The ainb mux fixes the two worst cases so a shared server behaves correctly per-client.
 
 <Aside type="tip" title="Initialize cache">
-MCP servers expect exactly one `initialize` per process lifetime, but every session sends its own. The mux forwards the **first** one, caches the backend's `InitializeResult`, and answers every later session's `initialize` from that cache — the child sees one handshake, every client gets a valid reply with its own id. Errors aren't cached, so a failed handshake retries cleanly.
+MCP servers expect exactly one `initialize` per process lifetime, but every session sends its own. The mux forwards the **first** one, caches the backend's `InitializeResult`, and answers every later session's `initialize` from that cache: the child sees one handshake, every client gets a valid reply with its own id. Errors aren't cached, so a failed handshake retries cleanly.
 </Aside>
 
 <Aside type="tip" title="progressToken routing">
-Progress notifications carry a token, not a request id. The mux records which session owns each token at call time and delivers progress to that session only — so session A's "50% done" doesn't broadcast to B and C.
+Progress notifications carry a token, not a request id. The mux records which session owns each token at call time and delivers progress to that session only: so session A's "50% done" doesn't broadcast to B and C.
 </Aside>
 
 <Aside type="caution" title="v1 limitations">
-Server-initiated requests (sampling, elicitation, roots) still broadcast — most pooled tool-servers don't use them. Stateful servers (browser/db bridges) should opt out of sharing with `shared = false` and keep spawning per-session, since env/credentials bake in at spawn and are shared by every attached session.
+Server-initiated requests (sampling, elicitation, roots) still broadcast: most pooled tool-servers don't use them. Stateful servers (browser/db bridges) should opt out of sharing with `shared = false` and keep spawning per-session, since env/credentials bake in at spawn and are shared by every attached session.
 </Aside>
 
 ## Gotchas worth knowing
 
-- **Host/tmux sessions only.** Docker sessions keep their per-container MCP init — the pool doesn't touch that path.
+- **Host/tmux sessions only.** Docker sessions keep their per-container MCP init: the pool doesn't touch that path.
 - **The daemon reads config at *its* cwd**, so sessions in other projects push their server definitions over the control socket (`register`) rather than relying on what the daemon saw at startup.
-- **Shared identity.** Env/credentials bake in at spawn and are shared by every attached session — fine for tool servers, a reason to set `shared = false` for anything per-user-authenticated.
-- **Failure never blocks a session.** Daemon down, server not on PATH, socket gone — the session silently falls back to spawning its own MCP, exactly like today.
+- **Shared identity.** Env/credentials bake in at spawn and are shared by every attached session: fine for tool servers, a reason to set `shared = false` for anything per-user-authenticated.
+- **Failure never blocks a session.** Daemon down, server not on PATH, socket gone: the session silently falls back to spawning its own MCP, exactly like today.
 
 ## Commands
 
@@ -349,28 +349,28 @@ Server-initiated requests (sampling, elicitation, roots) still broadcast — mos
 <details>
 <summary>Does it work for any MCP, or just npm/npx?</summary>
 
-Any **stdio** server — npx, uvx, bun, a compiled binary, `docker run -i`. The mux speaks newline-delimited JSON-RPC over the child's stdio, which is identical regardless of runtime. Remote `http`/`sse` servers aren't pooled (there's no local process to share).
+Any **stdio** server: npx, uvx, bun, a compiled binary, `docker run -i`. The mux speaks newline-delimited JSON-RPC over the child's stdio, which is identical regardless of runtime. Remote `http`/`sse` servers aren't pooled (there's no local process to share).
 
 </details>
 
 <details>
 <summary>What stops two sessions' requests from colliding?</summary>
 
-The mux rewrites every request id to a global counter and remembers which session owned the original id, so responses and progress route back to exactly one session. Claude Code always starts ids at 1 — that's the collision this prevents.
+The mux rewrites every request id to a global counter and remembers which session owned the original id, so responses and progress route back to exactly one session. Claude Code always starts ids at 1: that's the collision this prevents.
 
 </details>
 
 <details>
 <summary>How was "one process" actually proven?</summary>
 
-Two ways. The committed GIF drives real context7 with two shim attaches and reads `child_pid` + the process group. And `scripts/validate-mcp-pool.sh 3` spins up three real ainb Claude sessions and asserts one backend, three shims, a working tool call from every session, kill-one-survives resilience, and post-grace reaping — 11/11 green.
+Two ways. The committed GIF drives real context7 with two shim attaches and reads `child_pid` + the process group. And `scripts/validate-mcp-pool.sh 3` spins up three real ainb Claude sessions and asserts one backend, three shims, a working tool call from every session, kill-one-survives resilience, and post-grace reaping: 11/11 green.
 
 </details>
 
 <details>
 <summary>What happens when a pooled server crashes mid-call?</summary>
 
-The daemon reaps the zombie and drops the clients; their shims reconnect with backoff while the health loop respawns the child (rate-limited). In-flight requests are lost and the agent retries — the same contract a per-session server gives you.
+The daemon reaps the zombie and drops the clients; their shims reconnect with backoff while the health loop respawns the child (rate-limited). In-flight requests are lost and the agent retries: the same contract a per-session server gives you.
 
 </details>
 
@@ -391,5 +391,5 @@ scripts/validate-mcp-pool.sh 3
 
 ## See also
 
-- [CLI reference](cli.md)
-- [Overview](overview.md)
+- [CLI reference](/tui/cli)
+- [Overview](/tui/overview)

--- a/docs/tui/overview.md
+++ b/docs/tui/overview.md
@@ -24,22 +24,22 @@ From the home screen, single keys jump to each screen:
 | Sessions | `s` | List, attach, restart, and delete agent sessions |
 | Agents | `a` | Select a provider or agent before spawning a session |
 | Recovery | `R` | Find and resume orphaned sessions or interrupted worktrees |
-| Stats | `i` | Usage analytics: Daily, Weekly, Project, Burndown, [Savings](token-optimization.mdx) (`[` / `]` switch tabs) |
-| Daemons | `d` | Read-only [Daemons overlay](daemons.mdx): shared MCP pool and Headroom proxy |
+| Stats | `i` | Usage analytics: Daily, Weekly, Project, Burndown, [Savings](/tui/token-optimization) (`[` / `]` switch tabs) |
+| Daemons | `d` | Read-only [Daemons overlay](/tui/daemons): shared MCP pool and Headroom proxy |
 | Skills | `k` | Browse and manage available skills |
 | Inbox | `I` | Central notification inbox for agent events |
 | Config | `C` | View configuration options |
 
 ## Session controls
 
-- **Code Review diff (`g`):** Open the Warp-style [Code Review](code-review.md) diff for the selected session. Displays file tree, collapsible blocks, syntax highlighting, and word-level emphasis. Also available standalone as `ainb diff-review`.
+- **Code Review diff (`g`):** Open the Warp-style [Code Review](/tui/code-review) diff for the selected session. Displays file tree, collapsible blocks, syntax highlighting, and word-level emphasis. Also available standalone as `ainb diff-review`.
 - **Full-screen attach (`a`):** Attach directly to the session tmux instance. Detach with `Ctrl-b d` to return to the TUI.
 - **In-pane attach (`A`):** Embed a live tmux client in-place inside the preview pane. Press `Ctrl+Q` to release keyboard focus back to the TUI.
 
 ## Next steps
 
-- [Quickstart](quickstart.md): start your first session
-- [Starting a new session](start-session.md): configure wizard options
-- [Attaching to sessions](attach.md): full-screen and embedded tmux modes
-- [Keyboard shortcuts](keyboard-shortcuts.md): complete keymap
-- [CLI reference](cli.md): all subcommands and flags
+- [Quickstart](/tui/quickstart): start your first session
+- [Starting a new session](/tui/start-session): configure wizard options
+- [Attaching to sessions](/tui/attach): full-screen and embedded tmux modes
+- [Keyboard shortcuts](/tui/keyboard-shortcuts): complete keymap
+- [CLI reference](/tui/cli): all subcommands and flags

--- a/docs/tui/quickstart.md
+++ b/docs/tui/quickstart.md
@@ -63,7 +63,7 @@ ainb kill my-project -f     # force, no prompt
 
 ## Where to go next
 
-- [Concepts](../product/concepts.md): workspaces, worktrees, and persistence
-- [Keyboard shortcuts](keyboard-shortcuts.md)
-- [CLI reference](cli.md): every subcommand and flag
-- [Starting a new session](start-session.md): new session wizard options
+- [Concepts](/product/concepts): workspaces, worktrees, and persistence
+- [Keyboard shortcuts](/tui/keyboard-shortcuts)
+- [CLI reference](/tui/cli): every subcommand and flag
+- [Starting a new session](/tui/start-session): new session wizard options

--- a/docs/tui/start-session.md
+++ b/docs/tui/start-session.md
@@ -73,7 +73,7 @@ Press `Enter` on **`[ Launch ]`**, or press **`Ctrl+Enter`** from any row to qui
 
 ## Next steps
 
-- [Quickstart](quickstart.md): command-line `ainb run` equivalents
-- [Attaching to sessions](attach.md): full-screen and embedded tmux attach
-- [Keyboard shortcuts](keyboard-shortcuts.md): complete keymap
-- [Overview](overview.md): all TUI screens
+- [Quickstart](/tui/quickstart): command-line `ainb run` equivalents
+- [Attaching to sessions](/tui/attach): full-screen and embedded tmux attach
+- [Keyboard shortcuts](/tui/keyboard-shortcuts): complete keymap
+- [Overview](/tui/overview): all TUI screens

--- a/docs/tui/token-optimization.mdx
+++ b/docs/tui/token-optimization.mdx
@@ -1,20 +1,20 @@
 ---
-title: "Token optimisation — Headroom & RTK"
+title: "Token optimisation: Headroom & RTK"
 description: "Turn on per-session token optimisation in ainb: route a session's CLI through the local Headroom compression proxy, wire the RTK PreToolUse hook, and watch real tokens saved on the burndown Savings tab. Opt-in per session, never global, fault-tolerant."
 ---
 
 import { Steps, Card, CardGrid, Aside } from '@astrojs/starlight/components';
 
-Two external tools can cut the tokens a session burns, and ainb wires both in **per session** — opt-in, never global:
+Two external tools can cut the tokens a session burns, and ainb wires both in **per session**: opt-in, never global:
 
-- **[Headroom](https://github.com/chopratejas/headroom)** — a local LLM-API compression proxy. A session's Claude/Codex CLI is pointed at it via `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`, so requests are compressed on the way out.
-- **[RTK](https://github.com/rtk-ai/rtk)** (Rust Token Killer) — a Claude Code `PreToolUse` hook that compresses tool output (Bash / test / diff) before it reaches the model.
+- **[Headroom](https://github.com/chopratejas/headroom)**: a local LLM-API compression proxy. A session's Claude/Codex CLI is pointed at it via `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`, so requests are compressed on the way out.
+- **[RTK](https://github.com/rtk-ai/rtk)** (Rust Token Killer): a Claude Code `PreToolUse` hook that compresses tool output (Bash / test / diff) before it reaches the model.
 
 Both are toggled when you create a session, both degrade gracefully when the binary isn't installed, and the savings show up live in the TUI.
 
 <CardGrid>
   <Card title="Per session" icon="setting">
-    Toggled on the Configure screen — one session can route through Headroom while another goes direct to Anthropic.
+    Toggled on the Configure screen: one session can route through Headroom while another goes direct to Anthropic.
   </Card>
   <Card title="Reflects reality" icon="approve-check">
     The statusline `HR` badge and the Savings tab read **actual routing** (the inherited base-URL env), not the stored toggle.
@@ -28,9 +28,9 @@ Both are toggled when you create a session, both degrade gracefully when the bin
 
 Headroom and RTK are rows on the **Configure** screen when you start a new session (provider must be Claude or Codex for Headroom; RTK is Claude-only). Use `←` / `→` to flip each toggle.
 
-![ainb new-session Configure screen showing the per-session Headroom toggle — Headroom on / [off] with arrow keys to change, a greyed note that it is a proxy that trims token usage with a link to the headroom GitHub](../assets/screenshots/headroom-toggle.gif)
+![ainb new-session Configure screen showing the per-session Headroom toggle: Headroom on / [off] with arrow keys to change, a greyed note that it is a proxy that trims token usage with a link to the headroom GitHub](../assets/screenshots/headroom-toggle.gif)
 
-*The Headroom row on Configure. The toggle is **per session** — flip it on here and only this session routes through the proxy. If the `headroom` binary isn't on `PATH`, the row shows `unavailable` with an install hint instead of a toggle, so you can never arm a proxy that can't exist.*
+*The Headroom row on Configure. The toggle is **per session**: flip it on here and only this session routes through the proxy. If the `headroom` binary isn't on `PATH`, the row shows `unavailable` with an install hint instead of a toggle, so you can never arm a proxy that can't exist.*
 
 <Aside type="note">
 Headroom proxies **Claude and Codex**; RTK is a Claude Code hook (`.claude/settings.json`), so its toggle only appears for Claude sessions. Gemini and Copilot are routed by neither.
@@ -45,37 +45,37 @@ export ANTHROPIC_BASE_URL='http://127.0.0.1:8787' && exec claude    # Claude
 export OPENAI_BASE_URL='http://127.0.0.1:8787/v1' && exec codex     # Codex
 ```
 
-If the proxy can't come up, the session **degrades to direct** — it launches without the base-URL so it talks to the provider straight, never to a dead port. A session with the toggle **off** always goes direct. The default port is `8787` (override with `AINB_HEADROOM_PORT`).
+If the proxy can't come up, the session **degrades to direct**: it launches without the base-URL so it talks to the provider straight, never to a dead port. A session with the toggle **off** always goes direct. The default port is `8787` (override with `AINB_HEADROOM_PORT`).
 
 ### Statusline `HR` badge
 
-A routed session shows an `HR` pill on the Claude Code statusline — **green** when the proxy is live, **grey** when the session is routed but the proxy is down. It reads the base-URL env the statusline process actually inherited, so it tells you whether requests are *really* being compressed, not just whether you flipped the toggle.
+A routed session shows an `HR` pill on the Claude Code statusline: **green** when the proxy is live, **grey** when the session is routed but the proxy is down. It reads the base-URL env the statusline process actually inherited, so it tells you whether requests are *really* being compressed, not just whether you flipped the toggle.
 
-## See what you saved — the Savings tab
+## See what you saved: the Savings tab
 
 Open the usage screen with `i`, then press `]` to cycle the outer tabs to **Savings**:
 
-![ainb usage Savings tab — the Token Savings card with a live green Headroom row showing real saved tokens, RTK not installed, a modelled caveman estimate at times 0.74, and a NET measured total of Headroom plus RTK](../assets/screenshots/savings-tab.gif)
+![ainb usage Savings tab: the Token Savings card with a live green Headroom row showing real saved tokens, RTK not installed, a modelled caveman estimate at times 0.74, and a NET measured total of Headroom plus RTK](../assets/screenshots/savings-tab.gif)
 
 *The Savings card pulls `savings.total_tokens` straight from the live proxy's `/stats`: `● Headroom 907K live`. RTK shows installed/not-installed and its own saved total. The **caveman** row is a modelled estimate (`×0.74`, labelled `est`) and is never counted as real. **NET (measured)** = Headroom + RTK only.*
 
 <Aside type="tip">
-The same figures are available headlessly with `ainb usage savings`, and the Headroom proxy's live saved-token count also appears on the [Daemons overlay](daemons.mdx) (`d`).
+The same figures are available headlessly with `ainb usage savings`, and the Headroom proxy's live saved-token count also appears on the [Daemons overlay](/tui/daemons) (`d`).
 </Aside>
 
 ## CLI surfaces
 
-Every surface has a headless equivalent — `ainb headroom status`, `ainb rtk status`, `ainb usage savings`, and `ainb doctor` (which lists both as token-opt deps):
+Every surface has a headless equivalent: `ainb headroom status`, `ainb rtk status`, `ainb usage savings`, and `ainb doctor` (which lists both as token-opt deps):
 
 ![ainb doctor listing rtk and headroom as token-opt dependencies, ainb rtk status reporting honestly when rtk is not installed, and ainb usage savings printing the Headroom live tokens, RTK, caveman estimate and NET](../assets/screenshots/headroom-cli-surfaces.gif)
 
-*See the [CLI reference](cli.md) for the full subcommand list.*
+*See the [CLI reference](/tui/cli) for the full subcommand list.*
 
 ## Fault tolerance
 
 Token optimisation is best-effort: it must never break a session. Every failure mode degrades cleanly.
 
-![fault-injection harness — the watchdog starts the proxy within seconds and respawns it with a new pid after a kill, and both the Headroom and RTK rows gate to unavailable when the binary is moved aside; 4 passed 0 failed](../assets/screenshots/headroom-fault-injection.gif)
+![fault-injection harness: the watchdog starts the proxy within seconds and respawns it with a new pid after a kill, and both the Headroom and RTK rows gate to unavailable when the binary is moved aside; 4 passed 0 failed](../assets/screenshots/headroom-fault-injection.gif)
 
 | Failure | Behaviour |
 |---------|-----------|
@@ -102,12 +102,12 @@ Token optimisation is best-effort: it must never break a session. Every failure 
    # or: curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh
    ```
 
-3. Re-open the **Configure** screen — the rows are now real toggles instead of `unavailable`.
+3. Re-open the **Configure** screen: the rows are now real toggles instead of `unavailable`.
 
 </Steps>
 
 ## See also
 
-- [Daemons overlay](daemons.mdx) — the `d` screen showing the live Headroom proxy + watchdog.
-- [Shared MCP pool](mcp-pool.mdx) — the other ainb-managed background daemon.
-- [Keyboard shortcuts](keyboard-shortcuts.md).
+- [Daemons overlay](/tui/daemons): the `d` screen showing the live Headroom proxy + watchdog.
+- [Shared MCP pool](/tui/mcp-pool): the other ainb-managed background daemon.
+- [Keyboard shortcuts](/tui/keyboard-shortcuts).

--- a/docs/tui/web.md
+++ b/docs/tui/web.md
@@ -1,15 +1,15 @@
 ---
-title: "ainb web — fleet dashboard"
+title: "ainb web: fleet dashboard"
 ---
 
 `ainb web` serves a browser-based dashboard *and remote-control surface* for
 your agent fleet: the live session list, fleet `needs` (ASK / ERR / IDLE /
-WAIT), and cost rollups — updated live over Server-Sent Events — plus a **live
+WAIT), and cost rollups: updated live over Server-Sent Events: plus a **live
 in-browser terminal** for any running session and **web-push notifications**
 when a session needs attention. It is an installable PWA.
 
 It is intended as a glanceable view of *what's running, what needs attention,
-and what it's costing* — and a way to actually *drive* a session — on
+and what it's costing*: and a way to actually *drive* a session: on
 localhost, or over a tailnet with a bearer token.
 
 > **The terminal is the one write surface.** Everything else (sessions, needs,
@@ -28,14 +28,14 @@ ainb web
 # Pick a port
 ainb web --listen 127.0.0.1:9000
 
-# Expose over a tailnet / LAN — a token is REQUIRED for a non-loopback bind
+# Expose over a tailnet / LAN: a token is REQUIRED for a non-loopback bind
 ainb web --listen 0.0.0.0:8420 --token "$(openssl rand -hex 24)"
 ```
 
 Then open the printed URL, e.g. <http://127.0.0.1:8420>.
 
-When a token is set, append it once to the URL —
-`http://host:8420/?token=YOUR_TOKEN` — the page stores it for the session and
+When a token is set, append it once to the URL , 
+`http://host:8420/?token=YOUR_TOKEN`: the page stores it for the session and
 strips it from the address bar.
 
 ---
@@ -46,7 +46,7 @@ strips it from the address bar.
 |------|---------|---------|
 | `--listen <ADDR>` | `127.0.0.1:8420` | Address to bind. Non-loopback requires `--token`. |
 | `--token <SECRET>` | _(none)_ | Bearer token required on every `/api/*` route + the WS terminal. Enables a non-loopback bind. |
-| `--insecure-bind` | `false` | Allow a non-loopback bind with **no** token. **Dangerous** — only honored with `--read-only`; refused otherwise, because an unauthenticated write surface exposes the live WS terminal (shell access to every session). |
+| `--insecure-bind` | `false` | Allow a non-loopback bind with **no** token. **Dangerous**: only honored with `--read-only`; refused otherwise, because an unauthenticated write surface exposes the live WS terminal (shell access to every session). |
 | `--read-only` | `false` | Viewer-only: disable the live terminal (the `/ws/session/{id}` upgrade is refused with `403`). |
 
 ---
@@ -54,7 +54,7 @@ strips it from the address bar.
 ## Security model
 
 The bind policy mirrors agent-deck's `CheckBindSecurity` and is enforced
-**before any socket is opened** — an unsafe bind is refused and never listens.
+**before any socket is opened**: an unsafe bind is refused and never listens.
 
 First matching rule wins:
 
@@ -85,16 +85,16 @@ When a token is configured:
   without `Authorization: Bearer <token>`, **200**/upgrade with the correct
   token.
 - The token is compared in **constant time** (no timing oracle).
-- The **two streaming surfaces** that cannot send an `Authorization` header —
+- The **two streaming surfaces** that cannot send an `Authorization` header , 
   the SSE `EventSource` (`/api/events`) and the WebSocket terminal
-  (`/ws/session/{id}`) — additionally accept the token via `?token=…` query
+  (`/ws/session/{id}`): additionally accept the token via `?token=…` query
   string. The fallback is scoped to exactly those two paths; every JSON route
   still requires the header, so tokens never leak via logs/history/`Referer` on
   ordinary requests. The frontend strips the token from the URL after
   connecting.
 
 The static frontend shell (`/`, `/static/*`) and the PWA surface
-(`/manifest.webmanifest`, `/sw.js`) are served **without** auth — they carry no
+(`/manifest.webmanifest`, `/sw.js`) are served **without** auth: they carry no
 secrets and must load before the page can prompt for a token. Only data and the
 terminal are gated.
 
@@ -104,9 +104,9 @@ The live terminal at `/ws/session/{id}` is the only route that can *change*
 fleet state (it forwards keystrokes into a session's tmux pane). It is gated
 twice:
 
-1. **Auth** — the bearer middleware runs before the WebSocket upgrade. An
+1. **Auth**: the bearer middleware runs before the WebSocket upgrade. An
    unauthenticated client never attaches.
-2. **Posture** — in `--read-only` mode the upgrade is refused outright with
+2. **Posture**: in `--read-only` mode the upgrade is refused outright with
    `403 READ_ONLY`. There is no "connect then reject input" half-state; the
    write surface simply does not exist.
 
@@ -128,7 +128,7 @@ All API responses are JSON. Errors use `{ "error": { "code", "message" } }`.
 | GET | `/manifest.webmanifest` | PWA manifest (no auth). |
 | GET | `/sw.js` | Service worker, `Service-Worker-Allowed: /` (no auth). |
 | GET | `/healthz` | `{ ok, readOnly, tokenRequired, version }` |
-| GET | `/api/snapshot` | `{ sessions, needs, cost }` — the full dashboard payload. |
+| GET | `/api/snapshot` | `{ sessions, needs, cost }`: the full dashboard payload. |
 | GET | `/api/sessions` | Live session list (proxies `ainb --format json list`). |
 | GET | `/api/needs` | Fleet needs (proxies `ainb --format json fleet needs`). |
 | GET | `/api/cost` | Cost rollups (proxies `ainb --format json fleet cost`); `null` when absent. |
@@ -139,10 +139,10 @@ All API responses are JSON. Errors use `{ "error": { "code", "message" } }`.
 | POST | `/api/push/unsubscribe` | Drop a subscription by `endpoint`. |
 | POST | `/api/push/presence` | Report tab focus (`{ endpoint, focused }`) to suppress pushes you don't need. |
 
-`401 UNAUTHORIZED` — missing/invalid bearer (only when a token is configured).
-`403 READ_ONLY` — the WS terminal in `--read-only` mode.
-`502 UPSTREAM_FAILED` — an underlying `ainb` command failed.
-`503 PUSH_NOT_CONFIGURED` — a `/api/push/*` route when push isn't enabled.
+`401 UNAUTHORIZED`: missing/invalid bearer (only when a token is configured).
+`403 READ_ONLY`: the WS terminal in `--read-only` mode.
+`502 UPSTREAM_FAILED`: an underlying `ainb` command failed.
+`503 PUSH_NOT_CONFIGURED`: a `/api/push/*` route when push isn't enabled.
 
 ### Terminal wire protocol
 
@@ -161,7 +161,7 @@ Resize is clamped to a minimum 10×3 to keep tmux out of a degenerate pane.
 
 A background task reads the same cached `needs` snapshot the dashboard renders
 and sends a push the moment a session **transitions into** an attention state
-(`ASK` / `ERR` / `WAIT` — the kinds `ainb fleet needs` emits; a permission
+(`ASK` / `ERR` / `WAIT`: the kinds `ainb fleet needs` emits; a permission
 prompt surfaces as `ASK`). The first tick is a baseline, so there's no flood
 on startup. Pushes are suppressed for any subscription whose tab reports itself
 focused (via `/api/push/presence`), and dead endpoints (404/410) are pruned
@@ -192,7 +192,7 @@ skipped entirely when there are no SSE subscribers.
 ### Cost graceful degradation
 
 `ainb fleet cost` ships with the **fleet cost-surface** feature. If it isn't
-present in your build, the dashboard does not fail — the Cost panel shows
+present in your build, the dashboard does not fail: the Cost panel shows
 "Cost surface not available in this build" and everything else works.
 
 ---
@@ -210,11 +210,11 @@ present in your build, the dashboard does not fail — the Cost panel shows
 
 - Core crate `ainb-web` (axum HTTP + SSE + WebSocket), wired in as the
   `ainb web` subcommand via `cli/registry.rs`.
-- The frontend is a single embedded vanilla-JS bundle (`rust-embed`) — **no
+- The frontend is a single embedded vanilla-JS bundle (`rust-embed`): **no
   Node build step, no framework, no runtime filesystem dependency**. xterm.js
   is vendored and embedded the same way (no runtime CDN).
 - The terminal uses `portable-pty` to run `tmux attach-session` and streams raw
-  bytes to xterm.js — the browser is the terminal emulator, so no server-side
+  bytes to xterm.js: the browser is the terminal emulator, so no server-side
   vt100 re-parse.
 - Web-push uses the `web-push` crate (`hyper-client`, no libcurl); the VAPID
   keypair is generated with `p256`.
@@ -231,5 +231,5 @@ present in your build, the dashboard does not fail — the Cost panel shows
   macOS, OpenSSL on Linux). This is isolated to the push send path.
 - **Push targets attention transitions, not every hook.** Delivery is driven
   off the polled `needs` surface (same cadence as the dashboard), not a direct
-  notifyd socket subscription — simple, and it reuses the existing cache. A
+  notifyd socket subscription: simple, and it reuses the existing cache. A
   future event-driven upgrade could hook notifyd directly for lower latency.


### PR DESCRIPTION
## Summary
- Convert 220+ relative markdown links across all public documentation files to clean canonical site routes.
- Eliminate all em-dashes in public docs, replacing with colons, commas, or parentheses per impeccable standards.
- Fix YAML frontmatter parsing errors in skill-manager docs.
- Rebuild static site via Starlight (70/70 pages built cleanly).
- Validate internal links (5,402 links scanned, 0 broken).
- Execute headless expect-cli browser test suite: 12/12 test journeys passed with zero console errors and zero horizontal overflow.

## Commits
- 66 atomic single-file commits, GPG signed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation navigation to use consistent website-style links that resolve correctly across pages.
  - Standardized punctuation, headings, link formatting, and presentation throughout the documentation.
  - Expanded guidance for daemon controls, MCP pool monitoring and actions, keyboard shortcuts, and token-optimization setup.
  - Clarified several TUI, plugin, observability, and architecture references without changing product behavior.
  - Added links and notes to improve discoverability of related guides and component documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->