### PR TITLE
feat: clarify sidebar session state

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -796,6 +796,11 @@ pub struct SessionsPaneState {
     last_sessions_rect: Option<Rect>,
     last_preview_rect: Option<Rect>,
     last_list_scroll_offset: usize,
+    /// Physical terminal-line height for each logical `ListItem` from the
+    /// latest render. Session rows have metadata on a second line, while
+    /// headers and separators remain one line; mouse hit-testing needs this
+    /// mapping rather than assuming one item equals one terminal row.
+    last_list_item_heights: Vec<usize>,
     last_attachable_click: Option<(AttachableRef, Instant)>,
     filter_toggle_area: Option<Rect>,
 }
@@ -810,6 +815,7 @@ impl Default for SessionsPaneState {
             last_sessions_rect: None,
             last_preview_rect: None,
             last_list_scroll_offset: 0,
+            last_list_item_heights: Vec::new(),
             last_attachable_click: None,
             filter_toggle_area: None,
         }
@@ -831,6 +837,10 @@ impl SessionsPaneState {
 
     pub fn set_list_scroll_offset(&mut self, offset: usize) {
         self.last_list_scroll_offset = offset;
+    }
+
+    pub fn set_list_item_heights(&mut self, heights: Vec<usize>) {
+        self.last_list_item_heights = heights;
     }
 
     pub fn set_filter_toggle_area(&mut self, area: Rect) {
@@ -950,7 +960,17 @@ impl SessionsPaneState {
             return None;
         }
 
-        Some(self.last_list_scroll_offset + usize::from(y - rect.y - 1))
+        let mut item_index = self.last_list_scroll_offset;
+        let mut line_in_view = usize::from(y - rect.y - 1);
+        while let Some(&height) = self.last_list_item_heights.get(item_index) {
+            let height = height.max(1);
+            if line_in_view < height {
+                return Some(item_index);
+            }
+            line_in_view = line_in_view.saturating_sub(height);
+            item_index += 1;
+        }
+        None
     }
 
     pub fn record_row_click(&mut self, target: SessionListRowTarget, now: Instant) -> bool {
@@ -4040,6 +4060,8 @@ impl Default for NewSessionState {
 struct ConfigureLaunchSnapshot {
     repo_source: crate::git::repo_source::RepoSource,
     branch_name: String,
+    /// Optional durable session prefix; Git branch remains unchanged.
+    session_prefix: Option<String>,
     skip_permissions: bool,
     mode: crate::models::SessionMode,
     boss_prompt: Option<String>,
@@ -8402,9 +8424,17 @@ impl AppState {
         } else {
             None
         };
+        let session_prefix = match crate::config::normalize_session_label(&spec.session_prefix) {
+            Ok(prefix) => prefix,
+            Err(error) => {
+                self.add_error_notification(error);
+                return;
+            }
+        };
         let snapshot = ConfigureLaunchSnapshot {
             repo_source: spec.repo_source.clone(),
             branch_name: spec.branch_worktree.clone(),
+            session_prefix,
             skip_permissions: preset.permissions.skip_all,
             mode,
             boss_prompt,
@@ -8580,6 +8610,21 @@ impl AppState {
             Ok(()) => {
                 info!("Session created successfully via configure flow");
                 self.load_real_workspaces().await;
+                if let Some(prefix) = snapshot.session_prefix.as_ref() {
+                    let tmux_name = self
+                        .find_session(session_id)
+                        .and_then(|session| session.tmux_session_name.clone());
+                    if let Some(tmux_name) = tmux_name {
+                        self.session_label_store.set(tmux_name, Some(prefix.clone()));
+                        if let Err(error) = self.session_label_store.save() {
+                            self.add_error_notification(format!(
+                                "Session started but prefix could not be saved: {error}"
+                            ));
+                        } else if let Some(session) = self.find_session_mut(session_id) {
+                            session.display_name = Some(prefix.clone());
+                        }
+                    }
+                }
                 if let Err(e) = self.start_log_streaming_for_session(session_id).await {
                     warn!(
                         "Failed to start log streaming for session {}: {}",
@@ -12126,11 +12171,18 @@ impl AppState {
                         .unanswerable(crate::fleet::attention::Unanswerable::NativePicker),
                 );
             }
-            return Some(
-                SessionAttention::local(Self::chip_for_alert(kind), rec.ts).with_detail(
-                    payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),
-                ),
-            );
+            // Legacy Codex emits an explicit request token. It is a question,
+            // not the generic unstructured wait that notifyd's toast class
+            // uses for both shapes. Keep this fallback aligned with Fleet's
+            // authoritative Codex reducer until its snapshot arrives.
+            let attention = if agent == "codex" && rec.raw_event == "request_user_input" {
+                AttentionKind::Ask
+            } else {
+                Self::chip_for_alert(kind)
+            };
+            return Some(SessionAttention::local(attention, rec.ts).with_detail(
+                payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),
+            ));
         }
         None
     }

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2335,6 +2335,16 @@ mod tests {
     }
 
     #[test]
+    fn legacy_codex_request_user_input_marks_ask_not_wait() {
+        use crate::fleet::attention::AttentionKind;
+        let recent = vec![rec("codex", CWD, "request_user_input", NOW - 1_000)];
+        assert_eq!(
+            kind_of(CWD, Some("codex"), false, 0, NOW, &recent),
+            Some(AttentionKind::Ask),
+        );
+    }
+
+    #[test]
     fn attention_stop_clears_immediately() {
         let fresh = vec![rec("claude", CWD, "Stop", NOW - 1000)];
         assert_eq!(kind_of(CWD, Some("claude"), false, 0, NOW, &fresh), None);
@@ -2514,7 +2524,7 @@ mod tests {
         use crate::fleet::attention::AttentionKind;
         use crate::models::Session;
         use ainb_hangar_proto::fleet::{
-            AttentionState, FleetCapabilities, FleetConfidence, FleetProvider, FleetProvenance,
+            AttentionState, FleetCapabilities, FleetConfidence, FleetProvenance, FleetProvider,
             FleetSession, LifecycleState, ManagementState, TransportHealth,
         };
 

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -270,6 +270,9 @@ pub enum ConfigureRow {
     /// ephemeral override of the configured Workspace default.
     Prefix,
     Branch,
+    /// Optional durable label rendered ahead of the Git branch in the session
+    /// list. Unlike [`Self::Prefix`], this never changes a branch name.
+    SessionPrefix,
     Prompt,
     /// Explicit submit row. Renders as a `[ Launch ]` button at the bottom of
     /// the form. Tab past Prompt lands here; Enter fires the launch. Avoids
@@ -312,6 +315,11 @@ pub struct ConfigureState {
     /// Inline prefix edit buffer. The committed value applies only to this
     /// launch; it never changes the Workspace default in `config.toml`.
     pub branch_prefix_edit: Option<String>,
+    /// Optional human prefix for the session row, persisted after a successful
+    /// tmux-backed launch through `SessionLabelStore`.
+    pub session_prefix: String,
+    /// Inline edit buffer for [`Self::session_prefix`].
+    pub session_prefix_edit: Option<String>,
     /// Multi-line prompt editor (Boss mode only).
     pub prompt: TextEditor,
     /// When `Some`, the save-preset modal is open and the contained string is
@@ -454,6 +462,8 @@ impl ConfigureState {
             branch_override: None,
             branch_edit: None,
             branch_prefix_edit: None,
+            session_prefix: String::new(),
+            session_prefix_edit: None,
             prompt,
             save_preset_modal: None,
             presets_cache,
@@ -694,6 +704,7 @@ impl ConfigureState {
         // Settings → Workspace.
         rows.push(ConfigureRow::Prefix);
         rows.push(ConfigureRow::Branch);
+        rows.push(ConfigureRow::SessionPrefix);
         // Prompt row visible only in Boss mode for non-shell agents.
         if preset.mode == SessionMode::Boss && preset.agent_provider != "shell" {
             rows.push(ConfigureRow::Prompt);
@@ -724,6 +735,9 @@ impl ConfigureState {
         }
         if self.focused_row != ConfigureRow::Prefix {
             self.branch_prefix_edit = None;
+        }
+        if self.focused_row != ConfigureRow::SessionPrefix {
+            self.session_prefix_edit = None;
         }
     }
 }
@@ -766,6 +780,8 @@ pub struct LaunchSpec {
     /// Persisted to `session-defaults.per_repo[].last_branch_override` so the
     /// next launch can pre-fill the textarea.
     pub branch_override: Option<String>,
+    /// Optional durable label displayed before the branch in the sidebar.
+    pub session_prefix: String,
     /// The base-branch popup pick, when used. `None` = legacy base policy
     /// (HEAD for local repos, origin/HEAD for remote/star launches).
     pub base: Option<BaseSelection>,
@@ -867,6 +883,9 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
             }
             ConfigureRow::Prefix => render_prefix_row(f, state, area_for_row, focused),
             ConfigureRow::Branch => render_branch_row(f, state, area_for_row, focused),
+            ConfigureRow::SessionPrefix => {
+                render_session_prefix_row(f, state, area_for_row, focused);
+            }
             ConfigureRow::Prompt => render_prompt_row(f, state, area_for_row, focused),
             ConfigureRow::Launch => render_launch_row(f, area_for_row, focused),
         }
@@ -890,11 +909,14 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
     let help_chunk = *chunks.last().expect("layout always emits help row");
     let in_prompt =
         state.focused_row == ConfigureRow::Prompt && rows.contains(&ConfigureRow::Prompt);
-    let help = render_help_bar(
-        variant,
-        in_prompt,
-        state.branch_edit.is_some() || state.branch_prefix_edit.is_some(),
-    );
+    let active_edit = if state.branch_edit.is_some() || state.branch_prefix_edit.is_some() {
+        Some("branch")
+    } else if state.session_prefix_edit.is_some() {
+        Some("session prefix")
+    } else {
+        None
+    };
+    let help = render_help_bar(variant, in_prompt, active_edit);
     f.render_widget(
         Paragraph::new(help).alignment(Alignment::Center),
         help_chunk,
@@ -913,8 +935,8 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
 
 /// Build the bottom help bar. Shape switches based on whether the prompt
 /// textarea is the focused row (which captures plain chars).
-fn render_help_bar(variant: Variant, in_prompt: bool, branch_editing: bool) -> Line<'static> {
-    if branch_editing {
+fn render_help_bar(variant: Variant, in_prompt: bool, active_edit: Option<&str>) -> Line<'static> {
+    if let Some(active_edit) = active_edit {
         return Line::from(vec![
             Span::styled(
                 "Enter",
@@ -925,7 +947,10 @@ fn render_help_bar(variant: Variant, in_prompt: bool, branch_editing: bool) -> L
                 "Esc",
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("=Cancel branch edit", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("=Cancel {active_edit} edit"),
+                Style::default().fg(MUTED_GRAY),
+            ),
         ]);
     }
     if in_prompt {
@@ -1565,6 +1590,46 @@ fn render_prefix_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused:
     f.render_widget(Paragraph::new(line), area);
 }
 
+/// Render optional durable prefix shown before the branch in the session list.
+/// This is independent of the worktree branch-generation prefix above.
+fn render_session_prefix_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
+    if let Some(prefix) = state.session_prefix_edit.as_ref() {
+        let line = Line::from(vec![
+            focus_indicator(focused),
+            label_span("Session prefix:  "),
+            Span::styled(
+                prefix.clone(),
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("_", Style::default().fg(MUTED_GRAY)),
+        ]);
+        f.render_widget(Paragraph::new(line), area);
+        return;
+    }
+
+    let mut style = Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD);
+    if focused {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    let prefix = if state.session_prefix.is_empty() {
+        "(none)"
+    } else {
+        &state.session_prefix
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            focus_indicator(focused),
+            label_span("Session prefix:  "),
+            Span::styled(prefix, style),
+            Span::styled(
+                "   [Enter to edit]",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ])),
+        area,
+    );
+}
+
 fn render_prompt_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
     let border_color = if focused { GOLD } else { MUTED_GRAY };
     let prompt_block = Block::default()
@@ -2089,6 +2154,9 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
     if state.branch_prefix_edit.is_some() {
         return handle_branch_prefix_edit_key(state, key);
     }
+    if state.session_prefix_edit.is_some() {
+        return handle_session_prefix_edit_key(state, key);
+    }
 
     // Ctrl shortcuts.
     if key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -2122,6 +2190,10 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
         KeyCode::Enter => match state.focused_row {
             ConfigureRow::Prefix => {
                 state.branch_prefix_edit = Some(state.branch_prefix.clone());
+                ConfigureOutcome::Stay
+            }
+            ConfigureRow::SessionPrefix => {
+                state.session_prefix_edit = Some(state.session_prefix.clone());
                 ConfigureOutcome::Stay
             }
             ConfigureRow::Branch => match state.branch_segment {
@@ -2258,6 +2330,7 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         branch_worktree,
         branch_source: state.branch_source.clone(),
         branch_override: state.branch_override.clone(),
+        session_prefix: state.session_prefix.trim().to_string(),
         base: state.base_selection.clone(),
         prompt,
         // Defensive: never launch with Headroom on if the binary isn't there,
@@ -2307,6 +2380,9 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
         }
         ConfigureRow::Prefix => {
             // Prefix is an editable text row, not a value ring.
+        }
+        ConfigureRow::SessionPrefix => {
+            // Session prefix is an editable text row, not a value ring.
         }
         ConfigureRow::Branch => {
             // ←/→ on the Branch row toggles the targeted segment
@@ -2552,6 +2628,31 @@ fn handle_branch_prefix_edit_key(state: &mut ConfigureState, key: KeyEvent) -> C
     }
 }
 
+/// Inline edit for the durable session prefix. Empty deliberately clears it.
+fn handle_session_prefix_edit_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome {
+    let buffer = state.session_prefix_edit.as_mut().expect("guard checked");
+    match key.code {
+        KeyCode::Esc => {
+            state.session_prefix_edit = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Enter => {
+            state.session_prefix = buffer.trim().to_string();
+            state.session_prefix_edit = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Backspace => {
+            buffer.pop();
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            buffer.push(c);
+            ConfigureOutcome::Stay
+        }
+        _ => ConfigureOutcome::Stay,
+    }
+}
+
 /// Base-branch popup key handler. Chars/Backspace edit the fuzzy filter,
 /// ↑/↓ move the selection, Tab toggles the action mode (base-off ⇄ checkout),
 /// Enter commits the pick, Esc closes without changes.
@@ -2717,6 +2818,8 @@ mod tests {
             branch_override: None,
             branch_edit: None,
             branch_prefix_edit: None,
+            session_prefix: String::new(),
+            session_prefix_edit: None,
             prompt: TextEditor::new(),
             save_preset_modal: None,
             presets_cache,
@@ -3270,7 +3373,8 @@ mod tests {
     fn tab_cycles_focus_through_visible_rows() {
         let mut s = mk_state();
         // Named preset, default mode = Boss, Claude/Codex provider → rows =
-        // [Preset, Mode, Yolo, HeadroomProxy, Rtk, Prefix, Branch, Prompt, Launch].
+        // [Preset, Mode, Yolo, HeadroomProxy, Rtk, Prefix, Branch,
+        //  SessionPrefix, Prompt, Launch].
         assert_eq!(s.focused_row, ConfigureRow::Preset);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Mode);
@@ -3285,12 +3389,39 @@ mod tests {
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Branch);
         s.cycle_focus(1);
+        assert_eq!(s.focused_row, ConfigureRow::SessionPrefix);
+        s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Prompt);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Launch);
         // Wraps.
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Preset);
+    }
+
+    #[test]
+    fn session_prefix_is_optional_and_threads_into_launch() {
+        let mut s = mk_state();
+        s.focused_row = ConfigureRow::SessionPrefix;
+        assert_eq!(
+            handle_key(&mut s, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            ConfigureOutcome::Stay
+        );
+        for c in "slice-c".chars() {
+            assert_eq!(
+                handle_key(&mut s, KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)),
+                ConfigureOutcome::Stay
+            );
+        }
+        assert_eq!(
+            handle_key(&mut s, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            ConfigureOutcome::Stay
+        );
+        assert_eq!(s.session_prefix, "slice-c");
+        let ConfigureOutcome::Launch(spec) = launch_outcome(&mut s) else {
+            panic!("launch should proceed")
+        };
+        assert_eq!(spec.session_prefix, "slice-c");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -8,6 +8,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
+use unicode_width::UnicodeWidthChar;
 
 // Premium color palette (TUI Style Guide)
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
@@ -25,9 +26,7 @@ const ALERT_WAITING_AMBER: Color = Color::Rgb(230, 180, 80);
 const ALERT_PERMISSION_RED: Color = Color::Rgb(220, 90, 90);
 const ALERT_ERROR_RED: Color = Color::Rgb(230, 100, 100);
 
-// Per-agent brand colors for the coding-agent pill chip. The chip is a
-// filled block in these colors so the agent is identifiable at a glance —
-// orange = Claude, blue = Gemini, etc. — even before the glyph resolves.
+// Per-agent brand colours for the compact provider icon on the metadata line.
 const BRAND_CLAUDE: Color = Color::Rgb(217, 119, 87); // Anthropic clay-orange
 const BRAND_CODEX: Color = Color::Rgb(236, 236, 241); // OpenAI near-white
 const BRAND_COPILOT: Color = Color::Rgb(46, 160, 67); // GitHub green
@@ -37,10 +36,6 @@ const BRAND_KIRO: Color = Color::Rgb(171, 121, 224); // crystal purple
 const BRAND_SHELL: Color = Color::Rgb(150, 150, 165); // muted slate
 const BRAND_SSH: Color = Color::Rgb(255, 165, 0); // amber
 
-// Powerline rounded caps that wrap the pill chip's filled middle.
-const PILL_LEFT: &str = "\u{e0b6}"; //
-const PILL_RIGHT: &str = "\u{e0b4}"; //
-
 use crate::fleet::attention::{
     AttentionKind, AttentionTone, SessionAttention, format_age, needs_you_count, tone,
 };
@@ -49,9 +44,7 @@ use crate::app::{
     AppState,
     state::{AttachableRef, SessionContextAction, SessionListRowTarget},
 };
-use crate::models::{
-    Session, SessionAgentType, SessionMode, SessionStatus, ShellSessionStatus, Workspace,
-};
+use crate::models::{Session, SessionAgentType, SessionStatus, ShellSessionStatus, Workspace};
 
 /// Width of the leading badge slot rendered before every list row.
 /// Two characters: a digit (or space) and a trailing space separator.
@@ -115,56 +108,64 @@ fn chip_label(chip: &SessionAttention, sending: Option<&SessionAttention>) -> &'
     }
 }
 
-/// Cell width of the chip strip for `chips`, including the leading gap.
-fn chip_strip_width(
+/// Cell width of attention content, excluding its gap from the lifecycle word.
+fn attention_width(
     chips: &[SessionAttention],
     now_ms: i64,
     sending: Option<&SessionAttention>,
 ) -> usize {
-    if chips.is_empty() {
-        return 0;
-    }
     chips
         .iter()
-        .map(|chip| {
-            CHIP_GAP + chip_label(chip, sending).len() + 1 + format_age(now_ms, chip.since_ms).len()
+        .enumerate()
+        .map(|(index, chip)| {
+            usize::from(index > 0) * CHIP_GAP
+                + chip_label(chip, sending).len()
+                + 1
+                + format_age(now_ms, chip.since_ms).len()
         })
         .sum()
 }
 
-/// Append the row's attention chips, RIGHT-ALIGNED against `row_width`.
+/// Append a lifecycle plus attention gutter, right-aligned against `row_width`.
 ///
-/// Right-aligned because the strip is a column an operator scans down: chips
-/// that trail a variable-length branch name land at a different column on every
-/// row, which is exactly the scan the four-word vocabulary exists to make fast.
-///
-/// Width is measured with `Span::width` (unicode-width), never byte length —
-/// the row already carries a Nerd Font agent pill and a status glyph whose byte
-/// counts have nothing to do with their cell counts.
-///
-/// When the row is too narrow, the SESSION NAME at `name_index` gives way, not
-/// the chips: a truncated name still identifies the row (the tree, the agent
-/// pill and the attach digit are all still there), while a truncated `APPROVE`
-/// reading `APPRO` is a word the operator has to decode. This is the spec's
-/// 80-column rule — chip words never abbreviate.
-fn push_attention_chips(
+/// A row reads left-to-right as identity, then status. The lifecycle word is
+/// deliberately in the gutter with `ASK`/`WAIT`/`APPROVE`, rather than mixed
+/// into the title. Names give way first: status words never abbreviate.
+fn push_status_gutter(
     spans: &mut Vec<Span<'static>>,
+    status_indicator: &str,
+    lifecycle_label: &str,
+    lifecycle_style: Style,
     chips: &[SessionAttention],
     now_ms: i64,
     row_width: usize,
     name_index: usize,
     sending: Option<&SessionAttention>,
 ) {
-    if chips.is_empty() {
-        return;
-    }
-    let strip = chip_strip_width(chips, now_ms, sending);
+    let attention = attention_width(chips, now_ms, sending);
     let mut used: usize = spans.iter().map(Span::width).sum();
-    // The gap belongs in the BUDGET, not in the padding: applied afterwards as
-    // a floor it pushes the strip past the row's right edge on exactly the
-    // narrow rows the budget was computed to protect, and the widget then clips
-    // the age off the end.
-    let budget = row_width.saturating_sub(strip + CHIP_GAP + CHIP_RIGHT_MARGIN);
+    let fixed_title_width: usize = spans
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != name_index)
+        .map(|(_, span)| span.width())
+        .sum();
+    let lifecycle_width = Span::raw(status_indicator).width() + 1 + lifecycle_label.len();
+    // At the supported minimum width, an operator action wins over passive
+    // process state. Dropping `○ IDLE` leaves `APPROVE` whole rather than
+    // asking Ratatui to clip either word. Wider rows retain the full gutter.
+    let show_lifecycle = fixed_title_width
+        .saturating_add(lifecycle_width)
+        .saturating_add((!chips.is_empty()).then_some(CHIP_GAP).unwrap_or_default())
+        .saturating_add(attention)
+        .saturating_add(CHIP_RIGHT_MARGIN)
+        <= row_width;
+    let gutter_width = if show_lifecycle { lifecycle_width } else { 0 }
+        .saturating_add(
+            (show_lifecycle && !chips.is_empty()).then_some(CHIP_GAP).unwrap_or_default(),
+        )
+        .saturating_add(attention);
+    let budget = row_width.saturating_sub(gutter_width + CHIP_RIGHT_MARGIN);
     if used > budget {
         if let Some(name) = spans.get_mut(name_index) {
             let over = used - budget;
@@ -176,10 +177,18 @@ fn push_attention_chips(
             used += name.width();
         }
     }
-    let pad = row_width.saturating_sub(used + strip + CHIP_RIGHT_MARGIN).max(CHIP_GAP);
+    let pad = row_width.saturating_sub(used + gutter_width + CHIP_RIGHT_MARGIN);
     spans.push(Span::raw(" ".repeat(pad)));
+    if show_lifecycle {
+        spans.push(Span::styled(status_indicator.to_string(), lifecycle_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            lifecycle_label.to_string(),
+            lifecycle_style.add_modifier(Modifier::BOLD),
+        ));
+    }
     for (index, chip) in chips.iter().enumerate() {
-        if index > 0 {
+        if show_lifecycle || index > 0 {
             spans.push(Span::raw(" ".repeat(CHIP_GAP)));
         }
         // A chip nothing can answer renders DIMMED, never hidden. Hidden is
@@ -263,13 +272,17 @@ impl SessionListComponent {
         self.update_selection(state);
         state.sessions_pane_state.set_list_scroll_offset(self.list_state.offset());
 
-        // Width a row's own spans may occupy. `List` already takes its
-        // highlight symbol out of the item area before the row is laid out, so
-        // this is the panel interior and nothing further comes off it —
-        // measured, not assumed (`every_chip_strip_ends_one_cell_clear_of_the_border`).
-        let row_width = usize::from(area.width.saturating_sub(2));
+        // Width a row's own spans may occupy: the panel borders and List's
+        // reserved highlight column are both outside the item area. Reserving
+        // this here keeps the status gutter one cell clear of the right border
+        // on selected and unselected rows alike.
+        let row_width = usize::from(area.width.saturating_sub(2))
+            .saturating_sub(Span::raw(HIGHLIGHT_SYMBOL).width());
         let now_ms = chrono::Utc::now().timestamp_millis();
         let items = SessionListComponent::build_list_items_static(state, row_width, now_ms);
+        state
+            .sessions_pane_state
+            .set_list_item_heights(items.iter().map(ListItem::height).collect());
 
         // Show focus indicator with premium colors
         use crate::app::state::FocusedPane;
@@ -647,20 +660,7 @@ impl SessionListComponent {
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };
 
                     let status_indicator = session.status.indicator();
-                    let lifecycle_label = session_lifecycle_label(&session.status);
-
-                    // Mode indicator (controlled by show_container_status config).
-                    // 1-cell Nerd Font glyphs (dev-docker / fa-desktop) instead of
-                    // the 🐳/🖥️ emoji — emoji render 2-cell and the variation
-                    // selector made width unpredictable across terminals.
-                    let mode_indicator = if state.app_config.ui_preferences.show_container_status {
-                        match session.mode {
-                            SessionMode::Boss => "\u{e7b0} ",        // dev-docker
-                            SessionMode::Interactive => "\u{f108} ", // fa-desktop
-                        }
-                    } else {
-                        ""
-                    };
+                    let lifecycle_label = session_lifecycle_label(state, session);
 
                     // Git changes (controlled by show_git_status config)
                     let changes_text = if state.app_config.ui_preferences.show_git_status
@@ -686,37 +686,8 @@ impl SessionListComponent {
                         }
                     };
                     let branch_color = state_color;
-                    // Background behind the agent pill's powerline caps so they
-                    // blend with the row (panel bg normally, highlight bar when
-                    // selected).
-                    let row_bg = if is_selected_session {
-                        LIST_HIGHLIGHT_BG
-                    } else {
-                        DARK_BG
-                    };
-
                     let agent_icon = session.agent_type.icon();
                     let agent_color = agent_brand_color(&session.agent_type);
-                    // Agent chip: non-selected rows get the filled brand pill;
-                    // the selected row drops the fill (bold brand glyph only) so
-                    // there is no square box around the glyph on the highlight
-                    // bar. Caps collapse to spaces to preserve column width.
-                    let (pill_l, pill_r, agent_style) = if is_selected_session {
-                        (
-                            " ",
-                            " ",
-                            Style::default().fg(agent_color).add_modifier(Modifier::BOLD),
-                        )
-                    } else {
-                        (
-                            PILL_LEFT,
-                            PILL_RIGHT,
-                            Style::default()
-                                .fg(DARK_BG)
-                                .bg(agent_color)
-                                .add_modifier(Modifier::BOLD),
-                        )
-                    };
                     let is_multi_selected = state.selected_sessions.contains(&session.id);
 
                     let checkbox = ballot_checkbox(is_multi_selected);
@@ -728,54 +699,21 @@ impl SessionListComponent {
                     // on a human then.
                     let session_alert = session.live_attention.as_slice();
 
-                    let mut session_spans = vec![
+                    // Line one contains only stable session identity. Status lives
+                    // in a fixed right gutter so it is readable as a column while
+                    // scanning; provider/model metadata moves to line two.
+                    let mut title_spans = vec![
                         next_badge(&mut attach_no),
                         checkbox,
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
-                        Span::styled(
-                            format!(" {} ", status_indicator),
-                            Style::default().fg(state_color),
-                        ),
-                        // Lifecycle reports process/turn state only. It is
-                        // intentionally separate from ASK/WAIT/APPROVE chips,
-                        // which report an attention request and answer route.
-                        Span::styled(
-                            format!("{lifecycle_label} "),
-                            Style::default().fg(state_color).add_modifier(Modifier::BOLD),
-                        ),
-                        Span::styled(mode_indicator.to_string(), Style::default().fg(MUTED_GRAY)),
-                        // Coding-agent chip — brand colour carries identity
-                        // (orange Claude, blue Gemini, …). Filled pill on normal
-                        // rows; bold glyph only on the selected row (no square).
-                        Span::styled(pill_l, Style::default().fg(agent_color).bg(row_bg)),
-                        Span::styled(format!(" {} ", agent_icon), agent_style),
-                        Span::styled(pill_r, Style::default().fg(agent_color).bg(row_bg)),
                         Span::raw(" "),
                     ];
-                    // Model/effort belongs on the row rather than the selected
-                    // session footer: scanning the roster should answer what is
-                    // running where. It yields on narrow panes because an
-                    // attention chip must never be clipped to make room for
-                    // metadata.
-                    if let Some(metadata) = session_model_effort_label(state, session) {
-                        let fixed_width: usize = session_spans.iter().map(Span::width).sum();
-                        let required = fixed_width
-                            .saturating_add(Span::raw(metadata.as_str()).width())
-                            .saturating_add(Span::raw(session_list_name(session)).width().min(4))
-                            .saturating_add(Span::raw(changes_text.as_str()).width())
-                            .saturating_add(chip_strip_width(session_alert, now_ms, None))
-                            .saturating_add(CHIP_RIGHT_MARGIN);
-                        if required <= row_width {
-                            session_spans
-                                .push(Span::styled(metadata, Style::default().fg(MUTED_GRAY)));
-                        }
-                    }
-                    // The name is the span that gives way when the chip strip
-                    // needs the room. Its index is captured rather than searched
-                    // for, so reordering the row above can never silently
-                    // truncate the branch decoration instead.
-                    let name_span_index = session_spans.len();
-                    session_spans.push(Span::styled(
+                    // The title is the span that gives way when the fixed
+                    // right gutter needs room. Its index is captured rather
+                    // than searched, so future reordering cannot silently
+                    // truncate a tree or status decoration instead.
+                    let name_span_index = title_spans.len();
+                    title_spans.push(Span::styled(
                         session_list_name(session),
                         Style::default().fg(branch_color).add_modifier(if is_selected_session {
                             Modifier::BOLD
@@ -783,12 +721,12 @@ impl SessionListComponent {
                             Modifier::empty()
                         }),
                     ));
-                    session_spans.push(Span::styled(
+                    title_spans.push(Span::styled(
                         changes_text,
                         Style::default().fg(WARNING_ORANGE),
                     ));
                     debug_assert_eq!(
-                        session_spans[name_span_index].content,
+                        title_spans[name_span_index].content,
                         session_list_name(session),
                         "name_span_index must track the session-name span"
                     );
@@ -799,17 +737,38 @@ impl SessionListComponent {
                     // has navigated to a different question.
                     let sending =
                         session_alert.iter().find(|chip| state.ask_state.is_sending(chip));
-                    push_attention_chips(
-                        &mut session_spans,
+                    push_status_gutter(
+                        &mut title_spans,
+                        status_indicator,
+                        lifecycle_label,
+                        Style::default().fg(state_color),
                         session_alert,
                         now_ms,
                         row_width,
                         name_span_index,
                         sending,
                     );
-                    let session_line = Line::from(session_spans);
+                    let title_line = Line::from(title_spans);
 
-                    items.push(ListItem::new(session_line));
+                    // Keep model/effort visible for every row without making
+                    // identity compete with provider metadata. It is a separate
+                    // line, aligned underneath the title rather than a pill.
+                    let mut metadata_spans = vec![
+                        empty_badge(),
+                        Span::raw("     "),
+                        Span::styled(agent_icon.to_string(), Style::default().fg(agent_color)),
+                    ];
+                    if let Some(metadata) = session_model_effort_label(state, session) {
+                        let prefix_width: usize = metadata_spans.iter().map(Span::width).sum();
+                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans.push(Span::styled(
+                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
+                            Style::default().fg(MUTED_GRAY),
+                        ));
+                    }
+                    let metadata_line = Line::from(metadata_spans);
+
+                    items.push(ListItem::new(vec![title_line, metadata_line]));
                 }
 
                 // Render workspace shell (single shell per workspace)
@@ -1223,15 +1182,51 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
-/// Compact process/turn lifecycle word for the sidebar. This is deliberately
-/// not an attention state: a RUN row can still carry ASK or WAIT separately.
-const fn session_lifecycle_label(status: &SessionStatus) -> &'static str {
-    match status {
+/// Compact process/turn lifecycle word for the sidebar. Fleet's completed-turn
+/// observation is more precise than local `SessionStatus::Idle`, so it gets a
+/// dedicated `DONE` label rather than being collapsed into normal idle.
+fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
+    if matches!(
+        state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
+        Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
+    ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
+        && session.live_attention.is_empty()
+    {
+        return "DONE";
+    }
+
+    match session.status {
         SessionStatus::Running => "RUN",
         SessionStatus::Idle => "IDLE",
         SessionStatus::Stopped => "STOP",
         SessionStatus::Error(_) => "ERR",
     }
+}
+
+/// Fit supplementary metadata into its independent second-line budget.
+/// Metadata is observational detail, so a clipped value is preferable to
+/// stealing room from the first line's identity and status gutter.
+fn truncate_text(text: &str, width: usize) -> String {
+    let full = Span::raw(text).width();
+    if full <= width {
+        return text.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let keep = width.saturating_sub(UnicodeWidthChar::width('…').unwrap_or(1));
+    let mut used: usize = 0;
+    let mut out = String::new();
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or_default();
+        if used.saturating_add(character_width) > keep {
+            break;
+        }
+        out.push(character);
+        used += character_width;
+    }
+    out.push('…');
+    out
 }
 
 /// Compact observed runtime metadata shown before a session's label.
@@ -1244,9 +1239,9 @@ fn session_model_effort_label(state: &AppState, session: &Session) -> Option<Str
         metadata.model.as_deref(),
         metadata.reasoning_effort.as_deref(),
     ) {
-        (Some(model), Some(effort)) => Some(format!("{model}/{effort} · ")),
-        (Some(model), None) => Some(format!("{model} · ")),
-        (None, Some(effort)) => Some(format!("effort:{effort} · ")),
+        (Some(model), Some(effort)) => Some(format!("{model} / {effort}")),
+        (Some(model), None) => Some(model.to_string()),
+        (None, Some(effort)) => Some(format!("effort: {effort}")),
         (None, None) => None,
     }
 }
@@ -1255,7 +1250,7 @@ fn context_action_label(action: SessionContextAction) -> &'static str {
     match action {
         SessionContextAction::Attach => "Attach",
         SessionContextAction::Restart => "Restart",
-        SessionContextAction::EditLabel => "Rename session label",
+        SessionContextAction::EditLabel => "Rename session prefix",
         SessionContextAction::OpenEditor => "Open editor",
         SessionContextAction::OpenShell => "Open shell",
         SessionContextAction::OpenGit => "Git",
@@ -1314,7 +1309,8 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                let row_width = usize::from(area.width.saturating_sub(2));
+                let row_width = usize::from(area.width.saturating_sub(2))
+                    .saturating_sub(Span::raw(HIGHLIGHT_SYMBOL).width());
                 let items =
                     SessionListComponent::build_list_items_static(state, row_width, CHIP_NOW);
                 // Mirror `render`'s block so the snapshot carries the real
@@ -1443,7 +1439,7 @@ mod tests {
             },
         );
 
-        let rendered = render_panel(&mut state, 120, 9);
+        let rendered = render_panel(&mut state, 120, 14);
         let first_row = rendered
             .lines()
             .find(|line| line.contains("ainb/acp-chat"))
@@ -1452,16 +1448,23 @@ mod tests {
             .lines()
             .find(|line| line.contains("ainb/disk-clean"))
             .expect("second observed session row");
-        assert!(first_row.contains("gpt-5.6-terra/high"), "{first_row}");
-        assert!(second_row.contains("claude-opus-5/medium"), "{second_row}");
+        assert!(!first_row.contains("gpt-5.6-terra / high"), "{first_row}");
         assert!(
-            first_row.find("gpt-5.6-terra/high") < first_row.find("ainb/acp-chat"),
-            "metadata stays next to the agent marker, before the session label: {first_row}"
+            !second_row.contains("claude-opus-5 / medium"),
+            "{second_row}"
+        );
+        assert!(
+            rendered.contains("gpt-5.6-terra / high"),
+            "first row gets a second-line model/effort label: {rendered}"
+        );
+        assert!(
+            rendered.contains("claude-opus-5 / medium"),
+            "second row gets a second-line model/effort label: {rendered}"
         );
     }
 
     #[test]
-    fn sidebar_hides_model_effort_before_clipping_attention_at_narrow_width() {
+    fn sidebar_keeps_model_effort_on_its_own_line_at_narrow_width() {
         let mut state = chip_state();
         let first = state.workspaces[0].sessions[0].id;
         state.fleet_metadata.insert(
@@ -1473,8 +1476,8 @@ mod tests {
             },
         );
 
-        let rendered = render_panel(&mut state, 42, 9);
-        assert!(!rendered.contains("gpt-5.6-terra/high"), "{rendered}");
+        let rendered = render_panel(&mut state, 42, 14);
+        assert!(rendered.contains("gpt-5.6-terra / high"), "{rendered}");
         assert!(
             rendered.contains("ASK 40s"),
             "attention survives: {rendered}"
@@ -1488,9 +1491,12 @@ mod tests {
         state.workspaces[0].sessions[1].status = SessionStatus::Idle;
         state.workspaces[0].sessions[2].status = SessionStatus::Stopped;
         state.workspaces[0].sessions[3].status = SessionStatus::Error("lost transport".into());
-        assert_eq!(session_lifecycle_label(&SessionStatus::Stopped), "STOP");
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[2]),
+            "STOP"
+        );
 
-        let rendered = render_panel(&mut state, 140, 14);
+        let rendered = render_panel(&mut state, 140, 16);
         for (name, lifecycle) in [
             ("ainb/acp-chat", "RUN"),
             ("ainb/disk-clean", "IDLE"),
@@ -1506,15 +1512,131 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_uses_fleet_turn_complete_for_done_gutter() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = true;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        let rendered = render_panel(&mut state, 100, 16);
+        let row = rendered
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("completed session row");
+        assert!(
+            row.contains("DONE"),
+            "Fleet TurnComplete renders DONE: {row}"
+        );
+        assert!(
+            !row.contains("IDLE"),
+            "DONE must not collapse into IDLE: {row}"
+        );
+    }
+
+    #[test]
+    fn stale_or_contradicted_fleet_done_never_overrides_live_status() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        // A current ASK is newer operator-facing evidence than an old turn
+        // completion and must not create the impossible `DONE ASK` row.
+        state.daemon_attention.lock().unwrap().reachable = true;
+        let with_ask = render_panel(&mut state, 100, 16);
+        let ask_row = with_ask
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("ask session row");
+        assert!(
+            ask_row.contains("IDLE") && ask_row.contains("ASK"),
+            "{ask_row}"
+        );
+        assert!(!ask_row.contains("DONE"), "{ask_row}");
+
+        // A retained snapshot cannot drive lifecycle after daemon reachability
+        // is lost, even when no current attention chip exists.
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = false;
+        let unreachable = render_panel(&mut state, 100, 16);
+        let row = unreachable
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("unreachable daemon row");
+        assert!(row.contains("IDLE"), "{row}");
+        assert!(!row.contains("DONE"), "{row}");
+    }
+
+    #[test]
+    fn metadata_line_click_targets_its_own_session() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut state = chip_state();
+        state
+            .sessions_pane_state
+            .set_layout(Rect::new(0, 0, 100, 16), Rect::new(100, 0, 1, 16));
+        let mut list = SessionListComponent::new();
+        let mut terminal = Terminal::new(TestBackend::new(100, 16)).expect("terminal");
+        terminal
+            .draw(|frame| list.render(frame, frame.area(), &mut state))
+            .expect("render");
+
+        let first = SessionListRowTarget::Attachable(AttachableRef::WorkspaceSession {
+            workspace_idx: 0,
+            session_idx: 0,
+        });
+        assert_eq!(state.session_list_row_at_mouse(8, 2), Some(first));
+        assert_eq!(state.session_list_row_at_mouse(8, 3), Some(first));
+
+        // When List has scrolled past the one-line workspace header, the two
+        // physical rows of the first session still resolve to the same logical
+        // item before the next session starts.
+        state.sessions_pane_state.set_list_scroll_offset(1);
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 1), Some(1));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 2), Some(1));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 3), Some(2));
+    }
+
+    #[test]
+    fn minimum_width_keeps_attention_words_whole() {
+        let mut state = chip_state();
+        let rendered = render_panel(&mut state, 24, 16);
+        for word in ["ASK 40s", "ERR 9m", "APPROVE 3m", "DONE 1m"] {
+            assert!(
+                rendered.contains(word),
+                "`{word}` survives at minimum width: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn unicode_metadata_truncation_respects_terminal_cells() {
+        let truncated = truncate_text("界界界", 4);
+        assert_eq!(Span::raw(truncated).width(), 3);
+    }
+
+    #[test]
     fn chip_strip_at_100_columns() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 100, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 100, 16));
     }
 
     #[test]
     fn chip_strip_at_80_columns() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 80, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 80, 16));
     }
 
     /// The sidebar's real default width. The chip strip has to survive here,
@@ -1522,7 +1644,7 @@ mod tests {
     #[test]
     fn chip_strip_at_the_default_sidebar_width() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 42, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 42, 16));
     }
 
     #[test]
@@ -1532,7 +1654,7 @@ mod tests {
             SessionAttention::local(AttentionKind::Err, CHIP_NOW - 9 * 60_000),
             SessionAttention::local(AttentionKind::Ask, CHIP_NOW - 40_000),
         ]);
-        let rendered = render_panel(&mut state, 100, 9);
+        let rendered = render_panel(&mut state, 100, 16);
         let row = rendered
             .lines()
             .find(|line| line.contains("disk-clean"))
@@ -1555,7 +1677,7 @@ mod tests {
     fn every_chip_strip_ends_one_cell_clear_of_the_border() {
         for width in [42_u16, 60, 80, 100, 140] {
             let mut state = chip_state();
-            let rendered = render_panel(&mut state, width, 9);
+            let rendered = render_panel(&mut state, width, 16);
             // Cells between the last age character and the right border. The
             // line length itself proves nothing (`List` pads every row to the
             // full width), so measure the gap the operator actually sees.
@@ -1590,7 +1712,7 @@ mod tests {
     #[test]
     fn chip_words_survive_a_width_the_name_does_not() {
         let mut state = chip_state();
-        let rendered = render_panel(&mut state, 42, 9);
+        let rendered = render_panel(&mut state, 42, 16);
         for word in ["ASK 40s", "ERR 9m", "APPROVE 3m", "DONE 1m"] {
             assert!(
                 rendered.contains(word),
@@ -1607,7 +1729,7 @@ mod tests {
     fn a_request_the_screen_cannot_place_gets_its_own_row_not_a_truncated_badge() {
         let mut state = chip_state();
         state.attention_elsewhere = 1;
-        let rendered = render_panel(&mut state, 42, 11);
+        let rendered = render_panel(&mut state, 42, 16);
         assert!(
             rendered.contains("1 waiting elsewhere"),
             "the whole phrase must survive the narrow sidebar that clipped the \
@@ -1621,7 +1743,7 @@ mod tests {
     fn no_elsewhere_row_when_every_request_found_its_session() {
         let mut state = chip_state();
         state.attention_elsewhere = 0;
-        let rendered = render_panel(&mut state, 42, 11);
+        let rendered = render_panel(&mut state, 42, 16);
         assert!(
             !rendered.contains("elsewhere"),
             "the row must be absent, not zero: {rendered}"
@@ -1638,7 +1760,7 @@ mod tests {
         let mut without = chip_state();
         without.attention_elsewhere = 0;
         let digits = |state: &mut AppState| -> Vec<String> {
-            render_panel(state, 100, 12)
+            render_panel(state, 100, 16)
                 .lines()
                 .filter_map(|line| {
                     let trimmed = line.trim_start_matches(['│', '▶', ' ']);
@@ -1660,7 +1782,7 @@ mod tests {
         for session in &mut state.workspaces[0].sessions {
             session.live_attention.clear();
         }
-        let rendered = render_panel(&mut state, 100, 9);
+        let rendered = render_panel(&mut state, 100, 16);
         assert!(
             !rendered.contains("need you") && !rendered.contains("needs you"),
             "the badge must be absent, not zero: {rendered}"

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 100, 9)"
+assertion_line: 1494
+expression: "render_panel(&mut state, 100, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                                       │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                                     ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                                    ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                                                 APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                                                   DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                                                │
+│▶ 1 ☐ ├─ ainb/acp-chat                                                            ○ IDLE  ASK 40s │
+│         ✻                                                                                        │
+│  2 ☐ ├─ ainb/disk-clean                                                           ○ IDLE  ERR 9m │
+│         ✻                                                                                        │
+│  3 ☐ ├─ ainb/api-stats                                                        ○ IDLE  APPROVE 3m │
+│         ✻                                                                                        │
+│  4 ☐ ├─ ainb/site-build                                                          ○ IDLE  DONE 1m │
+│         ✻                                                                                        │
+│  5 ☐ └─ ainb/quiet                                                                        ○ IDLE │
+│         ✻                                                                                        │
+│                                                                                                  │
+│                                                                                                  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 80, 9)"
+assertion_line: 1500
+expression: "render_panel(&mut state, 80, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                   │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                 ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                             APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                               DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                            │
+│▶ 1 ☐ ├─ ainb/acp-chat                                        ○ IDLE  ASK 40s │
+│         ✻                                                                    │
+│  2 ☐ ├─ ainb/disk-clean                                       ○ IDLE  ERR 9m │
+│         ✻                                                                    │
+│  3 ☐ ├─ ainb/api-stats                                    ○ IDLE  APPROVE 3m │
+│         ✻                                                                    │
+│  4 ☐ ├─ ainb/site-build                                      ○ IDLE  DONE 1m │
+│         ✻                                                                    │
+│  5 ☐ └─ ainb/quiet                                                    ○ IDLE │
+│         ✻                                                                    │
+│                                                                              │
+│                                                                              │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 42, 9)"
+assertion_line: 1508
+expression: "render_panel(&mut state, 42, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ───────────╮
 │    ▼  agents-in-a-box (5)             │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/…  ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/d…  ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ai…  APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/…  DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet      │
+│▶ 1 ☐ ├─ ainb/acp-chat  ○ IDLE  ASK 40s │
+│         ✻                              │
+│  2 ☐ ├─ ainb/disk-clean ○ IDLE  ERR 9m │
+│         ✻                              │
+│  3 ☐ ├─ ainb/api-st…○ IDLE  APPROVE 3m │
+│         ✻                              │
+│  4 ☐ ├─ ainb/site-build○ IDLE  DONE 1m │
+│         ✻                              │
+│  5 ☐ └─ ainb/quiet              ○ IDLE │
+│         ✻                              │
+│                                        │
+│                                        │
 │                                        │
 ╰────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -401,7 +401,13 @@ impl AttentionIngest {
                 envelope.insert("payload".to_string(), raw_value);
             }
         }
-        let provider = if line.agent.is_empty() {
+        // A Codex rollout is stronger evidence than the hook's `agent` field:
+        // old Codex hooks can still carry `agent: claude`. Use the same source
+        // of truth as transcript-model parsing, or the row is keyed as Claude
+        // while its lifecycle is being reduced from Codex events.
+        let provider = if is_codex_rollout(&line.transcript_path) {
+            "codex"
+        } else if line.agent.is_empty() {
             "unknown"
         } else {
             line.agent.as_str()
@@ -440,11 +446,11 @@ impl AttentionIngest {
         // Every hook line feeds the canonical Fleet reducer, including events
         // that do not raise an attention card. The source event ID is replay-safe;
         // legacy lines use their durable byte offset.
-        let semantic_event = if line.event_type == "PreToolUse" && line.matcher == "AskUserQuestion"
-        {
+        let raw_event = line.event_type.split(':').next().unwrap_or(&line.event_type);
+        let semantic_event = if raw_event == "PreToolUse" && line.matcher == "AskUserQuestion" {
             "AskUserQuestion"
         } else {
-            line.event_type.as_str()
+            crate::fleet::canonical_hook_event_type(provider, &line.event_type, &payload)
         };
         if !line.session_id.is_empty() {
             // Taken HERE, before the observation is built, and so before the
@@ -454,7 +460,7 @@ impl AttentionIngest {
             let transcript_model = self.transcript_model(&line, &payload).await;
             let observation = crate::fleet::HookObservation {
                 event_id: event_id.clone(),
-                provider: &line.agent,
+                provider,
                 provider_session_id: &line.session_id,
                 cwd: &line.cwd,
                 event_type: semantic_event,
@@ -501,10 +507,10 @@ impl AttentionIngest {
         // re-derived from the transcript. The distinction is load-bearing at the
         // stale-ASK gate below, so it travels with the context.
         let (context, from_hook_payload) =
-            match ask_context_from_hook_payload(&line.agent, semantic_event, &payload) {
+            match ask_context_from_hook_payload(provider, semantic_event, &payload) {
                 Some(ask) => (ask, true),
                 None => match permission_context_from_hook_payload(
-                    &line.agent,
+                    provider,
                     semantic_event,
                     &line.matcher,
                     &payload,
@@ -1191,12 +1197,11 @@ mod tests {
     /// CODEX parser.
     ///
     /// This is a measured shape, not a hypothetical: running the real event log
-    /// through this pipeline produced 9 sessions keyed `claude:<uuid>` whose
-    /// transcript is a codex rollout, because their opening hook predates the
-    /// `agent` field. Dispatching the parser on that label handed the rollout to
-    /// the claude parser, which finds no `assistant` record and returns nothing,
-    /// so the row showed a model (the hook supplies it) with the effort silently
-    /// missing, and every test still passed.
+    /// through this pipeline produced 9 sessions with a stale Claude label whose
+    /// transcript is a Codex rollout, because their opening hook predates the
+    /// `agent` field. Dispatching either parser OR Fleet identity on that label
+    /// handed the rollout to Claude and made all later Codex lifecycle hooks miss
+    /// the row.
     #[tokio::test]
     async fn a_codex_rollout_is_read_as_codex_even_when_labelled_claude() {
         let dir = tempfile::tempdir().unwrap();
@@ -1234,7 +1239,7 @@ mod tests {
         ingest.ingest_once(1_700_000_001_000).await;
 
         assert_eq!(
-            row_model_pair(&store, "claude:sid-rollout").await,
+            row_model_pair(&store, "codex:sid-rollout").await,
             (Some("gpt-5.6-terra".to_string()), Some("high".to_string())),
             "the rollout's turn_context must be parsed as codex despite the agent label"
         );
@@ -1583,6 +1588,47 @@ mod tests {
             open[0].payload.contains("Bash"),
             "the card must name the tool being approved, got {:?}",
             open[0].payload
+        );
+        let session = FleetRepo::get_session(store.pool(), "codex:codex-sid-1")
+            .await
+            .unwrap()
+            .expect("Codex hook must project a Fleet session");
+        assert_eq!(session.lifecycle_state, "IDLE");
+        assert_eq!(
+            session.attention_state, "APPROVAL",
+            "the Fleet status remains approval even though a degraded hook card is waiting-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_rollout_overrides_a_stale_claude_label_for_legacy_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let events_jsonl = dir.path().join("events.jsonl");
+        let cursor = dir.path().join("attention_ingest.offset");
+        let line = codex_permission_hook_line("codex-sid-2", "/tmp/codex-work", "evt-done", "Bash")
+            .replace(r#""agent":"codex""#, r#""agent":"claude""#)
+            .replace(
+                r#""event_type":"PermissionRequest""#,
+                r#""event_type":"agent-turn-complete""#,
+            );
+        std::fs::write(&events_jsonl, format!("{line}\n")).unwrap();
+
+        let ingest = ingest_for(&store, &events_jsonl, &cursor);
+        ingest.ingest_once(1_700_000_000_000).await;
+
+        let session = FleetRepo::get_session(store.pool(), "codex:codex-sid-2")
+            .await
+            .unwrap()
+            .expect("rollout path identifies Codex despite stale hook label");
+        assert_eq!(session.lifecycle_state, "TURN_COMPLETE");
+        assert_eq!(session.attention_state, "NONE");
+        assert!(
+            FleetRepo::get_session(store.pool(), "claude:codex-sid-2")
+                .await
+                .unwrap()
+                .is_none(),
+            "the stale Claude label must not create a second Fleet row"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -123,7 +123,7 @@ pub async fn reproject_claude_interview(
         let Ok(payload) = serde_json::from_str::<Value>(&event.payload) else {
             continue;
         };
-        let event_type = canonical_hook_event_type(&event.event_type, &payload);
+        let event_type = canonical_hook_event_type("claude", &event.event_type, &payload);
         let (_, attention) = states_for_hook(event_type, &payload);
         match attention {
             Some(AttentionState::Ask)
@@ -325,7 +325,11 @@ pub async fn apply_hook(
     let source_event_id = observation.event_id.clone();
     // Claude emits a PermissionRequest and then a generic notification around an
     // AskUserQuestion. They describe the same picker, not two operator actions.
-    let event_type = canonical_hook_event_type(observation.event_type, observation.payload);
+    let event_type = canonical_hook_event_type(
+        provider.as_str(),
+        observation.event_type,
+        observation.payload,
+    );
     let source_event_type = observation
         .payload
         .pointer("/payload/hook_event_name")
@@ -334,7 +338,8 @@ pub async fn apply_hook(
     let duplicate_claude_structured_permission = provider == Provider::Claude
         && source_event_type == "PermissionRequest"
         && claude_hook_tool_name(observation.payload) == Some("AskUserQuestion");
-    let preserve_active_request = (observation.event_type == "Notification"
+    let preserve_active_request = (provider == Provider::Claude
+        && observation.event_type.split(':').next() == Some("Notification")
         || duplicate_claude_structured_permission)
         && FleetRepo::get_session(pool, session_key.as_str())
             .await?
@@ -2304,7 +2309,32 @@ fn states_for_hook(
     }
 }
 
-fn canonical_hook_event_type<'a>(event_type: &'a str, payload: &Value) -> &'a str {
+/// Normalize hook-specific spellings before reducing them into Fleet state.
+///
+/// `ainb-hooks` deliberately persists Codex's raw `type` token. That keeps the
+/// event log useful for provider debugging, but Fleet must not treat those
+/// tokens as unrelated telemetry: a Codex question, blocking wait, completed
+/// turn, and permission request are the same operator-facing facts as their
+/// Claude counterparts. Matcher suffixes are presentation/context only and do
+/// not alter lifecycle semantics.
+pub(crate) fn canonical_hook_event_type<'a>(
+    provider: &str,
+    event_type: &'a str,
+    payload: &Value,
+) -> &'a str {
+    let event_type = event_type.split(':').next().unwrap_or(event_type);
+    if provider.eq_ignore_ascii_case("codex") {
+        return match event_type {
+            "request_user_input" => "AskUserQuestion",
+            "wait_for_user" => "Notification",
+            "agent-turn-complete" | "agentStop" | "task_complete" => "Stop",
+            "PermissionRequest"
+            | "permission_request"
+            | "exec_approval_request"
+            | "apply_patch_approval_request" => "PermissionRequest",
+            _ => event_type,
+        };
+    }
     if event_type == "PermissionRequest"
         && claude_hook_tool_name(payload) == Some("AskUserQuestion")
     {
@@ -3900,6 +3930,82 @@ mod tests {
             states_for_hook("SessionEnd", &serde_json::json!({})),
             (Some(LifecycleState::Exited), Some(AttentionState::None))
         );
+    }
+
+    #[test]
+    fn codex_legacy_hook_tokens_normalize_to_shared_lifecycle_semantics() {
+        let payload = serde_json::json!({});
+        assert_eq!(
+            canonical_hook_event_type("codex", "request_user_input", &payload),
+            "AskUserQuestion"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "wait_for_user", &payload),
+            "Notification"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "agent-turn-complete", &payload),
+            "Stop"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "PermissionRequest:Bash", &payload),
+            "PermissionRequest"
+        );
+        assert_eq!(
+            canonical_hook_event_type("claude", "PermissionRequest", &payload),
+            "PermissionRequest",
+            "Codex aliases must not alter Claude's native permission semantics"
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_legacy_hooks_project_ask_wait_done_and_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let payload = serde_json::json!({ "payload": { "model": "gpt-5.6-sol" } });
+
+        for (event_id, event_type, observed_at, expected_lifecycle, expected_attention) in [
+            ("codex-ask", "request_user_input", 1, "IDLE", "ASK"),
+            ("codex-wait", "wait_for_user", 2, "IDLE", "WAITING"),
+            (
+                "codex-done",
+                "agent-turn-complete",
+                3,
+                "TURN_COMPLETE",
+                "NONE",
+            ),
+            (
+                "codex-approval",
+                "PermissionRequest:Bash",
+                4,
+                "IDLE",
+                "APPROVAL",
+            ),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider: "codex",
+                    provider_session_id: "legacy-thread-1",
+                    cwd: "/repo",
+                    event_type,
+                    payload: &payload,
+                    observed_at,
+                    transcript_model: None,
+                },
+            )
+            .await
+            .expect("legacy Codex hook applies");
+            let session = FleetRepo::get_session(store.pool(), "codex:legacy-thread-1")
+                .await
+                .expect("read session")
+                .expect("Codex session present");
+            assert_eq!(session.lifecycle_state, expected_lifecycle, "{event_type}");
+            assert_eq!(session.attention_state, expected_attention, "{event_type}");
+        }
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -253,7 +253,9 @@ pub fn classify_attention(raw_event: &str, subtype: Option<&str>) -> Option<Aler
         | "permission_request"
         | "exec_approval_request"
         | "apply_patch_approval_request" => AlertKind::NeedsPermission,
-        // Asked the user something / idle awaiting input.
+        // OS notifications use one actionable attention class, while the
+        // materialized state keeps the important distinction: Codex
+        // `request_user_input` becomes ASK and `wait_for_user` becomes WAIT.
         "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
             AlertKind::WaitingOnUser
         }
@@ -312,7 +314,8 @@ pub fn render_title(env: &Envelope) -> String {
         "Stop" | "SessionEnd" | "agentStop" | "agent-turn-complete" | "task_complete" => {
             format!("{agent} session finished")
         }
-        "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
+        "request_user_input" => format!("{agent} asked for input"),
+        "wait_for_user" | "Notification" | "notification" => {
             format!("{agent} is waiting for you")
         }
         "PermissionRequest"
@@ -787,6 +790,14 @@ mod tests {
         assert_eq!(
             render_title(&env("Notification:idle_prompt", "claude")),
             "Claude is waiting for you"
+        );
+        assert_eq!(
+            render_title(&env("request_user_input", "codex")),
+            "Codex asked for input"
+        );
+        assert_eq!(
+            render_title(&env("wait_for_user", "codex")),
+            "Codex is waiting for you"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
@@ -39,7 +39,7 @@
 //! | `Stop`                                | `IDLE` once `age >= idle_threshold`, else `RUNNING` (turn-ended-but-fresh) |
 //! | `UserPromptSubmit`                    | `RUNNING` | a new user turn → clears ASK/WAIT/IDLE/ERR/APPROVE |
 //! | `PostToolUse` / `SubagentStart`       | `RUNNING` | active work resumed → clears ASK/WAIT/APPROVE |
-//! | `SessionEnd`                          | `DONE` | terminal                                  |
+//! | `SessionEnd` / legacy `agent-turn-complete` | `DONE` | terminal                             |
 //!
 //! So the materialized kind is "the latest non-lifecycle signal (ASK/WAIT/ERR),
 //! UNLESS a newer user turn reset it to RUNNING, OR a `Stop` aged it into IDLE,
@@ -317,7 +317,7 @@ impl Accum {
             self.parent = Some(p);
         }
 
-        let decision = match ev.event_type.as_str() {
+        let decision = match canonical_event_type(ev) {
             "PreToolUse" if ev.matcher.as_deref() == Some("AskUserQuestion") => {
                 Some(Decision::Ask(ask_context(&ev.payload)))
             }
@@ -333,12 +333,26 @@ impl Accum {
                 ev.matcher.as_deref(),
                 &ev.payload,
             ))),
+            // Codex's legacy hook transport names the user-input request and
+            // blocking wait directly.  They must not collapse into the same
+            // generic notification: the former is an answerable ASK, while
+            // the latter is an informational WAIT.
+            "CodexRequestUserInput" => Some(Decision::Ask(codex_ask_context(&ev.payload))),
+            "CodexWaitForUser" => Some(Decision::Wait(wait_context(
+                Some("wait_for_user"),
+                &ev.payload,
+            ))),
             "Stop" => Some(Decision::Stopped(ev.ts)),
             "UserPromptSubmit" => Some(Decision::Running),
             "SessionStart" => Some(Decision::Starting),
             // Active work resumed after an ASK/WAIT/APPROVE — clear back to RUNNING.
             "PostToolUse" | "SubagentStart" => Some(Decision::Running),
-            "SessionEnd" => Some(Decision::Done(reason_from_payload(&ev.payload))),
+            // Unlike Claude's `Stop` (which has an IDLE age policy), this
+            // event is an explicit Codex turn-completion acknowledgement.
+            // Persist DONE now; never create a stop-pending fake RUNNING row.
+            "SessionEnd" | "CodexTurnComplete" => {
+                Some(Decision::Done(reason_from_payload(&ev.payload)))
+            }
             // Unknown / telemetry event — does not change the decided kind.
             _ => None,
         };
@@ -407,6 +421,27 @@ impl Accum {
     }
 }
 
+/// Normalize legacy hook names before applying lifecycle policy.
+///
+/// Hooks predate the canonical event log and use provider-specific names.  Do
+/// the normalization at the fold boundary so existing durable logs acquire the
+/// same semantics on their next materialization without a migration.  These
+/// names are Codex-specific in practice; retaining the aliases regardless of
+/// `agent` is deliberate because a producer may omit/mislabel its agent while
+/// the event name itself is still unambiguous.
+fn canonical_event_type(ev: &EventRow) -> &str {
+    let event_type = ev.event_type.split(':').next().unwrap_or(&ev.event_type);
+    match event_type {
+        "request_user_input" => "CodexRequestUserInput",
+        "wait_for_user" => "CodexWaitForUser",
+        "agent-turn-complete" | "task_complete" | "agentStop" => "CodexTurnComplete",
+        "permission_request" | "exec_approval_request" | "apply_patch_approval_request" => {
+            "PermissionRequest"
+        }
+        other => other,
+    }
+}
+
 /// Extract the ASK context (serialized `AskUserQuestionData`) from a
 /// `PreToolUse(AskUserQuestion)` payload. The raw hook stdin carries
 /// `tool_input` = the AskUserQuestion tool input
@@ -424,6 +459,30 @@ fn ask_context(payload: &str) -> String {
         multi_select: false,
     });
     serde_json::to_string(&data).unwrap_or_default()
+}
+
+/// Build ASK context for Codex's legacy `request_user_input` hook.
+///
+/// Codex payloads are not `AskUserQuestion` tool input, but frequently carry
+/// an equivalent `question` or `message`.  Preserve that text when present;
+/// callers still receive a valid ASK row if an older hook sent no payload.
+fn codex_ask_context(payload: &str) -> String {
+    let v: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
+    let question = v
+        .get("question")
+        .or_else(|| v.get("message"))
+        .or_else(|| v.get("prompt"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("(input requested)")
+        .to_string();
+    serde_json::to_string(&AskUserQuestionData {
+        question,
+        header: None,
+        options: Vec::new(),
+        multi_select: false,
+    })
+    .unwrap_or_default()
 }
 
 /// Parse the first question out of a PreToolUse payload's `tool_input`.
@@ -554,6 +613,24 @@ mod tests {
         matcher: Option<&str>,
         payload: &str,
     ) -> i64 {
+        push_as(
+            store, ts, session, cwd, "claude", event_type, matcher, payload,
+        )
+    }
+
+    /// Append an event from a specific provider. Legacy Codex hooks carry
+    /// provider-specific event names, so their fold must be exercised against
+    /// the same durable event-log path as production.
+    fn push_as(
+        store: &Store,
+        ts: i64,
+        session: &str,
+        cwd: &str,
+        agent: &str,
+        event_type: &str,
+        matcher: Option<&str>,
+        payload: &str,
+    ) -> i64 {
         store
             .append_event(&EventRow {
                 seq: 0,
@@ -561,7 +638,7 @@ mod tests {
                 session_id: session.into(),
                 cwd: cwd.into(),
                 transcript_path: format!("/t/{session}.jsonl"),
-                agent: "claude".into(),
+                agent: agent.into(),
                 event_type: event_type.into(),
                 matcher: matcher.map(str::to_string),
                 payload: payload.into(),
@@ -623,6 +700,114 @@ mod tests {
         );
         assert_eq!(ctx.options[1].label, "prod");
         assert_eq!(ctx.options[1].description, None);
+    }
+
+    #[test]
+    fn legacy_codex_request_user_input_is_an_answerable_ask() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "request_user_input",
+            None,
+            r#"{"question":"Choose deployment target"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "ASK");
+        let ctx: AskUserQuestionData =
+            serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.question, "Choose deployment target");
+    }
+
+    #[test]
+    fn legacy_codex_wait_for_user_is_wait_not_ask() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "wait_for_user",
+            None,
+            r#"{"message":"Waiting for external review"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "WAIT");
+        let ctx: WaitContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.reason, "wait_for_user");
+        assert_eq!(ctx.message.as_deref(), Some("Waiting for external review"));
+    }
+
+    #[test]
+    fn legacy_codex_permission_alias_is_approve() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "exec_approval_request",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{"command":"git push"}}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "APPROVE");
+        let ctx: ApproveContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.tool, "Bash");
+    }
+
+    #[test]
+    fn suffixed_permission_request_is_approve_too() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "PermissionRequest:Bash",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{"command":"git push"}}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "APPROVE");
+    }
+
+    #[test]
+    fn legacy_codex_turn_completion_is_done_immediately() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "agent-turn-complete",
+            None,
+            r#"{"reason":"completed"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "DONE");
+        assert_eq!(row.context.as_deref(), Some(r#"{"reason":"completed"}"#));
+        assert!(
+            stopped_ts_from_context(row.context.as_deref()).is_none(),
+            "explicit turn completion must never become a delayed RUNNING stop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements sidebar prefix and model/effort layout with fixed right-side lifecycle status. Normalizes legacy Codex hooks into ASK, WAIT, APPROVE, and DONE semantics. Includes stale-state, narrow-width, mouse-hit, and hook materialization coverage. Follow-up tmux test stability tracked in issue 917.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional, durable session prefix in the new-session configuration screen.
  * Session list entries now display clearer lifecycle statuses, attention indicators, and provider metadata across two lines.
  * Improved mouse targeting for multi-line session entries.

* **Bug Fixes**
  * Improved recognition of Codex questions, approval requests, waits, and completed turns.
  * Corrected Codex provider identification when event metadata is inaccurate.
  * Added clearer notifications for Codex requests for input and waiting states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->