### PR TITLE
fix: reconcile stale tmux sessions

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1128,6 +1128,7 @@ pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::S
                 | SessionAgentType::Codex
                 | SessionAgentType::Gemini
                 | SessionAgentType::Copilot
+                | SessionAgentType::Antigravity
         )
 }
 
@@ -10284,6 +10285,37 @@ impl AppState {
         result
     }
 
+    /// Record the terminal fact discovered by a failed attach: the exact tmux
+    /// target no longer exists.  This is deliberately narrower than a generic
+    /// attach failure: nesting and terminal errors must leave a live row alone.
+    ///
+    /// Keeping the persisted metadata intact makes the row immediately
+    /// resumable and makes the next reload retain it under the Stopped filter.
+    pub(crate) fn mark_session_stopped_for_missing_tmux(
+        &mut self,
+        session_id: Uuid,
+        tmux_session_name: &str,
+    ) -> bool {
+        use crate::models::SessionStatus;
+
+        let matches_target = self
+            .find_session(session_id)
+            .is_some_and(|session| session.tmux_session_name.as_deref() == Some(tmux_session_name));
+        if !matches_target {
+            return false;
+        }
+
+        self.tmux_sessions.remove(&session_id);
+        if let Some(session) = self.find_session_mut(session_id) {
+            session.set_status(SessionStatus::Stopped);
+            session.is_attached = false;
+            // A dead pane cannot still be waiting for input. Keep historical
+            // errors for the Err tab, but remove actionable row chips.
+            session.live_attention.clear();
+        }
+        true
+    }
+
     /// Soft-stop every session in `session_ids`.
     ///
     /// Each one goes through `stop_interactive_session`, so tmux is killed and
@@ -12858,18 +12890,24 @@ impl AppState {
                 // Attaching advances this to "now" (see below).
                 let baseline = self.attention_baseline.get(&s.id).copied().unwrap_or(0);
                 let mut chips = Vec::new();
-                if let Some(chip) = Self::attention_for_session_identity(
-                    &s.workspace_path,
-                    Self::agent_hook_name(s.agent_type),
-                    provider_session_id.as_deref(),
-                    allow_unidentified_cwd,
-                    true,
-                    generating,
-                    baseline,
-                    now_ms,
-                    &recent,
-                ) {
-                    chips.push(chip);
+                // The exact tmux target is gone. A retained daemon snapshot
+                // can still describe an older ASK/WAIT, but it has no pane to
+                // receive an answer and must not resurrect an actionable chip.
+                let locally_stopped = matches!(s.status, crate::models::SessionStatus::Stopped);
+                if !locally_stopped {
+                    if let Some(chip) = Self::attention_for_session_identity(
+                        &s.workspace_path,
+                        Self::agent_hook_name(s.agent_type),
+                        provider_session_id.as_deref(),
+                        allow_unidentified_cwd,
+                        true,
+                        generating,
+                        baseline,
+                        now_ms,
+                        &recent,
+                    ) {
+                        chips.push(chip);
+                    }
                 }
                 // The daemon's rows for the same worktree. Added unconditionally,
                 // NOT gated on `generating`: the generating gate exists because
@@ -12878,7 +12916,7 @@ impl AppState {
                 // and an agent can be mid-turn and blocked on an approval at the
                 // same time — suppressing it there is how an operator ends up
                 // watching a spinner that is waiting on them.
-                if !daemon_rows.is_empty() {
+                if !locally_stopped && !daemon_rows.is_empty() {
                     chips.extend(daemon_rows.iter().cloned());
                 }
                 // The REASON, not a boolean. `SessionStatus::Error` has always
@@ -12952,6 +12990,20 @@ impl AppState {
                         changed = true;
                     }
                 }
+            }
+            // Stop is terminal for the pane, not for historical diagnostics.
+            // Do not rebuild live chips from a retained daemon snapshot, and
+            // do not overwrite the Err tab's history with an empty set.
+            if self.find_session(id).is_some_and(|session| {
+                matches!(session.status, crate::models::SessionStatus::Stopped)
+            }) {
+                if let Some(session) = self.find_session_mut(id) {
+                    if !session.live_attention.is_empty() {
+                        session.live_attention.clear();
+                        changed = true;
+                    }
+                }
+                continue;
             }
             if let Some(reason) = failure {
                 // ERR is a SECOND, independent chip, not a competitor: a

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -31,6 +31,63 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_is_stoppable_and_resumable_interactive() {
+        let session = crate::models::Session::new_with_options(
+            "agent".to_string(),
+            "/tmp/agent".to_string(),
+            true,
+            SessionMode::Interactive,
+            None,
+            SessionAgentType::Antigravity,
+            None,
+        );
+
+        assert!(crate::app::state::is_stoppable_interactive(&session));
+    }
+
+    #[test]
+    fn missing_exact_tmux_target_becomes_stopped_and_resumable() {
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        let mut workspace = crate::models::Workspace::new("ws".to_string(), "/tmp/ws".into());
+        let mut session = crate::models::Session::new_with_options(
+            "agent".to_string(),
+            "/tmp/ws/agent".to_string(),
+            true,
+            SessionMode::Interactive,
+            None,
+            SessionAgentType::Antigravity,
+            None,
+        );
+        let id = session.id;
+        session.tmux_session_name = Some("tmux_missing_exact".to_string());
+        session.status = crate::models::SessionStatus::Idle;
+        session.is_attached = true;
+        session.live_attention.push(crate::fleet::attention::SessionAttention::local(
+            crate::fleet::attention::AttentionKind::Wait,
+            1,
+        ));
+        workspace.add_session(session);
+        state.workspaces.push(workspace);
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing_exact"));
+        let session = state.workspaces[0].sessions.first().expect("session");
+        assert!(matches!(
+            session.status,
+            crate::models::SessionStatus::Stopped
+        ));
+        assert!(!session.is_attached);
+        assert!(session.live_attention.is_empty());
+        assert_eq!(
+            state.selected_resumable_session_ids(),
+            Vec::<uuid::Uuid>::new()
+        );
+
+        state.selected_sessions.insert(id);
+        assert_eq!(state.selected_resumable_session_ids(), vec![id]);
+    }
+
+    #[test]
     fn observer_waits_for_a_stable_selection() {
         let mut state = AppState::new();
         let now = std::time::Instant::now();
@@ -2724,6 +2781,59 @@ mod tests {
         assert_eq!(chips[0].kind, AttentionKind::Ask);
         assert_eq!(chips[0].source, AttentionSource::Daemon);
         assert_eq!(chips[0].detail.as_deref(), Some("Decide the sqlite path"));
+    }
+
+    #[test]
+    fn missing_tmux_stop_cannot_regain_a_stale_daemon_question() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let cwd = "/work/missing-tmux";
+        let mut state = state_with_session_at(cwd, Some("tmux_missing"));
+        let id = state.workspaces[0].sessions[0].id;
+        install_daemon_row(
+            &state,
+            cwd,
+            SessionAttention::daemon(AttentionKind::Ask, 1_000, "att-stale".into()),
+        );
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing"));
+        state.refresh_attention_markers(2_000);
+
+        assert!(
+            state.workspaces[0].sessions[0].live_attention.is_empty(),
+            "a stopped row must not regain an unanswerable daemon question"
+        );
+    }
+
+    #[test]
+    fn missing_tmux_stop_keeps_daemon_error_history() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let cwd = "/work/missing-tmux-error";
+        let mut state = state_with_session_at(cwd, Some("tmux_missing_error"));
+        let id = state.workspaces[0].sessions[0].id;
+        install_daemon_row(
+            &state,
+            cwd,
+            SessionAttention::daemon(AttentionKind::Err, 1_000, "att-error".into())
+                .with_detail("agent command failed"),
+        );
+
+        state.refresh_attention_markers(2_000);
+        assert_eq!(state.workspaces[0].sessions[0].errors.len(), 1);
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing_error"));
+        state.refresh_attention_markers(3_000);
+
+        let session = &state.workspaces[0].sessions[0];
+        assert!(session.live_attention.is_empty());
+        assert_eq!(
+            session.errors.len(),
+            1,
+            "stopping must preserve Err tab history"
+        );
+        assert_eq!(
+            session.errors[0].detail.as_deref(),
+            Some("agent command failed")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -654,6 +654,14 @@ impl SessionListComponent {
                     .filter(|(_, s)| state.session_passes_filter(s))
                     .collect();
                 let visible_len = visible.len();
+                // A Git branch is not session identity: two agents can work
+                // the same branch concurrently. Keep normal rows clean, but
+                // make a collision explicitly distinguishable instead of
+                // rendering two visually identical entries.
+                let mut title_counts = std::collections::HashMap::<String, usize>::new();
+                for (_, session) in &visible {
+                    *title_counts.entry(session_list_name(session)).or_default() += 1;
+                }
                 for (visible_pos, &(session_idx, session)) in visible.iter().enumerate() {
                     let is_selected_session =
                         is_selected_workspace && state.selected_session_index == Some(session_idx);
@@ -692,6 +700,11 @@ impl SessionListComponent {
                     let agent_icon = session.agent_type.icon();
                     let agent_color = agent_brand_color(&session.agent_type);
                     let is_multi_selected = state.selected_sessions.contains(&session.id);
+                    let title = session_list_name(session);
+                    let collision_id = session_collision_id(
+                        session,
+                        title_counts.get(&title).copied().unwrap_or_default() > 1,
+                    );
 
                     let checkbox = ballot_checkbox(is_multi_selected);
 
@@ -717,7 +730,7 @@ impl SessionListComponent {
                     // truncate a tree or status decoration instead.
                     let name_span_index = title_spans.len();
                     title_spans.push(Span::styled(
-                        session_list_name(session),
+                        title.clone(),
                         Style::default().fg(branch_color).add_modifier(if is_selected_session {
                             Modifier::BOLD
                         } else {
@@ -729,8 +742,7 @@ impl SessionListComponent {
                         Style::default().fg(WARNING_ORANGE),
                     ));
                     debug_assert_eq!(
-                        title_spans[name_span_index].content,
-                        session_list_name(session),
+                        title_spans[name_span_index].content, title,
                         "name_span_index must track the session-name span"
                     );
                     // The chip whose answer is still in flight, if it is on
@@ -761,11 +773,19 @@ impl SessionListComponent {
                         Span::raw("     "),
                         Span::styled(agent_icon.to_string(), Style::default().fg(agent_color)),
                     ];
+                    if let Some(identity) = collision_id {
+                        // Metadata has an independent second-line budget. Put
+                        // collision identity first there so a narrow title can
+                        // still yield to the fixed right status/ASK gutter.
+                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans
+                            .push(Span::styled(identity, Style::default().fg(METADATA_GRAY)));
+                    }
                     if let Some(metadata) = session_model_effort_label(state, session) {
                         let prefix_width: usize = metadata_spans.iter().map(Span::width).sum();
-                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans.push(Span::raw(" · "));
                         metadata_spans.push(Span::styled(
-                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
+                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 3)),
                             Style::default().fg(METADATA_GRAY),
                         ));
                     }
@@ -1185,15 +1205,23 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
+/// Same-workspace title collisions need stable identity. It belongs on the
+/// independent metadata line so a blocking status chip always wins on narrow
+/// terminals.
+fn session_collision_id(session: &Session, has_collision: bool) -> Option<String> {
+    has_collision.then(|| format!("#{}", &session.id.to_string()[..8]))
+}
+
 /// Compact process/turn lifecycle word for the sidebar. Fleet's completed-turn
 /// observation is more precise than local `SessionStatus::Idle`, so it gets a
 /// dedicated `DONE` label rather than being collapsed into normal idle.
 fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
     if matches!(session.status, SessionStatus::Idle)
         && matches!(
-        state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
-        Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
-    ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
+            state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
+            Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
+        )
+        && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
         && session.live_attention.is_empty()
     {
         return "DONE";
@@ -1598,7 +1626,10 @@ mod tests {
             },
         );
 
-        assert_eq!(session_lifecycle_label(&state, &state.workspaces[0].sessions[0]), "STOP");
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            "STOP"
+        );
     }
 
     #[test]
@@ -1910,5 +1941,49 @@ mod tests {
         session.display_name = Some("RPC flake".to_string());
 
         assert_eq!(session_list_name(&session), "RPC flake · fix/rpc-acp-flake");
+    }
+
+    #[test]
+    fn colliding_session_titles_include_a_stable_short_identity() {
+        let mut session = Session::new("workspace".to_string(), "/tmp/workspace".to_string());
+        session.branch_name = "freeman/hosted-entitlement-issuer".to_string();
+
+        assert_eq!(session_collision_id(&session, false), None);
+        assert_eq!(
+            session_collision_id(&session, true),
+            Some(format!("#{}", &session.id.to_string()[..8]))
+        );
+    }
+
+    #[test]
+    fn narrow_duplicate_rows_keep_their_short_id_visible() {
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        state.expand_all_workspaces = true;
+
+        let mut workspace = Workspace::new("ws".to_string(), "/tmp/ws".into());
+        let mut first = Session::new("first".to_string(), "/tmp/ws/first".to_string());
+        first.branch_name = "freeman/hosted-entitlement-issuer".to_string();
+        first
+            .live_attention
+            .push(SessionAttention::local(AttentionKind::Approve, CHIP_NOW));
+        let first_id = first.id.to_string()[..8].to_string();
+        let mut second = Session::new("second".to_string(), "/tmp/ws/second".to_string());
+        second.branch_name = first.branch_name.clone();
+        let second_id = second.id.to_string()[..8].to_string();
+        workspace.add_session(first);
+        workspace.add_session(second);
+        state.workspaces.push(workspace);
+
+        let painted = render_panel(&mut state, 24, 8);
+        assert!(
+            painted.contains(&format!("#{first_id}")),
+            "painted: {painted}"
+        );
+        assert!(
+            painted.contains(&format!("#{second_id}")),
+            "painted: {painted}"
+        );
+        assert!(painted.contains("APPROVE"), "painted: {painted}");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1851,6 +1851,7 @@ async fn run_tui_loop(
                             );
                             let mut attach_handler = AttachHandler::new_from_terminal(terminal)?;
                             info!("[ACTION] Attach handler created, calling attach_to_session...");
+                            let mut target_missing = false;
                             match attach_handler.attach_to_session(&tmux_session_name).await {
                                 Ok(()) => {
                                     info!(
@@ -1867,6 +1868,14 @@ async fn run_tui_loop(
                                         &tmux_session_name,
                                         &e,
                                     ));
+                                    // An attach can fail because the terminal is nested even
+                                    // though the target is alive. Probe the exact target before
+                                    // changing lifecycle state, so only a terminally missing
+                                    // tmux session becomes resumable Stopped.
+                                    target_missing = matches!(
+                                        tmux_session_presence(&tmux_session_name).await,
+                                        TmuxSessionPresence::Missing
+                                    );
                                 }
                             }
 
@@ -1878,6 +1887,17 @@ async fn run_tui_loop(
                                         break;
                                     }
                                 }
+                            }
+
+                            if target_missing
+                                && app.state.mark_session_stopped_for_missing_tmux(
+                                    session_id,
+                                    &tmux_session_name,
+                                )
+                            {
+                                // Rebuild from the persisted record too. This keeps the row
+                                // correctly filtered after an immediate refresh or TUI restart.
+                                app.state.load_real_workspaces().await;
                             }
 
                             app.state.ui_needs_refresh = true;
@@ -1943,6 +1963,47 @@ fn attach_failure_notice(session_name: &str, error: &impl std::fmt::Display) -> 
          the list was drawn — press f to refresh — or it is the tmux session ainb is \
          itself running in, which tmux refuses to nest."
     )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TmuxSessionPresence {
+    Exists,
+    Missing,
+    Uncertain,
+}
+
+/// Probe an exact tmux target without converting a transport failure into a
+/// lifecycle fact. A bare `-t name` can prefix-match a different live session;
+/// `=name` cannot.
+async fn tmux_session_presence(session_name: &str) -> TmuxSessionPresence {
+    let output = match tokio::process::Command::new("tmux")
+        .args(["has-session", "-t", &format!("={session_name}")])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(%error, %session_name, "could not verify tmux target after attach failure");
+            return TmuxSessionPresence::Uncertain;
+        }
+    };
+    if output.status.success() {
+        return TmuxSessionPresence::Exists;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_explicitly_missing_tmux_target(&stderr) {
+        TmuxSessionPresence::Missing
+    } else {
+        tracing::warn!(%session_name, %stderr, "tmux target probe was inconclusive after attach failure");
+        TmuxSessionPresence::Uncertain
+    }
+}
+
+fn is_explicitly_missing_tmux_target(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    stderr.contains("can't find session")
+        || stderr.contains("no server running")
+        || (stderr.contains("error connecting to") && stderr.contains("no such file or directory"))
 }
 
 fn setup_logging() {
@@ -2141,7 +2202,7 @@ where
 
 #[cfg(test)]
 mod attach_failure_notice_tests {
-    use super::attach_failure_notice;
+    use super::{attach_failure_notice, is_explicitly_missing_tmux_target};
 
     /// The three things the old one-liner never said.
     #[test]
@@ -2157,6 +2218,23 @@ mod attach_failure_notice_tests {
             "the remedy: {notice}"
         );
         assert!(notice.contains("nest"), "the other cause: {notice}");
+    }
+
+    #[test]
+    fn only_definitive_tmux_diagnostics_mean_target_missing() {
+        assert!(is_explicitly_missing_tmux_target(
+            "can't find session: tmux_dead"
+        ));
+        assert!(is_explicitly_missing_tmux_target(
+            "no server running on /tmp/tmux-1/default"
+        ));
+        assert!(is_explicitly_missing_tmux_target(
+            "error connecting to /tmp/tmux-1/default (No such file or directory)"
+        ));
+        assert!(!is_explicitly_missing_tmux_target("permission denied"));
+        assert!(!is_explicitly_missing_tmux_target(
+            "protocol version mismatch"
+        ));
     }
 }
 


### PR DESCRIPTION
## What changed
- reconcile definitively missing tmux targets to stopped, resumable sessions
- support Antigravity stop/restart lifecycle
- disambiguate same-title rows without crowding status chips
- preserve error history while clearing stale attention

## Validation
- exact tmux audit: 32/32 registry targets matched
- direct dead-Codex-pane restart test passed
- focused lifecycle, attach, and narrow-layout tests passed
- review agent approved