### PR TITLE
fix(release): ad-hoc sign Fleet archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,7 +357,7 @@ jobs:
         with:
           ref: v${{ needs.prepare.outputs.version }}
 
-      - name: Archive unsigned universal Fleet app
+      - name: Archive universal Fleet app
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
@@ -391,6 +391,8 @@ jobs:
           test "$(plutil -extract CFBundleShortVersionString raw "$app_path/Contents/Info.plist")" = "$VERSION"
           test "$(plutil -extract CFBundleVersion raw "$app_path/Contents/Info.plist")" = "$VERSION"
           test "$(plutil -extract SUPublicEDKey raw "$app_path/Contents/Info.plist")" = "$SPARKLE_PUBLIC_ED_KEY"
+          codesign --force --deep --sign - "$app_path"
+          codesign --verify --deep --strict "$app_path"
 
           mkdir -p "$staging_path" "$update_path"
           ditto "$app_path" "$staging_path/AINBFleet.app"

--- a/apps/ainb-fleet-macos/ci/check-release-diagnostics.sh
+++ b/apps/ainb-fleet-macos/ci/check-release-diagnostics.sh
@@ -22,5 +22,7 @@ test "$(plutil -extract SUPublicEDKey raw "$plist")" = "$public_key"
 test "$(plutil -extract SUEnableAutomaticChecks raw "$plist")" = "true"
 test "$(plutil -extract SURequireSignedFeed raw "$plist")" = "true"
 test "$(plutil -extract SUVerifyUpdateBeforeExtraction raw "$plist")" = "true"
+codesign --force --deep --sign - "${binary%/Contents/MacOS/AINBFleet}"
+codesign --verify --deep --strict "${binary%/Contents/MacOS/AINBFleet}"
 ! strings "$binary" | rg -F -- '--fleet-test-read-range'
 ! strings "$binary" | rg -F -- '--fleet-test-open-window'

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -22,7 +22,7 @@ Prerelease tags do not ship Fleet, because the app's stable update feed must not
 offer a prerelease to ordinary users.
 
 Stable releases stop before tagging if a Sparkle update secret is absent. They
-archive an unsigned universal app, create an EdDSA-signed Sparkle appcast,
+archive an ad-hoc-signed universal app, create an EdDSA-signed Sparkle appcast,
 attach both to the GitHub release, and write `Casks/ainb-fleet.rb` into
 `stevengonsalvez/homebrew-agents-in-a-box`.
 


### PR DESCRIPTION
## Summary
- ad-hoc sign the unsigned Fleet archive before Sparkle appcast generation
- verify the ad-hoc signature in release diagnostics
- clarify distribution documentation

## Why
Sparkle 2.9 rejects an archive whose app bundle has no Apple code signature, even when the appcast is EdDSA-signed.

## Validation
- `bash apps/ainb-fleet-macos/ci/check-release-diagnostics.sh`
- generated a signed appcast from an ad-hoc-signed Fleet DMG with Sparkle 2.9.6
- `git diff --check`