### PR TITLE
chore(v2): sync main and add lane goal prompts

### DIFF
--- a/ainb-tui/CHANGELOG.md
+++ b/ainb-tui/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.2] - 2026-09-11
+### Added
+- **fleet-macos**: add signed Sparkle updates
+- clarify sidebar session state
+
+### Fixed
+- **fleet**: verify updates before extraction
+- **release**: ad-hoc sign Fleet archives
+
+### Documentation
+- **plan**: drop the desktop handover from the repo
+- **plan**: handover for the desktop shared-core work
+- **release**: document Fleet distribution
+- **release**: document unsigned Fleet install
+
+
 ## [1.28.1] - 2026-09-11
 ### Added
 - label session lifecycle

--- a/ainb-tui/Cargo.lock
+++ b/ainb-tui/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "ainb"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "ainb-cli",
  "ainb-fleet-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-hangar-daemon"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "agent-client-protocol",
  "ainb-acp",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-cts-v2"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-secrets",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-hangar"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-plugin-notifyd"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "ainb-web"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "ainb-hangar-core",
  "ainb-hangar-proto",

--- a/ainb-tui/Cargo.toml
+++ b/ainb-tui/Cargo.toml
@@ -46,7 +46,7 @@ default-members = ["crates/ainb-core", "crates/ainb-hangar-daemon"]
 # parallel under agents-in-a-box-4is.
 
 [workspace.package]
-version = "1.28.1"
+version = "1.28.2"
 edition = "2021"
 authors = ["Agents-in-a-Box Team"]
 license = "MIT"

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -796,6 +796,11 @@ pub struct SessionsPaneState {
     last_sessions_rect: Option<Rect>,
     last_preview_rect: Option<Rect>,
     last_list_scroll_offset: usize,
+    /// Physical terminal-line height for each logical `ListItem` from the
+    /// latest render. Session rows have metadata on a second line, while
+    /// headers and separators remain one line; mouse hit-testing needs this
+    /// mapping rather than assuming one item equals one terminal row.
+    last_list_item_heights: Vec<usize>,
     last_attachable_click: Option<(AttachableRef, Instant)>,
     filter_toggle_area: Option<Rect>,
 }
@@ -810,6 +815,7 @@ impl Default for SessionsPaneState {
             last_sessions_rect: None,
             last_preview_rect: None,
             last_list_scroll_offset: 0,
+            last_list_item_heights: Vec::new(),
             last_attachable_click: None,
             filter_toggle_area: None,
         }
@@ -831,6 +837,10 @@ impl SessionsPaneState {
 
     pub fn set_list_scroll_offset(&mut self, offset: usize) {
         self.last_list_scroll_offset = offset;
+    }
+
+    pub fn set_list_item_heights(&mut self, heights: Vec<usize>) {
+        self.last_list_item_heights = heights;
     }
 
     pub fn set_filter_toggle_area(&mut self, area: Rect) {
@@ -950,7 +960,17 @@ impl SessionsPaneState {
             return None;
         }
 
-        Some(self.last_list_scroll_offset + usize::from(y - rect.y - 1))
+        let mut item_index = self.last_list_scroll_offset;
+        let mut line_in_view = usize::from(y - rect.y - 1);
+        while let Some(&height) = self.last_list_item_heights.get(item_index) {
+            let height = height.max(1);
+            if line_in_view < height {
+                return Some(item_index);
+            }
+            line_in_view = line_in_view.saturating_sub(height);
+            item_index += 1;
+        }
+        None
     }
 
     pub fn record_row_click(&mut self, target: SessionListRowTarget, now: Instant) -> bool {
@@ -4040,6 +4060,8 @@ impl Default for NewSessionState {
 struct ConfigureLaunchSnapshot {
     repo_source: crate::git::repo_source::RepoSource,
     branch_name: String,
+    /// Optional durable session prefix; Git branch remains unchanged.
+    session_prefix: Option<String>,
     skip_permissions: bool,
     mode: crate::models::SessionMode,
     boss_prompt: Option<String>,
@@ -8402,9 +8424,17 @@ impl AppState {
         } else {
             None
         };
+        let session_prefix = match crate::config::normalize_session_label(&spec.session_prefix) {
+            Ok(prefix) => prefix,
+            Err(error) => {
+                self.add_error_notification(error);
+                return;
+            }
+        };
         let snapshot = ConfigureLaunchSnapshot {
             repo_source: spec.repo_source.clone(),
             branch_name: spec.branch_worktree.clone(),
+            session_prefix,
             skip_permissions: preset.permissions.skip_all,
             mode,
             boss_prompt,
@@ -8580,6 +8610,21 @@ impl AppState {
             Ok(()) => {
                 info!("Session created successfully via configure flow");
                 self.load_real_workspaces().await;
+                if let Some(prefix) = snapshot.session_prefix.as_ref() {
+                    let tmux_name = self
+                        .find_session(session_id)
+                        .and_then(|session| session.tmux_session_name.clone());
+                    if let Some(tmux_name) = tmux_name {
+                        self.session_label_store.set(tmux_name, Some(prefix.clone()));
+                        if let Err(error) = self.session_label_store.save() {
+                            self.add_error_notification(format!(
+                                "Session started but prefix could not be saved: {error}"
+                            ));
+                        } else if let Some(session) = self.find_session_mut(session_id) {
+                            session.display_name = Some(prefix.clone());
+                        }
+                    }
+                }
                 if let Err(e) = self.start_log_streaming_for_session(session_id).await {
                     warn!(
                         "Failed to start log streaming for session {}: {}",
@@ -12126,11 +12171,18 @@ impl AppState {
                         .unanswerable(crate::fleet::attention::Unanswerable::NativePicker),
                 );
             }
-            return Some(
-                SessionAttention::local(Self::chip_for_alert(kind), rec.ts).with_detail(
-                    payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),
-                ),
-            );
+            // Legacy Codex emits an explicit request token. It is a question,
+            // not the generic unstructured wait that notifyd's toast class
+            // uses for both shapes. Keep this fallback aligned with Fleet's
+            // authoritative Codex reducer until its snapshot arrives.
+            let attention = if agent == "codex" && rec.raw_event == "request_user_input" {
+                AttentionKind::Ask
+            } else {
+                Self::chip_for_alert(kind)
+            };
+            return Some(SessionAttention::local(attention, rec.ts).with_detail(
+                payload.as_ref().and_then(Self::payload_message).unwrap_or_default(),
+            ));
         }
         None
     }

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -12642,6 +12642,32 @@ impl AppState {
         }
     }
 
+    /// A local stopped observation means its tmux session is gone. A retained
+    /// Fleet `IDLE` row only means its last observed pane was quiet, so it must
+    /// not resurrect a stopped session into the Active filter. Fleet may still
+    /// confirm the stop with an explicit `EXITED` projection.
+    const fn lifecycle_projection_may_replace_local_status(
+        local: &crate::models::SessionStatus,
+        projected: &crate::models::SessionStatus,
+    ) -> bool {
+        !matches!(local, crate::models::SessionStatus::Stopped)
+            || matches!(projected, crate::models::SessionStatus::Stopped)
+    }
+
+    /// A local `SessionEnd` is a terminal fact. Fleet can briefly retain an
+    /// older live lifecycle after the pane is gone, so let only this explicit
+    /// local stop beat Fleet's otherwise-preferred lifecycle projection.
+    fn projected_session_status(
+        fleet: Option<crate::models::SessionStatus>,
+        local: Option<crate::models::SessionStatus>,
+    ) -> Option<crate::models::SessionStatus> {
+        if matches!(local, Some(crate::models::SessionStatus::Stopped)) {
+            local
+        } else {
+            fleet.or(local)
+        }
+    }
+
     /// Hangar metadata for the selected session, if identity correlation was
     /// unambiguous and Hangar observed at least one requested field.
     #[must_use]
@@ -12785,7 +12811,8 @@ impl AppState {
                     self.attention_baseline.get(&s.id).copied().unwrap_or(0),
                     &recent,
                 );
-                let projected_status = fleet_status.or(local_terminal_status);
+                let projected_status =
+                    Self::projected_session_status(fleet_status, local_terminal_status);
                 let cwd = s.workspace_path.trim_end_matches('/').to_string();
                 // Exact provider id wins. A cwd fallback is safe only if that
                 // cwd names one local session; sibling subagents otherwise
@@ -12915,6 +12942,10 @@ impl AppState {
                     // Do not erase it with a Fleet lifecycle projection that
                     // has no recovery/error detail of its own.
                     if !matches!(session.status, crate::models::SessionStatus::Error(_))
+                        && Self::lifecycle_projection_may_replace_local_status(
+                            &session.status,
+                            &status,
+                        )
                         && session.status != status
                     {
                         session.set_status(status);

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -1128,6 +1128,7 @@ pub(crate) const fn is_stoppable_interactive(session: &crate::models::session::S
                 | SessionAgentType::Codex
                 | SessionAgentType::Gemini
                 | SessionAgentType::Copilot
+                | SessionAgentType::Antigravity
         )
 }
 
@@ -10284,6 +10285,37 @@ impl AppState {
         result
     }
 
+    /// Record the terminal fact discovered by a failed attach: the exact tmux
+    /// target no longer exists.  This is deliberately narrower than a generic
+    /// attach failure: nesting and terminal errors must leave a live row alone.
+    ///
+    /// Keeping the persisted metadata intact makes the row immediately
+    /// resumable and makes the next reload retain it under the Stopped filter.
+    pub(crate) fn mark_session_stopped_for_missing_tmux(
+        &mut self,
+        session_id: Uuid,
+        tmux_session_name: &str,
+    ) -> bool {
+        use crate::models::SessionStatus;
+
+        let matches_target = self
+            .find_session(session_id)
+            .is_some_and(|session| session.tmux_session_name.as_deref() == Some(tmux_session_name));
+        if !matches_target {
+            return false;
+        }
+
+        self.tmux_sessions.remove(&session_id);
+        if let Some(session) = self.find_session_mut(session_id) {
+            session.set_status(SessionStatus::Stopped);
+            session.is_attached = false;
+            // A dead pane cannot still be waiting for input. Keep historical
+            // errors for the Err tab, but remove actionable row chips.
+            session.live_attention.clear();
+        }
+        true
+    }
+
     /// Soft-stop every session in `session_ids`.
     ///
     /// Each one goes through `stop_interactive_session`, so tmux is killed and
@@ -12858,18 +12890,24 @@ impl AppState {
                 // Attaching advances this to "now" (see below).
                 let baseline = self.attention_baseline.get(&s.id).copied().unwrap_or(0);
                 let mut chips = Vec::new();
-                if let Some(chip) = Self::attention_for_session_identity(
-                    &s.workspace_path,
-                    Self::agent_hook_name(s.agent_type),
-                    provider_session_id.as_deref(),
-                    allow_unidentified_cwd,
-                    true,
-                    generating,
-                    baseline,
-                    now_ms,
-                    &recent,
-                ) {
-                    chips.push(chip);
+                // The exact tmux target is gone. A retained daemon snapshot
+                // can still describe an older ASK/WAIT, but it has no pane to
+                // receive an answer and must not resurrect an actionable chip.
+                let locally_stopped = matches!(s.status, crate::models::SessionStatus::Stopped);
+                if !locally_stopped {
+                    if let Some(chip) = Self::attention_for_session_identity(
+                        &s.workspace_path,
+                        Self::agent_hook_name(s.agent_type),
+                        provider_session_id.as_deref(),
+                        allow_unidentified_cwd,
+                        true,
+                        generating,
+                        baseline,
+                        now_ms,
+                        &recent,
+                    ) {
+                        chips.push(chip);
+                    }
                 }
                 // The daemon's rows for the same worktree. Added unconditionally,
                 // NOT gated on `generating`: the generating gate exists because
@@ -12878,7 +12916,7 @@ impl AppState {
                 // and an agent can be mid-turn and blocked on an approval at the
                 // same time — suppressing it there is how an operator ends up
                 // watching a spinner that is waiting on them.
-                if !daemon_rows.is_empty() {
+                if !locally_stopped && !daemon_rows.is_empty() {
                     chips.extend(daemon_rows.iter().cloned());
                 }
                 // The REASON, not a boolean. `SessionStatus::Error` has always
@@ -12952,6 +12990,20 @@ impl AppState {
                         changed = true;
                     }
                 }
+            }
+            // Stop is terminal for the pane, not for historical diagnostics.
+            // Do not rebuild live chips from a retained daemon snapshot, and
+            // do not overwrite the Err tab's history with an empty set.
+            if self.find_session(id).is_some_and(|session| {
+                matches!(session.status, crate::models::SessionStatus::Stopped)
+            }) {
+                if let Some(session) = self.find_session_mut(id) {
+                    if !session.live_attention.is_empty() {
+                        session.live_attention.clear();
+                        changed = true;
+                    }
+                }
+                continue;
             }
             if let Some(reason) = failure {
                 // ERR is a SECOND, independent chip, not a competitor: a

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2335,6 +2335,16 @@ mod tests {
     }
 
     #[test]
+    fn legacy_codex_request_user_input_marks_ask_not_wait() {
+        use crate::fleet::attention::AttentionKind;
+        let recent = vec![rec("codex", CWD, "request_user_input", NOW - 1_000)];
+        assert_eq!(
+            kind_of(CWD, Some("codex"), false, 0, NOW, &recent),
+            Some(AttentionKind::Ask),
+        );
+    }
+
+    #[test]
     fn attention_stop_clears_immediately() {
         let fresh = vec![rec("claude", CWD, "Stop", NOW - 1000)];
         assert_eq!(kind_of(CWD, Some("claude"), false, 0, NOW, &fresh), None);
@@ -2514,7 +2524,7 @@ mod tests {
         use crate::fleet::attention::AttentionKind;
         use crate::models::Session;
         use ainb_hangar_proto::fleet::{
-            AttentionState, FleetCapabilities, FleetConfidence, FleetProvider, FleetProvenance,
+            AttentionState, FleetCapabilities, FleetConfidence, FleetProvenance, FleetProvider,
             FleetSession, LifecycleState, ManagementState, TransportHealth,
         };
 

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -31,6 +31,63 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_is_stoppable_and_resumable_interactive() {
+        let session = crate::models::Session::new_with_options(
+            "agent".to_string(),
+            "/tmp/agent".to_string(),
+            true,
+            SessionMode::Interactive,
+            None,
+            SessionAgentType::Antigravity,
+            None,
+        );
+
+        assert!(crate::app::state::is_stoppable_interactive(&session));
+    }
+
+    #[test]
+    fn missing_exact_tmux_target_becomes_stopped_and_resumable() {
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        let mut workspace = crate::models::Workspace::new("ws".to_string(), "/tmp/ws".into());
+        let mut session = crate::models::Session::new_with_options(
+            "agent".to_string(),
+            "/tmp/ws/agent".to_string(),
+            true,
+            SessionMode::Interactive,
+            None,
+            SessionAgentType::Antigravity,
+            None,
+        );
+        let id = session.id;
+        session.tmux_session_name = Some("tmux_missing_exact".to_string());
+        session.status = crate::models::SessionStatus::Idle;
+        session.is_attached = true;
+        session.live_attention.push(crate::fleet::attention::SessionAttention::local(
+            crate::fleet::attention::AttentionKind::Wait,
+            1,
+        ));
+        workspace.add_session(session);
+        state.workspaces.push(workspace);
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing_exact"));
+        let session = state.workspaces[0].sessions.first().expect("session");
+        assert!(matches!(
+            session.status,
+            crate::models::SessionStatus::Stopped
+        ));
+        assert!(!session.is_attached);
+        assert!(session.live_attention.is_empty());
+        assert_eq!(
+            state.selected_resumable_session_ids(),
+            Vec::<uuid::Uuid>::new()
+        );
+
+        state.selected_sessions.insert(id);
+        assert_eq!(state.selected_resumable_session_ids(), vec![id]);
+    }
+
+    #[test]
     fn observer_waits_for_a_stable_selection() {
         let mut state = AppState::new();
         let now = std::time::Instant::now();
@@ -2724,6 +2781,59 @@ mod tests {
         assert_eq!(chips[0].kind, AttentionKind::Ask);
         assert_eq!(chips[0].source, AttentionSource::Daemon);
         assert_eq!(chips[0].detail.as_deref(), Some("Decide the sqlite path"));
+    }
+
+    #[test]
+    fn missing_tmux_stop_cannot_regain_a_stale_daemon_question() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let cwd = "/work/missing-tmux";
+        let mut state = state_with_session_at(cwd, Some("tmux_missing"));
+        let id = state.workspaces[0].sessions[0].id;
+        install_daemon_row(
+            &state,
+            cwd,
+            SessionAttention::daemon(AttentionKind::Ask, 1_000, "att-stale".into()),
+        );
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing"));
+        state.refresh_attention_markers(2_000);
+
+        assert!(
+            state.workspaces[0].sessions[0].live_attention.is_empty(),
+            "a stopped row must not regain an unanswerable daemon question"
+        );
+    }
+
+    #[test]
+    fn missing_tmux_stop_keeps_daemon_error_history() {
+        use crate::fleet::attention::{AttentionKind, SessionAttention};
+        let cwd = "/work/missing-tmux-error";
+        let mut state = state_with_session_at(cwd, Some("tmux_missing_error"));
+        let id = state.workspaces[0].sessions[0].id;
+        install_daemon_row(
+            &state,
+            cwd,
+            SessionAttention::daemon(AttentionKind::Err, 1_000, "att-error".into())
+                .with_detail("agent command failed"),
+        );
+
+        state.refresh_attention_markers(2_000);
+        assert_eq!(state.workspaces[0].sessions[0].errors.len(), 1);
+
+        assert!(state.mark_session_stopped_for_missing_tmux(id, "tmux_missing_error"));
+        state.refresh_attention_markers(3_000);
+
+        let session = &state.workspaces[0].sessions[0];
+        assert!(session.live_attention.is_empty());
+        assert_eq!(
+            session.errors.len(),
+            1,
+            "stopping must preserve Err tab history"
+        );
+        assert_eq!(
+            session.errors[0].detail.as_deref(),
+            Some("agent command failed")
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2406,6 +2406,35 @@ mod tests {
     }
 
     #[test]
+    fn stale_fleet_idle_cannot_reactivate_a_locally_stopped_session() {
+        use crate::models::SessionStatus;
+
+        assert!(!AppState::lifecycle_projection_may_replace_local_status(
+            &SessionStatus::Stopped,
+            &SessionStatus::Idle,
+        ));
+        assert!(AppState::lifecycle_projection_may_replace_local_status(
+            &SessionStatus::Stopped,
+            &SessionStatus::Stopped,
+        ));
+
+        let projected = AppState::projected_session_status(
+            Some(SessionStatus::Idle),
+            Some(SessionStatus::Stopped),
+        );
+        assert_eq!(projected, Some(SessionStatus::Stopped));
+
+        let mut state = AppState::new();
+        state.session_filter = crate::app::state::SessionFilter::ActiveOnly;
+        let mut session = Session::new("ended".to_string(), CWD.to_string());
+        session.status = projected.expect("terminal stop projects");
+        assert!(
+            !state.session_passes_filter(&session),
+            "a locally confirmed stop is absent from Active"
+        );
+    }
+
+    #[test]
     fn attention_suppressed_while_generating() {
         let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
         assert_eq!(

--- a/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
+++ b/ainb-tui/crates/ainb-core/src/components/new_session/configure.rs
@@ -270,6 +270,9 @@ pub enum ConfigureRow {
     /// ephemeral override of the configured Workspace default.
     Prefix,
     Branch,
+    /// Optional durable label rendered ahead of the Git branch in the session
+    /// list. Unlike [`Self::Prefix`], this never changes a branch name.
+    SessionPrefix,
     Prompt,
     /// Explicit submit row. Renders as a `[ Launch ]` button at the bottom of
     /// the form. Tab past Prompt lands here; Enter fires the launch. Avoids
@@ -312,6 +315,11 @@ pub struct ConfigureState {
     /// Inline prefix edit buffer. The committed value applies only to this
     /// launch; it never changes the Workspace default in `config.toml`.
     pub branch_prefix_edit: Option<String>,
+    /// Optional human prefix for the session row, persisted after a successful
+    /// tmux-backed launch through `SessionLabelStore`.
+    pub session_prefix: String,
+    /// Inline edit buffer for [`Self::session_prefix`].
+    pub session_prefix_edit: Option<String>,
     /// Multi-line prompt editor (Boss mode only).
     pub prompt: TextEditor,
     /// When `Some`, the save-preset modal is open and the contained string is
@@ -454,6 +462,8 @@ impl ConfigureState {
             branch_override: None,
             branch_edit: None,
             branch_prefix_edit: None,
+            session_prefix: String::new(),
+            session_prefix_edit: None,
             prompt,
             save_preset_modal: None,
             presets_cache,
@@ -694,6 +704,7 @@ impl ConfigureState {
         // Settings → Workspace.
         rows.push(ConfigureRow::Prefix);
         rows.push(ConfigureRow::Branch);
+        rows.push(ConfigureRow::SessionPrefix);
         // Prompt row visible only in Boss mode for non-shell agents.
         if preset.mode == SessionMode::Boss && preset.agent_provider != "shell" {
             rows.push(ConfigureRow::Prompt);
@@ -724,6 +735,9 @@ impl ConfigureState {
         }
         if self.focused_row != ConfigureRow::Prefix {
             self.branch_prefix_edit = None;
+        }
+        if self.focused_row != ConfigureRow::SessionPrefix {
+            self.session_prefix_edit = None;
         }
     }
 }
@@ -766,6 +780,8 @@ pub struct LaunchSpec {
     /// Persisted to `session-defaults.per_repo[].last_branch_override` so the
     /// next launch can pre-fill the textarea.
     pub branch_override: Option<String>,
+    /// Optional durable label displayed before the branch in the sidebar.
+    pub session_prefix: String,
     /// The base-branch popup pick, when used. `None` = legacy base policy
     /// (HEAD for local repos, origin/HEAD for remote/star launches).
     pub base: Option<BaseSelection>,
@@ -867,6 +883,9 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
             }
             ConfigureRow::Prefix => render_prefix_row(f, state, area_for_row, focused),
             ConfigureRow::Branch => render_branch_row(f, state, area_for_row, focused),
+            ConfigureRow::SessionPrefix => {
+                render_session_prefix_row(f, state, area_for_row, focused);
+            }
             ConfigureRow::Prompt => render_prompt_row(f, state, area_for_row, focused),
             ConfigureRow::Launch => render_launch_row(f, area_for_row, focused),
         }
@@ -890,11 +909,14 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
     let help_chunk = *chunks.last().expect("layout always emits help row");
     let in_prompt =
         state.focused_row == ConfigureRow::Prompt && rows.contains(&ConfigureRow::Prompt);
-    let help = render_help_bar(
-        variant,
-        in_prompt,
-        state.branch_edit.is_some() || state.branch_prefix_edit.is_some(),
-    );
+    let active_edit = if state.branch_edit.is_some() || state.branch_prefix_edit.is_some() {
+        Some("branch")
+    } else if state.session_prefix_edit.is_some() {
+        Some("session prefix")
+    } else {
+        None
+    };
+    let help = render_help_bar(variant, in_prompt, active_edit);
     f.render_widget(
         Paragraph::new(help).alignment(Alignment::Center),
         help_chunk,
@@ -913,8 +935,8 @@ pub fn render(f: &mut Frame, state: &ConfigureState, area: Rect) {
 
 /// Build the bottom help bar. Shape switches based on whether the prompt
 /// textarea is the focused row (which captures plain chars).
-fn render_help_bar(variant: Variant, in_prompt: bool, branch_editing: bool) -> Line<'static> {
-    if branch_editing {
+fn render_help_bar(variant: Variant, in_prompt: bool, active_edit: Option<&str>) -> Line<'static> {
+    if let Some(active_edit) = active_edit {
         return Line::from(vec![
             Span::styled(
                 "Enter",
@@ -925,7 +947,10 @@ fn render_help_bar(variant: Variant, in_prompt: bool, branch_editing: bool) -> L
                 "Esc",
                 Style::default().fg(GOLD).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("=Cancel branch edit", Style::default().fg(MUTED_GRAY)),
+            Span::styled(
+                format!("=Cancel {active_edit} edit"),
+                Style::default().fg(MUTED_GRAY),
+            ),
         ]);
     }
     if in_prompt {
@@ -1565,6 +1590,46 @@ fn render_prefix_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused:
     f.render_widget(Paragraph::new(line), area);
 }
 
+/// Render optional durable prefix shown before the branch in the session list.
+/// This is independent of the worktree branch-generation prefix above.
+fn render_session_prefix_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
+    if let Some(prefix) = state.session_prefix_edit.as_ref() {
+        let line = Line::from(vec![
+            focus_indicator(focused),
+            label_span("Session prefix:  "),
+            Span::styled(
+                prefix.clone(),
+                Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("_", Style::default().fg(MUTED_GRAY)),
+        ]);
+        f.render_widget(Paragraph::new(line), area);
+        return;
+    }
+
+    let mut style = Style::default().fg(SELECTION_GREEN).add_modifier(Modifier::BOLD);
+    if focused {
+        style = style.add_modifier(Modifier::UNDERLINED);
+    }
+    let prefix = if state.session_prefix.is_empty() {
+        "(none)"
+    } else {
+        &state.session_prefix
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            focus_indicator(focused),
+            label_span("Session prefix:  "),
+            Span::styled(prefix, style),
+            Span::styled(
+                "   [Enter to edit]",
+                Style::default().fg(MUTED_GRAY).add_modifier(Modifier::ITALIC),
+            ),
+        ])),
+        area,
+    );
+}
+
 fn render_prompt_row(f: &mut Frame, state: &ConfigureState, area: Rect, focused: bool) {
     let border_color = if focused { GOLD } else { MUTED_GRAY };
     let prompt_block = Block::default()
@@ -2089,6 +2154,9 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
     if state.branch_prefix_edit.is_some() {
         return handle_branch_prefix_edit_key(state, key);
     }
+    if state.session_prefix_edit.is_some() {
+        return handle_session_prefix_edit_key(state, key);
+    }
 
     // Ctrl shortcuts.
     if key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -2122,6 +2190,10 @@ pub fn handle_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome
         KeyCode::Enter => match state.focused_row {
             ConfigureRow::Prefix => {
                 state.branch_prefix_edit = Some(state.branch_prefix.clone());
+                ConfigureOutcome::Stay
+            }
+            ConfigureRow::SessionPrefix => {
+                state.session_prefix_edit = Some(state.session_prefix.clone());
                 ConfigureOutcome::Stay
             }
             ConfigureRow::Branch => match state.branch_segment {
@@ -2258,6 +2330,7 @@ fn launch_outcome(state: &mut ConfigureState) -> ConfigureOutcome {
         branch_worktree,
         branch_source: state.branch_source.clone(),
         branch_override: state.branch_override.clone(),
+        session_prefix: state.session_prefix.trim().to_string(),
         base: state.base_selection.clone(),
         prompt,
         // Defensive: never launch with Headroom on if the binary isn't there,
@@ -2307,6 +2380,9 @@ fn cycle_value_in_focused_row(state: &mut ConfigureState, delta: i32) {
         }
         ConfigureRow::Prefix => {
             // Prefix is an editable text row, not a value ring.
+        }
+        ConfigureRow::SessionPrefix => {
+            // Session prefix is an editable text row, not a value ring.
         }
         ConfigureRow::Branch => {
             // ←/→ on the Branch row toggles the targeted segment
@@ -2552,6 +2628,31 @@ fn handle_branch_prefix_edit_key(state: &mut ConfigureState, key: KeyEvent) -> C
     }
 }
 
+/// Inline edit for the durable session prefix. Empty deliberately clears it.
+fn handle_session_prefix_edit_key(state: &mut ConfigureState, key: KeyEvent) -> ConfigureOutcome {
+    let buffer = state.session_prefix_edit.as_mut().expect("guard checked");
+    match key.code {
+        KeyCode::Esc => {
+            state.session_prefix_edit = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Enter => {
+            state.session_prefix = buffer.trim().to_string();
+            state.session_prefix_edit = None;
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Backspace => {
+            buffer.pop();
+            ConfigureOutcome::Stay
+        }
+        KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            buffer.push(c);
+            ConfigureOutcome::Stay
+        }
+        _ => ConfigureOutcome::Stay,
+    }
+}
+
 /// Base-branch popup key handler. Chars/Backspace edit the fuzzy filter,
 /// ↑/↓ move the selection, Tab toggles the action mode (base-off ⇄ checkout),
 /// Enter commits the pick, Esc closes without changes.
@@ -2717,6 +2818,8 @@ mod tests {
             branch_override: None,
             branch_edit: None,
             branch_prefix_edit: None,
+            session_prefix: String::new(),
+            session_prefix_edit: None,
             prompt: TextEditor::new(),
             save_preset_modal: None,
             presets_cache,
@@ -3270,7 +3373,8 @@ mod tests {
     fn tab_cycles_focus_through_visible_rows() {
         let mut s = mk_state();
         // Named preset, default mode = Boss, Claude/Codex provider → rows =
-        // [Preset, Mode, Yolo, HeadroomProxy, Rtk, Prefix, Branch, Prompt, Launch].
+        // [Preset, Mode, Yolo, HeadroomProxy, Rtk, Prefix, Branch,
+        //  SessionPrefix, Prompt, Launch].
         assert_eq!(s.focused_row, ConfigureRow::Preset);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Mode);
@@ -3285,12 +3389,39 @@ mod tests {
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Branch);
         s.cycle_focus(1);
+        assert_eq!(s.focused_row, ConfigureRow::SessionPrefix);
+        s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Prompt);
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Launch);
         // Wraps.
         s.cycle_focus(1);
         assert_eq!(s.focused_row, ConfigureRow::Preset);
+    }
+
+    #[test]
+    fn session_prefix_is_optional_and_threads_into_launch() {
+        let mut s = mk_state();
+        s.focused_row = ConfigureRow::SessionPrefix;
+        assert_eq!(
+            handle_key(&mut s, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            ConfigureOutcome::Stay
+        );
+        for c in "slice-c".chars() {
+            assert_eq!(
+                handle_key(&mut s, KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)),
+                ConfigureOutcome::Stay
+            );
+        }
+        assert_eq!(
+            handle_key(&mut s, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            ConfigureOutcome::Stay
+        );
+        assert_eq!(s.session_prefix, "slice-c");
+        let ConfigureOutcome::Launch(spec) = launch_outcome(&mut s) else {
+            panic!("launch should proceed")
+        };
+        assert_eq!(spec.session_prefix, "slice-c");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -8,6 +8,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
+use unicode_width::UnicodeWidthChar;
 
 // Premium color palette (TUI Style Guide)
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
@@ -25,9 +26,7 @@ const ALERT_WAITING_AMBER: Color = Color::Rgb(230, 180, 80);
 const ALERT_PERMISSION_RED: Color = Color::Rgb(220, 90, 90);
 const ALERT_ERROR_RED: Color = Color::Rgb(230, 100, 100);
 
-// Per-agent brand colors for the coding-agent pill chip. The chip is a
-// filled block in these colors so the agent is identifiable at a glance —
-// orange = Claude, blue = Gemini, etc. — even before the glyph resolves.
+// Per-agent brand colours for the compact provider icon on the metadata line.
 const BRAND_CLAUDE: Color = Color::Rgb(217, 119, 87); // Anthropic clay-orange
 const BRAND_CODEX: Color = Color::Rgb(236, 236, 241); // OpenAI near-white
 const BRAND_COPILOT: Color = Color::Rgb(46, 160, 67); // GitHub green
@@ -37,10 +36,6 @@ const BRAND_KIRO: Color = Color::Rgb(171, 121, 224); // crystal purple
 const BRAND_SHELL: Color = Color::Rgb(150, 150, 165); // muted slate
 const BRAND_SSH: Color = Color::Rgb(255, 165, 0); // amber
 
-// Powerline rounded caps that wrap the pill chip's filled middle.
-const PILL_LEFT: &str = "\u{e0b6}"; //
-const PILL_RIGHT: &str = "\u{e0b4}"; //
-
 use crate::fleet::attention::{
     AttentionKind, AttentionTone, SessionAttention, format_age, needs_you_count, tone,
 };
@@ -49,9 +44,7 @@ use crate::app::{
     AppState,
     state::{AttachableRef, SessionContextAction, SessionListRowTarget},
 };
-use crate::models::{
-    Session, SessionAgentType, SessionMode, SessionStatus, ShellSessionStatus, Workspace,
-};
+use crate::models::{Session, SessionAgentType, SessionStatus, ShellSessionStatus, Workspace};
 
 /// Width of the leading badge slot rendered before every list row.
 /// Two characters: a digit (or space) and a trailing space separator.
@@ -115,56 +108,64 @@ fn chip_label(chip: &SessionAttention, sending: Option<&SessionAttention>) -> &'
     }
 }
 
-/// Cell width of the chip strip for `chips`, including the leading gap.
-fn chip_strip_width(
+/// Cell width of attention content, excluding its gap from the lifecycle word.
+fn attention_width(
     chips: &[SessionAttention],
     now_ms: i64,
     sending: Option<&SessionAttention>,
 ) -> usize {
-    if chips.is_empty() {
-        return 0;
-    }
     chips
         .iter()
-        .map(|chip| {
-            CHIP_GAP + chip_label(chip, sending).len() + 1 + format_age(now_ms, chip.since_ms).len()
+        .enumerate()
+        .map(|(index, chip)| {
+            usize::from(index > 0) * CHIP_GAP
+                + chip_label(chip, sending).len()
+                + 1
+                + format_age(now_ms, chip.since_ms).len()
         })
         .sum()
 }
 
-/// Append the row's attention chips, RIGHT-ALIGNED against `row_width`.
+/// Append a lifecycle plus attention gutter, right-aligned against `row_width`.
 ///
-/// Right-aligned because the strip is a column an operator scans down: chips
-/// that trail a variable-length branch name land at a different column on every
-/// row, which is exactly the scan the four-word vocabulary exists to make fast.
-///
-/// Width is measured with `Span::width` (unicode-width), never byte length —
-/// the row already carries a Nerd Font agent pill and a status glyph whose byte
-/// counts have nothing to do with their cell counts.
-///
-/// When the row is too narrow, the SESSION NAME at `name_index` gives way, not
-/// the chips: a truncated name still identifies the row (the tree, the agent
-/// pill and the attach digit are all still there), while a truncated `APPROVE`
-/// reading `APPRO` is a word the operator has to decode. This is the spec's
-/// 80-column rule — chip words never abbreviate.
-fn push_attention_chips(
+/// A row reads left-to-right as identity, then status. The lifecycle word is
+/// deliberately in the gutter with `ASK`/`WAIT`/`APPROVE`, rather than mixed
+/// into the title. Names give way first: status words never abbreviate.
+fn push_status_gutter(
     spans: &mut Vec<Span<'static>>,
+    status_indicator: &str,
+    lifecycle_label: &str,
+    lifecycle_style: Style,
     chips: &[SessionAttention],
     now_ms: i64,
     row_width: usize,
     name_index: usize,
     sending: Option<&SessionAttention>,
 ) {
-    if chips.is_empty() {
-        return;
-    }
-    let strip = chip_strip_width(chips, now_ms, sending);
+    let attention = attention_width(chips, now_ms, sending);
     let mut used: usize = spans.iter().map(Span::width).sum();
-    // The gap belongs in the BUDGET, not in the padding: applied afterwards as
-    // a floor it pushes the strip past the row's right edge on exactly the
-    // narrow rows the budget was computed to protect, and the widget then clips
-    // the age off the end.
-    let budget = row_width.saturating_sub(strip + CHIP_GAP + CHIP_RIGHT_MARGIN);
+    let fixed_title_width: usize = spans
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != name_index)
+        .map(|(_, span)| span.width())
+        .sum();
+    let lifecycle_width = Span::raw(status_indicator).width() + 1 + lifecycle_label.len();
+    // At the supported minimum width, an operator action wins over passive
+    // process state. Dropping `○ IDLE` leaves `APPROVE` whole rather than
+    // asking Ratatui to clip either word. Wider rows retain the full gutter.
+    let show_lifecycle = fixed_title_width
+        .saturating_add(lifecycle_width)
+        .saturating_add((!chips.is_empty()).then_some(CHIP_GAP).unwrap_or_default())
+        .saturating_add(attention)
+        .saturating_add(CHIP_RIGHT_MARGIN)
+        <= row_width;
+    let gutter_width = if show_lifecycle { lifecycle_width } else { 0 }
+        .saturating_add(
+            (show_lifecycle && !chips.is_empty()).then_some(CHIP_GAP).unwrap_or_default(),
+        )
+        .saturating_add(attention);
+    let budget = row_width.saturating_sub(gutter_width + CHIP_RIGHT_MARGIN);
     if used > budget {
         if let Some(name) = spans.get_mut(name_index) {
             let over = used - budget;
@@ -176,10 +177,18 @@ fn push_attention_chips(
             used += name.width();
         }
     }
-    let pad = row_width.saturating_sub(used + strip + CHIP_RIGHT_MARGIN).max(CHIP_GAP);
+    let pad = row_width.saturating_sub(used + gutter_width + CHIP_RIGHT_MARGIN);
     spans.push(Span::raw(" ".repeat(pad)));
+    if show_lifecycle {
+        spans.push(Span::styled(status_indicator.to_string(), lifecycle_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            lifecycle_label.to_string(),
+            lifecycle_style.add_modifier(Modifier::BOLD),
+        ));
+    }
     for (index, chip) in chips.iter().enumerate() {
-        if index > 0 {
+        if show_lifecycle || index > 0 {
             spans.push(Span::raw(" ".repeat(CHIP_GAP)));
         }
         // A chip nothing can answer renders DIMMED, never hidden. Hidden is
@@ -263,13 +272,17 @@ impl SessionListComponent {
         self.update_selection(state);
         state.sessions_pane_state.set_list_scroll_offset(self.list_state.offset());
 
-        // Width a row's own spans may occupy. `List` already takes its
-        // highlight symbol out of the item area before the row is laid out, so
-        // this is the panel interior and nothing further comes off it —
-        // measured, not assumed (`every_chip_strip_ends_one_cell_clear_of_the_border`).
-        let row_width = usize::from(area.width.saturating_sub(2));
+        // Width a row's own spans may occupy: the panel borders and List's
+        // reserved highlight column are both outside the item area. Reserving
+        // this here keeps the status gutter one cell clear of the right border
+        // on selected and unselected rows alike.
+        let row_width = usize::from(area.width.saturating_sub(2))
+            .saturating_sub(Span::raw(HIGHLIGHT_SYMBOL).width());
         let now_ms = chrono::Utc::now().timestamp_millis();
         let items = SessionListComponent::build_list_items_static(state, row_width, now_ms);
+        state
+            .sessions_pane_state
+            .set_list_item_heights(items.iter().map(ListItem::height).collect());
 
         // Show focus indicator with premium colors
         use crate::app::state::FocusedPane;
@@ -647,20 +660,7 @@ impl SessionListComponent {
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };
 
                     let status_indicator = session.status.indicator();
-                    let lifecycle_label = session_lifecycle_label(&session.status);
-
-                    // Mode indicator (controlled by show_container_status config).
-                    // 1-cell Nerd Font glyphs (dev-docker / fa-desktop) instead of
-                    // the 🐳/🖥️ emoji — emoji render 2-cell and the variation
-                    // selector made width unpredictable across terminals.
-                    let mode_indicator = if state.app_config.ui_preferences.show_container_status {
-                        match session.mode {
-                            SessionMode::Boss => "\u{e7b0} ",        // dev-docker
-                            SessionMode::Interactive => "\u{f108} ", // fa-desktop
-                        }
-                    } else {
-                        ""
-                    };
+                    let lifecycle_label = session_lifecycle_label(state, session);
 
                     // Git changes (controlled by show_git_status config)
                     let changes_text = if state.app_config.ui_preferences.show_git_status
@@ -686,37 +686,8 @@ impl SessionListComponent {
                         }
                     };
                     let branch_color = state_color;
-                    // Background behind the agent pill's powerline caps so they
-                    // blend with the row (panel bg normally, highlight bar when
-                    // selected).
-                    let row_bg = if is_selected_session {
-                        LIST_HIGHLIGHT_BG
-                    } else {
-                        DARK_BG
-                    };
-
                     let agent_icon = session.agent_type.icon();
                     let agent_color = agent_brand_color(&session.agent_type);
-                    // Agent chip: non-selected rows get the filled brand pill;
-                    // the selected row drops the fill (bold brand glyph only) so
-                    // there is no square box around the glyph on the highlight
-                    // bar. Caps collapse to spaces to preserve column width.
-                    let (pill_l, pill_r, agent_style) = if is_selected_session {
-                        (
-                            " ",
-                            " ",
-                            Style::default().fg(agent_color).add_modifier(Modifier::BOLD),
-                        )
-                    } else {
-                        (
-                            PILL_LEFT,
-                            PILL_RIGHT,
-                            Style::default()
-                                .fg(DARK_BG)
-                                .bg(agent_color)
-                                .add_modifier(Modifier::BOLD),
-                        )
-                    };
                     let is_multi_selected = state.selected_sessions.contains(&session.id);
 
                     let checkbox = ballot_checkbox(is_multi_selected);
@@ -728,54 +699,21 @@ impl SessionListComponent {
                     // on a human then.
                     let session_alert = session.live_attention.as_slice();
 
-                    let mut session_spans = vec![
+                    // Line one contains only stable session identity. Status lives
+                    // in a fixed right gutter so it is readable as a column while
+                    // scanning; provider/model metadata moves to line two.
+                    let mut title_spans = vec![
                         next_badge(&mut attach_no),
                         checkbox,
                         Span::styled(tree_prefix, Style::default().fg(SUBDUED_BORDER)),
-                        Span::styled(
-                            format!(" {} ", status_indicator),
-                            Style::default().fg(state_color),
-                        ),
-                        // Lifecycle reports process/turn state only. It is
-                        // intentionally separate from ASK/WAIT/APPROVE chips,
-                        // which report an attention request and answer route.
-                        Span::styled(
-                            format!("{lifecycle_label} "),
-                            Style::default().fg(state_color).add_modifier(Modifier::BOLD),
-                        ),
-                        Span::styled(mode_indicator.to_string(), Style::default().fg(MUTED_GRAY)),
-                        // Coding-agent chip — brand colour carries identity
-                        // (orange Claude, blue Gemini, …). Filled pill on normal
-                        // rows; bold glyph only on the selected row (no square).
-                        Span::styled(pill_l, Style::default().fg(agent_color).bg(row_bg)),
-                        Span::styled(format!(" {} ", agent_icon), agent_style),
-                        Span::styled(pill_r, Style::default().fg(agent_color).bg(row_bg)),
                         Span::raw(" "),
                     ];
-                    // Model/effort belongs on the row rather than the selected
-                    // session footer: scanning the roster should answer what is
-                    // running where. It yields on narrow panes because an
-                    // attention chip must never be clipped to make room for
-                    // metadata.
-                    if let Some(metadata) = session_model_effort_label(state, session) {
-                        let fixed_width: usize = session_spans.iter().map(Span::width).sum();
-                        let required = fixed_width
-                            .saturating_add(Span::raw(metadata.as_str()).width())
-                            .saturating_add(Span::raw(session_list_name(session)).width().min(4))
-                            .saturating_add(Span::raw(changes_text.as_str()).width())
-                            .saturating_add(chip_strip_width(session_alert, now_ms, None))
-                            .saturating_add(CHIP_RIGHT_MARGIN);
-                        if required <= row_width {
-                            session_spans
-                                .push(Span::styled(metadata, Style::default().fg(MUTED_GRAY)));
-                        }
-                    }
-                    // The name is the span that gives way when the chip strip
-                    // needs the room. Its index is captured rather than searched
-                    // for, so reordering the row above can never silently
-                    // truncate the branch decoration instead.
-                    let name_span_index = session_spans.len();
-                    session_spans.push(Span::styled(
+                    // The title is the span that gives way when the fixed
+                    // right gutter needs room. Its index is captured rather
+                    // than searched, so future reordering cannot silently
+                    // truncate a tree or status decoration instead.
+                    let name_span_index = title_spans.len();
+                    title_spans.push(Span::styled(
                         session_list_name(session),
                         Style::default().fg(branch_color).add_modifier(if is_selected_session {
                             Modifier::BOLD
@@ -783,12 +721,12 @@ impl SessionListComponent {
                             Modifier::empty()
                         }),
                     ));
-                    session_spans.push(Span::styled(
+                    title_spans.push(Span::styled(
                         changes_text,
                         Style::default().fg(WARNING_ORANGE),
                     ));
                     debug_assert_eq!(
-                        session_spans[name_span_index].content,
+                        title_spans[name_span_index].content,
                         session_list_name(session),
                         "name_span_index must track the session-name span"
                     );
@@ -799,17 +737,38 @@ impl SessionListComponent {
                     // has navigated to a different question.
                     let sending =
                         session_alert.iter().find(|chip| state.ask_state.is_sending(chip));
-                    push_attention_chips(
-                        &mut session_spans,
+                    push_status_gutter(
+                        &mut title_spans,
+                        status_indicator,
+                        lifecycle_label,
+                        Style::default().fg(state_color),
                         session_alert,
                         now_ms,
                         row_width,
                         name_span_index,
                         sending,
                     );
-                    let session_line = Line::from(session_spans);
+                    let title_line = Line::from(title_spans);
 
-                    items.push(ListItem::new(session_line));
+                    // Keep model/effort visible for every row without making
+                    // identity compete with provider metadata. It is a separate
+                    // line, aligned underneath the title rather than a pill.
+                    let mut metadata_spans = vec![
+                        empty_badge(),
+                        Span::raw("     "),
+                        Span::styled(agent_icon.to_string(), Style::default().fg(agent_color)),
+                    ];
+                    if let Some(metadata) = session_model_effort_label(state, session) {
+                        let prefix_width: usize = metadata_spans.iter().map(Span::width).sum();
+                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans.push(Span::styled(
+                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
+                            Style::default().fg(MUTED_GRAY),
+                        ));
+                    }
+                    let metadata_line = Line::from(metadata_spans);
+
+                    items.push(ListItem::new(vec![title_line, metadata_line]));
                 }
 
                 // Render workspace shell (single shell per workspace)
@@ -1223,15 +1182,51 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
-/// Compact process/turn lifecycle word for the sidebar. This is deliberately
-/// not an attention state: a RUN row can still carry ASK or WAIT separately.
-const fn session_lifecycle_label(status: &SessionStatus) -> &'static str {
-    match status {
+/// Compact process/turn lifecycle word for the sidebar. Fleet's completed-turn
+/// observation is more precise than local `SessionStatus::Idle`, so it gets a
+/// dedicated `DONE` label rather than being collapsed into normal idle.
+fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
+    if matches!(
+        state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
+        Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
+    ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
+        && session.live_attention.is_empty()
+    {
+        return "DONE";
+    }
+
+    match session.status {
         SessionStatus::Running => "RUN",
         SessionStatus::Idle => "IDLE",
         SessionStatus::Stopped => "STOP",
         SessionStatus::Error(_) => "ERR",
     }
+}
+
+/// Fit supplementary metadata into its independent second-line budget.
+/// Metadata is observational detail, so a clipped value is preferable to
+/// stealing room from the first line's identity and status gutter.
+fn truncate_text(text: &str, width: usize) -> String {
+    let full = Span::raw(text).width();
+    if full <= width {
+        return text.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let keep = width.saturating_sub(UnicodeWidthChar::width('…').unwrap_or(1));
+    let mut used: usize = 0;
+    let mut out = String::new();
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or_default();
+        if used.saturating_add(character_width) > keep {
+            break;
+        }
+        out.push(character);
+        used += character_width;
+    }
+    out.push('…');
+    out
 }
 
 /// Compact observed runtime metadata shown before a session's label.
@@ -1244,9 +1239,9 @@ fn session_model_effort_label(state: &AppState, session: &Session) -> Option<Str
         metadata.model.as_deref(),
         metadata.reasoning_effort.as_deref(),
     ) {
-        (Some(model), Some(effort)) => Some(format!("{model}/{effort} · ")),
-        (Some(model), None) => Some(format!("{model} · ")),
-        (None, Some(effort)) => Some(format!("effort:{effort} · ")),
+        (Some(model), Some(effort)) => Some(format!("{model} / {effort}")),
+        (Some(model), None) => Some(model.to_string()),
+        (None, Some(effort)) => Some(format!("effort: {effort}")),
         (None, None) => None,
     }
 }
@@ -1255,7 +1250,7 @@ fn context_action_label(action: SessionContextAction) -> &'static str {
     match action {
         SessionContextAction::Attach => "Attach",
         SessionContextAction::Restart => "Restart",
-        SessionContextAction::EditLabel => "Rename session label",
+        SessionContextAction::EditLabel => "Rename session prefix",
         SessionContextAction::OpenEditor => "Open editor",
         SessionContextAction::OpenShell => "Open shell",
         SessionContextAction::OpenGit => "Git",
@@ -1314,7 +1309,8 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                let row_width = usize::from(area.width.saturating_sub(2));
+                let row_width = usize::from(area.width.saturating_sub(2))
+                    .saturating_sub(Span::raw(HIGHLIGHT_SYMBOL).width());
                 let items =
                     SessionListComponent::build_list_items_static(state, row_width, CHIP_NOW);
                 // Mirror `render`'s block so the snapshot carries the real
@@ -1443,7 +1439,7 @@ mod tests {
             },
         );
 
-        let rendered = render_panel(&mut state, 120, 9);
+        let rendered = render_panel(&mut state, 120, 14);
         let first_row = rendered
             .lines()
             .find(|line| line.contains("ainb/acp-chat"))
@@ -1452,16 +1448,23 @@ mod tests {
             .lines()
             .find(|line| line.contains("ainb/disk-clean"))
             .expect("second observed session row");
-        assert!(first_row.contains("gpt-5.6-terra/high"), "{first_row}");
-        assert!(second_row.contains("claude-opus-5/medium"), "{second_row}");
+        assert!(!first_row.contains("gpt-5.6-terra / high"), "{first_row}");
         assert!(
-            first_row.find("gpt-5.6-terra/high") < first_row.find("ainb/acp-chat"),
-            "metadata stays next to the agent marker, before the session label: {first_row}"
+            !second_row.contains("claude-opus-5 / medium"),
+            "{second_row}"
+        );
+        assert!(
+            rendered.contains("gpt-5.6-terra / high"),
+            "first row gets a second-line model/effort label: {rendered}"
+        );
+        assert!(
+            rendered.contains("claude-opus-5 / medium"),
+            "second row gets a second-line model/effort label: {rendered}"
         );
     }
 
     #[test]
-    fn sidebar_hides_model_effort_before_clipping_attention_at_narrow_width() {
+    fn sidebar_keeps_model_effort_on_its_own_line_at_narrow_width() {
         let mut state = chip_state();
         let first = state.workspaces[0].sessions[0].id;
         state.fleet_metadata.insert(
@@ -1473,8 +1476,8 @@ mod tests {
             },
         );
 
-        let rendered = render_panel(&mut state, 42, 9);
-        assert!(!rendered.contains("gpt-5.6-terra/high"), "{rendered}");
+        let rendered = render_panel(&mut state, 42, 14);
+        assert!(rendered.contains("gpt-5.6-terra / high"), "{rendered}");
         assert!(
             rendered.contains("ASK 40s"),
             "attention survives: {rendered}"
@@ -1488,9 +1491,12 @@ mod tests {
         state.workspaces[0].sessions[1].status = SessionStatus::Idle;
         state.workspaces[0].sessions[2].status = SessionStatus::Stopped;
         state.workspaces[0].sessions[3].status = SessionStatus::Error("lost transport".into());
-        assert_eq!(session_lifecycle_label(&SessionStatus::Stopped), "STOP");
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[2]),
+            "STOP"
+        );
 
-        let rendered = render_panel(&mut state, 140, 14);
+        let rendered = render_panel(&mut state, 140, 16);
         for (name, lifecycle) in [
             ("ainb/acp-chat", "RUN"),
             ("ainb/disk-clean", "IDLE"),
@@ -1506,15 +1512,131 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_uses_fleet_turn_complete_for_done_gutter() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = true;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        let rendered = render_panel(&mut state, 100, 16);
+        let row = rendered
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("completed session row");
+        assert!(
+            row.contains("DONE"),
+            "Fleet TurnComplete renders DONE: {row}"
+        );
+        assert!(
+            !row.contains("IDLE"),
+            "DONE must not collapse into IDLE: {row}"
+        );
+    }
+
+    #[test]
+    fn stale_or_contradicted_fleet_done_never_overrides_live_status() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        // A current ASK is newer operator-facing evidence than an old turn
+        // completion and must not create the impossible `DONE ASK` row.
+        state.daemon_attention.lock().unwrap().reachable = true;
+        let with_ask = render_panel(&mut state, 100, 16);
+        let ask_row = with_ask
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("ask session row");
+        assert!(
+            ask_row.contains("IDLE") && ask_row.contains("ASK"),
+            "{ask_row}"
+        );
+        assert!(!ask_row.contains("DONE"), "{ask_row}");
+
+        // A retained snapshot cannot drive lifecycle after daemon reachability
+        // is lost, even when no current attention chip exists.
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = false;
+        let unreachable = render_panel(&mut state, 100, 16);
+        let row = unreachable
+            .lines()
+            .find(|line| line.contains("ainb/acp-chat"))
+            .expect("unreachable daemon row");
+        assert!(row.contains("IDLE"), "{row}");
+        assert!(!row.contains("DONE"), "{row}");
+    }
+
+    #[test]
+    fn metadata_line_click_targets_its_own_session() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut state = chip_state();
+        state
+            .sessions_pane_state
+            .set_layout(Rect::new(0, 0, 100, 16), Rect::new(100, 0, 1, 16));
+        let mut list = SessionListComponent::new();
+        let mut terminal = Terminal::new(TestBackend::new(100, 16)).expect("terminal");
+        terminal
+            .draw(|frame| list.render(frame, frame.area(), &mut state))
+            .expect("render");
+
+        let first = SessionListRowTarget::Attachable(AttachableRef::WorkspaceSession {
+            workspace_idx: 0,
+            session_idx: 0,
+        });
+        assert_eq!(state.session_list_row_at_mouse(8, 2), Some(first));
+        assert_eq!(state.session_list_row_at_mouse(8, 3), Some(first));
+
+        // When List has scrolled past the one-line workspace header, the two
+        // physical rows of the first session still resolve to the same logical
+        // item before the next session starts.
+        state.sessions_pane_state.set_list_scroll_offset(1);
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 1), Some(1));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 2), Some(1));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 3), Some(2));
+    }
+
+    #[test]
+    fn minimum_width_keeps_attention_words_whole() {
+        let mut state = chip_state();
+        let rendered = render_panel(&mut state, 24, 16);
+        for word in ["ASK 40s", "ERR 9m", "APPROVE 3m", "DONE 1m"] {
+            assert!(
+                rendered.contains(word),
+                "`{word}` survives at minimum width: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn unicode_metadata_truncation_respects_terminal_cells() {
+        let truncated = truncate_text("界界界", 4);
+        assert_eq!(Span::raw(truncated).width(), 3);
+    }
+
+    #[test]
     fn chip_strip_at_100_columns() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 100, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 100, 16));
     }
 
     #[test]
     fn chip_strip_at_80_columns() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 80, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 80, 16));
     }
 
     /// The sidebar's real default width. The chip strip has to survive here,
@@ -1522,7 +1644,7 @@ mod tests {
     #[test]
     fn chip_strip_at_the_default_sidebar_width() {
         let mut state = chip_state();
-        insta::assert_snapshot!(render_panel(&mut state, 42, 9));
+        insta::assert_snapshot!(render_panel(&mut state, 42, 16));
     }
 
     #[test]
@@ -1532,7 +1654,7 @@ mod tests {
             SessionAttention::local(AttentionKind::Err, CHIP_NOW - 9 * 60_000),
             SessionAttention::local(AttentionKind::Ask, CHIP_NOW - 40_000),
         ]);
-        let rendered = render_panel(&mut state, 100, 9);
+        let rendered = render_panel(&mut state, 100, 16);
         let row = rendered
             .lines()
             .find(|line| line.contains("disk-clean"))
@@ -1555,7 +1677,7 @@ mod tests {
     fn every_chip_strip_ends_one_cell_clear_of_the_border() {
         for width in [42_u16, 60, 80, 100, 140] {
             let mut state = chip_state();
-            let rendered = render_panel(&mut state, width, 9);
+            let rendered = render_panel(&mut state, width, 16);
             // Cells between the last age character and the right border. The
             // line length itself proves nothing (`List` pads every row to the
             // full width), so measure the gap the operator actually sees.
@@ -1590,7 +1712,7 @@ mod tests {
     #[test]
     fn chip_words_survive_a_width_the_name_does_not() {
         let mut state = chip_state();
-        let rendered = render_panel(&mut state, 42, 9);
+        let rendered = render_panel(&mut state, 42, 16);
         for word in ["ASK 40s", "ERR 9m", "APPROVE 3m", "DONE 1m"] {
             assert!(
                 rendered.contains(word),
@@ -1607,7 +1729,7 @@ mod tests {
     fn a_request_the_screen_cannot_place_gets_its_own_row_not_a_truncated_badge() {
         let mut state = chip_state();
         state.attention_elsewhere = 1;
-        let rendered = render_panel(&mut state, 42, 11);
+        let rendered = render_panel(&mut state, 42, 16);
         assert!(
             rendered.contains("1 waiting elsewhere"),
             "the whole phrase must survive the narrow sidebar that clipped the \
@@ -1621,7 +1743,7 @@ mod tests {
     fn no_elsewhere_row_when_every_request_found_its_session() {
         let mut state = chip_state();
         state.attention_elsewhere = 0;
-        let rendered = render_panel(&mut state, 42, 11);
+        let rendered = render_panel(&mut state, 42, 16);
         assert!(
             !rendered.contains("elsewhere"),
             "the row must be absent, not zero: {rendered}"
@@ -1638,7 +1760,7 @@ mod tests {
         let mut without = chip_state();
         without.attention_elsewhere = 0;
         let digits = |state: &mut AppState| -> Vec<String> {
-            render_panel(state, 100, 12)
+            render_panel(state, 100, 16)
                 .lines()
                 .filter_map(|line| {
                     let trimmed = line.trim_start_matches(['│', '▶', ' ']);
@@ -1660,7 +1782,7 @@ mod tests {
         for session in &mut state.workspaces[0].sessions {
             session.live_attention.clear();
         }
-        let rendered = render_panel(&mut state, 100, 9);
+        let rendered = render_panel(&mut state, 100, 16);
         assert!(
             !rendered.contains("need you") && !rendered.contains("needs you"),
             "the badge must be absent, not zero: {rendered}"

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -654,6 +654,14 @@ impl SessionListComponent {
                     .filter(|(_, s)| state.session_passes_filter(s))
                     .collect();
                 let visible_len = visible.len();
+                // A Git branch is not session identity: two agents can work
+                // the same branch concurrently. Keep normal rows clean, but
+                // make a collision explicitly distinguishable instead of
+                // rendering two visually identical entries.
+                let mut title_counts = std::collections::HashMap::<String, usize>::new();
+                for (_, session) in &visible {
+                    *title_counts.entry(session_list_name(session)).or_default() += 1;
+                }
                 for (visible_pos, &(session_idx, session)) in visible.iter().enumerate() {
                     let is_selected_session =
                         is_selected_workspace && state.selected_session_index == Some(session_idx);
@@ -692,6 +700,11 @@ impl SessionListComponent {
                     let agent_icon = session.agent_type.icon();
                     let agent_color = agent_brand_color(&session.agent_type);
                     let is_multi_selected = state.selected_sessions.contains(&session.id);
+                    let title = session_list_name(session);
+                    let collision_id = session_collision_id(
+                        session,
+                        title_counts.get(&title).copied().unwrap_or_default() > 1,
+                    );
 
                     let checkbox = ballot_checkbox(is_multi_selected);
 
@@ -717,7 +730,7 @@ impl SessionListComponent {
                     // truncate a tree or status decoration instead.
                     let name_span_index = title_spans.len();
                     title_spans.push(Span::styled(
-                        session_list_name(session),
+                        title.clone(),
                         Style::default().fg(branch_color).add_modifier(if is_selected_session {
                             Modifier::BOLD
                         } else {
@@ -729,8 +742,7 @@ impl SessionListComponent {
                         Style::default().fg(WARNING_ORANGE),
                     ));
                     debug_assert_eq!(
-                        title_spans[name_span_index].content,
-                        session_list_name(session),
+                        title_spans[name_span_index].content, title,
                         "name_span_index must track the session-name span"
                     );
                     // The chip whose answer is still in flight, if it is on
@@ -761,11 +773,19 @@ impl SessionListComponent {
                         Span::raw("     "),
                         Span::styled(agent_icon.to_string(), Style::default().fg(agent_color)),
                     ];
+                    if let Some(identity) = collision_id {
+                        // Metadata has an independent second-line budget. Put
+                        // collision identity first there so a narrow title can
+                        // still yield to the fixed right status/ASK gutter.
+                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans
+                            .push(Span::styled(identity, Style::default().fg(METADATA_GRAY)));
+                    }
                     if let Some(metadata) = session_model_effort_label(state, session) {
                         let prefix_width: usize = metadata_spans.iter().map(Span::width).sum();
-                        metadata_spans.push(Span::raw(" "));
+                        metadata_spans.push(Span::raw(" · "));
                         metadata_spans.push(Span::styled(
-                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
+                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 3)),
                             Style::default().fg(METADATA_GRAY),
                         ));
                     }
@@ -1185,15 +1205,23 @@ fn session_list_name(session: &Session) -> String {
         .unwrap_or_else(|| session.branch_name.clone())
 }
 
+/// Same-workspace title collisions need stable identity. It belongs on the
+/// independent metadata line so a blocking status chip always wins on narrow
+/// terminals.
+fn session_collision_id(session: &Session, has_collision: bool) -> Option<String> {
+    has_collision.then(|| format!("#{}", &session.id.to_string()[..8]))
+}
+
 /// Compact process/turn lifecycle word for the sidebar. Fleet's completed-turn
 /// observation is more precise than local `SessionStatus::Idle`, so it gets a
 /// dedicated `DONE` label rather than being collapsed into normal idle.
 fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
     if matches!(session.status, SessionStatus::Idle)
         && matches!(
-        state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
-        Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
-    ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
+            state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
+            Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
+        )
+        && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
         && session.live_attention.is_empty()
     {
         return "DONE";
@@ -1598,7 +1626,10 @@ mod tests {
             },
         );
 
-        assert_eq!(session_lifecycle_label(&state, &state.workspaces[0].sessions[0]), "STOP");
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            "STOP"
+        );
     }
 
     #[test]
@@ -1910,5 +1941,49 @@ mod tests {
         session.display_name = Some("RPC flake".to_string());
 
         assert_eq!(session_list_name(&session), "RPC flake · fix/rpc-acp-flake");
+    }
+
+    #[test]
+    fn colliding_session_titles_include_a_stable_short_identity() {
+        let mut session = Session::new("workspace".to_string(), "/tmp/workspace".to_string());
+        session.branch_name = "freeman/hosted-entitlement-issuer".to_string();
+
+        assert_eq!(session_collision_id(&session, false), None);
+        assert_eq!(
+            session_collision_id(&session, true),
+            Some(format!("#{}", &session.id.to_string()[..8]))
+        );
+    }
+
+    #[test]
+    fn narrow_duplicate_rows_keep_their_short_id_visible() {
+        let mut state = AppState::new();
+        state.workspaces.clear();
+        state.expand_all_workspaces = true;
+
+        let mut workspace = Workspace::new("ws".to_string(), "/tmp/ws".into());
+        let mut first = Session::new("first".to_string(), "/tmp/ws/first".to_string());
+        first.branch_name = "freeman/hosted-entitlement-issuer".to_string();
+        first
+            .live_attention
+            .push(SessionAttention::local(AttentionKind::Approve, CHIP_NOW));
+        let first_id = first.id.to_string()[..8].to_string();
+        let mut second = Session::new("second".to_string(), "/tmp/ws/second".to_string());
+        second.branch_name = first.branch_name.clone();
+        let second_id = second.id.to_string()[..8].to_string();
+        workspace.add_session(first);
+        workspace.add_session(second);
+        state.workspaces.push(workspace);
+
+        let painted = render_panel(&mut state, 24, 8);
+        assert!(
+            painted.contains(&format!("#{first_id}")),
+            "painted: {painted}"
+        );
+        assert!(
+            painted.contains(&format!("#{second_id}")),
+            "painted: {painted}"
+        );
+        assert!(painted.contains("APPROVE"), "painted: {painted}");
     }
 }

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -19,6 +19,9 @@ const DARK_BG: Color = Color::Rgb(25, 25, 35);
 const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
 const SOFT_WHITE: Color = Color::Rgb(220, 220, 230);
 const MUTED_GRAY: Color = Color::Rgb(120, 120, 140);
+/// Runtime model/effort is secondary to a session name, but must remain
+/// readable on a selected-row background without terminal-specific dimming.
+const METADATA_GRAY: Color = Color::Rgb(150, 150, 170);
 const SUBDUED_BORDER: Color = Color::Rgb(60, 60, 80);
 // Attention chips (`ASK` `APPROVE` `ERR` `DONE`). One colour per state,
 // shared with the age that trails it so a chip reads as one object.
@@ -763,7 +766,7 @@ impl SessionListComponent {
                         metadata_spans.push(Span::raw(" "));
                         metadata_spans.push(Span::styled(
                             truncate_text(&metadata, row_width.saturating_sub(prefix_width + 1)),
-                            Style::default().fg(MUTED_GRAY),
+                            Style::default().fg(METADATA_GRAY),
                         ));
                     }
                     let metadata_line = Line::from(metadata_spans);
@@ -1186,7 +1189,8 @@ fn session_list_name(session: &Session) -> String {
 /// observation is more precise than local `SessionStatus::Idle`, so it gets a
 /// dedicated `DONE` label rather than being collapsed into normal idle.
 fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
-    if matches!(
+    if matches!(session.status, SessionStatus::Idle)
+        && matches!(
         state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
         Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
     ) && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
@@ -1577,6 +1581,24 @@ mod tests {
             .expect("unreachable daemon row");
         assert!(row.contains("IDLE"), "{row}");
         assert!(!row.contains("DONE"), "{row}");
+    }
+
+    #[test]
+    fn retained_fleet_done_never_relabels_a_stopped_session() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].status = SessionStatus::Stopped;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.daemon_attention.lock().unwrap().reachable = true;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(session_lifecycle_label(&state, &state.workspaces[0].sessions[0]), "STOP");
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 100, 9)"
+assertion_line: 1494
+expression: "render_panel(&mut state, 100, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                                       │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                                     ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                                    ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                                                 APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                                                   DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                                                │
+│▶ 1 ☐ ├─ ainb/acp-chat                                                            ○ IDLE  ASK 40s │
+│         ✻                                                                                        │
+│  2 ☐ ├─ ainb/disk-clean                                                           ○ IDLE  ERR 9m │
+│         ✻                                                                                        │
+│  3 ☐ ├─ ainb/api-stats                                                        ○ IDLE  APPROVE 3m │
+│         ✻                                                                                        │
+│  4 ☐ ├─ ainb/site-build                                                          ○ IDLE  DONE 1m │
+│         ✻                                                                                        │
+│  5 ☐ └─ ainb/quiet                                                                        ○ IDLE │
+│         ✻                                                                                        │
+│                                                                                                  │
+│                                                                                                  │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 80, 9)"
+assertion_line: 1500
+expression: "render_panel(&mut state, 80, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                   │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/acp-chat                                 ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/disk-clean                                ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ainb/api-stats                             APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/site-build                               DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet                                            │
+│▶ 1 ☐ ├─ ainb/acp-chat                                        ○ IDLE  ASK 40s │
+│         ✻                                                                    │
+│  2 ☐ ├─ ainb/disk-clean                                       ○ IDLE  ERR 9m │
+│         ✻                                                                    │
+│  3 ☐ ├─ ainb/api-stats                                    ○ IDLE  APPROVE 3m │
+│         ✻                                                                    │
+│  4 ☐ ├─ ainb/site-build                                      ○ IDLE  DONE 1m │
+│         ✻                                                                    │
+│  5 ☐ └─ ainb/quiet                                                    ○ IDLE │
+│         ✻                                                                    │
+│                                                                              │
+│                                                                              │
 │                                                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
@@ -1,13 +1,21 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-expression: "render_panel(&mut state, 42, 9)"
+assertion_line: 1508
+expression: "render_panel(&mut state, 42, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ───────────╮
 │    ▼  agents-in-a-box (5)             │
-│▶ 1 ☐ ├─ ○ IDLE    ✻   ainb/…  ASK 40s │
-│  2 ☐ ├─ ○ IDLE   ✻  ainb/d…  ERR 9m │
-│  3 ☐ ├─ ○ IDLE   ✻  ai…  APPROVE 3m │
-│  4 ☐ ├─ ○ IDLE   ✻  ainb/…  DONE 1m │
-│  5 ☐ └─ ○ IDLE   ✻  ainb/quiet      │
+│▶ 1 ☐ ├─ ainb/acp-chat  ○ IDLE  ASK 40s │
+│         ✻                              │
+│  2 ☐ ├─ ainb/disk-clean ○ IDLE  ERR 9m │
+│         ✻                              │
+│  3 ☐ ├─ ainb/api-st…○ IDLE  APPROVE 3m │
+│         ✻                              │
+│  4 ☐ ├─ ainb/site-build○ IDLE  DONE 1m │
+│         ✻                              │
+│  5 ☐ └─ ainb/quiet              ○ IDLE │
+│         ✻                              │
+│                                        │
+│                                        │
 │                                        │
 ╰────────────────────────────────────────╯

--- a/ainb-tui/crates/ainb-core/src/main.rs
+++ b/ainb-tui/crates/ainb-core/src/main.rs
@@ -1851,6 +1851,7 @@ async fn run_tui_loop(
                             );
                             let mut attach_handler = AttachHandler::new_from_terminal(terminal)?;
                             info!("[ACTION] Attach handler created, calling attach_to_session...");
+                            let mut target_missing = false;
                             match attach_handler.attach_to_session(&tmux_session_name).await {
                                 Ok(()) => {
                                     info!(
@@ -1867,6 +1868,14 @@ async fn run_tui_loop(
                                         &tmux_session_name,
                                         &e,
                                     ));
+                                    // An attach can fail because the terminal is nested even
+                                    // though the target is alive. Probe the exact target before
+                                    // changing lifecycle state, so only a terminally missing
+                                    // tmux session becomes resumable Stopped.
+                                    target_missing = matches!(
+                                        tmux_session_presence(&tmux_session_name).await,
+                                        TmuxSessionPresence::Missing
+                                    );
                                 }
                             }
 
@@ -1878,6 +1887,17 @@ async fn run_tui_loop(
                                         break;
                                     }
                                 }
+                            }
+
+                            if target_missing
+                                && app.state.mark_session_stopped_for_missing_tmux(
+                                    session_id,
+                                    &tmux_session_name,
+                                )
+                            {
+                                // Rebuild from the persisted record too. This keeps the row
+                                // correctly filtered after an immediate refresh or TUI restart.
+                                app.state.load_real_workspaces().await;
                             }
 
                             app.state.ui_needs_refresh = true;
@@ -1943,6 +1963,47 @@ fn attach_failure_notice(session_name: &str, error: &impl std::fmt::Display) -> 
          the list was drawn — press f to refresh — or it is the tmux session ainb is \
          itself running in, which tmux refuses to nest."
     )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TmuxSessionPresence {
+    Exists,
+    Missing,
+    Uncertain,
+}
+
+/// Probe an exact tmux target without converting a transport failure into a
+/// lifecycle fact. A bare `-t name` can prefix-match a different live session;
+/// `=name` cannot.
+async fn tmux_session_presence(session_name: &str) -> TmuxSessionPresence {
+    let output = match tokio::process::Command::new("tmux")
+        .args(["has-session", "-t", &format!("={session_name}")])
+        .output()
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(%error, %session_name, "could not verify tmux target after attach failure");
+            return TmuxSessionPresence::Uncertain;
+        }
+    };
+    if output.status.success() {
+        return TmuxSessionPresence::Exists;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_explicitly_missing_tmux_target(&stderr) {
+        TmuxSessionPresence::Missing
+    } else {
+        tracing::warn!(%session_name, %stderr, "tmux target probe was inconclusive after attach failure");
+        TmuxSessionPresence::Uncertain
+    }
+}
+
+fn is_explicitly_missing_tmux_target(stderr: &str) -> bool {
+    let stderr = stderr.to_ascii_lowercase();
+    stderr.contains("can't find session")
+        || stderr.contains("no server running")
+        || (stderr.contains("error connecting to") && stderr.contains("no such file or directory"))
 }
 
 fn setup_logging() {
@@ -2141,7 +2202,7 @@ where
 
 #[cfg(test)]
 mod attach_failure_notice_tests {
-    use super::attach_failure_notice;
+    use super::{attach_failure_notice, is_explicitly_missing_tmux_target};
 
     /// The three things the old one-liner never said.
     #[test]
@@ -2157,6 +2218,23 @@ mod attach_failure_notice_tests {
             "the remedy: {notice}"
         );
         assert!(notice.contains("nest"), "the other cause: {notice}");
+    }
+
+    #[test]
+    fn only_definitive_tmux_diagnostics_mean_target_missing() {
+        assert!(is_explicitly_missing_tmux_target(
+            "can't find session: tmux_dead"
+        ));
+        assert!(is_explicitly_missing_tmux_target(
+            "no server running on /tmp/tmux-1/default"
+        ));
+        assert!(is_explicitly_missing_tmux_target(
+            "error connecting to /tmp/tmux-1/default (No such file or directory)"
+        ));
+        assert!(!is_explicitly_missing_tmux_target("permission denied"));
+        assert!(!is_explicitly_missing_tmux_target(
+            "protocol version mismatch"
+        ));
     }
 }
 

--- a/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
+++ b/ainb-tui/crates/ainb-fleet-core/src/fleet/discover/tmux.rs
@@ -220,14 +220,13 @@ fn parse_row(line: &str) -> Result<TmuxPaneRow> {
 /// desktop app (`…/Claude.app/Contents/MacOS/Claude`) nor a branch called
 /// `f/claude-resume` can pass as a session.
 ///
-/// Copilot is admitted now that `Provider::Copilot` exists on the wire AND the
-/// Swift client decodes unknown enum values tolerantly. Emitting a provider token
-/// an older client has never seen used to fail its whole snapshot decode, so this
-/// name could not land before those two.
+/// Antigravity's terminal executable is `agy`; accept its exact process name
+/// alongside Claude and Codex so its footer metadata reaches Fleet too.
 fn agent_provider(processes: &ProcessTable, pane_pid: u32) -> Option<Provider> {
     processes.tree_commands(pane_pid).into_iter().find_map(|command| match command {
         "claude" => Some(Provider::Claude),
         "codex" => Some(Provider::Codex),
+        "agy" => Some(Provider::Antigravity),
         _ => None,
     })
 }
@@ -251,8 +250,18 @@ mod tests {
             "  111   101 /Users/me/.local/bin/claude\n",
             "  202     1 /bin/zsh\n",
             "  222   202 /opt/homebrew/bin/codex\n",
+            "  303     1 /bin/zsh\n",
+            "  333   303 /opt/homebrew/bin/agy\n",
             "  909     1 /bin/zsh\n",
         ))
+    }
+
+    #[test]
+    fn antigravity_terminal_process_is_a_roster_provider() {
+        assert_eq!(
+            agent_provider(&processes(), 303),
+            Some(Provider::Antigravity)
+        );
     }
 
     #[test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/attention_ingest.rs
@@ -401,7 +401,13 @@ impl AttentionIngest {
                 envelope.insert("payload".to_string(), raw_value);
             }
         }
-        let provider = if line.agent.is_empty() {
+        // A Codex rollout is stronger evidence than the hook's `agent` field:
+        // old Codex hooks can still carry `agent: claude`. Use the same source
+        // of truth as transcript-model parsing, or the row is keyed as Claude
+        // while its lifecycle is being reduced from Codex events.
+        let provider = if is_codex_rollout(&line.transcript_path) {
+            "codex"
+        } else if line.agent.is_empty() {
             "unknown"
         } else {
             line.agent.as_str()
@@ -440,11 +446,11 @@ impl AttentionIngest {
         // Every hook line feeds the canonical Fleet reducer, including events
         // that do not raise an attention card. The source event ID is replay-safe;
         // legacy lines use their durable byte offset.
-        let semantic_event = if line.event_type == "PreToolUse" && line.matcher == "AskUserQuestion"
-        {
+        let raw_event = line.event_type.split(':').next().unwrap_or(&line.event_type);
+        let semantic_event = if raw_event == "PreToolUse" && line.matcher == "AskUserQuestion" {
             "AskUserQuestion"
         } else {
-            line.event_type.as_str()
+            crate::fleet::canonical_hook_event_type(provider, &line.event_type, &payload)
         };
         if !line.session_id.is_empty() {
             // Taken HERE, before the observation is built, and so before the
@@ -454,7 +460,7 @@ impl AttentionIngest {
             let transcript_model = self.transcript_model(&line, &payload).await;
             let observation = crate::fleet::HookObservation {
                 event_id: event_id.clone(),
-                provider: &line.agent,
+                provider,
                 provider_session_id: &line.session_id,
                 cwd: &line.cwd,
                 event_type: semantic_event,
@@ -501,10 +507,10 @@ impl AttentionIngest {
         // re-derived from the transcript. The distinction is load-bearing at the
         // stale-ASK gate below, so it travels with the context.
         let (context, from_hook_payload) =
-            match ask_context_from_hook_payload(&line.agent, semantic_event, &payload) {
+            match ask_context_from_hook_payload(provider, semantic_event, &payload) {
                 Some(ask) => (ask, true),
                 None => match permission_context_from_hook_payload(
-                    &line.agent,
+                    provider,
                     semantic_event,
                     &line.matcher,
                     &payload,
@@ -1191,12 +1197,11 @@ mod tests {
     /// CODEX parser.
     ///
     /// This is a measured shape, not a hypothetical: running the real event log
-    /// through this pipeline produced 9 sessions keyed `claude:<uuid>` whose
-    /// transcript is a codex rollout, because their opening hook predates the
-    /// `agent` field. Dispatching the parser on that label handed the rollout to
-    /// the claude parser, which finds no `assistant` record and returns nothing,
-    /// so the row showed a model (the hook supplies it) with the effort silently
-    /// missing, and every test still passed.
+    /// through this pipeline produced 9 sessions with a stale Claude label whose
+    /// transcript is a Codex rollout, because their opening hook predates the
+    /// `agent` field. Dispatching either parser OR Fleet identity on that label
+    /// handed the rollout to Claude and made all later Codex lifecycle hooks miss
+    /// the row.
     #[tokio::test]
     async fn a_codex_rollout_is_read_as_codex_even_when_labelled_claude() {
         let dir = tempfile::tempdir().unwrap();
@@ -1234,7 +1239,7 @@ mod tests {
         ingest.ingest_once(1_700_000_001_000).await;
 
         assert_eq!(
-            row_model_pair(&store, "claude:sid-rollout").await,
+            row_model_pair(&store, "codex:sid-rollout").await,
             (Some("gpt-5.6-terra".to_string()), Some("high".to_string())),
             "the rollout's turn_context must be parsed as codex despite the agent label"
         );
@@ -1583,6 +1588,47 @@ mod tests {
             open[0].payload.contains("Bash"),
             "the card must name the tool being approved, got {:?}",
             open[0].payload
+        );
+        let session = FleetRepo::get_session(store.pool(), "codex:codex-sid-1")
+            .await
+            .unwrap()
+            .expect("Codex hook must project a Fleet session");
+        assert_eq!(session.lifecycle_state, "IDLE");
+        assert_eq!(
+            session.attention_state, "APPROVAL",
+            "the Fleet status remains approval even though a degraded hook card is waiting-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_rollout_overrides_a_stale_claude_label_for_legacy_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let events_jsonl = dir.path().join("events.jsonl");
+        let cursor = dir.path().join("attention_ingest.offset");
+        let line = codex_permission_hook_line("codex-sid-2", "/tmp/codex-work", "evt-done", "Bash")
+            .replace(r#""agent":"codex""#, r#""agent":"claude""#)
+            .replace(
+                r#""event_type":"PermissionRequest""#,
+                r#""event_type":"agent-turn-complete""#,
+            );
+        std::fs::write(&events_jsonl, format!("{line}\n")).unwrap();
+
+        let ingest = ingest_for(&store, &events_jsonl, &cursor);
+        ingest.ingest_once(1_700_000_000_000).await;
+
+        let session = FleetRepo::get_session(store.pool(), "codex:codex-sid-2")
+            .await
+            .unwrap()
+            .expect("rollout path identifies Codex despite stale hook label");
+        assert_eq!(session.lifecycle_state, "TURN_COMPLETE");
+        assert_eq!(session.attention_state, "NONE");
+        assert!(
+            FleetRepo::get_session(store.pool(), "claude:codex-sid-2")
+                .await
+                .unwrap()
+                .is_none(),
+            "the stale Claude label must not create a second Fleet row"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -123,7 +123,7 @@ pub async fn reproject_claude_interview(
         let Ok(payload) = serde_json::from_str::<Value>(&event.payload) else {
             continue;
         };
-        let event_type = canonical_hook_event_type(&event.event_type, &payload);
+        let event_type = canonical_hook_event_type("claude", &event.event_type, &payload);
         let (_, attention) = states_for_hook(event_type, &payload);
         match attention {
             Some(AttentionState::Ask)
@@ -325,7 +325,11 @@ pub async fn apply_hook(
     let source_event_id = observation.event_id.clone();
     // Claude emits a PermissionRequest and then a generic notification around an
     // AskUserQuestion. They describe the same picker, not two operator actions.
-    let event_type = canonical_hook_event_type(observation.event_type, observation.payload);
+    let event_type = canonical_hook_event_type(
+        provider.as_str(),
+        observation.event_type,
+        observation.payload,
+    );
     let source_event_type = observation
         .payload
         .pointer("/payload/hook_event_name")
@@ -334,7 +338,8 @@ pub async fn apply_hook(
     let duplicate_claude_structured_permission = provider == Provider::Claude
         && source_event_type == "PermissionRequest"
         && claude_hook_tool_name(observation.payload) == Some("AskUserQuestion");
-    let preserve_active_request = (observation.event_type == "Notification"
+    let preserve_active_request = (provider == Provider::Claude
+        && observation.event_type.split(':').next() == Some("Notification")
         || duplicate_claude_structured_permission)
         && FleetRepo::get_session(pool, session_key.as_str())
             .await?
@@ -2304,7 +2309,32 @@ fn states_for_hook(
     }
 }
 
-fn canonical_hook_event_type<'a>(event_type: &'a str, payload: &Value) -> &'a str {
+/// Normalize hook-specific spellings before reducing them into Fleet state.
+///
+/// `ainb-hooks` deliberately persists Codex's raw `type` token. That keeps the
+/// event log useful for provider debugging, but Fleet must not treat those
+/// tokens as unrelated telemetry: a Codex question, blocking wait, completed
+/// turn, and permission request are the same operator-facing facts as their
+/// Claude counterparts. Matcher suffixes are presentation/context only and do
+/// not alter lifecycle semantics.
+pub(crate) fn canonical_hook_event_type<'a>(
+    provider: &str,
+    event_type: &'a str,
+    payload: &Value,
+) -> &'a str {
+    let event_type = event_type.split(':').next().unwrap_or(event_type);
+    if provider.eq_ignore_ascii_case("codex") {
+        return match event_type {
+            "request_user_input" => "AskUserQuestion",
+            "wait_for_user" => "Notification",
+            "agent-turn-complete" | "agentStop" | "task_complete" => "Stop",
+            "PermissionRequest"
+            | "permission_request"
+            | "exec_approval_request"
+            | "apply_patch_approval_request" => "PermissionRequest",
+            _ => event_type,
+        };
+    }
     if event_type == "PermissionRequest"
         && claude_hook_tool_name(payload) == Some("AskUserQuestion")
     {
@@ -3900,6 +3930,82 @@ mod tests {
             states_for_hook("SessionEnd", &serde_json::json!({})),
             (Some(LifecycleState::Exited), Some(AttentionState::None))
         );
+    }
+
+    #[test]
+    fn codex_legacy_hook_tokens_normalize_to_shared_lifecycle_semantics() {
+        let payload = serde_json::json!({});
+        assert_eq!(
+            canonical_hook_event_type("codex", "request_user_input", &payload),
+            "AskUserQuestion"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "wait_for_user", &payload),
+            "Notification"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "agent-turn-complete", &payload),
+            "Stop"
+        );
+        assert_eq!(
+            canonical_hook_event_type("codex", "PermissionRequest:Bash", &payload),
+            "PermissionRequest"
+        );
+        assert_eq!(
+            canonical_hook_event_type("claude", "PermissionRequest", &payload),
+            "PermissionRequest",
+            "Codex aliases must not alter Claude's native permission semantics"
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_legacy_hooks_project_ask_wait_done_and_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open_in(dir.path()).await.unwrap();
+        let sink = EventBroker::new().sink();
+        let payload = serde_json::json!({ "payload": { "model": "gpt-5.6-sol" } });
+
+        for (event_id, event_type, observed_at, expected_lifecycle, expected_attention) in [
+            ("codex-ask", "request_user_input", 1, "IDLE", "ASK"),
+            ("codex-wait", "wait_for_user", 2, "IDLE", "WAITING"),
+            (
+                "codex-done",
+                "agent-turn-complete",
+                3,
+                "TURN_COMPLETE",
+                "NONE",
+            ),
+            (
+                "codex-approval",
+                "PermissionRequest:Bash",
+                4,
+                "IDLE",
+                "APPROVAL",
+            ),
+        ] {
+            apply_hook(
+                store.pool(),
+                &sink,
+                HookObservation {
+                    event_id: event_id.to_string(),
+                    provider: "codex",
+                    provider_session_id: "legacy-thread-1",
+                    cwd: "/repo",
+                    event_type,
+                    payload: &payload,
+                    observed_at,
+                    transcript_model: None,
+                },
+            )
+            .await
+            .expect("legacy Codex hook applies");
+            let session = FleetRepo::get_session(store.pool(), "codex:legacy-thread-1")
+                .await
+                .expect("read session")
+                .expect("Codex session present");
+            assert_eq!(session.lifecycle_state, expected_lifecycle, "{event_type}");
+            assert_eq!(session.attention_state, expected_attention, "{event_type}");
+        }
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -5,7 +5,7 @@
 //! subscribers after the matching revision commits.
 
 use ainb_fleet_core::discover::{discover_all_tmux_panes, discover_from_tmux};
-use ainb_fleet_core::read::ModelInfo;
+use ainb_fleet_core::read::{ModelInfo, capture_pane};
 use ainb_fleet_core::types::{
     AttentionState, Confidence, FleetSession, LifecycleState, ManagementState, Provider,
     SessionKey, TransportHealth,
@@ -1423,7 +1423,44 @@ async fn reconcile_discovered_panes(
 
     let mut applied = 0;
     for (session, owner) in sessions.iter().zip(&owners) {
+        // Codex and Antigravity expose their current model/effort in the
+        // terminal status footer, but neither has a complete hook feed. Keep
+        // this bounded to one rendered line and these two providers: it is a
+        // direct observation of the running agent, not a guessed default.
+        // Once both fields are recorded, skip the subprocess entirely. Model
+        // selection is session setup metadata, while a 3s capture per pane is
+        // the hot reconciliation path on large fleets.
+        let tracked = (*owner).or_else(|| {
+            registered.iter().find(|row| row.session_key == session.session_key.as_str())
+        });
+        let status_model = if tracked.is_none_or(|row| !tmux_model_is_complete(row)) {
+            tmux_status_model(session).await
+        } else {
+            None
+        };
         if let Some(owner) = owner {
+            if let Some(model) = status_model.as_ref() {
+                if tmux_model_needs_update(owner, model) {
+                    match FleetRepo::apply_event(
+                        pool,
+                        &tmux_model_event(&owner.session_key, model, observed_at),
+                    )
+                    .await
+                    {
+                        Ok(result) => {
+                            if !result.duplicate {
+                                events.emit_fleet_revision(result.revision);
+                            }
+                            if result.applied {
+                                applied += 1;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(error = %error, "fleet tmux model observation failed")
+                        }
+                    }
+                }
+            }
             // The pane already has its row. Collapse a duplicate written under
             // the scan's own key ONLY when the snapshot in hand still shows one:
             // `supersede_session` opens an IMMEDIATE transaction, so calling
@@ -1447,10 +1484,13 @@ async fn reconcile_discovered_panes(
             continue;
         }
         let prior = FleetRepo::get_session(pool, session.session_key.as_str()).await?;
-        if prior.as_ref().is_some_and(|row| tmux_row_matches(row, session)) {
+        if prior
+            .as_ref()
+            .is_some_and(|row| tmux_row_matches(row, session, status_model.as_ref()))
+        {
             continue;
         }
-        let mut event = tmux_event(session, observed_at);
+        let mut event = tmux_event(session, status_model.as_ref(), observed_at);
         if prior.is_some() {
             event.event_id.push_str(&format!(":{observed_at}"));
         }
@@ -1788,13 +1828,22 @@ fn stable_pane_id(fingerprint: Option<&str>) -> String {
     }
 }
 
-fn tmux_row_matches(row: &FleetSessionRow, session: &FleetSession) -> bool {
+fn tmux_row_matches(
+    row: &FleetSessionRow,
+    session: &FleetSession,
+    status_model: Option<&ModelInfo>,
+) -> bool {
     // A lifecycle set by a provider hook outranks this inferred tmux sample, so
     // the repo will never apply ours over it. Comparing them anyway would report
     // a permanent mismatch and append one no-op `fleet_event` per discovery
     // tick, forever, for every hook-backed session.
     let lifecycle_settled = row.lifecycle_authority == "authoritative"
         || row.lifecycle_state == state_token(session.lifecycle);
+    // The footer is a direct reading of this running provider's own UI. Keep
+    // checking it even after a hook wrote an earlier model pair so a live
+    // `/model` or effort change reaches the roster; stop only once both fields
+    // agree, which prevents a new Fleet event every discovery tick.
+    let model_settled = status_model.is_none_or(|model| !tmux_model_needs_update(row, model));
     row.provider == session.provider.as_str()
         && row.tmux_target == session.exact_tmux_target
         && row.process_start_fingerprint == session.process_start_fingerprint
@@ -1804,6 +1853,7 @@ fn tmux_row_matches(row: &FleetSessionRow, session: &FleetSession) -> bool {
         && lifecycle_settled
         && row.attention_state == attention_token(session.attention)
         && row.transport_health == transport_token(session.transport_health)
+        && model_settled
 }
 
 /// How many 3s discovery ticks pass between full missing sweeps.
@@ -2241,7 +2291,11 @@ fn capabilities_for_tmux_state(row: &FleetSessionRow, available: bool) -> String
     with_tmux_capabilities(&serialized, available)
 }
 
-fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
+fn tmux_event(
+    session: &FleetSession,
+    status_model: Option<&ModelInfo>,
+    observed_at: i64,
+) -> NewFleetEvent {
     let payload = serde_json::to_string(session).unwrap_or_else(|_| "{}".to_string());
     NewFleetEvent {
         event_id: format!(
@@ -2251,7 +2305,10 @@ fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
         ),
         session_key: session.session_key.to_string(),
         observed_at,
-        authority: ObservationAuthority::Inferred,
+        // This is the provider's current status footer for this exact tmux
+        // pane. Treat its model pair as authoritative so it can complete the
+        // partial model-only observation Codex hooks provide.
+        authority: ObservationAuthority::Authoritative,
         event_type: "tmux_discovered".to_string(),
         payload,
         patch: FleetSessionPatch {
@@ -2266,6 +2323,134 @@ fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
             lifecycle_state: Some(state_token(session.lifecycle)),
             attention_state: Some(attention_token(session.attention)),
             transport_health: Some(transport_token(session.transport_health).to_string()),
+            model: status_model.and_then(|model| model.model.clone()),
+            reasoning_effort: status_model.and_then(|model| model.effort.clone()),
+            ..FleetSessionPatch::default()
+        },
+    }
+}
+
+/// Read model metadata from providers whose active terminal footer is their
+/// only complete, current runtime source.
+async fn tmux_status_model(session: &FleetSession) -> Option<ModelInfo> {
+    if !matches!(session.provider, Provider::Codex | Provider::Antigravity) {
+        return None;
+    }
+    let target = session.exact_tmux_target.as_deref()?;
+    let footer = capture_pane(target, 0).await.ok()?;
+    model_info_from_tmux_footer(session.provider, &footer)
+}
+
+/// Parse a provider-owned terminal footer into canonical model metadata.
+///
+/// This accepts only a model visibly present in the footer plus an explicit
+/// effort token. No provider gets a default model or default effort.
+fn model_info_from_tmux_footer(provider: Provider, footer: &str) -> Option<ModelInfo> {
+    // `capture-pane -S -0` includes the visible screen, not a reserved status
+    // channel. Only the final nonblank terminal row can be provider chrome;
+    // accepting a matching phrase from agent output would let untrusted text
+    // forge roster metadata.
+    let line = footer.lines().rev().find(|line| !line.trim().is_empty())?.trim();
+    let model = match provider {
+        Provider::Codex => {
+            let parts: Vec<_> = line.split('·').collect();
+            let first = parts.first()?.trim();
+            if parts.len() < 3 || !first.to_ascii_lowercase().starts_with("gpt-") {
+                return None;
+            }
+            let mut fields = first.split_whitespace();
+            let token: String = fields
+                .next()?
+                .chars()
+                .take_while(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+                })
+                .collect();
+            model_token(&token)?;
+            footer_effort(fields.next()?)?;
+            if fields.next().is_some() {
+                return None;
+            }
+            model_token(&token)?
+        }
+        Provider::Antigravity => {
+            let parts: Vec<_> = line.split('·').collect();
+            let first = parts.first()?.trim();
+            if parts.len() < 2 || !first.to_ascii_lowercase().starts_with("gemini ") {
+                return None;
+            }
+            let value = first
+                .split_whitespace()
+                .take(3)
+                .collect::<Vec<_>>()
+                .join("-")
+                .to_ascii_lowercase();
+            if first.split_whitespace().count() != 3 {
+                return None;
+            }
+            model_token(&value)?
+        }
+        _ => return None,
+    };
+    let effort_field = line.split('·').nth(1)?.trim();
+    if effort_field.split_whitespace().count() != 1 {
+        return None;
+    }
+    let effort = match provider {
+        Provider::Codex | Provider::Antigravity => footer_effort(effort_field)?,
+        _ => return None,
+    };
+    Some(ModelInfo {
+        model: Some(model),
+        effort: Some(effort),
+    })
+}
+
+fn footer_effort(line: &str) -> Option<String> {
+    line.split(|character: char| !character.is_ascii_alphanumeric())
+        .map(str::to_ascii_lowercase)
+        .find(|token| {
+            matches!(
+                token.as_str(),
+                "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
+            )
+        })
+}
+
+fn tmux_model_needs_update(row: &FleetSessionRow, observed: &ModelInfo) -> bool {
+    observed
+        .model
+        .as_deref()
+        .is_some_and(|model| row.model.as_deref() != Some(model))
+        || observed
+            .effort
+            .as_deref()
+            .is_some_and(|effort| row.reasoning_effort.as_deref() != Some(effort))
+}
+
+fn tmux_model_is_complete(row: &FleetSessionRow) -> bool {
+    row.model.is_some() && row.reasoning_effort.is_some()
+}
+
+fn tmux_model_event(session_key: &str, model: &ModelInfo, observed_at: i64) -> NewFleetEvent {
+    let fingerprint = format!(
+        "{}:{}",
+        model.model.as_deref().unwrap_or_default(),
+        model.effort.as_deref().unwrap_or_default()
+    );
+    NewFleetEvent {
+        event_id: format!(
+            "tmux:model:{session_key}:{observed_at}:{}",
+            fingerprint_bytes(fingerprint.as_bytes()),
+        ),
+        session_key: session_key.to_string(),
+        observed_at,
+        authority: ObservationAuthority::Inferred,
+        event_type: "tmux_model_observed".to_string(),
+        payload: fingerprint,
+        patch: FleetSessionPatch {
+            model: model.model.clone(),
+            reasoning_effort: model.effort.clone(),
             ..FleetSessionPatch::default()
         },
     }
@@ -2276,6 +2461,7 @@ fn parse_provider(value: &str) -> Provider {
         "claude" => Provider::Claude,
         "codex" => Provider::Codex,
         "copilot" => Provider::Copilot,
+        "antigravity" | "agy" => Provider::Antigravity,
         _ => Provider::Unknown,
     }
 }
@@ -2578,6 +2764,68 @@ mod tests {
                 "{rejected:?} must clamp to never-observed, not reach the roster"
             );
         }
+    }
+
+    #[test]
+    fn terminal_footers_supply_codex_and_antigravity_model_effort() {
+        let codex = model_info_from_tmux_footer(
+            Provider::Codex,
+            "gpt-5.6-terra high · high · agents-in-a-box",
+        )
+        .expect("Codex footer has model and effort");
+        assert_eq!(
+            codex,
+            ModelInfo {
+                model: Some("gpt-5.6-terra".to_string()),
+                effort: Some("high".to_string()),
+            }
+        );
+
+        let antigravity =
+            model_info_from_tmux_footer(Provider::Antigravity, "Gemini 3.8 Flash · high")
+                .expect("Antigravity footer has model and effort");
+        assert_eq!(
+            antigravity,
+            ModelInfo {
+                model: Some("gemini-3.8-flash".to_string()),
+                effort: Some("high".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_footer_never_invents_missing_effort() {
+        assert!(model_info_from_tmux_footer(Provider::Codex, "gpt-5.6-terra").is_none());
+        assert!(model_info_from_tmux_footer(Provider::Antigravity, "Gemini 3.8 Flash").is_none());
+    }
+
+    #[test]
+    fn terminal_footer_rejects_agent_output_that_looks_like_metadata() {
+        assert!(
+            model_info_from_tmux_footer(Provider::Codex, "gpt-4 high · high\nregular shell prompt")
+                .is_none()
+        );
+        assert!(
+            model_info_from_tmux_footer(
+                Provider::Antigravity,
+                "please use Gemini 3.8 Flash · high"
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn terminal_model_event_can_complete_a_partial_hook_pair() {
+        let event = tmux_model_event(
+            "codex:thread",
+            &ModelInfo {
+                model: Some("gpt-5.6-terra".to_string()),
+                effort: Some("high".to_string()),
+            },
+            1,
+        );
+        assert_eq!(event.authority, ObservationAuthority::Authoritative);
+        assert_eq!(event.patch.reasoning_effort.as_deref(), Some("high"));
     }
 
     /// The session under test for every model/effort capture case below.
@@ -2976,7 +3224,7 @@ mod tests {
             cwd: "/Users/dev/d/git/ai-coder-rules".to_string(),
             ..tmux_discovery_fixture()
         };
-        let event = tmux_event(&discovered, 1);
+        let event = tmux_event(&discovered, None, 1);
         FleetRepo::apply_event(store.pool(), &event).await.expect("discovery applies");
 
         let session = FleetRepo::get_session(store.pool(), &event.session_key)
@@ -4509,7 +4757,9 @@ mod tests {
                 last_seen_ms: None,
                 version: 0,
             };
-            FleetRepo::apply_event(store.pool(), &tmux_event(&session, 100)).await.unwrap();
+            FleetRepo::apply_event(store.pool(), &tmux_event(&session, None, 100))
+                .await
+                .unwrap();
         }
 
         let payload = serde_json::json!({

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/osnotify.rs
@@ -253,7 +253,9 @@ pub fn classify_attention(raw_event: &str, subtype: Option<&str>) -> Option<Aler
         | "permission_request"
         | "exec_approval_request"
         | "apply_patch_approval_request" => AlertKind::NeedsPermission,
-        // Asked the user something / idle awaiting input.
+        // OS notifications use one actionable attention class, while the
+        // materialized state keeps the important distinction: Codex
+        // `request_user_input` becomes ASK and `wait_for_user` becomes WAIT.
         "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
             AlertKind::WaitingOnUser
         }
@@ -312,7 +314,8 @@ pub fn render_title(env: &Envelope) -> String {
         "Stop" | "SessionEnd" | "agentStop" | "agent-turn-complete" | "task_complete" => {
             format!("{agent} session finished")
         }
-        "Notification" | "notification" | "request_user_input" | "wait_for_user" => {
+        "request_user_input" => format!("{agent} asked for input"),
+        "wait_for_user" | "Notification" | "notification" => {
             format!("{agent} is waiting for you")
         }
         "PermissionRequest"
@@ -787,6 +790,14 @@ mod tests {
         assert_eq!(
             render_title(&env("Notification:idle_prompt", "claude")),
             "Claude is waiting for you"
+        );
+        assert_eq!(
+            render_title(&env("request_user_input", "codex")),
+            "Codex asked for input"
+        );
+        assert_eq!(
+            render_title(&env("wait_for_user", "codex")),
+            "Codex is waiting for you"
         );
     }
 

--- a/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
+++ b/ainb-tui/crates/ainb-plugin-notifyd/src/transition.rs
@@ -39,7 +39,7 @@
 //! | `Stop`                                | `IDLE` once `age >= idle_threshold`, else `RUNNING` (turn-ended-but-fresh) |
 //! | `UserPromptSubmit`                    | `RUNNING` | a new user turn → clears ASK/WAIT/IDLE/ERR/APPROVE |
 //! | `PostToolUse` / `SubagentStart`       | `RUNNING` | active work resumed → clears ASK/WAIT/APPROVE |
-//! | `SessionEnd`                          | `DONE` | terminal                                  |
+//! | `SessionEnd` / legacy `agent-turn-complete` | `DONE` | terminal                             |
 //!
 //! So the materialized kind is "the latest non-lifecycle signal (ASK/WAIT/ERR),
 //! UNLESS a newer user turn reset it to RUNNING, OR a `Stop` aged it into IDLE,
@@ -317,7 +317,7 @@ impl Accum {
             self.parent = Some(p);
         }
 
-        let decision = match ev.event_type.as_str() {
+        let decision = match canonical_event_type(ev) {
             "PreToolUse" if ev.matcher.as_deref() == Some("AskUserQuestion") => {
                 Some(Decision::Ask(ask_context(&ev.payload)))
             }
@@ -333,12 +333,26 @@ impl Accum {
                 ev.matcher.as_deref(),
                 &ev.payload,
             ))),
+            // Codex's legacy hook transport names the user-input request and
+            // blocking wait directly.  They must not collapse into the same
+            // generic notification: the former is an answerable ASK, while
+            // the latter is an informational WAIT.
+            "CodexRequestUserInput" => Some(Decision::Ask(codex_ask_context(&ev.payload))),
+            "CodexWaitForUser" => Some(Decision::Wait(wait_context(
+                Some("wait_for_user"),
+                &ev.payload,
+            ))),
             "Stop" => Some(Decision::Stopped(ev.ts)),
             "UserPromptSubmit" => Some(Decision::Running),
             "SessionStart" => Some(Decision::Starting),
             // Active work resumed after an ASK/WAIT/APPROVE — clear back to RUNNING.
             "PostToolUse" | "SubagentStart" => Some(Decision::Running),
-            "SessionEnd" => Some(Decision::Done(reason_from_payload(&ev.payload))),
+            // Unlike Claude's `Stop` (which has an IDLE age policy), this
+            // event is an explicit Codex turn-completion acknowledgement.
+            // Persist DONE now; never create a stop-pending fake RUNNING row.
+            "SessionEnd" | "CodexTurnComplete" => {
+                Some(Decision::Done(reason_from_payload(&ev.payload)))
+            }
             // Unknown / telemetry event — does not change the decided kind.
             _ => None,
         };
@@ -407,6 +421,27 @@ impl Accum {
     }
 }
 
+/// Normalize legacy hook names before applying lifecycle policy.
+///
+/// Hooks predate the canonical event log and use provider-specific names.  Do
+/// the normalization at the fold boundary so existing durable logs acquire the
+/// same semantics on their next materialization without a migration.  These
+/// names are Codex-specific in practice; retaining the aliases regardless of
+/// `agent` is deliberate because a producer may omit/mislabel its agent while
+/// the event name itself is still unambiguous.
+fn canonical_event_type(ev: &EventRow) -> &str {
+    let event_type = ev.event_type.split(':').next().unwrap_or(&ev.event_type);
+    match event_type {
+        "request_user_input" => "CodexRequestUserInput",
+        "wait_for_user" => "CodexWaitForUser",
+        "agent-turn-complete" | "task_complete" | "agentStop" => "CodexTurnComplete",
+        "permission_request" | "exec_approval_request" | "apply_patch_approval_request" => {
+            "PermissionRequest"
+        }
+        other => other,
+    }
+}
+
 /// Extract the ASK context (serialized `AskUserQuestionData`) from a
 /// `PreToolUse(AskUserQuestion)` payload. The raw hook stdin carries
 /// `tool_input` = the AskUserQuestion tool input
@@ -424,6 +459,30 @@ fn ask_context(payload: &str) -> String {
         multi_select: false,
     });
     serde_json::to_string(&data).unwrap_or_default()
+}
+
+/// Build ASK context for Codex's legacy `request_user_input` hook.
+///
+/// Codex payloads are not `AskUserQuestion` tool input, but frequently carry
+/// an equivalent `question` or `message`.  Preserve that text when present;
+/// callers still receive a valid ASK row if an older hook sent no payload.
+fn codex_ask_context(payload: &str) -> String {
+    let v: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
+    let question = v
+        .get("question")
+        .or_else(|| v.get("message"))
+        .or_else(|| v.get("prompt"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("(input requested)")
+        .to_string();
+    serde_json::to_string(&AskUserQuestionData {
+        question,
+        header: None,
+        options: Vec::new(),
+        multi_select: false,
+    })
+    .unwrap_or_default()
 }
 
 /// Parse the first question out of a PreToolUse payload's `tool_input`.
@@ -554,6 +613,24 @@ mod tests {
         matcher: Option<&str>,
         payload: &str,
     ) -> i64 {
+        push_as(
+            store, ts, session, cwd, "claude", event_type, matcher, payload,
+        )
+    }
+
+    /// Append an event from a specific provider. Legacy Codex hooks carry
+    /// provider-specific event names, so their fold must be exercised against
+    /// the same durable event-log path as production.
+    fn push_as(
+        store: &Store,
+        ts: i64,
+        session: &str,
+        cwd: &str,
+        agent: &str,
+        event_type: &str,
+        matcher: Option<&str>,
+        payload: &str,
+    ) -> i64 {
         store
             .append_event(&EventRow {
                 seq: 0,
@@ -561,7 +638,7 @@ mod tests {
                 session_id: session.into(),
                 cwd: cwd.into(),
                 transcript_path: format!("/t/{session}.jsonl"),
-                agent: "claude".into(),
+                agent: agent.into(),
                 event_type: event_type.into(),
                 matcher: matcher.map(str::to_string),
                 payload: payload.into(),
@@ -623,6 +700,114 @@ mod tests {
         );
         assert_eq!(ctx.options[1].label, "prod");
         assert_eq!(ctx.options[1].description, None);
+    }
+
+    #[test]
+    fn legacy_codex_request_user_input_is_an_answerable_ask() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "request_user_input",
+            None,
+            r#"{"question":"Choose deployment target"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "ASK");
+        let ctx: AskUserQuestionData =
+            serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.question, "Choose deployment target");
+    }
+
+    #[test]
+    fn legacy_codex_wait_for_user_is_wait_not_ask() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "wait_for_user",
+            None,
+            r#"{"message":"Waiting for external review"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "WAIT");
+        let ctx: WaitContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.reason, "wait_for_user");
+        assert_eq!(ctx.message.as_deref(), Some("Waiting for external review"));
+    }
+
+    #[test]
+    fn legacy_codex_permission_alias_is_approve() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "exec_approval_request",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{"command":"git push"}}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "APPROVE");
+        let ctx: ApproveContext = serde_json::from_str(row.context.as_deref().unwrap()).unwrap();
+        assert_eq!(ctx.tool, "Bash");
+    }
+
+    #[test]
+    fn suffixed_permission_request_is_approve_too() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "PermissionRequest:Bash",
+            None,
+            r#"{"tool_name":"Bash","tool_input":{"command":"git push"}}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "APPROVE");
+    }
+
+    #[test]
+    fn legacy_codex_turn_completion_is_done_immediately() {
+        let (_d, store) = store();
+        push_as(
+            &store,
+            NOW,
+            "codex",
+            "/p",
+            "codex",
+            "agent-turn-complete",
+            None,
+            r#"{"reason":"completed"}"#,
+        );
+
+        materialize_at(&store, NOW, IDLE_MIN).unwrap();
+        let row = state(&store, "codex", "/p");
+        assert_eq!(row.kind, "DONE");
+        assert_eq!(row.context.as_deref(), Some(r#"{"reason":"completed"}"#));
+        assert!(
+            stopped_ts_from_context(row.context.as_deref()).is_none(),
+            "explicit turn completion must never become a delayed RUNNING stop"
+        );
     }
 
     #[test]

--- a/docs/plans/goals/2026-09-12-p0-closure.md
+++ b/docs/plans/goals/2026-09-12-p0-closure.md
@@ -1,0 +1,45 @@
+# /goal Slice 1 (P0 + S) is complete on v2: every wave landed, every gate green, and the human G6 check is handed to Stevie with proof
+
+— CONTEXT —
+· Project: agents-in-a-box (ainb), Rust TUI + Hangar daemon; branch `v2` is the integration branch for the desktop programme. Plan: `docs/plans/2026-09-05-desktop-p0-surface-safety.md`. Resume point: `docs/plans/2026-09-12-p0-surface-safety-handoff.md`. Programme DAG: `docs/plans/2026-09-12-desktop-programme.md`. Base spec: `docs/plans/2026-09-04-desktop-shared-core-spec.md` (decisions D1-D9 are locked, never re-open them).
+· Stack: Rust workspace under `ainb-tui/` (crates `ainb-core`, `ainb-hangar-daemon`, `ainb-hangar-proto`, `ainb-hangar-store`, plugins); ratatui TUI; tmux; SQLite via sqlx; tripwire tests under `ainb-tui/crates/ainb-core/tests/tripwire_*.rs` driven through tmux (read the `tmux-ui-tripwire` skill before touching one).
+· Current state: wave 1 (Phase 1 keymap, S-A locks and atomic writes, S-B ConnectionRegistry) is on `v2`. Waves 2, 3, 4 (Phase 3 UiState, S-C card retirement, Phase 2 Versioned sections, S-D concurrency tests) are not started; `ui_state.rs`, `versioned.rs`, `sections.rs`, `tests/answer_race.rs` do not exist. Open gates: GitHub issue #925 (site build fails because `ainb keymap list --format md` writes `docs/tui/keyboard-shortcuts.md` without Starlight `title` frontmatter; `browse_modal_searches_and_enter_installs_live` panics at `tests/tripwire_core_skill_manager_browse_live.rs:288` because typed search keys no longer reach the modal after keymap routing), `tripwire_burndown_heatmap` fails after `Left` (plain capture unchanged), burndown Esc fixture review findings (name the seeded origin session with the `tmux_` prefix, set `AINB_HOME` to the fixture, assert the `burndown-origin` row before opening Analytics), human G6 two-terminal validation pending.
+· Working dir: the Orca worktree this session was launched in, branched from `origin/v2`.
+· Constraints: every PR targets `v2`, never `main`; signed commits only (`git commit -S`); one concern per commit, stage by named path, never `git add -A`; never edit `ainb-hangar-daemon/src/rpc/mod.rs`, `rpc/auth.rs`, `answer.rs`, `hangar-proto/src/auth.rs` (another lane owns them); never add a store migration; keep the 19-section table from the plan as the section boundaries (`agent_status` is section 20 and belongs to another lane, do not add it); run `cargo test -p ainb-core --tests` and `cargo clippy --workspace -- -D warnings` before every PR; tripwires are contract tests, never rerun a red one to green it; tmux safety: private sockets only for tests, never `tmux kill-server`, kill sessions by exact name; update the node rows for slice 1 in `docs/plans/2026-09-12-desktop-programme.md` in the same PR that flips them.
+· Audience: Stevie, who performs the G6 human checkpoint (keymap.toml override plus embed passthrough, then scroll and mouse after the UiState seal) from two terminals when you hand it over with exact steps.
+
+— SUCCESS CRITERIA (ALL MUST BE TRUE) —
+1. `Test ainb installations` and `Build site` are green on `v2` CI, #925 is closed by a merged PR, and `tripwire_burndown_heatmap` passes without weakening the selected-day assertion.
+2. Phase 3, S-C, Phase 2 and S-D are merged to `v2` as separate PRs, each with its plan exit gate met: `tests/ui_state.rs` green, `AttentionAnswered` folding in TUI and web, 19 `Versioned<Section>` with `SectionVersions`, `answer_race.rs` yielding one `Delivered` and one `AlreadyAnswered`, `tripwire_multi_attach_resize.rs` green, `surface-combo-smoke.sh` in CI.
+3. `cargo test -p ainb-core --tests` (all tripwires) and `cargo clippy --workspace -- -D warnings` pass on the final `v2` head, and the programme doc rows for slice 1 read done with the merge SHAs.
+4. Final deliverable runs without errors
+5. You can show proof (screenshot · test output · URL)
+
+— OPERATING RULES — NON-NEGOTIABLE —
+1. PLAN FIRST. Output a numbered task list before writing any code.
+2. WORK AUTONOMOUSLY. Don't ask clarifying Qs unless genuinely blocked.
+3. SELF-VERIFY. After every step: run tests, inspect output, confirm it worked.
+4. DEBUG YOURSELF. If it fails, diagnose + fix. Don't hand it back.
+5. USE EVERY TOOL. MCPs · terminal · web · code exec · pull real data.
+6. NO PLACEHOLDERS. No TODOs · no stubs · real components + real states.
+7. PROGRESS LOG. Track completed · in-flight · decisions · blockers.
+8. STAY ON GOAL. Discoveries off-spec? Note + keep moving.
+9. IF BLOCKED. Log the wall · continue everything parallelizable.
+10. CHECK SUCCESS BEFORE STOPPING. Re-read criteria · confirm each is met.
+
+— QUALITY BAR —
+· Code: clean, typed, follows project conventions
+· Design: looks like a well-funded startup shipped it
+· Output: survives a senior code review
+· Docs: every new pattern / env var / decision logged
+
+— FINAL DELIVERABLE —
+✅ Confirmation each criterion is satisfied
+📂 Every file created / modified
+🚀 How to run / test / deploy
+📊 Proof (screenshot · test output · URL)
+📝 Decisions made + anything to know
+⚠️ Known limitations + follow-ups
+
+Begin by outputting your plan. Then execute end-to-end without checking
+in until done or genuinely blocked.

--- a/docs/plans/goals/2026-09-12-spike-2-emulator.md
+++ b/docs/plans/goals/2026-09-12-spike-2-emulator.md
@@ -1,0 +1,45 @@
+# /goal Spike 2 is answered with measurements: a Rust VT emulator fed by tmux control mode reproduces a live agent screen byte-equal to a direct PTY, and the report names the crate and the R2 scope it flips
+
+— CONTEXT —
+· Project: agents-in-a-box (ainb) desktop programme, phase R2 (daemon-side headless emulator as a cache over tmux, tmux stays the PTY owner). Spec: `docs/plans/2026-09-11-multi-surface-decisions-spec.md` D10, phase row R2, spike rows 2 and 7, edge cases "one pane floods", "daemon feed dies". Prior results: `research/2026-09-11_multi-surface_SPIKE-1-osc-through-tmux.md` (control mode delivers OSC frames verbatim; `-f ignore-size` does not pin size on tmux 3.4, `window-size manual` does) and `SPIKE-7-control-mode-flow.md` (`refresh-client -f pause-after=2` pauses only the flooding pane; `%continue` drops the paused interval; quote `-A "%<id>:continue"`; `pause-after` switches the client to `%extended-output`). Programme DAG: `docs/plans/2026-09-12-desktop-programme.md`.
+· Stack: tmux 3.4 (verify `tmux -V` on this box), Rust scratch crate, candidate emulator crates `vt100`, `alacritty_terminal`, `wezterm-term` (evaluate at least two), `portable-pty` for the direct-PTY control, real agent TUIs available on the box (`claude`, `codex`) plus synthetic fixtures for alt-screen, mouse tracking, wide characters (CJK, emoji), OSC 8 links, and a custom OSC status frame.
+· Current state: no emulator code exists in the repo; R2 is planned after R1; this spike gates R2's scope and the "daemon-owned PTY" do-not-build row reopens only if fidelity is poor.
+· Working dir: the Orca worktree this session was launched in, branched from `origin/v2`; all code lives under a scratch directory outside the crates (for example `research/spikes/spike-2/` or `/tmp`), never inside `ainb-tui/crates`.
+· Constraints: read-only on the repo except the report file `research/2026-09-11_multi-surface_SPIKE-2-control-mode-fidelity.md` (force-add, the directory is gitignored) and an optional PR to `v2` that updates the spike-2 row and the R2 row in the programme doc; private tmux server only, every tmux command uses `-L ainb-spike2`, never `tmux kill-server` or any bulk kill, clean up by exact session name; no product names of prior-art systems anywhere; no em-dashes; signed commits; `timeout` on every run; measure RSS per emulator at 100 sessions and CPU during `cat` of 50 MB; confirm `#{window_width}` seen by a second attached client never changes while the daemon-style control client is attached; feed = `tmux -C attach` on a pipe with `refresh-client -A "%<pane>:on"` and `-f pause-after=2`, parse `%extended-output`.
+· Audience: the R2 implementer and Stevie, who decide the emulator crate and whether R2 stays on the tmux hybrid.
+
+— SUCCESS CRITERIA (ALL MUST BE TRUE) —
+1. For each fixture (alt-screen TUI, mouse-tracking mode, wide chars, OSC 8 link, custom OSC status frame) the emulator snapshot at 120x40 and at 40x20 from the control-mode feed is byte-equal after ANSI normalisation to the same fixture driven through a direct `portable-pty`, or every difference is listed with the exact bytes and a verdict (cosmetic, fixable, blocker).
+2. The report has a crate comparison table (fidelity per fixture, RSS at 100 emulators, CPU during the 50 MB flood, API fit for snapshot-then-tail and re-snapshot on `%continue`) and names one crate with a one-paragraph rationale, plus the `#{window_width}` proof and the pause and resume behaviour reproduced once.
+3. The "Decision input" section states whether R2 proceeds on the tmux hybrid as specified, what R2's live-window and re-snapshot rules must be, and, if fidelity is a blocker on every crate, the concrete case for reopening the daemon-owned PTY row.
+4. Final deliverable runs without errors
+5. You can show proof (screenshot · test output · URL)
+
+— OPERATING RULES — NON-NEGOTIABLE —
+1. PLAN FIRST. Output a numbered task list before writing any code.
+2. WORK AUTONOMOUSLY. Don't ask clarifying Qs unless genuinely blocked.
+3. SELF-VERIFY. After every step: run tests, inspect output, confirm it worked.
+4. DEBUG YOURSELF. If it fails, diagnose + fix. Don't hand it back.
+5. USE EVERY TOOL. MCPs · terminal · web · code exec · pull real data.
+6. NO PLACEHOLDERS. No TODOs · no stubs · real components + real states.
+7. PROGRESS LOG. Track completed · in-flight · decisions · blockers.
+8. STAY ON GOAL. Discoveries off-spec? Note + keep moving.
+9. IF BLOCKED. Log the wall · continue everything parallelizable.
+10. CHECK SUCCESS BEFORE STOPPING. Re-read criteria · confirm each is met.
+
+— QUALITY BAR —
+· Code: clean, typed, follows project conventions
+· Design: looks like a well-funded startup shipped it
+· Output: survives a senior code review
+· Docs: every new pattern / env var / decision logged
+
+— FINAL DELIVERABLE —
+✅ Confirmation each criterion is satisfied
+📂 Every file created / modified
+🚀 How to run / test / deploy
+📊 Proof (screenshot · test output · URL)
+📝 Decisions made + anything to know
+⚠️ Known limitations + follow-ups
+
+Begin by outputting your plan. Then execute end-to-end without checking
+in until done or genuinely blocked.

--- a/docs/plans/goals/2026-09-12-spike-3-peer-ws.md
+++ b/docs/plans/goals/2026-09-12-spike-3-peer-ws.md
@@ -1,0 +1,45 @@
+# /goal Spike 3 is answered with measurements across two real boxes: a peer WebSocket with Noise IK carries the daemon wire over tailnet and over ssh -L, survives the client closing, resyncs on reconnect, and holds the 50 MB terminal gate
+
+— CONTEXT —
+· Project: agents-in-a-box (ainb) desktop programme, phase R1 (peer daemon on the box, WebSocket + Noise IK transport, per-device tokens). Spec: `docs/plans/2026-09-11-multi-surface-decisions-spec.md` D11, D13, "D13 pairing, keys, scopes" contract, phase row R1, spike row 3, edge cases for reconnect storms and listings. Evidence: `research/2026-09-11_multi-surface_B-remote-federation.md` sections 4 and 8 (streaming constants: 48 KiB chunks, 512 KiB initial window, 8 MiB total, acks batched at 192 KiB or 4 ms; session authority), `F-ours-current.md` section 3 (JSON-RPC 2.0 over LSP Content-Length framing, `fleet/subscribe {after_revision}` cursor replay, `SnapshotReset`). Programme DAG: `docs/plans/2026-09-12-desktop-programme.md`.
+· Stack: Rust scratch crate (`tokio`, `tokio-tungstenite`, `snow` for Noise IK, `ainb-hangar-proto` as a path dependency for the envelope); two boxes reachable over tailscale: the paired Orca runtimes `claude-gcp` and `claude-hetzner` (this session runs on one of them and reaches the other by its tailnet name and by `ssh -L`); the real `ainb-hangar-daemon` may be started on a private `AINB_HANGAR_HOME` on the remote box as the thing being proxied, or a stub daemon speaking the same framing if the real one cannot run there.
+· Current state: today the daemon has one door, a `0600` unix socket guarded by `SO_PEERCRED`; `ainb-hangar-client` hardcodes `UnixStream::connect` at three sites; no `HostId` exists; the spec plans `ssh -L` as one carrier among tailnet and LAN. This spike is the go/no-go for R1's scope and for rescoping D4 before it starts.
+· Working dir: the Orca worktree this session was launched in, branched from `origin/v2`; scratch code outside the crates; the report goes to `research/2026-09-11_multi-surface_SPIKE-3-peer-ws-noise.md` (force-add) plus an optional PR to `v2` updating the spike-3 row in the programme doc.
+· Constraints: read-only on the repo except the report and the programme row; never touch the boxes' real `~/.agents-in-a-box` daemon or its socket, use a private `AINB_HANGAR_HOME` and a private port; never store secrets in the report; Noise IK via `snow` with the host static key pinned client-side and the handshake transcript binding transport kind and a placeholder host id; one multiplexed WS per host carrying request/response and subscriptions; measure with `timeout` and record exact commands; no prior-art product names; no em-dashes; signed commits; when driving the other box use `orca terminal` on the paired runtime or plain ssh, never a bulk process kill, clean up every process you started by PID.
+· Audience: the R1 implementer and Stevie, deciding R1 scope and whether the terminal stream needs a second unencrypted WS inside `ssh -L`.
+
+— SUCCESS CRITERIA (ALL MUST BE TRUE) —
+1. A client on box A completes a Noise IK handshake to a daemon-proxy on box B over the tailnet address and separately through `ssh -L`, issues at least `auth/hello`, `fleet/snapshot` and a `fleet/subscribe` against the real proto envelope, kills itself mid-subscription, waits 60 s while the remote side keeps emitting events, reconnects with `after_revision`, and receives a `Complete` replay with no gap; numbers for handshake time and reconnect-to-resync time are in the report for both carriers.
+2. `cat` of a 50 MB file through the terminal stream path (48 KiB chunks, ack window as specified) completes under 2 s on the tailnet carrier and the `ssh -L` carrier, or the report shows the measured throughput for each and states whether the double encryption inside `ssh -L` is the cause, with the fallback (second WS without Noise inside `ssh -L`) measured too.
+3. A laptop sleep/wake storm is simulated (5 hosts x 3 devices reconnecting at once, jittered backoff 1 s to 60 s, at most 2 concurrent resyncs per client) and the report records connection count, resync count and peak daemon-proxy RSS, ending with a "Decision input" section that says go or no-go for R1 as scoped and what D4 must be rescoped to.
+4. Final deliverable runs without errors
+5. You can show proof (screenshot · test output · URL)
+
+— OPERATING RULES — NON-NEGOTIABLE —
+1. PLAN FIRST. Output a numbered task list before writing any code.
+2. WORK AUTONOMOUSLY. Don't ask clarifying Qs unless genuinely blocked.
+3. SELF-VERIFY. After every step: run tests, inspect output, confirm it worked.
+4. DEBUG YOURSELF. If it fails, diagnose + fix. Don't hand it back.
+5. USE EVERY TOOL. MCPs · terminal · web · code exec · pull real data.
+6. NO PLACEHOLDERS. No TODOs · no stubs · real components + real states.
+7. PROGRESS LOG. Track completed · in-flight · decisions · blockers.
+8. STAY ON GOAL. Discoveries off-spec? Note + keep moving.
+9. IF BLOCKED. Log the wall · continue everything parallelizable.
+10. CHECK SUCCESS BEFORE STOPPING. Re-read criteria · confirm each is met.
+
+— QUALITY BAR —
+· Code: clean, typed, follows project conventions
+· Design: looks like a well-funded startup shipped it
+· Output: survives a senior code review
+· Docs: every new pattern / env var / decision logged
+
+— FINAL DELIVERABLE —
+✅ Confirmation each criterion is satisfied
+📂 Every file created / modified
+🚀 How to run / test / deploy
+📊 Proof (screenshot · test output · URL)
+📝 Decisions made + anything to know
+⚠️ Known limitations + follow-ups
+
+Begin by outputting your plan. Then execute end-to-end without checking
+in until done or genuinely blocked.

--- a/docs/plans/goals/2026-09-12-status-t0.md
+++ b/docs/plans/goals/2026-09-12-status-t0.md
@@ -1,0 +1,45 @@
+# /goal Hook events bind to panes without launcher env (#916 closed) and T0-daemon is merged to v2: one status truth on the fleet_session family that every surface reads identically
+
+— CONTEXT —
+· Project: agents-in-a-box (ainb) Hangar daemon status pipeline. Spec: `docs/plans/2026-09-11-multi-surface-decisions-spec.md` D14 and its "D14 status store" contract (clocks table, spool, boot order, incarnation fence, unknown-event counters, rollback flag, tier-0 identity rule, daemon-side pane binding, no per-launch provider overrides), phase rows T0-daemon and T0-section, Operability section. GitHub issue #916 (pane binding without launcher env). Evidence: `research/2026-09-11_multi-surface_SPIKE-9-codex-daemon-reuse.md`, `SPIKE-1-osc-through-tmux.md`, `SPIKE-8-sqlite-write-path.md`, `D-agent-status.md`. Programme DAG: `docs/plans/2026-09-12-desktop-programme.md`. Decisions D1-D18 are locked.
+· Stack: Rust workspace under `ainb-tui/`; hook script `plugins/ainb-hooks/hooks/notify.sh` (reads `session_id` and `cwd` from the payload, posts to `$HOME/.agents-in-a-box/notify.sock`, then execs `ainb fleet atc hook`); `ainb-core/src/cli/fleet/atc.rs:2533` derives `tmux_target` from `$TMUX_PANE` only; daemon consumer `ainb-hangar-daemon/src/attention_ingest.rs`; store repos `ainb-hangar-store/src/repo/fleet.rs`, `fleet_provider_event.rs`, `attention.rs`; pure classifier `ainb-fleet-core/src/fleet/read/needs.rs` (`classify()`); `fleet_session` and `fleet_event` tables from migration `0044`; today two records of needs-input drift (`attention` vs `fleet_session.attention_state`, reconciled by a 300 s sweep at `attention_ingest.rs`).
+· Current state: Codex 0.148 runs its TUI in-process, 0.154 attaches to a shared app-server and runs hooks in its environment; hook lines from the ainb-owned app-server carry null `tmux_target` (1,215 of 1,215 sampled), which skips `retire_correlated_legacy` (`daemon/src/fleet.rs:423`) and makes send-keys control return unbound (`rpc/mod.rs:5222`). The W0-wire lane is concurrently adding a protocol version, capability catalogue and op-id ledger in `rpc/mod.rs`, `rpc/auth.rs`, `answer.rs` and new migrations.
+· Working dir: the Orca worktree this session was launched in, branched from `origin/v2`.
+· Constraints: PRs target `v2`; signed commits; one concern per commit, named paths; you own `fleet.rs`, `attention_ingest.rs`, `atc.rs`, `fleet_provider_event.rs`, `attention.rs`, `needs.rs`, `plugins/ainb-hooks/*`; in `rpc/mod.rs` add dispatch arms only, never reshape, and rebase daily on `v2`; add no store migration until the W0-wire lane's ledger migration is merged to `v2` (check `git log origin/v2 -- ainb-tui/crates/ainb-hangar-store/migrations` first), then number yours after it; never touch `ainb-core/src/app/*`; do not add per-launch provider config overrides (`codex -c`, `--enable hooks`); the store IS the `fleet_session` + `fleet_event` family extended with provenance, tier, three clocks (`received_at`, `evidence_observed_at`, `state_started_at`) and `session_incarnation`, `attention` rows become a projection written in the same transaction by the single apply path, `sweep_once` becomes a drift assertion that logs and never mutates; one SQLite transaction per event, never per drain tick; pane binding: hook `tmux_target` when present, else `(provider, cwd)` against tier-5 discovered panes when exactly one matches, else `pane_unbound` surfaced in the fleet panel and `ainb doctor`; legacy-row retirement keys on the resolved binding; provider order Claude-compatible family (claude, codex, droid, copilot, devin, kimi) first, then a published OSC in-band frame schema (pick an unused OSC number), then the session-state family; `status_unknown_event{provider,name}` counters in `hangar/health` and `ainb doctor`; `[fleet.status] legacy_classify_primary = true` rollback flag for one release; retention paths for `fleet_action_receipt` (7 d) and `attention` (30 d after close) and rate-aware `fleet_event` payload eviction under the 1 GB ceiling; run `cargo test -p ainb-hangar-daemon -p ainb-hangar-store -p ainb-fleet-core` and clippy before each PR; the `agent_status` renderer section (T0-section) is out of scope until P1 lands, do not add it; update the #916 and T0-daemon rows in the programme doc in the PR that flips them.
+· Audience: TUI fleet panel, `ainb fleet needs`, `ainb-web` `/api/needs`, and later the desktop and phone, all of which must show one row per agent with the same state.
+
+— SUCCESS CRITERIA (ALL MUST BE TRUE) —
+1. #916: the managed hook run under `env -i HOME=<fixture>` with a Codex payload produces one attributed row when exactly one discovered pane matches `(provider, cwd)`, one `pane_unbound` row when zero or two match, and no duplicate legacy row either way; answering a `pane_unbound` ASK names the pane it could not find instead of silently failing.
+2. One fixture session driven hook to store makes `ainb fleet needs --format json`, `GET /api/needs`, and the TUI fleet panel `TestBackend` snapshot produce identical `(session_key, state, provenance, tier, evidence_observed_at)` tuples; a tier-0 `waiting` followed by a tier-5 `idle` from the same pane stays `waiting` with provenance `hook`; a property test over random event sequences never yields `done` from silence; zero rows where `attention.open` disagrees with `fleet_session.attention_state` after a 1,000-event replay.
+3. Retention deletes receipts older than 7 d and closed attention rows older than 30 d in the hourly sweep, payload eviction adapts to event rate, and the spike-8 bench at 100 sessions and 10/s stays at or below 15 ms p99 with the projection inside the apply transaction.
+4. Final deliverable runs without errors
+5. You can show proof (screenshot · test output · URL)
+
+— OPERATING RULES — NON-NEGOTIABLE —
+1. PLAN FIRST. Output a numbered task list before writing any code.
+2. WORK AUTONOMOUSLY. Don't ask clarifying Qs unless genuinely blocked.
+3. SELF-VERIFY. After every step: run tests, inspect output, confirm it worked.
+4. DEBUG YOURSELF. If it fails, diagnose + fix. Don't hand it back.
+5. USE EVERY TOOL. MCPs · terminal · web · code exec · pull real data.
+6. NO PLACEHOLDERS. No TODOs · no stubs · real components + real states.
+7. PROGRESS LOG. Track completed · in-flight · decisions · blockers.
+8. STAY ON GOAL. Discoveries off-spec? Note + keep moving.
+9. IF BLOCKED. Log the wall · continue everything parallelizable.
+10. CHECK SUCCESS BEFORE STOPPING. Re-read criteria · confirm each is met.
+
+— QUALITY BAR —
+· Code: clean, typed, follows project conventions
+· Design: looks like a well-funded startup shipped it
+· Output: survives a senior code review
+· Docs: every new pattern / env var / decision logged
+
+— FINAL DELIVERABLE —
+✅ Confirmation each criterion is satisfied
+📂 Every file created / modified
+🚀 How to run / test / deploy
+📊 Proof (screenshot · test output · URL)
+📝 Decisions made + anything to know
+⚠️ Known limitations + follow-ups
+
+Begin by outputting your plan. Then execute end-to-end without checking
+in until done or genuinely blocked.

--- a/docs/plans/goals/2026-09-12-w0-wire.md
+++ b/docs/plans/goals/2026-09-12-w0-wire.md
@@ -1,0 +1,45 @@
+# /goal W0-wire is merged to v2: one protocol version and capability catalogue in hello, a two-direction skew harness, and an op-id ledger with transactional receipts on every mutation
+
+— CONTEXT —
+· Project: agents-in-a-box (ainb) Hangar daemon and its clients. Spec: `docs/plans/2026-09-11-multi-surface-decisions-spec.md` sections D17, D18, "Contracts in detail" (D17 versioning, D18 mutation envelope), phase row W0-wire, and the critique amendments 15-21 in `research/2026-09-11_multi-surface_CRITIQUE-amendments.md`. Programme DAG: `docs/plans/2026-09-12-desktop-programme.md`. Decisions D1-D18 are locked; do not re-open them.
+· Stack: Rust workspace under `ainb-tui/`; JSON-RPC 2.0 over LSP Content-Length framing on a unix socket (`ainb-hangar-daemon/src/rpc/mod.rs:240 bind()`, `:352 serve_conn`); proto crate `ainb-hangar-proto` (159 methods, `FLEET_PROTOCOL_VERSION = 2` fleet-only, `HelloParams { token }` at `proto/auth.rs:43-47`, advisory capabilities at `proto/fleet.rs:50-61`); store crate `ainb-hangar-store` with sqlx migrations (`0044_fleet_control_plane.sql` already has `fleet_action_receipt(request_id, expected_version, idempotency_key, status)`); three clients: `ainb-hangar-client`, `ainb-web/src/daemon.rs`, Swift `FleetWire.swift`.
+· Current state: S-B (ConnectionRegistry, hello extension with `{surface_kind, host, pid}`) is on `v2`. No protocol integer exists for the `hangar/*` and `attention/*` families. `answer.rs` (1,940 lines) has first-answer-wins and compensating reopen but no receipt lifecycle. Spike 8 (`research/2026-09-11_multi-surface_SPIKE-8-sqlite-write-path.md`) proved one SQLite transaction per event holds p99 11 ms; today's shape commits three transactions per event (`repo/fleet.rs:495`, `attention_ingest.rs:610`, `rpc/mod.rs:2475`).
+· Working dir: the Orca worktree this session was launched in, branched from `origin/v2`.
+· Constraints: PRs target `v2`; signed commits; one concern per commit, named paths only; you own `hangar-proto/src/auth.rs`, `methods.rs`, `rpc/mod.rs`, `rpc/auth.rs`, `answer.rs`, `hangar-client`, and new store migrations; never touch `ainb-core/src/app/*` or `state.rs` (slice 1 owns them) nor `fleet.rs`, `atc.rs`, `attention_ingest.rs` (the status lane owns them); `HelloParams` reaches its final shape `{ token, surface, protocol: {min, max}, capabilities, device? }` once, in this lane; `FLEET_PROTOCOL_VERSION` stays frozen at 2 and `fleet/negotiate` stays as an echo whose 25 ids append to the one catalogue; the catalogue is a committed file with a test that fails when a string is removed; the daemon binds `hangar.sock` and symlinks `hangar-v<N>.sock`; op ids are opaque 128-bit values keyed `(host_id_placeholder, principal, op_id)` with 7 d or 100k-row retention, `FleetActionParams.request_id` is the op id for that family and `fleet_action_receipt` is its ledger, rename nothing on the wire; receipts `claimed -> writing -> delivered | failed | unknown` are written in the same transaction as the state flip, never through the event outbox, `writing` set immediately before the first PTY byte, boot turns leftover `writing` into `unknown{effects_ambiguous}` surfaced as an attention row of kind `delivery_unconfirmed`; the fences table in the spec (answer: attention `version` + `open`; prompt send: `lifecycle_updated_at`; cancel/kill: `session_incarnation`; device_revoke: registry `version`); generic dedupe at dispatch for every mutation, transactional receipts only for `attention/answer`, prompt send, `fleet/action{cancel,kill}`, `terminal/input`; keep `synchronous=NORMAL`; the Swift client and `ainb-web` keep working at N-1 through the skew harness; run `cargo test -p ainb-hangar-daemon -p ainb-hangar-proto -p ainb-hangar-store -p ainb-hangar-client` and `cargo clippy --workspace -- -D warnings` before each PR; update the W0-wire row in the programme doc in the PR that flips it.
+· Audience: the desktop, TUI, web and later phone clients, and the status lane which will build on the ledger.
+
+— SUCCESS CRITERIA (ALL MUST BE TRUE) —
+1. A proto test walks a committed `MUTATING_METHODS` list and asserts each params struct embeds `MutationEnvelope`; a daemon test replays every mutating method twice and gets exactly one `created` and one `replayed` per method; a second principal replaying the same op id gets `rejected{op_id_foreign}`.
+2. The skew harness runs {daemon N, daemon N-1} x {hangar-client, ainb-web, Swift fixture} in both directions in CI and is green, and `auth/hello` carries `protocol {min,max}` plus the capability catalogue with the removal-fails test.
+3. A crash injected between claim and `send-keys` in `answer.rs` leaves a `delivery_unconfirmed` attention row after daemon restart and a retry returns `replayed` with receipt state `unknown`; the answer race test still yields one `Delivered` and one `AlreadyAnswered`; commit-only p50 for an answer stays at or below 0.4 ms on the spike-8 bench.
+4. Final deliverable runs without errors
+5. You can show proof (screenshot · test output · URL)
+
+— OPERATING RULES — NON-NEGOTIABLE —
+1. PLAN FIRST. Output a numbered task list before writing any code.
+2. WORK AUTONOMOUSLY. Don't ask clarifying Qs unless genuinely blocked.
+3. SELF-VERIFY. After every step: run tests, inspect output, confirm it worked.
+4. DEBUG YOURSELF. If it fails, diagnose + fix. Don't hand it back.
+5. USE EVERY TOOL. MCPs · terminal · web · code exec · pull real data.
+6. NO PLACEHOLDERS. No TODOs · no stubs · real components + real states.
+7. PROGRESS LOG. Track completed · in-flight · decisions · blockers.
+8. STAY ON GOAL. Discoveries off-spec? Note + keep moving.
+9. IF BLOCKED. Log the wall · continue everything parallelizable.
+10. CHECK SUCCESS BEFORE STOPPING. Re-read criteria · confirm each is met.
+
+— QUALITY BAR —
+· Code: clean, typed, follows project conventions
+· Design: looks like a well-funded startup shipped it
+· Output: survives a senior code review
+· Docs: every new pattern / env var / decision logged
+
+— FINAL DELIVERABLE —
+✅ Confirmation each criterion is satisfied
+📂 Every file created / modified
+🚀 How to run / test / deploy
+📊 Proof (screenshot · test output · URL)
+📝 Decisions made + anything to know
+⚠️ Known limitations + follow-ups
+
+Begin by outputting your plan. Then execute end-to-end without checking
+in until done or genuinely blocked.

--- a/docs/tui/cli.md
+++ b/docs/tui/cli.md
@@ -71,6 +71,46 @@ EXAMPLES:
   ainb diff-review --format json   Emit the structured diff as JSON (headless)
 ```
 
+## `ainb keymap`
+
+List effective terminal shortcuts
+
+```console
+$ ainb keymap --help
+List effective terminal shortcuts
+
+Usage: ainb keymap [OPTIONS] <COMMAND>
+
+Commands:
+  list  Print the merged, effective keymap
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+
+EXAMPLES:
+  \
+             ainb keymap list
+  \
+             ainb keymap list --format json
+```
+
+### `ainb keymap list`
+
+Print the merged, effective keymap
+
+```console
+$ ainb keymap list --help
+Print the merged, effective keymap
+
+Usage: ainb keymap list [OPTIONS]
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
 ## `ainb run`
 
 Spawn a new AI coding session
@@ -4214,25 +4254,26 @@ Hangar managed-agents control plane (issue / task / beads / daemon)
 Usage: ainb hangar [OPTIONS] <COMMAND>
 
 Commands:
-  issue      Manage Hangar issues
-  task       Inspect and control Hangar tasks
-  beads      Sync Hangar issues with the beads (`bd`) tracker
-  daemon     Inspect the Hangar control-plane daemon
-  auth       Manage Hangar auth tokens (PATs + daemon tokens)
-  config     Configure Hangar (env allowlist, …)
-  skills     Import + list workspace-scoped skills
-  templates  List, inspect, and apply curated agent templates
-  agent      Edit, archive, and list workspace agents
-  member     List, re-role, and remove workspace members
-  squad      Create squads, manage membership, and view squad status + leader
-  autopilot  Create and control cron-scheduled autopilots
-  workspace  View + set per-workspace config (context prompt, issue prefix, repo whitelist)
-  logs       Read the daemon's structured logs
-  property   Define and archive a workspace's custom issue properties
-  comment    Post issue comments and preview their `@`-mention routing
-  inbox      Read an actor's notification inbox
-  pipeline   Provision and inspect the role-gated pull pipeline
-  help       Print this message or the help of the given subcommand(s)
+  issue        Manage Hangar issues
+  task         Inspect and control Hangar tasks
+  beads        Sync Hangar issues with the beads (`bd`) tracker
+  daemon       Inspect the Hangar control-plane daemon
+  connections  Inspect live authenticated Hangar client connections
+  auth         Manage Hangar auth tokens (PATs + daemon tokens)
+  config       Configure Hangar (env allowlist, …)
+  skills       Import + list workspace-scoped skills
+  templates    List, inspect, and apply curated agent templates
+  agent        Edit, archive, and list workspace agents
+  member       List, re-role, and remove workspace members
+  squad        Create squads, manage membership, and view squad status + leader
+  autopilot    Create and control cron-scheduled autopilots
+  workspace    View + set per-workspace config (context prompt, issue prefix, repo whitelist)
+  logs         Read the daemon's structured logs
+  property     Define and archive a workspace's custom issue properties
+  comment      Post issue comments and preview their `@`-mention routing
+  inbox        Read an actor's notification inbox
+  pipeline     Provision and inspect the role-gated pull pipeline
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
@@ -5075,6 +5116,40 @@ Commands:
   set     Store a long-lived token. Reads the token from STDIN by default (so it never lands on argv or in shell history); `--setup-token` instead drives the interactive `claude setup-token` browser flow and captures the result
   clear   Remove the stored credential. Idempotent
   help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+### `ainb hangar connections`
+
+Inspect live authenticated Hangar client connections
+
+```console
+$ ainb hangar connections --help
+Inspect live authenticated Hangar client connections
+
+Usage: ainb hangar connections [OPTIONS] <COMMAND>
+
+Commands:
+  list  List connection id, surface kind, process id, and daemon host
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]
+  -h, --help             Print help
+```
+
+#### `ainb hangar connections list`
+
+List connection id, surface kind, process id, and daemon host
+
+```console
+$ ainb hangar connections list --help
+List connection id, surface kind, process id, and daemon host
+
+Usage: ainb hangar connections list [OPTIONS]
 
 Options:
       --format <format>  Output format [default: text] [possible values: text, json, csv, markdown]


### PR DESCRIPTION
## Summary

- Merge `main` into `v2` (10 commits: tmux reconcile fixes, sidebar session state, release v1.28.2). One conflict in `ainb-core/src/main.rs` where both sides added helpers at the same spot (`PreviewScrollRoute` on v2, `TmuxSessionPresence` on main); resolved by keeping both. `cargo check -p ainb --lib` passes.
- Add `docs/plans/goals/2026-09-12-*.md`: one goal prompt per parallel lane (slice-1 closure, W0-wire, status/T0, spike 2, spike 3), used verbatim as the prompt for each Orca worktree.

## Test plan

- [x] `cargo check -p ainb --lib` on the merge result
- [ ] full CI on this PR
