### PR TITLE
test(tripwires): the learnings return leg never retried a dropped Esc

### DIFF
--- a/.claude/skills/tmux-ui-tripwire/SKILL.md
+++ b/.claude/skills/tmux-ui-tripwire/SKILL.md
@@ -71,6 +71,8 @@ Full copy-paste helper functions in `references/helpers.md`.
 |---|---|---|
 | Stage plugins (if test exercises plugin path) | `just stage-plugins` | Plugins live at `dist/plugins/<id>/<id>` and are re-signed for macOS AMFI |
 | Build ainb | `cargo build -p ainb` | Test resolves binary via `env!("CARGO_BIN_EXE_ainb")` |
+| Build the plugin host binaries | `cargo build -p ainb-plugin-runtime --bins` | A tripwire that drives a plugin screen needs the host's own binaries present, not just the staged plugin. Without them the TUI comes up on the home screen and the test's first assertion fails against a screen that never opened |
+| Use a private tmux server | `export TMUX_TMPDIR=$HOME/.<lane>-tmux` | The shared server sizes new windows to whatever its existing client has, commonly 63x36, which truncates every screen these tests assert on. Set it as its OWN command, never behind a `&&` after a `cd` that can fail |
 
 ## Hard rules (violating these costs hours)
 

--- a/ainb-tui/crates/ainb-core/tests/tripwire_learnings_open.rs
+++ b/ainb-tui/crates/ainb-core/tests/tripwire_learnings_open.rs
@@ -278,12 +278,17 @@ fn learnings_screen_opens_and_renders_title() {
     // Return path (skill hard-rule 6): Esc is host-reserved and must
     // navigate back to home, NOT get swallowed by the plugin. Assert the
     // title token is gone and a HomeScreen marker is back.
-    send_key(&session, "Escape");
+    // Resent, like the open above: `esc` resolves to `GoToHomeScreen` in the
+    // Global context, so a second press once home is up is a no-op, and a
+    // first press dropped on a loaded box is otherwise never retried.
     let home_again_deadline = Instant::now() + Duration::from_secs(15);
-    let home_again = poll_capture(&session, home_again_deadline, |c| {
+    let home_again = poll_capture_resending(&session, "Escape", home_again_deadline, |c| {
         !c.contains(TITLE_TOKEN) && c.contains("Stats")
     });
 
+    // Captured BEFORE the kill: the failure message below reads this, and a
+    // capture taken after `kill_session` is empty on every failure.
+    let last = capture_pane(&session);
     kill_session(&session);
 
     assert!(
@@ -293,8 +298,7 @@ fn learnings_screen_opens_and_renders_title() {
     assert!(
         home_again.is_some(),
         "Esc from learnings did not return to HomeScreen (title token swallowed the key); \
-         last capture:\n---\n{}\n---",
-        capture_pane(&session)
+         last capture:\n---\n{last}\n---"
     );
 }
 
@@ -344,12 +348,13 @@ fn learnings_screen_opens_via_slash_recall() {
     };
 
     // Return path (skill hard-rule 6): Esc must navigate back to home.
-    send_key(&session, "Escape");
+    // Same resend and the same reason as the `m` case above.
     let home_again_deadline = Instant::now() + Duration::from_secs(15);
-    let home_again = poll_capture(&session, home_again_deadline, |c| {
+    let home_again = poll_capture_resending(&session, "Escape", home_again_deadline, |c| {
         !c.contains(TITLE_TOKEN) && c.contains("Stats")
     });
 
+    let last = capture_pane(&session);
     kill_session(&session);
 
     assert!(
@@ -359,7 +364,6 @@ fn learnings_screen_opens_via_slash_recall() {
     assert!(
         home_again.is_some(),
         "Esc from learnings (opened via /recall) did not return to HomeScreen; \
-         last capture:\n---\n{}\n---",
-        capture_pane(&session)
+         last capture:\n---\n{last}\n---"
     );
 }


### PR DESCRIPTION
`tripwire_learnings_open` flakes at roughly one run in four, always on the return leg, never on the open. This is the mechanism and the fix, plus the two pre-work rows that would have saved a different afternoon.

## The asymmetry

Both cases open the screen with a resending poll. `poll_capture_resending` (`:121`) and `poll_capture_resending_recall` (`:169`) re-press until the title paints, and the comment above the `/recall` one says why: a cold start drops the first keystroke.

Both cases then LEAVE by sending `Escape` exactly once and polling for 15 s with the plain helper. So the hardening that exists for the open was never applied to the return. A dropped `Escape` is never retried and the poll just runs out, which is exactly the observed signature: 18.28 s red against 4.52 s green, and `home_again.is_none()` as the only real signal.

`esc` resolves to `AppEvent::GoToHomeScreen` in the `Global` context (`keymap_defaults.rs:549-554`), so pressing it again once home is up is a no-op. Skill hard-rule 7 bars resending TOGGLES, not idempotent navigation, so the return leg now uses the same helper the open leg does.

## The failure message was empty by construction

`kill_session` ran before both assertions, and the message then called `capture_pane` on the session it had just killed. Every failure of either case therefore printed

```
last capture:
---

---
```

which is not a flaky capture, it is a reporting bug that made three separate investigations chase a dead pane. The capture now happens before the kill.

Credit where it is due: the `phase3-uistate` agent found both, and retracted its own earlier "the pane is dead before capture, so this is teardown" inference when it spotted the ordering.

## Evidence

25 consecutive green after the change (5 then 20), 4.1 to 5.8 s each, on lane A's private tmux server. Before the change the same binary was measured at 11 pass / 3 fail over 14 runs on one head, and it is the failing entry in two separate sweeps.

Falsifiable, and worth saying: if it still flakes with the resend in, the missing resend was not the cause and this only fixed the reporting.

## The skill rows

Second commit, same theme, `.claude/skills/tmux-ui-tripwire/SKILL.md`:

- `cargo build -p ainb-plugin-runtime --bins` is required pre-work for any tripwire that drives a plugin screen. Without it the TUI comes up on the home screen and the first assertion fails against a screen that never opened.
- `TMUX_TMPDIR` must be a private server, set as its OWN command. The shared server sizes a new window to whatever its existing client has, commonly 63x36, and truncates every screen these tests assert on. I lost a full run to exactly this today: `cd ainb-tui && export TMUX_TMPDIR=... && cargo test ...` where the shell was already in `ainb-tui`, so the `cd` failed, the `&&` short-circuited, the export never ran, and five tripwires went red against the shared server.

## Gates

`cargo fmt --all --check` clean. No product code touched: one test file and one skill doc.
