### PR TITLE
fix: make sidebar status authoritative

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -77,6 +77,8 @@ pub struct SessionFleetMetadata {
     pub provider_session_id: Option<String>,
     /// Exact Fleet lifecycle, omitted when Fleet has no observation.
     pub lifecycle: Option<ainb_hangar_proto::fleet::LifecycleState>,
+    /// Timestamp paired with `lifecycle`, used to reject an older snapshot.
+    pub lifecycle_updated_at: i64,
 }
 
 /// Ephemeral state for the keyboard-accessible right-click context menu.
@@ -12030,9 +12032,10 @@ impl AppState {
     /// `recent` MUST be newest-first (as [`Store::recent_since`] returns
     /// it). The marker is the kind implied by the newest user-facing
     /// event for this session's `(cwd, agent)` whose `ts` is strictly
-    /// newer than `baseline_ms` — unless the agent is currently
-    /// `generating` (suppressed; the `●` busy dot covers it) or the only
-    /// match is a terminal lifecycle event. Returns `None`
+    /// newer than `baseline_ms`, unless the only match is a terminal lifecycle
+    /// event. A hook notification is explicit evidence and is deliberately
+    /// not suppressed by tmux discovery's coarse `generating` observation.
+    /// Returns `None`
     /// (blank — no marker) when nothing qualifies, which is the common
     /// case for an idle session with no pending hook event.
     /// The one-line message a hook payload carried, if it carried one.
@@ -12121,13 +12124,16 @@ impl AppState {
         cwd_fallback_requires_unidentified_id: bool,
         generating: bool,
         baseline_ms: i64,
-        now_ms: i64,
+        _now_ms: i64,
         recent: &[ainb_plugin_notifyd::NotificationRecord],
     ) -> Option<SessionAttention> {
         use ainb_plugin_notifyd::{AlertKind, classify_attention};
-        if generating {
-            return None;
-        }
+        // A hook notification is explicit evidence, not the old quiet-pane
+        // heuristic. In particular, a session can retain its tmux process
+        // while Claude is blocked at an idle/permission prompt. Suppressing
+        // that WAIT because discovery initially called the process `Running`
+        // made every attachable quiet session look like active work.
+        let _ = generating;
         let agent = agent?;
         let cwd = session_cwd.trim_end_matches('/');
 
@@ -12238,6 +12244,7 @@ impl AppState {
             baseline_ms,
             recent,
         )
+        .map(|(status, _)| status)
     }
 
     /// Identity-safe terminal lifecycle lookup; mirrors attention lookup.
@@ -12249,7 +12256,7 @@ impl AppState {
         cwd_fallback_requires_unidentified_id: bool,
         baseline_ms: i64,
         recent: &[ainb_plugin_notifyd::NotificationRecord],
-    ) -> Option<crate::models::SessionStatus> {
+    ) -> Option<(crate::models::SessionStatus, i64)> {
         let agent = agent?;
         let cwd = session_cwd.trim_end_matches('/');
         let newest = recent.iter().find(|record| {
@@ -12265,9 +12272,9 @@ impl AppState {
             )
         })?;
         match newest.raw_event.as_str() {
-            "SessionEnd" => Some(crate::models::SessionStatus::Stopped),
+            "SessionEnd" => Some((crate::models::SessionStatus::Stopped, newest.ts)),
             "Stop" | "agentStop" | "agent-turn-complete" | "task_complete" => {
-                Some(crate::models::SessionStatus::Idle)
+                Some((crate::models::SessionStatus::Idle, newest.ts))
             }
             _ => None,
         }
@@ -12657,6 +12664,7 @@ impl AppState {
                 provider_session_id,
                 lifecycle: (row.lifecycle != ainb_hangar_proto::fleet::LifecycleState::Unknown)
                     .then_some(row.lifecycle),
+                lifecycle_updated_at: row.lifecycle_updated_at,
             })
     }
 
@@ -12686,17 +12694,20 @@ impl AppState {
             || matches!(projected, crate::models::SessionStatus::Stopped)
     }
 
-    /// A local `SessionEnd` is a terminal fact. Fleet can briefly retain an
-    /// older live lifecycle after the pane is gone, so let only this explicit
-    /// local stop beat Fleet's otherwise-preferred lifecycle projection.
+    /// A hook is the session's own latest lifecycle fact. Fleet is useful when
+    /// hooks have not observed the session, but must not turn a just-stopped
+    /// agent back into `RUN`: a live tmux server is attachability, not work.
     fn projected_session_status(
-        fleet: Option<crate::models::SessionStatus>,
-        local: Option<crate::models::SessionStatus>,
+        fleet: Option<(crate::models::SessionStatus, i64)>,
+        local: Option<(crate::models::SessionStatus, i64)>,
     ) -> Option<crate::models::SessionStatus> {
-        if matches!(local, Some(crate::models::SessionStatus::Stopped)) {
-            local
-        } else {
-            fleet.or(local)
+        match (fleet, local) {
+            (Some((fleet, fleet_at)), Some((local, local_at))) => {
+                Some(if local_at >= fleet_at { local } else { fleet })
+            }
+            (Some((fleet, _)), None) => Some(fleet),
+            (None, Some((local, _))) => Some(local),
+            (None, None) => None,
         }
     }
 
@@ -12815,17 +12826,19 @@ impl AppState {
                 let fleet_status = daemon
                     .reachable
                     .then(|| {
-                        fleet_metadata
-                            .get(&s.id)
-                            .and_then(|metadata| metadata.lifecycle)
-                            .and_then(Self::session_status_for_fleet_lifecycle)
+                        fleet_metadata.get(&s.id).and_then(|metadata| {
+                            metadata
+                                .lifecycle
+                                .and_then(Self::session_status_for_fleet_lifecycle)
+                                .map(|status| (status, metadata.lifecycle_updated_at))
+                        })
                     })
                     .flatten();
                 // Persisted identity is authoritative. Older local rows have
                 // none, so use only the Fleet ID that `fleet_metadata_for`
                 // correlated exactly by its persisted provider id. Never infer
                 // an id from tmux or cwd.
-                let provider_session_id = s.provider_session_id.clone().or_else(|| {
+                let known_provider_session_id = s.provider_session_id.clone().or_else(|| {
                     fleet_metadata
                         .get(&s.id)
                         .and_then(|metadata| metadata.provider_session_id.clone())
@@ -12834,6 +12847,7 @@ impl AppState {
                     .get(&s.workspace_path.trim_end_matches('/').to_string())
                     .copied()
                     == Some(1);
+                let provider_session_id = known_provider_session_id;
                 let local_terminal_status = Self::local_terminal_status_for_session_identity(
                     &s.workspace_path,
                     Self::agent_hook_name(s.agent_type),

--- a/ainb-tui/crates/ainb-core/src/app/state_tests.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state_tests.rs
@@ -2476,8 +2476,8 @@ mod tests {
         ));
 
         let projected = AppState::projected_session_status(
-            Some(SessionStatus::Idle),
-            Some(SessionStatus::Stopped),
+            Some((SessionStatus::Idle, 100)),
+            Some((SessionStatus::Stopped, 200)),
         );
         assert_eq!(projected, Some(SessionStatus::Stopped));
 
@@ -2492,12 +2492,41 @@ mod tests {
     }
 
     #[test]
-    fn attention_suppressed_while_generating() {
+    fn fresh_local_hook_beats_stale_fleet_lifecycle() {
+        use crate::models::SessionStatus;
+
+        assert_eq!(
+            AppState::projected_session_status(
+                Some((SessionStatus::Running, 1_000)),
+                Some((SessionStatus::Idle, 2_000)),
+            ),
+            Some(SessionStatus::Idle),
+            "a Stop hook must not be repainted RUN by a retained Fleet row"
+        );
+    }
+
+    #[test]
+    fn fresh_fleet_lifecycle_beats_an_older_local_hook() {
+        use crate::models::SessionStatus;
+
+        assert_eq!(
+            AppState::projected_session_status(
+                Some((SessionStatus::Running, 2_000)),
+                Some((SessionStatus::Idle, 1_000)),
+            ),
+            Some(SessionStatus::Running),
+            "a new Fleet observation may replace an older terminal hook"
+        );
+    }
+
+    #[test]
+    fn attention_survives_tmux_generating_observation() {
+        use crate::fleet::attention::AttentionKind;
         let recent = vec![rec("claude", CWD, "PermissionRequest", NOW - 1000)];
         assert_eq!(
             kind_of(CWD, Some("claude"), true, 0, NOW, &recent),
-            None,
-            "a generating session shows the busy dot, not an attention chip",
+            Some(AttentionKind::Approve),
+            "an explicit hook prompt beats tmux discovery's coarse busy observation",
         );
     }
 
@@ -2602,6 +2631,28 @@ mod tests {
             )
             .map(|chip| chip.kind),
             Some(AttentionKind::Wait)
+        );
+    }
+
+    #[test]
+    fn unidentified_codex_hook_never_binds_by_cwd() {
+        let mut event = rec("codex", CWD, "PermissionRequest", NOW - 100);
+        event.session_id = "unbound-codex-thread".into();
+        assert_eq!(
+            AppState::attention_for_session_identity(
+                CWD,
+                Some("codex"),
+                None,
+                true,
+                true,
+                false,
+                0,
+                NOW,
+                &[event],
+            )
+            .map(|chip| chip.kind),
+            None,
+            "a legacy row without an exact thread id stays unknown, never guessed by cwd"
         );
     }
 

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -670,8 +670,8 @@ impl SessionListComponent {
                     // Tree line characters with subdued color
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };
 
-                    let status_indicator = session.status.indicator();
                     let lifecycle_label = session_lifecycle_label(state, session);
+                    let status_indicator = session_lifecycle_indicator(lifecycle_label);
 
                     // Git changes (controlled by show_git_status config)
                     let changes_text = if state.app_config.ui_preferences.show_git_status
@@ -682,19 +682,12 @@ impl SessionListComponent {
                         String::new()
                     };
 
-                    // Session state drives the row colour so active vs stopped
-                    // reads at a glance: running = green, idle = soft white,
-                    // stopped = muted grey, error = red. The selected row is
-                    // always green (reinforced by the ▶ arrow + highlight bar).
+                    // Agent state drives the row colour. A discoverable tmux
+                    // shell alone is `LIVE` (muted), never green `RUN`.
                     let state_color = if is_selected_session {
                         SELECTION_GREEN
                     } else {
-                        match session.status {
-                            SessionStatus::Running => SELECTION_GREEN,
-                            SessionStatus::Idle => SOFT_WHITE,
-                            SessionStatus::Stopped => MUTED_GRAY,
-                            SessionStatus::Error(_) => Color::Rgb(230, 100, 100),
-                        }
+                        session_lifecycle_color(lifecycle_label)
                     };
                     let branch_color = state_color;
                     let agent_icon = session.agent_type.icon();
@@ -710,10 +703,36 @@ impl SessionListComponent {
 
                     // The row's live attention chips, already in precedence
                     // order (ASK, WAIT, APPROVE, ERR, DONE). Recomputed each refresh
-                    // from the hook events and the session's own status; empty
-                    // while the agent is generating, because nothing is waiting
-                    // on a human then.
+                    // from hook events and status. Explicit hook evidence beats
+                    // tmux discovery's coarse "process exists" observation.
                     let session_alert = session.live_attention.as_slice();
+                    // The sending state belongs to the full chip list: the
+                    // primary chip moves into the lifecycle cell below, but
+                    // must still read `SENT` until its answer is delivered.
+                    let sending =
+                        session_alert.iter().find(|chip| state.ask_state.is_sending(chip));
+                    let primary_chip =
+                        session_alert.first().filter(|chip| chip.kind.label() == lifecycle_label);
+                    // A primary attention state replaces the lifecycle word,
+                    // but retains its age in that one gutter cell. `ASK 40s`
+                    // is readable at a glance; dropping the chip entirely
+                    // would turn it into the unhelpful bare `ASK`.
+                    let lifecycle_display = primary_chip
+                        .map(|chip| {
+                            format!(
+                                "{} {}",
+                                chip_label(chip, sending),
+                                format_age(now_ms, chip.since_ms)
+                            )
+                        })
+                        .unwrap_or_else(|| lifecycle_label.to_string());
+                    // The primary attention state is the right-hand status
+                    // itself. Do not render `WAIT  WAIT 3m`; retain any
+                    // secondary state (for example `ASK  APPROVE`) after it.
+                    let gutter_alert = primary_chip
+                        .is_some()
+                        .then(|| &session_alert[1..])
+                        .unwrap_or(session_alert);
 
                     // Line one contains only stable session identity. Status lives
                     // in a fixed right gutter so it is readable as a column while
@@ -750,14 +769,20 @@ impl SessionListComponent {
                     // session cannot render every other session's chip as
                     // SENT, and this one keeps reading SENT after the operator
                     // has navigated to a different question.
-                    let sending =
-                        session_alert.iter().find(|chip| state.ask_state.is_sending(chip));
                     push_status_gutter(
                         &mut title_spans,
                         status_indicator,
-                        lifecycle_label,
-                        Style::default().fg(state_color),
-                        session_alert,
+                        &lifecycle_display,
+                        Style::default().fg(
+                            if primary_chip.is_some_and(|chip| {
+                                sending.is_some_and(|target| std::ptr::eq(target, chip))
+                            }) {
+                                GOLD
+                            } else {
+                                session_lifecycle_color(lifecycle_label)
+                            },
+                        ),
+                        gutter_alert,
                         now_ms,
                         row_width,
                         name_span_index,
@@ -1212,10 +1237,22 @@ fn session_collision_id(session: &Session, has_collision: bool) -> Option<String
     has_collision.then(|| format!("#{}", &session.id.to_string()[..8]))
 }
 
-/// Compact process/turn lifecycle word for the sidebar. Fleet's completed-turn
-/// observation is more precise than local `SessionStatus::Idle`, so it gets a
-/// dedicated `DONE` label rather than being collapsed into normal idle.
+/// Compact agent-state word for the sidebar.
+///
+/// `SessionStatus::Running` is seeded from tmux discovery, so it means only
+/// that a pane was found. Never paint that as `RUN`: an attachable shell may be
+/// quiet, waiting, or already complete. Explicit hook attention wins, then an
+/// authoritative Fleet lifecycle; a live pane with neither is honestly `LIVE`.
 fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
+    // A stopped session has no attachable pane. It must never retain an old
+    // chip in its right gutter while refresh is catching up.
+    if matches!(session.status, SessionStatus::Stopped) {
+        return "STOP";
+    }
+    if let Some(chip) = session.live_attention.first() {
+        return chip.kind.label();
+    }
+
     if matches!(session.status, SessionStatus::Idle)
         && matches!(
             state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
@@ -1228,10 +1265,49 @@ fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str 
     }
 
     match session.status {
-        SessionStatus::Running => "RUN",
+        SessionStatus::Running => {
+            let fleet_is_live =
+                state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false);
+            match fleet_is_live
+                .then(|| {
+                    state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle)
+                })
+                .flatten()
+            {
+                Some(
+                    ainb_hangar_proto::fleet::LifecycleState::Starting
+                    | ainb_hangar_proto::fleet::LifecycleState::Running,
+                ) => "RUN",
+                _ => "LIVE",
+            }
+        }
         SessionStatus::Idle => "IDLE",
         SessionStatus::Stopped => "STOP",
         SessionStatus::Error(_) => "ERR",
+    }
+}
+
+/// One-cell marker for the sidebar's agent state. This is deliberately derived
+/// from the displayed state rather than `SessionStatus::indicator()`: the
+/// latter reports tmux discovery and would paint a green busy dot next to WAIT.
+fn session_lifecycle_indicator(label: &str) -> &'static str {
+    match label {
+        "RUN" => "●",
+        "ERR" => "✗",
+        "STOP" => "\u{ead1}",
+        _ => "○",
+    }
+}
+
+/// Agent-state colour shared by the title and right-hand status word.
+fn session_lifecycle_color(label: &str) -> Color {
+    match label {
+        "RUN" | "DONE" => SELECTION_GREEN,
+        "ASK" | "APPROVE" | "ERR" => ALERT_PERMISSION_RED,
+        "WAIT" => ALERT_WAITING_AMBER,
+        "LIVE" | "STOP" => MUTED_GRAY,
+        "IDLE" => SOFT_WHITE,
+        _ => MUTED_GRAY,
     }
 }
 
@@ -1517,12 +1593,38 @@ mod tests {
     }
 
     #[test]
+    fn selected_ask_keeps_its_red_status_gutter() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut state = chip_state();
+        let mut terminal = Terminal::new(TestBackend::new(100, 16)).expect("terminal");
+        let mut list = SessionListComponent::new();
+        terminal
+            .draw(|frame| list.render(frame, frame.area(), &mut state))
+            .expect("draw sessions panel");
+        let buffer = terminal.backend().buffer();
+        let ask = (0..buffer.area.height).find_map(|y| {
+            (0..buffer.area.width.saturating_sub(2)).find_map(|x| {
+                (buffer[(x, y)].symbol() == "A"
+                    && buffer[(x + 1, y)].symbol() == "S"
+                    && buffer[(x + 2, y)].symbol() == "K")
+                    .then_some((x, y))
+            })
+        });
+        let (x, y) = ask.expect("selected ASK is painted");
+        assert_eq!(buffer[(x, y)].fg, ALERT_PERMISSION_RED);
+    }
+
+    #[test]
     fn sidebar_shows_lifecycle_words_separate_from_attention() {
         let mut state = chip_state();
         state.workspaces[0].sessions[0].status = SessionStatus::Running;
         state.workspaces[0].sessions[1].status = SessionStatus::Idle;
         state.workspaces[0].sessions[2].status = SessionStatus::Stopped;
         state.workspaces[0].sessions[3].status = SessionStatus::Error("lost transport".into());
+        for session in &mut state.workspaces[0].sessions {
+            session.live_attention.clear();
+        }
         assert_eq!(
             session_lifecycle_label(&state, &state.workspaces[0].sessions[2]),
             "STOP"
@@ -1530,7 +1632,7 @@ mod tests {
 
         let rendered = render_panel(&mut state, 140, 16);
         for (name, lifecycle) in [
-            ("ainb/acp-chat", "RUN"),
+            ("ainb/acp-chat", "LIVE"),
             ("ainb/disk-clean", "IDLE"),
             ("ainb/site-build", "ERR"),
             ("ainb/quiet", "IDLE"),
@@ -1541,6 +1643,34 @@ mod tests {
                 .unwrap_or_else(|| panic!("{name} session row renders: {rendered}"));
             assert!(row.contains(lifecycle), "{name} shows {lifecycle}: {row}");
         }
+    }
+
+    #[test]
+    fn sidebar_only_calls_a_session_run_with_authoritative_work_evidence() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.workspaces[0].sessions[0].status = SessionStatus::Running;
+
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            "LIVE",
+            "tmux discovery alone is only attachability"
+        );
+
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::Running),
+                ..Default::default()
+            },
+        );
+        state.daemon_attention.lock().unwrap().reachable = true;
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            "RUN",
+            "authoritative Fleet active-work lifecycle permits RUN"
+        );
     }
 
     #[test]
@@ -1592,10 +1722,7 @@ mod tests {
             .lines()
             .find(|line| line.contains("ainb/acp-chat"))
             .expect("ask session row");
-        assert!(
-            ask_row.contains("IDLE") && ask_row.contains("ASK"),
-            "{ask_row}"
-        );
+        assert!(ask_row.contains("ASK"), "{ask_row}");
         assert!(!ask_row.contains("DONE"), "{ask_row}");
 
         // A retained snapshot cannot drive lifecycle after daemon reachability
@@ -1761,9 +1888,10 @@ mod tests {
     }
 
     /// Chip words are never abbreviated, at any width the panel can be dragged
-    /// to. The session NAME is what gives way.
+    /// to. Removing duplicated lifecycle text keeps ordinary session names
+    /// readable at the narrow default width.
     #[test]
-    fn chip_words_survive_a_width_the_name_does_not() {
+    fn chip_words_and_names_survive_the_narrow_default_width() {
         let mut state = chip_state();
         let rendered = render_panel(&mut state, 42, 16);
         for word in ["ASK 40s", "ERR 9m", "APPROVE 3m", "DONE 1m"] {
@@ -1773,8 +1901,8 @@ mod tests {
             );
         }
         assert!(
-            rendered.contains('\u{2026}'),
-            "the session name is what truncates instead: {rendered}"
+            rendered.contains("ainb/api-stats"),
+            "name stays whole: {rendered}"
         );
     }
 
@@ -1960,6 +2088,7 @@ mod tests {
         let mut state = AppState::new();
         state.workspaces.clear();
         state.expand_all_workspaces = true;
+        state.session_filter = SessionFilter::All;
 
         let mut workspace = Workspace::new("ws".to_string(), "/tmp/ws".into());
         let mut first = Session::new("first".to_string(), "/tmp/ws/first".to_string());

--- a/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_tabs.rs
@@ -2070,6 +2070,7 @@ mod tests {
                 direct_child_count: 2,
                 provider_session_id: None,
                 lifecycle: None,
+                lifecycle_updated_at: 0,
             },
         );
         let rendered = footer_text(&state, SessionTab::Preview, false);

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1494
+assertion_line: 1830
 expression: "render_panel(&mut state, 100, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                                       │
-│▶ 1 ☐ ├─ ainb/acp-chat                                                            ○ IDLE  ASK 40s │
+│▶ 1 ☐ ├─ ainb/acp-chat                                                                  ○ ASK 40s │
 │         ✻                                                                                        │
-│  2 ☐ ├─ ainb/disk-clean                                                           ○ IDLE  ERR 9m │
+│  2 ☐ ├─ ainb/disk-clean                                                                 ✗ ERR 9m │
 │         ✻                                                                                        │
-│  3 ☐ ├─ ainb/api-stats                                                        ○ IDLE  APPROVE 3m │
+│  3 ☐ ├─ ainb/api-stats                                                              ○ APPROVE 3m │
 │         ✻                                                                                        │
-│  4 ☐ ├─ ainb/site-build                                                          ○ IDLE  DONE 1m │
+│  4 ☐ ├─ ainb/site-build                                                                ○ DONE 1m │
 │         ✻                                                                                        │
 │  5 ☐ └─ ainb/quiet                                                                        ○ IDLE │
 │         ✻                                                                                        │

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1500
+assertion_line: 1836
 expression: "render_panel(&mut state, 80, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                   │
-│▶ 1 ☐ ├─ ainb/acp-chat                                        ○ IDLE  ASK 40s │
+│▶ 1 ☐ ├─ ainb/acp-chat                                              ○ ASK 40s │
 │         ✻                                                                    │
-│  2 ☐ ├─ ainb/disk-clean                                       ○ IDLE  ERR 9m │
+│  2 ☐ ├─ ainb/disk-clean                                             ✗ ERR 9m │
 │         ✻                                                                    │
-│  3 ☐ ├─ ainb/api-stats                                    ○ IDLE  APPROVE 3m │
+│  3 ☐ ├─ ainb/api-stats                                          ○ APPROVE 3m │
 │         ✻                                                                    │
-│  4 ☐ ├─ ainb/site-build                                      ○ IDLE  DONE 1m │
+│  4 ☐ ├─ ainb/site-build                                            ○ DONE 1m │
 │         ✻                                                                    │
 │  5 ☐ └─ ainb/quiet                                                    ○ IDLE │
 │         ✻                                                                    │

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1508
+assertion_line: 1844
 expression: "render_panel(&mut state, 42, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ───────────╮
 │    ▼  agents-in-a-box (5)             │
-│▶ 1 ☐ ├─ ainb/acp-chat  ○ IDLE  ASK 40s │
+│▶ 1 ☐ ├─ ainb/acp-chat        ○ ASK 40s │
 │         ✻                              │
-│  2 ☐ ├─ ainb/disk-clean ○ IDLE  ERR 9m │
+│  2 ☐ ├─ ainb/disk-clean       ✗ ERR 9m │
 │         ✻                              │
-│  3 ☐ ├─ ainb/api-st…○ IDLE  APPROVE 3m │
+│  3 ☐ ├─ ainb/api-stats    ○ APPROVE 3m │
 │         ✻                              │
-│  4 ☐ ├─ ainb/site-build○ IDLE  DONE 1m │
+│  4 ☐ ├─ ainb/site-build      ○ DONE 1m │
 │         ✻                              │
 │  5 ☐ └─ ainb/quiet              ○ IDLE │
 │         ✻                              │

--- a/ainb-tui/crates/ainb-core/src/models/session.rs
+++ b/ainb-tui/crates/ainb-core/src/models/session.rs
@@ -657,8 +657,9 @@ pub struct Session {
     ///
     /// A row can carry MORE THAN ONE: an ASK arriving while an ERR is still
     /// open shows both, and only the ASK is counted in the header badge (see
-    /// [`crate::fleet::attention::needs_you_count`]). Empty while the agent is
-    /// actively generating — nothing is waiting on a human then.
+    /// [`crate::fleet::attention::needs_you_count`]). Explicit hook evidence
+    /// remains visible even while tmux discovery sees a live process;
+    /// `Running` there means attachability, not proof of work.
     ///
     /// Transient — never persisted; set in `AppState::refresh_attention_markers`.
     #[serde(skip)]


### PR DESCRIPTION
## Summary
- show RUN only from live authoritative work evidence
- retain hook attention over stale tmux discovery
- use fresh lifecycle timestamps and exact Codex identity only
- keep sidebar status gutter readable and truthful

## Validation
- cargo test --lib session_list::tests
- cargo test --test behavioral tmux_lifecycle
- cargo check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session statuses now reflect the most recent lifecycle information from local activity and Fleet observations.
  * Attention prompts remain visible while a session is actively generating.
  * Session list indicators and colors now more clearly distinguish running, live, idle, stopped, completed, errored, and attention states.
  * Running sessions display a definitive running state only when supported by authoritative, reachable lifecycle information.
  * Primary attention states now take priority in the status area while preserving additional session indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->