### PR TITLE
fix: keep stopped sessions out of active

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -12642,6 +12642,32 @@ impl AppState {
         }
     }
 
+    /// A local stopped observation means its tmux session is gone. A retained
+    /// Fleet `IDLE` row only means its last observed pane was quiet, so it must
+    /// not resurrect a stopped session into the Active filter. Fleet may still
+    /// confirm the stop with an explicit `EXITED` projection.
+    const fn lifecycle_projection_may_replace_local_status(
+        local: &crate::models::SessionStatus,
+        projected: &crate::models::SessionStatus,
+    ) -> bool {
+        !matches!(local, crate::models::SessionStatus::Stopped)
+            || matches!(projected, crate::models::SessionStatus::Stopped)
+    }
+
+    /// A local `SessionEnd` is a terminal fact. Fleet can briefly retain an
+    /// older live lifecycle after the pane is gone, so let only this explicit
+    /// local stop beat Fleet's otherwise-preferred lifecycle projection.
+    fn projected_session_status(
+        fleet: Option<crate::models::SessionStatus>,
+        local: Option<crate::models::SessionStatus>,
+    ) -> Option<crate::models::SessionStatus> {
+        if matches!(local, Some(crate::models::SessionStatus::Stopped)) {
+            local
+        } else {
+            fleet.or(local)
+        }
+    }
+
     /// Hangar metadata for the selected session, if identity correlation was
     /// unambiguous and Hangar observed at least one requested field.
     #[must_use]
@@ -12785,7 +12811,8 @@ impl AppState {
                     self.attention_baseline.get(&s.id).copied().unwrap_or(0),
                     &recent,
                 );
-                let projected_status = fleet_status.or(local_terminal_status);
+                let projected_status =
+                    Self::projected_session_status(fleet_status, local_terminal_status);
                 let cwd = s.workspace_path.trim_end_matches('/').to_string();
                 // Exact provider id wins. A cwd fallback is safe only if that
                 // cwd names one local session; sibling subagents otherwise
@@ -12915,6 +12942,10 @@ impl AppState {
                     // Do not erase it with a Fleet lifecycle projection that
                     // has no recovery/error detail of its own.
                     if !matches!(session.status, crate::models::SessionStatus::Error(_))
+                        && Self::lifecycle_projection_may_replace_local_status(
+                            &session.status,
+                            &status,
+                        )
                         && session.status != status
                     {
                         session.set_status(status);

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2406,6 +2406,35 @@ mod tests {
     }
 
     #[test]
+    fn stale_fleet_idle_cannot_reactivate_a_locally_stopped_session() {
+        use crate::models::SessionStatus;
+
+        assert!(!AppState::lifecycle_projection_may_replace_local_status(
+            &SessionStatus::Stopped,
+            &SessionStatus::Idle,
+        ));
+        assert!(AppState::lifecycle_projection_may_replace_local_status(
+            &SessionStatus::Stopped,
+            &SessionStatus::Stopped,
+        ));
+
+        let projected = AppState::projected_session_status(
+            Some(SessionStatus::Idle),
+            Some(SessionStatus::Stopped),
+        );
+        assert_eq!(projected, Some(SessionStatus::Stopped));
+
+        let mut state = AppState::new();
+        state.session_filter = crate::app::state::SessionFilter::ActiveOnly;
+        let mut session = Session::new("ended".to_string(), CWD.to_string());
+        session.status = projected.expect("terminal stop projects");
+        assert!(
+            !state.session_passes_filter(&session),
+            "a locally confirmed stop is absent from Active"
+        );
+    }
+
+    #[test]
     fn attention_suppressed_while_generating() {
         let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
         assert_eq!(

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -19,6 +19,9 @@ const DARK_BG: Color = Color::Rgb(25, 25, 35);
 const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+/// Runtime model/effort is secondary to a session name, but must remain
+/// readable on a selected-row background without terminal-specific dimming.
+const METADATA_GRAY: Color = Color::Rgb(150, 150, 170);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 // Attention chips (`ASK` `APPROVE` `ERR` `DONE`). One colour per state,
 // shared with the age that trails it so a chip reads as one object.
@@ -763,7 +766,7 @@ impl SessionListComponent {
                         metadata_spans.push(Span::raw(" "));
                         metadata_spans.push(Span::styled(
                             truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
-                            Style::default().fg(MUTED_GRAY),
+                            Style::default().fg(METADATA_GRAY),
                         ));
                     }
                     let metadata_line = Line::from(metadata_spans);
@@ -1186,7 +1189,8 @@ fn session_list_name(session: &Session) -> String {
 /// observation is more precise than local `SessionStatus::Idle`, so it gets a
 /// dedicated `DONE` label rather than being collapsed into normal idle.
 fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
-    if matches!(
+    if matches!(session.status, SessionStatus::Idle)
+        && matches!(
         state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
         Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
     ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
@@ -1577,6 +1581,24 @@ mod tests {
             .expect("unreachable daemon row");
         assert!(row.contains("IDLE"), "{row}");
         assert!(!row.contains("DONE"), "{row}");
+    }
+
+    #[test]
+    fn retained_fleet_done_never_relabels_a_stopped_session() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].status = SessionStatus::Stopped;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = true;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(session_lifecycle_label(&state, &state.workspaces[0].sessions[0]), "STOP");
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- prevent retained Fleet IDLE lifecycle from overriding local STOPPED state\n- dim model/effort metadata text for lower visual weight\n\n## Verification\n- cargo test -p ainb stale_fleet_idle_cannot_reactivate_a_locally_stopped_session --lib --quiet\n- cargo test -p ainb sidebar_keeps_model_effort_on_its_own_line_at_narrow_width --lib --quiet\n- cargo fmt --all --check\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale fleet lifecycle updates from incorrectly reactivating sessions that were locally detected as stopped.
  - Stopped sessions now remain stopped unless an explicit stopped lifecycle state is received.

- **Style**
  - Improved the readability of session metadata by adjusting its color and dimming presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->