### PR TITLE
fix: restore sidebar session state

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -72,6 +72,9 @@ pub struct SessionFleetMetadata {
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
     pub direct_child_count: i64,
+    /// Provider-owned identity from an exact Fleet correlation. This lets a
+    /// legacy local row consume its own hook events without guessing by cwd.
+    pub provider_session_id: Option<String>,
     /// Exact Fleet lifecycle, omitted when Fleet has no observation.
     pub lifecycle: Option<ainb_hangar_proto::fleet::LifecycleState>,
 }
@@ -12549,8 +12552,17 @@ impl AppState {
             .filter(|row| row.provider == provider && row.cwd.trim_end_matches('/') == cwd);
         let first = by_cwd.next();
         let by_unique_cwd = first.filter(|_| by_cwd.next().is_none());
-        let row = by_key.or(by_unique_tmux).or(by_unique_cwd)?;
-        (row.model.is_some()
+        // Cwd can recover *display metadata* but never hook identity: two
+        // local agent rows can share one worktree while only one provider row
+        // has been observed. An exact persisted id or unique tmux target is
+        // the only bridge allowed to carry the provider session id onward.
+        let (row, provider_session_id) = if let Some(row) = by_key.or(by_unique_tmux) {
+            (row, row.provider_session_id.clone())
+        } else {
+            (by_unique_cwd?, None)
+        };
+        (provider_session_id.is_some()
+            || row.model.is_some()
             || row.reasoning_effort.is_some()
             || row.active_work_count > 0
             || row.lifecycle != ainb_hangar_proto::fleet::LifecycleState::Unknown)
@@ -12558,6 +12570,7 @@ impl AppState {
                 model: row.model.clone(),
                 reasoning_effort: row.reasoning_effort.clone(),
                 direct_child_count: row.active_work_count,
+                provider_session_id,
                 lifecycle: (row.lifecycle != ainb_hangar_proto::fleet::LifecycleState::Unknown)
                     .then_some(row.lifecycle),
             })
@@ -12682,6 +12695,7 @@ impl AppState {
             bool,
             Option<String>,
             Option<crate::models::SessionStatus>,
+            Option<String>,
         )> = Vec::new();
         for ws in &self.workspaces {
             for s in &ws.sessions {
@@ -12697,6 +12711,15 @@ impl AppState {
                             .and_then(Self::session_status_for_fleet_lifecycle)
                     })
                     .flatten();
+                // Persisted identity is authoritative. Older local rows have
+                // none, so use only the Fleet ID that `fleet_metadata_for`
+                // correlated exactly by provider id or tmux target. Never
+                // infer an id from cwd.
+                let provider_session_id = s.provider_session_id.clone().or_else(|| {
+                    fleet_metadata
+                        .get(&s.id)
+                        .and_then(|metadata| metadata.provider_session_id.clone())
+                });
                 let allow_unidentified_cwd = sessions_per_cwd
                     .get(&s.workspace_path.trim_end_matches('/').to_string())
                     .copied()
@@ -12704,7 +12727,7 @@ impl AppState {
                 let local_terminal_status = Self::local_terminal_status_for_session_identity(
                     &s.workspace_path,
                     Self::agent_hook_name(s.agent_type),
-                    s.provider_session_id.as_deref(),
+                    provider_session_id.as_deref(),
                     allow_unidentified_cwd,
                     true,
                     self.attention_baseline.get(&s.id).copied().unwrap_or(0),
@@ -12715,12 +12738,11 @@ impl AppState {
                 // Exact provider id wins. A cwd fallback is safe only if that
                 // cwd names one local session; sibling subagents otherwise
                 // receive neither a copied ASK nor a guessed answer route.
-                let exact_rows = s
-                    .provider_session_id
+                let exact_rows = provider_session_id
                     .as_deref()
                     .map(|session_id| daemon.rows_for_session_id(session_id))
                     .unwrap_or_default();
-                let daemon_rows = if s.provider_session_id.is_none()
+                let daemon_rows = if provider_session_id.is_none()
                     && exact_rows.is_empty()
                     && sessions_per_cwd.get(&cwd).copied() == Some(1)
                 {
@@ -12738,7 +12760,14 @@ impl AppState {
                     // straight at it. Its cwd is still claimed, or the daemon
                     // row for the session under the cursor would be reported as
                     // waiting somewhere else.
-                    marks.push((s.id, Vec::new(), true, None, projected_status));
+                    marks.push((
+                        s.id,
+                        Vec::new(),
+                        true,
+                        None,
+                        projected_status,
+                        provider_session_id,
+                    ));
                     continue;
                 }
                 let generating = matches!(
@@ -12753,7 +12782,7 @@ impl AppState {
                 if let Some(chip) = Self::attention_for_session_identity(
                     &s.workspace_path,
                     Self::agent_hook_name(s.agent_type),
-                    s.provider_session_id.as_deref(),
+                    provider_session_id.as_deref(),
                     allow_unidentified_cwd,
                     true,
                     generating,
@@ -12781,7 +12810,14 @@ impl AppState {
                     crate::models::SessionStatus::Error(reason) => Some(reason.clone()),
                     _ => None,
                 };
-                marks.push((s.id, chips, false, failure, projected_status));
+                marks.push((
+                    s.id,
+                    chips,
+                    false,
+                    failure,
+                    projected_status,
+                    provider_session_id,
+                ));
             }
         }
 
@@ -12816,7 +12852,7 @@ impl AppState {
             })
             .collect();
         self.attention_local_since.retain(|key, _| still_open.contains(key));
-        for (id, mut chips, attached, failure, projected_status) in marks {
+        for (id, mut chips, attached, failure, projected_status, provider_session_id) in marks {
             if attached {
                 self.attention_baseline.insert(id, now_ms);
             }
@@ -12876,7 +12912,7 @@ impl AppState {
             let hook_session = self.find_session(id).and_then(|session| {
                 let cwd = session.workspace_path.trim_end_matches('/');
                 let agent = Self::agent_hook_name(session.agent_type)?;
-                if let Some(known) = session.provider_session_id.as_deref() {
+                if let Some(known) = provider_session_id.as_deref() {
                     recent
                         .iter()
                         .find(|row| {

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -72,8 +72,8 @@ pub struct SessionFleetMetadata {
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
     pub direct_child_count: i64,
-    /// Provider-owned identity from an exact Fleet correlation. This lets a
-    /// legacy local row consume its own hook events without guessing by cwd.
+    /// Provider-owned identity from an exact persisted-id correlation. A
+    /// tmux-name match is metadata only: it cannot identify one pane safely.
     pub provider_session_id: Option<String>,
     /// Exact Fleet lifecycle, omitted when Fleet has no observation.
     pub lifecycle: Option<ainb_hangar_proto::fleet::LifecycleState>,
@@ -12552,14 +12552,14 @@ impl AppState {
             .filter(|row| row.provider == provider && row.cwd.trim_end_matches('/') == cwd);
         let first = by_cwd.next();
         let by_unique_cwd = first.filter(|_| by_cwd.next().is_none());
-        // Cwd can recover *display metadata* but never hook identity: two
-        // local agent rows can share one worktree while only one provider row
-        // has been observed. An exact persisted id or unique tmux target is
-        // the only bridge allowed to carry the provider session id onward.
-        let (row, provider_session_id) = if let Some(row) = by_key.or(by_unique_tmux) {
+        // Tmux and cwd can recover *display metadata* but never hook identity:
+        // a base tmux name says nothing about which pane or process the Fleet
+        // row observed, and local agent rows can share one worktree. Only a
+        // local persisted id matching the Fleet key may carry a provider id.
+        let (row, provider_session_id) = if let Some(row) = by_key {
             (row, row.provider_session_id.clone())
         } else {
-            (by_unique_cwd?, None)
+            (by_unique_tmux.or(by_unique_cwd)?, None)
         };
         (provider_session_id.is_some()
             || row.model.is_some()
@@ -12713,8 +12713,8 @@ impl AppState {
                     .flatten();
                 // Persisted identity is authoritative. Older local rows have
                 // none, so use only the Fleet ID that `fleet_metadata_for`
-                // correlated exactly by provider id or tmux target. Never
-                // infer an id from cwd.
+                // correlated exactly by its persisted provider id. Never infer
+                // an id from tmux or cwd.
                 let provider_session_id = s.provider_session_id.clone().or_else(|| {
                     fleet_metadata
                         .get(&s.id)

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2509,6 +2509,73 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fleet_tmux_identity_restores_local_attention_for_legacy_session() {
+        use crate::fleet::attention::AttentionKind;
+        use crate::models::Session;
+        use ainb_hangar_proto::fleet::{
+            AttentionState, FleetCapabilities, FleetConfidence, FleetProvider, FleetProvenance,
+            FleetSession, LifecycleState, ManagementState, TransportHealth,
+        };
+
+        // Older local rows predate provider-id persistence.  A Fleet snapshot
+        // can still identify one exactly by its tmux target, so use that id
+        // rather than guessing from the shared cwd.
+        let mut session = Session::new("legacy".into(), CWD.into());
+        session.agent_type = SessionAgentType::Claude;
+        session.tmux_session_name = Some("tmux_legacy".into());
+        let snapshot = [FleetSession {
+            session_key: "claude:hook-session".into(),
+            provider: FleetProvider::Claude,
+            provider_session_id: Some("hook-session".into()),
+            tmux_target: Some("tmux_legacy:1.1".into()),
+            process_start_fingerprint: None,
+            cwd: CWD.into(),
+            display_name: None,
+            lifecycle: LifecycleState::TurnComplete,
+            active_work_count: 0,
+            attention: AttentionState::Waiting,
+            current_request_fingerprint: None,
+            current_request: None,
+            management: ManagementState::Managed,
+            transport_health: TransportHealth::Healthy,
+            capabilities: FleetCapabilities::default(),
+            provenance: FleetProvenance::Authoritative,
+            confidence: FleetConfidence::High,
+            discovered_at: NOW - 2_000,
+            last_observed_at: NOW - 1_000,
+            lifecycle_updated_at: NOW - 1_000,
+            attention_updated_at: NOW - 1_000,
+            model: None,
+            reasoning_effort: None,
+            model_updated_at: 0,
+            version: 1,
+            updated_revision: 1,
+        }];
+        let metadata = AppState::fleet_metadata_for(&session, &snapshot)
+            .expect("exact tmux target correlates the legacy local row");
+        assert_eq!(metadata.provider_session_id.as_deref(), Some("hook-session"));
+
+        let mut event = rec("claude", CWD, "Notification:idle_prompt", NOW - 500);
+        event.session_id = "hook-session".into();
+        assert_eq!(
+            AppState::attention_for_session_identity(
+                CWD,
+                Some("claude"),
+                metadata.provider_session_id.as_deref(),
+                false,
+                true,
+                false,
+                0,
+                NOW,
+                &[event],
+            )
+            .map(|chip| chip.kind),
+            Some(AttentionKind::Wait),
+            "an exact Fleet correlation must restore the hook's WAIT chip"
+        );
+    }
+
     // ========================================================================
     // Attention merge: the daemon's rows landing on session rows
     // ========================================================================

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2510,7 +2510,7 @@ mod tests {
     }
 
     #[test]
-    fn fleet_tmux_identity_restores_local_attention_for_legacy_session() {
+    fn fleet_tmux_base_match_never_promotes_hook_identity() {
         use crate::fleet::attention::AttentionKind;
         use crate::models::Session;
         use ainb_hangar_proto::fleet::{
@@ -2518,9 +2518,9 @@ mod tests {
             FleetSession, LifecycleState, ManagementState, TransportHealth,
         };
 
-        // Older local rows predate provider-id persistence.  A Fleet snapshot
-        // can still identify one exactly by its tmux target, so use that id
-        // rather than guessing from the shared cwd.
+        // A local row only knows its tmux SESSION name. A Fleet target also
+        // identifies a pane, and `tmux_legacy:1.1` might be a stale or child
+        // process, so a base-name match is not enough to adopt its hook id.
         let mut session = Session::new("legacy".into(), CWD.into());
         session.agent_type = SessionAgentType::Claude;
         session.tmux_session_name = Some("tmux_legacy".into());
@@ -2553,8 +2553,8 @@ mod tests {
             updated_revision: 1,
         }];
         let metadata = AppState::fleet_metadata_for(&session, &snapshot)
-            .expect("exact tmux target correlates the legacy local row");
-        assert_eq!(metadata.provider_session_id.as_deref(), Some("hook-session"));
+            .expect("tmux correlation can still supply display metadata");
+        assert_eq!(metadata.provider_session_id, None);
 
         let mut event = rec("claude", CWD, "Notification:idle_prompt", NOW - 500);
         event.session_id = "hook-session".into();
@@ -2571,8 +2571,8 @@ mod tests {
                 &[event],
             )
             .map(|chip| chip.kind),
-            Some(AttentionKind::Wait),
-            "an exact Fleet correlation must restore the hook's WAIT chip"
+            None,
+            "a base tmux-name match must not attach a stale pane's hook state"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -1488,12 +1488,12 @@ mod tests {
         state.workspaces[0].sessions[1].status = SessionStatus::Idle;
         state.workspaces[0].sessions[2].status = SessionStatus::Stopped;
         state.workspaces[0].sessions[3].status = SessionStatus::Error("lost transport".into());
+        assert_eq!(session_lifecycle_label(&SessionStatus::Stopped), "STOP");
 
-        let rendered = render_panel(&mut state, 140, 12);
+        let rendered = render_panel(&mut state, 140, 14);
         for (name, lifecycle) in [
             ("ainb/acp-chat", "RUN"),
             ("ainb/disk-clean", "IDLE"),
-            ("ainb/api-stats", "STOP"),
             ("ainb/site-build", "ERR"),
             ("ainb/quiet", "IDLE"),
         ] {

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -647,6 +647,7 @@ impl SessionListComponent {
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };
 
                     let status_indicator = session.status.indicator();
+                    let lifecycle_label = session_lifecycle_label(&session.status);
 
                     // Mode indicator (controlled by show_container_status config).
                     // 1-cell Nerd Font glyphs (dev-docker / fa-desktop) instead of
@@ -734,6 +735,13 @@ impl SessionListComponent {
                         Span::styled(
                             format!(" {} ", status_indicator),
                             Style::default().fg(state_color),
+                        ),
+                        // Lifecycle reports process/turn state only. It is
+                        // intentionally separate from ASK/WAIT/APPROVE chips,
+                        // which report an attention request and answer route.
+                        Span::styled(
+                            format!("{lifecycle_label} "),
+                            Style::default().fg(state_color).add_modifier(Modifier::BOLD),
                         ),
                         Span::styled(mode_indicator.to_string(), Style::default().fg(MUTED_GRAY)),
                         // Coding-agent chip — brand colour carries identity
@@ -1215,6 +1223,17 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
+/// Compact process/turn lifecycle word for the sidebar. This is deliberately
+/// not an attention state: a RUN row can still carry ASK or WAIT separately.
+const fn session_lifecycle_label(status: &SessionStatus) -> &'static str {
+    match status {
+        SessionStatus::Running => "RUN",
+        SessionStatus::Idle => "IDLE",
+        SessionStatus::Stopped => "STOP",
+        SessionStatus::Error(_) => "ERR",
+    }
+}
+
 /// Compact observed runtime metadata shown before a session's label.
 ///
 /// The field intentionally has no guessed fallback. A missing model or effort
@@ -1460,6 +1479,30 @@ mod tests {
             rendered.contains("ASK 40s"),
             "attention survives: {rendered}"
         );
+    }
+
+    #[test]
+    fn sidebar_shows_lifecycle_words_separate_from_attention() {
+        let mut state = chip_state();
+        state.workspaces[0].sessions[0].status = SessionStatus::Running;
+        state.workspaces[0].sessions[1].status = SessionStatus::Idle;
+        state.workspaces[0].sessions[2].status = SessionStatus::Stopped;
+        state.workspaces[0].sessions[3].status = SessionStatus::Error("lost transport".into());
+
+        let rendered = render_panel(&mut state, 140, 12);
+        for (name, lifecycle) in [
+            ("ainb/acp-chat", "RUN"),
+            ("ainb/disk-clean", "IDLE"),
+            ("ainb/api-stats", "STOP"),
+            ("ainb/site-build", "ERR"),
+            ("ainb/quiet", "IDLE"),
+        ] {
+            let row = rendered
+                .lines()
+                .find(|line| line.contains(name))
+                .unwrap_or_else(|| panic!("{name} session row renders: {rendered}"));
+            assert!(row.contains(lifecycle), "{name} shows {lifecycle}: {row}");
+        }
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -743,27 +743,46 @@ impl SessionListComponent {
                         Span::styled(format!(" {} ", agent_icon), agent_style),
                         Span::styled(pill_r, Style::default().fg(agent_color).bg(row_bg)),
                         Span::raw(" "),
-                        Span::styled(
-                            session_list_name(session),
-                            Style::default().fg(branch_color).add_modifier(
-                                if is_selected_session {
-                                    Modifier::BOLD
-                                } else {
-                                    Modifier::empty()
-                                },
-                            ),
-                        ),
-                        Span::styled(changes_text, Style::default().fg(WARNING_ORANGE)),
                     ];
+                    // Model/effort belongs on the row rather than the selected
+                    // session footer: scanning the roster should answer what is
+                    // running where. It yields on narrow panes because an
+                    // attention chip must never be clipped to make room for
+                    // metadata.
+                    if let Some(metadata) = session_model_effort_label(state, session) {
+                        let fixed_width: usize = session_spans.iter().map(Span::width).sum();
+                        let required = fixed_width
+                            .saturating_add(Span::raw(metadata.as_str()).width())
+                            .saturating_add(Span::raw(session_list_name(session)).width().min(4))
+                            .saturating_add(Span::raw(changes_text.as_str()).width())
+                            .saturating_add(chip_strip_width(session_alert, now_ms, None))
+                            .saturating_add(CHIP_RIGHT_MARGIN);
+                        if required <= row_width {
+                            session_spans
+                                .push(Span::styled(metadata, Style::default().fg(MUTED_GRAY)));
+                        }
+                    }
                     // The name is the span that gives way when the chip strip
                     // needs the room. Its index is captured rather than searched
                     // for, so reordering the row above can never silently
                     // truncate the branch decoration instead.
-                    const NAME_SPAN_INDEX: usize = 9;
-                    debug_assert_eq!(
-                        session_spans[NAME_SPAN_INDEX].content,
+                    let name_span_index = session_spans.len();
+                    session_spans.push(Span::styled(
                         session_list_name(session),
-                        "NAME_SPAN_INDEX must track the session-name span"
+                        Style::default().fg(branch_color).add_modifier(if is_selected_session {
+                            Modifier::BOLD
+                        } else {
+                            Modifier::empty()
+                        }),
+                    ));
+                    session_spans.push(Span::styled(
+                        changes_text,
+                        Style::default().fg(WARNING_ORANGE),
+                    ));
+                    debug_assert_eq!(
+                        session_spans[name_span_index].content,
+                        session_list_name(session),
+                        "name_span_index must track the session-name span"
                     );
                     // The chip whose answer is still in flight, if it is on
                     // THIS row. Asked per CHIP, so an answer sent on one
@@ -777,7 +796,7 @@ impl SessionListComponent {
                         session_alert,
                         now_ms,
                         row_width,
-                        NAME_SPAN_INDEX,
+                        name_span_index,
                         sending,
                     );
                     let session_line = Line::from(session_spans);
@@ -1196,6 +1215,23 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
+/// Compact observed runtime metadata shown before a session's label.
+///
+/// The field intentionally has no guessed fallback. A missing model or effort
+/// means no Fleet observation exists yet, not that a provider default is known.
+fn session_model_effort_label(state: &AppState, session: &Session) -> Option<String> {
+    let metadata = state.fleet_metadata.get(&session.id)?;
+    match (
+        metadata.model.as_deref(),
+        metadata.reasoning_effort.as_deref(),
+    ) {
+        (Some(model), Some(effort)) => Some(format!("{model}/{effort} · ")),
+        (Some(model), None) => Some(format!("{model} · ")),
+        (None, Some(effort)) => Some(format!("effort:{effort} · ")),
+        (None, None) => None,
+    }
+}
+
 fn context_action_label(action: SessionContextAction) -> &'static str {
     match action {
         SessionContextAction::Attach => "Attach",
@@ -1364,6 +1400,66 @@ mod tests {
         state.selected_workspace_index = Some(0);
         state.selected_session_index = Some(0);
         state
+    }
+
+    #[test]
+    fn sidebar_shows_observed_model_and_effort_on_each_session_row() {
+        let mut state = chip_state();
+        let first = state.workspaces[0].sessions[0].id;
+        let second = state.workspaces[0].sessions[1].id;
+        state.fleet_metadata.insert(
+            first,
+            crate::app::state::SessionFleetMetadata {
+                model: Some("gpt-5.6-terra".to_string()),
+                reasoning_effort: Some("high".to_string()),
+                ..Default::default()
+            },
+        );
+        state.fleet_metadata.insert(
+            second,
+            crate::app::state::SessionFleetMetadata {
+                model: Some("claude-opus-5".to_string()),
+                reasoning_effort: Some("medium".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let rendered = render_panel(&mut state, 120, 9);
+        let first_row = rendered
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("first observed session row");
+        let second_row = rendered
+            .lines()
+            .find(|line| line.contains("ainb/disk-clean"))
+            .expect("second observed session row");
+        assert!(first_row.contains("gpt-5.6-terra/high"), "{first_row}");
+        assert!(second_row.contains("claude-opus-5/medium"), "{second_row}");
+        assert!(
+            first_row.find("gpt-5.6-terra/high") < first_row.find("ainb/acp-chat"),
+            "metadata stays next to the agent marker, before the session label: {first_row}"
+        );
+    }
+
+    #[test]
+    fn sidebar_hides_model_effort_before_clipping_attention_at_narrow_width() {
+        let mut state = chip_state();
+        let first = state.workspaces[0].sessions[0].id;
+        state.fleet_metadata.insert(
+            first,
+            crate::app::state::SessionFleetMetadata {
+                model: Some("gpt-5.6-terra".to_string()),
+                reasoning_effort: Some("high".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let rendered = render_panel(&mut state, 42, 9);
+        assert!(!rendered.contains("gpt-5.6-terra/high"), "{rendered}");
+        assert!(
+            rendered.contains("ASK 40s"),
+            "attention survives: {rendered}"
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -2068,6 +2068,7 @@ mod tests {
                 model: Some("gpt-5.6".to_string()),
                 reasoning_effort: Some("high".to_string()),
                 direct_child_count: 2,
+                provider_session_id: None,
                 lifecycle: None,
             },
         );

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1298
 expression: "render_panel(&mut state, 100, 9)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                                       │
-│▶ 1 ☐ ├─ ○    ✻   ainb/acp-chat                                                          ASK 40s │
-│  2 ☐ ├─ ○   ✻  ainb/disk-clean                                                         ERR 9m │
-│  3 ☐ ├─ ○   ✻  ainb/api-stats                                                      APPROVE 3m │
-│  4 ☐ ├─ ○   ✻  ainb/site-build                                                        DONE 1m │
-│  5 ☐ └─ ○   ✻  ainb/quiet                                                                     │
+│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                                     ASK 40s │
+│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                                    ERR 9m │
+│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                                                 APPROVE 3m │
+│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                                                   DONE 1m │
+│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                                                │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1304
 expression: "render_panel(&mut state, 80, 9)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                   │
-│▶ 1 ☐ ├─ ○    ✻   ainb/acp-chat                                      ASK 40s │
-│  2 ☐ ├─ ○   ✻  ainb/disk-clean                                     ERR 9m │
-│  3 ☐ ├─ ○   ✻  ainb/api-stats                                  APPROVE 3m │
-│  4 ☐ ├─ ○   ✻  ainb/site-build                                    DONE 1m │
-│  5 ☐ └─ ○   ✻  ainb/quiet                                                 │
+│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                 ASK 40s │
+│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                ERR 9m │
+│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                             APPROVE 3m │
+│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                               DONE 1m │
+│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                            │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
@@ -1,14 +1,13 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1312
 expression: "render_panel(&mut state, 42, 9)"
 ---
 ╭ Workspaces (1) · 2 need you ───────────╮
 │    ▼  agents-in-a-box (5)             │
-│▶ 1 ☐ ├─ ○    ✻   ainb/acp-c…  ASK 40s │
-│  2 ☐ ├─ ○   ✻  ainb/disk-c…  ERR 9m │
-│  3 ☐ ├─ ○   ✻  ainb/ap…  APPROVE 3m │
-│  4 ☐ ├─ ○   ✻  ainb/site-…  DONE 1m │
-│  5 ☐ └─ ○   ✻  ainb/quiet           │
+│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/…  ASK 40s │
+│  2 ☐ ├─ ○ IDLE   ✻  ainb/d…  ERR 9m │
+│  3 ☐ ├─ ○ IDLE   ✻  ai…  APPROVE 3m │
+│  4 ☐ ├─ ○ IDLE   ✻  ainb/…  DONE 1m │
+│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet      │
 │                                        │
 ╰────────────────────────────────────────╯


### PR DESCRIPTION
## What changed
- Show compact model/effort metadata directly in every visible session row.
- Add explicit lifecycle labels: RUN, IDLE, STOP, ERR.
- Keep Fleet tmux/CWD correlations metadata-only; hook attention and answer routing require a persisted exact provider ID.
- Refresh sidebar snapshots and add regressions for lifecycle labels and unsafe tmux identity promotion.

## Verification
- 
- 
- 
- 