### PR TITLE
fix: expire stale sidebar run state

### DIFF
--- a/ainb-tui/crates/ainb-core/src/app/events.rs
+++ b/ainb-tui/crates/ainb-core/src/app/events.rs
@@ -211,15 +211,16 @@ pub enum AppEvent {
     GitReviewExpandAllFolders, // e — expand all folders
     GitReviewCollapseAllFolders, // E — collapse all folders
     // Tmux integration events
-    AttachTmuxSession,    // Attach to tmux session (full-screen)
-    EnterInteractivePane, // Attach in-place: interactive embedded tmux pane
-    DetachTmuxSession,    // Detach from tmux session
-    EnterScrollMode,      // Enter scroll mode in tmux preview
-    ExitScrollMode,       // Exit scroll mode in tmux preview
-    ScrollPreviewUp,      // Scroll tmux preview up
-    ScrollPreviewDown,    // Scroll tmux preview down
-    ToggleExpandAll,      // Toggle expand/collapse all workspaces
-    ToggleSessionMenuBar, // Hide/show the Sessions bottom keymap legend (⇧M)
+    AttachTmuxSession,     // Attach to tmux session (full-screen)
+    EnterInteractivePane,  // Attach in-place: interactive embedded tmux pane
+    DetachTmuxSession,     // Detach from tmux session
+    EnterScrollMode,       // Enter scroll mode in tmux preview
+    ExitScrollMode,        // Exit scroll mode in tmux preview
+    ScrollPreviewUp,       // Scroll tmux preview up
+    ScrollPreviewDown,     // Scroll tmux preview down
+    ToggleExpandAll,       // Toggle expand/collapse all workspaces
+    ToggleSessionMenuBar,  // Hide/show the Sessions bottom keymap legend (⇧M)
+    ToggleSessionMetadata, // Toggle compact model/effort titles (v)
     // Other tmux rename events
     OtherTmuxStartRename, // Start rename mode for selected "Other tmux" session
     OtherTmuxRenameChar(char), // Character input for rename
@@ -2531,6 +2532,9 @@ impl EventHandler {
             KeyCode::Char('B') => Some(AppEvent::ToggleSessionsSidebar),
             // Hide/show the bottom keymap legend to reclaim vertical space.
             KeyCode::Char('M') => Some(AppEvent::ToggleSessionMenuBar),
+            // `m` and ⇧M are occupied. A persistent toggle works in terminals
+            // that cannot report a held key's release event.
+            KeyCode::Char('v') => Some(AppEvent::ToggleSessionMetadata),
             // Panel screens mirror their home-menu letters here so every
             // panel opens from the session list too (i stats, w witr,
             // k skills, m memory, t abtop — same set
@@ -3874,6 +3878,7 @@ impl EventHandler {
             AppEvent::ToggleClaudeChat => state.toggle_claude_chat(),
             AppEvent::ToggleExpandAll => state.toggle_expand_all_workspaces(),
             AppEvent::ToggleSessionMenuBar => state.toggle_session_menu_bar(),
+            AppEvent::ToggleSessionMetadata => state.toggle_session_metadata(),
             AppEvent::ToggleSessionsSidebar => {
                 // Same path the [-]/[+] mouse glyph takes: flip + persist the
                 // preference so the choice survives restarts.
@@ -9149,6 +9154,18 @@ mod panel_back_tests {
             matches!(evt, AppEvent::GoToLearnings),
             "`m` must map to GoToLearnings, got {evt:?}"
         );
+    }
+
+    #[test]
+    fn session_list_v_key_toggles_compact_model_metadata() {
+        let mut state = AppState::default();
+        state.current_screen = ids::SESSION_LIST.to_string();
+        let key = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE);
+        let event = EventHandler::handle_key_event(key, &mut state)
+            .expect("v on the session list dispatches metadata toggle");
+        assert!(matches!(event, AppEvent::ToggleSessionMetadata));
+        EventHandler::process_event(event, &mut state);
+        assert!(state.show_session_metadata);
     }
 
     /// Activating the Memory tile on the home sidebar (Enter) must open the

--- a/ainb-tui/crates/ainb-core/src/app/state.rs
+++ b/ainb-tui/crates/ainb-core/src/app/state.rs
@@ -66,7 +66,8 @@ pub enum SessionContextAction {
 /// Fleet-only metadata for one local session row.
 ///
 /// Absent fields mean Hangar has never observed them. The UI must omit those
-/// fields, never replace them with a guessed provider default.
+/// fields, never replace them with a guessed provider default. The Session
+/// List can temporarily use model/effort as its one-line title.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SessionFleetMetadata {
     pub model: Option<String>,
@@ -3385,6 +3386,8 @@ pub struct AppState {
     pub selected_sessions: HashSet<Uuid>, // Multi-selected session IDs for bulk operations
     pub expand_all_workspaces: bool, // When true, show all sessions across all workspaces
     pub session_filter: SessionFilter, // View filter for Interactive sessions (Shift+F to cycle)
+    /// Session List alternate title mode; never persisted across TUI launches.
+    pub show_session_metadata: bool,
     pub current_screen: ScreenId,
     pub should_quit: bool,
     pub logs: HashMap<Uuid, Vec<String>>,
@@ -4177,6 +4180,7 @@ impl Default for AppState {
             selected_sessions: HashSet::new(),
             expand_all_workspaces: true, // Default to expanded view
             session_filter: app_config.ui_preferences.session_filter,
+            show_session_metadata: false,
             current_screen: screen_ids::HOME.to_string(),
             should_quit: false,
             logs: HashMap::new(),
@@ -7166,6 +7170,11 @@ impl AppState {
 
     pub fn toggle_expand_all_workspaces(&mut self) {
         self.expand_all_workspaces = !self.expand_all_workspaces;
+    }
+
+    /// Toggle compact model/effort titles for this TUI process only.
+    pub fn toggle_session_metadata(&mut self) {
+        self.show_session_metadata = !self.show_session_metadata;
     }
 
     /// Hide/show the Sessions bottom keymap legend (⇧M) and persist the choice.
@@ -12682,6 +12691,19 @@ impl AppState {
         }
     }
 
+    /// A daemon heartbeat proves transport only. Lifecycle remains authoritative
+    /// only while its own transition evidence is fresh. `0` is an explicit
+    /// no-expiry override for operators who require it.
+    pub(crate) fn fleet_lifecycle_is_fresh_at(
+        lifecycle_updated_at: i64,
+        now_ms: i64,
+        stale_after_ms: i64,
+    ) -> bool {
+        stale_after_ms == 0
+            || (lifecycle_updated_at > 0
+                && now_ms.saturating_sub(lifecycle_updated_at) <= stale_after_ms)
+    }
+
     /// A local stopped observation means its tmux session is gone. A retained
     /// Fleet `IDLE` row only means its last observed pane was quiet, so it must
     /// not resurrect a stopped session into the Active filter. Fleet may still
@@ -12827,10 +12849,18 @@ impl AppState {
                     .reachable
                     .then(|| {
                         fleet_metadata.get(&s.id).and_then(|metadata| {
-                            metadata
-                                .lifecycle
-                                .and_then(Self::session_status_for_fleet_lifecycle)
-                                .map(|status| (status, metadata.lifecycle_updated_at))
+                            Self::fleet_lifecycle_is_fresh_at(
+                                metadata.lifecycle_updated_at,
+                                now_ms,
+                                self.app_config.fleet.healthy_state_stale_ms,
+                            )
+                            .then(|| {
+                                metadata
+                                    .lifecycle
+                                    .and_then(Self::session_status_for_fleet_lifecycle)
+                                    .map(|status| (status, metadata.lifecycle_updated_at))
+                            })
+                            .flatten()
                         })
                     })
                     .flatten();

--- a/ainb-tui/crates/ainb-core/src/components/layout.rs
+++ b/ainb-tui/crates/ainb-core/src/components/layout.rs
@@ -799,6 +799,8 @@ impl LayoutComponent {
             desc(" refresh "),
             key("⇧F", WARNING_ORANGE),
             desc(" filter "),
+            key("v", CORNFLOWER_BLUE),
+            desc(" model "),
             sep(),
             key("u", MUTED_GRAY),
             desc(" re-auth "),
@@ -903,6 +905,8 @@ impl LayoutComponent {
                 desc(" filter  "),
                 key("u", MUTED_GRAY),
                 desc(" re-auth  "),
+                key("v", CORNFLOWER_BLUE),
+                desc(" model "),
             ]),
         ];
 

--- a/ainb-tui/crates/ainb-core/src/components/session_list.rs
+++ b/ainb-tui/crates/ainb-core/src/components/session_list.rs
@@ -14,6 +14,7 @@ use unicode_width::UnicodeWidthChar;
 const CORNFLOWER_BLUE: Color = Color::Rgb(100, 149, 237);
 const GOLD: Color = Color::Rgb(255, 215, 0);
 const SELECTION_GREEN: Color = Color::Rgb(100, 200, 100);
+const PROGRESS_CYAN: Color = Color::Rgb(100, 200, 230);
 const WARNING_ORANGE: Color = Color::Rgb(255, 165, 0);
 const DARK_BG: Color = Color::Rgb(25, 25, 35);
 const LIST_HIGHLIGHT_BG: Color = Color::Rgb(40, 40, 60);
@@ -29,7 +30,7 @@ const ALERT_WAITING_AMBER: Color = Color::Rgb(230, 180, 80);
 const ALERT_PERMISSION_RED: Color = Color::Rgb(220, 90, 90);
 const ALERT_ERROR_RED: Color = Color::Rgb(230, 100, 100);
 
-// Per-agent brand colours for the compact provider icon on the metadata line.
+// Per-agent brand colours for session metadata elsewhere in this component.
 const BRAND_CLAUDE: Color = Color::Rgb(217, 119, 87); // Anthropic clay-orange
 const BRAND_CODEX: Color = Color::Rgb(236, 236, 241); // OpenAI near-white
 const BRAND_COPILOT: Color = Color::Rgb(46, 160, 67); // GitHub green
@@ -670,7 +671,7 @@ impl SessionListComponent {
                     // Tree line characters with subdued color
                     let tree_prefix = if is_last_session { "└─" } else { "├─" };
 
-                    let lifecycle_label = session_lifecycle_label(state, session);
+                    let lifecycle_label = session_lifecycle_label(state, session, now_ms);
                     let status_indicator = session_lifecycle_indicator(lifecycle_label);
 
                     // Git changes (controlled by show_git_status config)
@@ -690,13 +691,17 @@ impl SessionListComponent {
                         session_lifecycle_color(lifecycle_label)
                     };
                     let branch_color = state_color;
-                    let agent_icon = session.agent_type.icon();
-                    let agent_color = agent_brand_color(&session.agent_type);
                     let is_multi_selected = state.selected_sessions.contains(&session.id);
-                    let title = session_list_name(session);
+                    let normal_title = session_list_name(session);
+                    let title = if state.show_session_metadata {
+                        session_model_effort_label(state, session)
+                            .unwrap_or_else(|| normal_title.clone())
+                    } else {
+                        normal_title.clone()
+                    };
                     let collision_id = session_collision_id(
                         session,
-                        title_counts.get(&title).copied().unwrap_or_default() > 1,
+                        title_counts.get(&normal_title).copied().unwrap_or_default() > 1,
                     );
 
                     let checkbox = ballot_checkbox(is_multi_selected);
@@ -748,20 +753,33 @@ impl SessionListComponent {
                     // than searched, so future reordering cannot silently
                     // truncate a tree or status decoration instead.
                     let name_span_index = title_spans.len();
+                    let title_with_collision = collision_id
+                        .as_ref()
+                        // Identity precedes the lossy title budget so two
+                        // same-branch rows remain distinguishable even when a
+                        // narrow sidebar must protect an attention/status gutter.
+                        .map(|identity| format!("{identity} · {title}"))
+                        .unwrap_or_else(|| title.clone());
                     title_spans.push(Span::styled(
-                        title.clone(),
-                        Style::default().fg(branch_color).add_modifier(if is_selected_session {
-                            Modifier::BOLD
-                        } else {
-                            Modifier::empty()
-                        }),
+                        title_with_collision.clone(),
+                        Style::default()
+                            .fg(if state.show_session_metadata {
+                                METADATA_GRAY
+                            } else {
+                                branch_color
+                            })
+                            .add_modifier(if is_selected_session {
+                                Modifier::BOLD
+                            } else {
+                                Modifier::empty()
+                            }),
                     ));
                     title_spans.push(Span::styled(
                         changes_text,
                         Style::default().fg(WARNING_ORANGE),
                     ));
                     debug_assert_eq!(
-                        title_spans[name_span_index].content, title,
+                        title_spans[name_span_index].content, title_with_collision,
                         "name_span_index must track the session-name span"
                     );
                     // The chip whose answer is still in flight, if it is on
@@ -790,33 +808,7 @@ impl SessionListComponent {
                     );
                     let title_line = Line::from(title_spans);
 
-                    // Keep model/effort visible for every row without making
-                    // identity compete with provider metadata. It is a separate
-                    // line, aligned underneath the title rather than a pill.
-                    let mut metadata_spans = vec![
-                        empty_badge(),
-                        Span::raw("     "),
-                        Span::styled(agent_icon.to_string(), Style::default().fg(agent_color)),
-                    ];
-                    if let Some(identity) = collision_id {
-                        // Metadata has an independent second-line budget. Put
-                        // collision identity first there so a narrow title can
-                        // still yield to the fixed right status/ASK gutter.
-                        metadata_spans.push(Span::raw(" "));
-                        metadata_spans
-                            .push(Span::styled(identity, Style::default().fg(METADATA_GRAY)));
-                    }
-                    if let Some(metadata) = session_model_effort_label(state, session) {
-                        let prefix_width: usize = metadata_spans.iter().map(Span::width).sum();
-                        metadata_spans.push(Span::raw(" · "));
-                        metadata_spans.push(Span::styled(
-                            truncate_text(&metadata, row_width.saturating_sub(prefix_width + 3)),
-                            Style::default().fg(METADATA_GRAY),
-                        ));
-                    }
-                    let metadata_line = Line::from(metadata_spans);
-
-                    items.push(ListItem::new(vec![title_line, metadata_line]));
+                    items.push(ListItem::new(title_line));
                 }
 
                 // Render workspace shell (single shell per workspace)
@@ -1243,7 +1235,7 @@ fn session_collision_id(session: &Session, has_collision: bool) -> Option<String
 /// that a pane was found. Never paint that as `RUN`: an attachable shell may be
 /// quiet, waiting, or already complete. Explicit hook attention wins, then an
 /// authoritative Fleet lifecycle; a live pane with neither is honestly `LIVE`.
-fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str {
+fn session_lifecycle_label(state: &AppState, session: &Session, now_ms: i64) -> &'static str {
     // A stopped session has no attachable pane. It must never retain an old
     // chip in its right gutter while refresh is catching up.
     if matches!(session.status, SessionStatus::Stopped) {
@@ -1253,12 +1245,21 @@ fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str 
         return chip.kind.label();
     }
 
+    let fleet_lifecycle_is_fresh = state.fleet_metadata.get(&session.id).is_some_and(|metadata| {
+        AppState::fleet_lifecycle_is_fresh_at(
+            metadata.lifecycle_updated_at,
+            now_ms,
+            state.app_config.fleet.healthy_state_stale_ms,
+        )
+    });
+
     if matches!(session.status, SessionStatus::Idle)
         && matches!(
             state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle),
             Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete)
         )
         && state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false)
+        && fleet_lifecycle_is_fresh
         && session.live_attention.is_empty()
     {
         return "DONE";
@@ -1268,7 +1269,7 @@ fn session_lifecycle_label(state: &AppState, session: &Session) -> &'static str 
         SessionStatus::Running => {
             let fleet_is_live =
                 state.daemon_attention.lock().map(|daemon| daemon.reachable).unwrap_or(false);
-            match fleet_is_live
+            match (fleet_is_live && fleet_lifecycle_is_fresh)
                 .then(|| {
                     state.fleet_metadata.get(&session.id).and_then(|metadata| metadata.lifecycle)
                 })
@@ -1302,7 +1303,8 @@ fn session_lifecycle_indicator(label: &str) -> &'static str {
 /// Agent-state colour shared by the title and right-hand status word.
 fn session_lifecycle_color(label: &str) -> Color {
     match label {
-        "RUN" | "DONE" => SELECTION_GREEN,
+        "RUN" => SELECTION_GREEN,
+        "DONE" => PROGRESS_CYAN,
         "ASK" | "APPROVE" | "ERR" => ALERT_PERMISSION_RED,
         "WAIT" => ALERT_WAITING_AMBER,
         "LIVE" | "STOP" => MUTED_GRAY,
@@ -1526,7 +1528,7 @@ mod tests {
     }
 
     #[test]
-    fn sidebar_shows_observed_model_and_effort_on_each_session_row() {
+    fn sidebar_toggles_observed_model_and_effort_into_one_line_titles() {
         let mut state = chip_state();
         let first = state.workspaces[0].sessions[0].id;
         let second = state.workspaces[0].sessions[1].id;
@@ -1562,17 +1564,23 @@ mod tests {
             "{second_row}"
         );
         assert!(
-            rendered.contains("gpt-5.6-terra / high"),
-            "first row gets a second-line model/effort label: {rendered}"
+            !rendered.contains("gpt-5.6-terra / high"),
+            "normal mode retains session names: {rendered}"
         );
         assert!(
-            rendered.contains("claude-opus-5 / medium"),
-            "second row gets a second-line model/effort label: {rendered}"
+            !rendered.contains("claude-opus-5 / medium"),
+            "normal mode retains session names: {rendered}"
         );
+
+        state.show_session_metadata = true;
+        let metadata = render_panel(&mut state, 120, 14);
+        assert!(metadata.contains("gpt-5.6-terra / high"), "{metadata}");
+        assert!(metadata.contains("claude-opus-5 / medium"), "{metadata}");
+        assert!(!metadata.contains("ainb/acp-chat"), "{metadata}");
     }
 
     #[test]
-    fn sidebar_keeps_model_effort_on_its_own_line_at_narrow_width() {
+    fn sidebar_metadata_mode_keeps_attention_in_the_fixed_gutter_at_narrow_width() {
         let mut state = chip_state();
         let first = state.workspaces[0].sessions[0].id;
         state.fleet_metadata.insert(
@@ -1584,6 +1592,7 @@ mod tests {
             },
         );
 
+        state.show_session_metadata = true;
         let rendered = render_panel(&mut state, 42, 14);
         assert!(rendered.contains("gpt-5.6-terra / high"), "{rendered}");
         assert!(
@@ -1616,6 +1625,18 @@ mod tests {
     }
 
     #[test]
+    fn lifecycle_gutter_uses_distinct_run_and_done_colours() {
+        assert_eq!(session_lifecycle_color("RUN"), SELECTION_GREEN);
+        assert_eq!(session_lifecycle_color("DONE"), PROGRESS_CYAN);
+        assert_ne!(
+            session_lifecycle_color("RUN"),
+            session_lifecycle_color("DONE")
+        );
+        assert_eq!(session_lifecycle_color("WAIT"), ALERT_WAITING_AMBER);
+        assert_eq!(session_lifecycle_color("ASK"), ALERT_PERMISSION_RED);
+    }
+
+    #[test]
     fn sidebar_shows_lifecycle_words_separate_from_attention() {
         let mut state = chip_state();
         state.workspaces[0].sessions[0].status = SessionStatus::Running;
@@ -1626,7 +1647,7 @@ mod tests {
             session.live_attention.clear();
         }
         assert_eq!(
-            session_lifecycle_label(&state, &state.workspaces[0].sessions[2]),
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[2], CHIP_NOW),
             "STOP"
         );
 
@@ -1653,7 +1674,7 @@ mod tests {
         state.workspaces[0].sessions[0].status = SessionStatus::Running;
 
         assert_eq!(
-            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0], CHIP_NOW),
             "LIVE",
             "tmux discovery alone is only attachability"
         );
@@ -1662,12 +1683,13 @@ mod tests {
             session,
             crate::app::state::SessionFleetMetadata {
                 lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::Running),
+                lifecycle_updated_at: CHIP_NOW,
                 ..Default::default()
             },
         );
         state.daemon_attention.lock().unwrap().reachable = true;
         assert_eq!(
-            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0], CHIP_NOW),
             "RUN",
             "authoritative Fleet active-work lifecycle permits RUN"
         );
@@ -1683,6 +1705,7 @@ mod tests {
             session,
             crate::app::state::SessionFleetMetadata {
                 lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete),
+                lifecycle_updated_at: CHIP_NOW,
                 ..Default::default()
             },
         );
@@ -1739,6 +1762,35 @@ mod tests {
     }
 
     #[test]
+    fn stale_fleet_running_is_live_not_run_and_stale_completion_is_not_done() {
+        let mut state = chip_state();
+        let session = state.workspaces[0].sessions[0].id;
+        state.workspaces[0].sessions[0].live_attention.clear();
+        state.workspaces[0].sessions[0].status = SessionStatus::Running;
+        state.daemon_attention.lock().unwrap().reachable = true;
+        state.fleet_metadata.insert(
+            session,
+            crate::app::state::SessionFleetMetadata {
+                lifecycle: Some(ainb_hangar_proto::fleet::LifecycleState::Running),
+                lifecycle_updated_at: CHIP_NOW - 5 * 60_000 - 1,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0], CHIP_NOW),
+            "LIVE"
+        );
+
+        state.workspaces[0].sessions[0].status = SessionStatus::Idle;
+        state.fleet_metadata.get_mut(&session).unwrap().lifecycle =
+            Some(ainb_hangar_proto::fleet::LifecycleState::TurnComplete);
+        assert_eq!(
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0], CHIP_NOW),
+            "IDLE"
+        );
+    }
+
+    #[test]
     fn retained_fleet_done_never_relabels_a_stopped_session() {
         let mut state = chip_state();
         let session = state.workspaces[0].sessions[0].id;
@@ -1754,13 +1806,13 @@ mod tests {
         );
 
         assert_eq!(
-            session_lifecycle_label(&state, &state.workspaces[0].sessions[0]),
+            session_lifecycle_label(&state, &state.workspaces[0].sessions[0], CHIP_NOW),
             "STOP"
         );
     }
 
     #[test]
-    fn metadata_line_click_targets_its_own_session() {
+    fn single_line_session_click_targets_its_own_session() {
         use ratatui::{Terminal, backend::TestBackend};
 
         let mut state = chip_state();
@@ -1778,15 +1830,22 @@ mod tests {
             session_idx: 0,
         });
         assert_eq!(state.session_list_row_at_mouse(8, 2), Some(first));
-        assert_eq!(state.session_list_row_at_mouse(8, 3), Some(first));
+        assert_eq!(
+            state.session_list_row_at_mouse(8, 3),
+            Some(SessionListRowTarget::Attachable(
+                AttachableRef::WorkspaceSession {
+                    workspace_idx: 0,
+                    session_idx: 1,
+                }
+            ))
+        );
 
-        // When List has scrolled past the one-line workspace header, the two
-        // physical rows of the first session still resolve to the same logical
-        // item before the next session starts.
+        // List row mapping remains one physical row per logical session after
+        // scrolling past the workspace header.
         state.sessions_pane_state.set_list_scroll_offset(1);
         assert_eq!(state.sessions_pane_state.row_index_at(8, 1), Some(1));
-        assert_eq!(state.sessions_pane_state.row_index_at(8, 2), Some(1));
-        assert_eq!(state.sessions_pane_state.row_index_at(8, 3), Some(2));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 2), Some(2));
+        assert_eq!(state.sessions_pane_state.row_index_at(8, 3), Some(3));
     }
 
     #[test]
@@ -2104,7 +2163,7 @@ mod tests {
         workspace.add_session(second);
         state.workspaces.push(workspace);
 
-        let painted = render_panel(&mut state, 24, 8);
+        let painted = render_panel(&mut state, 42, 8);
         assert!(
             painted.contains(&format!("#{first_id}")),
             "painted: {painted}"

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_100_columns.snap
@@ -1,20 +1,19 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1830
 expression: "render_panel(&mut state, 100, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                                       │
 │▶ 1 ☐ ├─ ainb/acp-chat                                                                  ○ ASK 40s │
-│         ✻                                                                                        │
 │  2 ☐ ├─ ainb/disk-clean                                                                 ✗ ERR 9m │
-│         ✻                                                                                        │
 │  3 ☐ ├─ ainb/api-stats                                                              ○ APPROVE 3m │
-│         ✻                                                                                        │
 │  4 ☐ ├─ ainb/site-build                                                                ○ DONE 1m │
-│         ✻                                                                                        │
 │  5 ☐ └─ ainb/quiet                                                                        ○ IDLE │
-│         ✻                                                                                        │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
 │                                                                                                  │
 │                                                                                                  │
 │                                                                                                  │

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_80_columns.snap
@@ -1,20 +1,19 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1836
 expression: "render_panel(&mut state, 80, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ─────────────────────────────────────────────────╮
 │    ▼  agents-in-a-box (5)                                                   │
 │▶ 1 ☐ ├─ ainb/acp-chat                                              ○ ASK 40s │
-│         ✻                                                                    │
 │  2 ☐ ├─ ainb/disk-clean                                             ✗ ERR 9m │
-│         ✻                                                                    │
 │  3 ☐ ├─ ainb/api-stats                                          ○ APPROVE 3m │
-│         ✻                                                                    │
 │  4 ☐ ├─ ainb/site-build                                            ○ DONE 1m │
-│         ✻                                                                    │
 │  5 ☐ └─ ainb/quiet                                                    ○ IDLE │
-│         ✻                                                                    │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
+++ b/ainb-tui/crates/ainb-core/src/components/snapshots/ainb__components__session_list__tests__chip_strip_at_the_default_sidebar_width.snap
@@ -1,20 +1,19 @@
 ---
 source: crates/ainb-core/src/components/session_list.rs
-assertion_line: 1844
 expression: "render_panel(&mut state, 42, 16)"
 ---
 ╭ Workspaces (1) · 2 need you ───────────╮
 │    ▼  agents-in-a-box (5)             │
 │▶ 1 ☐ ├─ ainb/acp-chat        ○ ASK 40s │
-│         ✻                              │
 │  2 ☐ ├─ ainb/disk-clean       ✗ ERR 9m │
-│         ✻                              │
 │  3 ☐ ├─ ainb/api-stats    ○ APPROVE 3m │
-│         ✻                              │
 │  4 ☐ ├─ ainb/site-build      ○ DONE 1m │
-│         ✻                              │
 │  5 ☐ └─ ainb/quiet              ○ IDLE │
-│         ✻                              │
+│                                        │
+│                                        │
+│                                        │
+│                                        │
+│                                        │
 │                                        │
 │                                        │
 │                                        │

--- a/ainb-tui/crates/ainb-core/tests/sessions_mouse.rs
+++ b/ainb-tui/crates/ainb-core/tests/sessions_mouse.rs
@@ -31,6 +31,11 @@ fn state_with_sessions(count: usize) -> (tempfile::TempDir, AppState) {
     state
         .sessions_pane_state
         .set_layout(Rect::new(0, 3, 40, 20), Rect::new(40, 3, 80, 20));
+    // One workspace header plus one physical terminal line per session.
+    // This is normally supplied by the renderer before mouse events arrive.
+    state
+        .sessions_pane_state
+        .set_list_item_heights(vec![1; count + 1]);
     state.sessions_pane_state.set_list_scroll_offset(0);
 
     (temp_home, state)
@@ -45,7 +50,7 @@ fn sessions_mouse_click_selects_session_row_without_async_work() {
     let _guard = HOME_LOCK.lock().expect("home env lock");
     let (_home, mut state) = state_with_two_sessions();
 
-    // y=3 is the top border, y=4 workspace header, y=5 first session, y=6 second session.
+    // Header is y=4; single-line sessions are y=5 and y=6.
     let outcome = EventHandler::handle_mouse_event(AppEvent::MouseClick { x: 8, y: 6 }, &mut state);
 
     assert!(outcome.is_none());

--- a/research/2026-09-12_15-59-17_orca-status-parity-and-sidebar-metadata.md
+++ b/research/2026-09-12_15-59-17_orca-status-parity-and-sidebar-metadata.md
@@ -1,0 +1,111 @@
+# Research: Orca status parity and sidebar metadata mode
+
+**Date**: 2026-09-12 15:59:17
+**Repository**: agents-in-a-box--f-improv43e2f972--cd2a9e8e
+**Branch**: f/improv43e2f972
+**Commit**: ed558a71
+**Research Type**: Comprehensive
+
+## Research Question
+
+Compare AINB session lifecycle status with Orca, diagnose stagnant `RUN`, and
+choose a compact model/effort display interaction.
+
+## Executive Summary
+
+AINB correctly receives provider lifecycle facts, but sidebar rendering trusts
+retained `RUNNING` and `TURN_COMPLETE` facts forever. Orca expires old working
+evidence, retaining only a non-committal live/idle state; AINB should reuse its
+existing five-minute healthy-state freshness policy. A literal held key is not
+reliable in macOS terminals, so `v` toggles the one-line model/effort view.
+
+## Key Findings
+
+- `skill-hub` has an attachable tmux pane, but its `RUNNING` lifecycle is over
+  26 hours old and has no active tracked work.
+- Orca treats only explicit provider evidence as agent status and decays stale
+  work to an unverifiable live state, never continued working.
+- AINB already stores `lifecycle_updated_at` and already has a five-minute
+  freshness tunable; the sidebar simply does not consume either.
+
+## Detailed Findings
+
+### Codebase Analysis
+
+#### Lifecycle authority
+
+- Current implementation: [`app/state.rs:12671`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/app/state.rs#L12671)
+- `Starting`/`Running` project to local `Running`; `TurnComplete`/`Idle` project
+  to local `Idle`.
+- Refresh accepts any reachable Fleet lifecycle without checking its timestamp:
+  [`app/state.rs:12758`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/app/state.rs#L12758).
+- Sidebar then calls any reachable `Starting`/`Running` state `RUN`, regardless
+  of `lifecycle_updated_at`: [`session_list.rs:1246`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/components/session_list.rs#L1246).
+- Existing `fleet.healthy_state_stale_ms` defaults to five minutes and is the
+  project policy for stale health state:
+  [`config/mod.rs:560`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/config/mod.rs#L560).
+
+#### `skill-hub` diagnosis
+
+| Field | Observed value |
+|---|---|
+| Lifecycle | `RUNNING` |
+| Lifecycle timestamp | Sep 11 13:12 BST |
+| Age at investigation | More than 26 hours |
+| Tracked active work | `0` |
+| Later lifecycle fact | None |
+
+`Stop` with background work intentionally retains `Running` in the Hangar
+reducer, but its synthetic work did not later produce a terminal event:
+[`fleet.rs:2482`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs#L2482).
+This is a stale-evidence rendering bug, not an attachability or tmux bug.
+
+#### Sidebar interaction
+
+- Session rows currently emit two physical lines, with model/effort on the
+  second: [`session_list.rs:643`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/components/session_list.rs#L643).
+- `Shift+M` is already the persistent bottom-keymap toggle:
+  [`events.rs:2531`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/app/events.rs#L2531).
+- Default macOS/Linux input deliberately drops key releases because those
+  terminals emit only presses: [`main.rs:581`](https://github.com/stevengonsalvez/agents-in-a-box/blob/ed558a71/ainb-tui/crates/ainb-core/src/main.rs#L581).
+  A literal hold action would therefore fail in the user’s terminal. `v` is
+  unbound in Session List and is the safe toggle for model/effort mode.
+
+### External Research
+
+- Orca owns status from explicit provider events only, with
+  `working`, `blocked`, `waiting`, and `done` as the shared vocabulary:
+  [agent status types](https://github.com/stablyai/orca/blob/403b62a8d8fa6e896a93acc4c15405be0f0b7dc7/src/shared/agent-status-types.ts#L1-L27).
+- Orca preserves original evidence time across replay and does not make replay
+  receipt time fresh:
+  [status application](https://github.com/stablyai/orca/blob/403b62a8d8fa6e896a93acc4c15405be0f0b7dc7/src/main/agent-hooks/server/server-status-application.ts#L19-L79).
+- Stale non-done evidence decays; a live PTY becomes `unverifiable`, otherwise
+  `idle`:
+  [row decay reducer](https://github.com/stablyai/orca/blob/403b62a8d8fa6e896a93acc4c15405be0f0b7dc7/src/renderer/src/lib/agent-row-decay-state.ts#L7-L31).
+- Claude and Codex hooks map prompts/tools to working, user/permission requests
+  to waiting, and stop to done:
+  [Claude mapping](https://github.com/stablyai/orca/blob/403b62a8d8fa6e896a93acc4c15405be0f0b7dc7/src/shared/agent-hook-listener/providers/claude-events.ts#L43-L116),
+  [Codex mapping](https://github.com/stablyai/orca/blob/403b62a8d8fa6e896a93acc4c15405be0f0b7dc7/src/shared/agent-hook-listener/providers/codex-events.ts#L102-L178).
+
+## Code References
+
+- `ainb-tui/crates/ainb-core/src/app/state.rs:12671` — Fleet lifecycle projection.
+- `ainb-tui/crates/ainb-core/src/components/session_list.rs:1246` — sidebar lifecycle labels.
+- `ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs:2469` — Claude hook lifecycle reducer.
+- `ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs:1216` — Codex lifecycle reducer.
+
+## Recommendations
+
+1. Treat Fleet lifecycle as authoritative only while daemon is reachable and
+   `lifecycle_updated_at` is within `fleet.healthy_state_stale_ms`.
+2. Render stale attachable work as `LIVE`, never `RUN`; do not turn stale work
+   into `DONE`.
+3. Keep explicit `ASK`, `WAIT`, `APPROVE`, and `ERR` ahead of lifecycle state.
+4. Make every session one physical line; use `v` to toggle titles between
+   prefix/session name and `model / effort`.
+5. Use distinct semantic colours: `RUN` green, `DONE` cyan, `WAIT` amber,
+   `ASK`/`APPROVE`/`ERR` red, `IDLE` white, `LIVE`/`STOP` grey.
+
+## Open Questions
+
+- [ ] None. Implement recommended options.


### PR DESCRIPTION
Render sessions on one line with a compact model/effort toggle, and let stale Fleet lifecycle evidence fall back to LIVE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press `v` to toggle model and effort details in the session list.
  * Session rows display optional model and effort information inline.
  * Active and completed session states now use distinct visual indicators.

* **Bug Fixes**
  * Stale or missing lifecycle information no longer incorrectly reports sessions as actively running.
  * Session selection remains accurate with the streamlined single-line layout.

* **Documentation**
  * Added documentation on session status freshness and metadata display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->