### PR TITLE
docs(plans): lane rows after #933 and #936 merged and #935 sent back

### DIFF
--- a/docs/plans/2026-09-12-desktop-programme.md
+++ b/docs/plans/2026-09-12-desktop-programme.md
@@ -147,9 +147,9 @@ One Orca worktree per lane, one `claude` agent each, goal prompt from `docs/plan
 
 | lane | goal | env | branch | agent handle |
 |---|---|---|---|---|
-| A | `2026-09-12-p0-closure.md`: slice-1 gates green (#925), waves 2-4, G6 handed over | claude-hetzner | `stevengonsalvez/p0-closure` PR #933 (nit fixed, checks running), `stevengonsalvez/s-c-card-retirement` PR #936 (sent back a second time, two majors in the retired-id map) | `term_f52c61ee-95c2-4878-beb8-aaf8b8de6abd` |
-| B | `2026-09-12-w0-wire.md`: protocol version, capabilities, skew harness, op-id ledger | claude-gcp | `stevengonsalvez/w0-wire`, draft PR #935 | `term_b78264e2-f6ba-4492-9391-333275ef7b16` (the original session; it had not died, the runtime reissued handles, and a duplicate relaunch was stood down and closed 2026-09-12) |
-| C | `2026-09-12-status-t0.md`: #916 pane binding, then T0-daemon, plus the three red daemon tests from #925 | claude-gcp | `feat/916-pane-binding`, draft PR #934 | `term_49ad9b50-e253-497d-ad2c-62059f021b16` (the idle original was closed 2026-09-12, this is the only lane C session) |
+| A | `2026-09-12-p0-closure.md`: slice-1 gates green (#925), waves 2-4, G6 handed over | claude-hetzner | `stevengonsalvez/p0-closure` **merged PR #933**, `stevengonsalvez/s-c-card-retirement` **merged PR #936**; Phase 3 and waves 2-4 in progress | `term_f52c61ee-95c2-4878-beb8-aaf8b8de6abd` |
+| B | `2026-09-12-w0-wire.md`: protocol version, capabilities, skew harness, op-id ledger | claude-gcp | `stevengonsalvez/w0-wire`, PR #935 sent back once (receipt-sweep reopen never matches, fence and retention gaps), back in draft | `term_577f77bd-ba69-47b0-9ed7-835aedc56beb` (resumed 2026-09-12 after a runtime restart killed the process) |
+| C | `2026-09-12-status-t0.md`: #916 pane binding, then T0-daemon, plus the three red daemon tests from #925 | claude-gcp | `feat/916-pane-binding`, draft PR #934 (15 commits) | `term_49ad9b50-e253-497d-ad2c-62059f021b16` (the only lane C session) |
 | D | `2026-09-12-spike-2-emulator.md`: control-mode emulator fidelity | claude-hetzner | `stevengonsalvez/spike-2-emulator`, **merged PR #931**, nits follow-up **merged PR #938**, done | closed |
 | E | `2026-09-12-spike-3-peer-ws.md`: peer WS + Noise over tailnet and ssh -L | claude-gcp | `stevengonsalvez/spike-3-peer-ws`, **merged PR #930, done** | closed |
 


### PR DESCRIPTION
Lane rows only.