### PR TITLE
feat(hangar): stored D14 status identity, the incarnation fence, and a written-once pane binding (#960, #961)

### DIFF
--- a/ainb-tui/crates/ainb-core/src/cli/doctor.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/doctor.rs
@@ -34,6 +34,10 @@ struct PaneUnboundRow {
     session_key: String,
     provider: String,
     cwd: String,
+    /// Why, when the daemon could establish it. The three cases have different
+    /// fixes, and an invalidated binding (#961) also names the pane that was
+    /// lost, which is the one an operator can act on straight away.
+    detail: Option<String>,
 }
 
 // `--offline` skips skill-source NETWORK probes. It deliberately does NOT skip
@@ -198,6 +202,7 @@ async fn collect_fleet_status() -> (
                     }
                     .to_string(),
                     cwd: row.cwd.clone(),
+                    detail: row.pane_unbound_detail.clone(),
                 })
                 .collect(),
             status.unknown_events,
@@ -251,6 +256,11 @@ fn print_pane_unbound_text(rows: &[PaneUnboundRow], error: Option<&str>) {
             "  pane_unbound  {}  {}  {}",
             row.session_key, row.provider, row.cwd
         );
+        // Indented under its row: the reason is a sentence, and a row that has
+        // one is the row the operator is looking for.
+        if let Some(detail) = &row.detail {
+            println!("                {detail}");
+        }
     }
 }
 

--- a/ainb-tui/crates/ainb-core/src/cli/fleet/archived.rs
+++ b/ainb-tui/crates/ainb-core/src/cli/fleet/archived.rs
@@ -153,6 +153,9 @@ mod tests {
             model_authority: "inferred".to_string(),
             version: 1,
             updated_revision: 0,
+            // The D14 columns are not what this fixture is about: it exists to
+            // put delimiters through the renderer.
+            ..FleetSessionRow::default()
         }
     }
 

--- a/ainb-tui/crates/ainb-core/tests/status_one_truth.rs
+++ b/ainb-tui/crates/ainb-core/tests/status_one_truth.rs
@@ -202,6 +202,7 @@ fn two_agents_in_one_directory_keep_their_own_identity() {
         evidence_observed_at: at,
         has_open_request: state == AgentState::Waiting,
         pane_unbound: false,
+        pane_unbound_detail: None,
     };
 
     let mut rows = vec![local_row("agent-a", CWD), local_row("agent-b", CWD)];
@@ -263,6 +264,7 @@ fn an_ambiguous_directory_leaves_the_row_unstamped() {
         evidence_observed_at: 1,
         has_open_request: false,
         pane_unbound: false,
+        pane_unbound_detail: None,
     };
     let mut rows = vec![local_row("something-else", CWD)];
     ainb::cli::fleet::needs::stamp_rows(&mut rows, &[row("x"), row("y")]);

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -148,10 +148,12 @@ pub async fn ensure(
             // Tier 1. An ACP child reports its own state over its feed, which
             // is second only to a provider hook and, like it, may assert that a
             // human is needed.
-            tier: Some(ainb_hangar_proto::agent_status::tier_token(
-                ainb_hangar_proto::agent_status::Tier::AcpFeed,
-            )
-            .to_string()),
+            tier: Some(
+                ainb_hangar_proto::agent_status::tier_token(
+                    ainb_hangar_proto::agent_status::Tier::AcpFeed,
+                )
+                .to_string(),
+            ),
             // An ACP child's incarnation is its pool session id: the child dies
             // with the daemon, so a row carrying an older one belongs to a
             // process that is already gone.

--- a/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/acp_session.rs
@@ -145,6 +145,17 @@ pub async fn ensure(
             // `fleet_acp_session.provider`. The snapshot maps this token to
             // `FleetProvider::Acp`; anything else would render as Unknown.
             provider: Some(crate::acp_pool::ACP_PROVIDER_TOKEN.to_string()),
+            // Tier 1. An ACP child reports its own state over its feed, which
+            // is second only to a provider hook and, like it, may assert that a
+            // human is needed.
+            tier: Some(ainb_hangar_proto::agent_status::tier_token(
+                ainb_hangar_proto::agent_status::Tier::AcpFeed,
+            )
+            .to_string()),
+            // An ACP child's incarnation is its pool session id: the child dies
+            // with the daemon, so a row carrying an older one belongs to a
+            // process that is already gone.
+            session_incarnation: Some(session_key.to_string()),
             cwd: Some(cwd.to_string()),
             display_name: crate::fleet::display_name_for_cwd(cwd),
             management_state: Some("MANAGED".to_string()),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -466,6 +466,17 @@ pub async fn apply_hook_with_attention(
             provider_session_id: Some(observation.provider_session_id.to_string()),
             tmux_target: tmux_target.clone(),
             process_start_fingerprint: process_start_fingerprint.clone(),
+            // Tier 0, recorded rather than left to be reverse-engineered. This
+            // is the one producer that may assert a human is needed, so it is
+            // the one whose tier the read path must not have to guess.
+            tier: Some(ainb_hangar_proto::agent_status::tier_token(
+                ainb_hangar_proto::agent_status::Tier::Hook,
+            )
+            .to_string()),
+            // The pane's process IS the incarnation for a tmux-hosted session:
+            // the same session id in a pane whose process has been replaced is
+            // a different run of the agent, which is what the fence is for.
+            session_incarnation: process_start_fingerprint.clone(),
             cwd: Some(observation.cwd.to_string()),
             display_name: display_name_for_cwd(observation.cwd),
             management_state: (provider == Provider::Claude).then(|| "MANAGED".to_string()),
@@ -722,13 +733,32 @@ pub async fn status_rows(
         .into_iter()
         .map(|row| row.session_id)
         .collect();
+    // The STORED tier, keyed by session, so the read prefers what wrote the row
+    // over what can be guessed from it. A row from before migration 0099 says
+    // `unknown` and `parse_tier` answers `None`, which falls back to the old
+    // derivation: pre-migration rows read exactly as they do today.
+    let stored_tiers: std::collections::HashMap<&str, Option<ainb_hangar_proto::agent_status::Tier>> =
+        projection
+            .sessions
+            .iter()
+            .map(|row| {
+                (
+                    row.session.session_key.as_str(),
+                    ainb_hangar_proto::agent_status::parse_tier(&row.session.tier),
+                )
+            })
+            .collect();
     let mut rows: Vec<_> = snapshot
         .sessions
         .iter()
         .map(|session| {
             let has_open_request =
                 session.provider_session_id.as_deref().is_some_and(|id| open.contains(id));
-            ainb_hangar_proto::agent_status::status_row(session, has_open_request)
+            ainb_hangar_proto::agent_status::status_row_with_tier(
+                session,
+                has_open_request,
+                stored_tiers.get(session.session_key.as_str()).copied().flatten(),
+            )
         })
         .collect();
     rows.sort_by(|a, b| a.session_key.cmp(&b.session_key));
@@ -2585,6 +2615,12 @@ fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
         event_type: "tmux_discovered".to_string(),
         payload,
         patch: FleetSessionPatch {
+            // Tier 5. A scan reads a pane; it never hears from the agent.
+            tier: Some(ainb_hangar_proto::agent_status::tier_token(
+                ainb_hangar_proto::agent_status::Tier::PaneText,
+            )
+            .to_string()),
+            session_incarnation: session.process_start_fingerprint.clone(),
             provider: Some(session.provider.as_str().to_string()),
             tmux_target: session.exact_tmux_target.clone(),
             process_start_fingerprint: session.process_start_fingerprint.clone(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -427,9 +427,7 @@ pub async fn apply_hook_with_attention(
     // (#961). `bound` records what was chosen; `invalidate_binding` clears both
     // the decision and the live route when the pane it chose has been taken
     // over, which is what stops send-keys typing into the new occupant.
-    let bound = tmux_target
-        .clone()
-        .map(|target| (target, process_start_fingerprint.clone()));
+    let bound = tmux_target.clone().map(|target| (target, process_start_fingerprint.clone()));
     let invalidate_binding = matches!(
         &binding,
         crate::pane_binding::PaneBinding::Unbound(
@@ -484,10 +482,12 @@ pub async fn apply_hook_with_attention(
             // Tier 0, recorded rather than left to be reverse-engineered. This
             // is the one producer that may assert a human is needed, so it is
             // the one whose tier the read path must not have to guess.
-            tier: Some(ainb_hangar_proto::agent_status::tier_token(
-                ainb_hangar_proto::agent_status::Tier::Hook,
-            )
-            .to_string()),
+            tier: Some(
+                ainb_hangar_proto::agent_status::tier_token(
+                    ainb_hangar_proto::agent_status::Tier::Hook,
+                )
+                .to_string(),
+            ),
             // The pane's process IS the incarnation for a tmux-hosted session:
             // the same session id in a pane whose process has been replaced is
             // a different run of the agent, which is what the fence is for.
@@ -752,17 +752,19 @@ pub async fn status_rows(
     // over what can be guessed from it. A row from before migration 0099 says
     // `unknown` and `parse_tier` answers `None`, which falls back to the old
     // derivation: pre-migration rows read exactly as they do today.
-    let stored_tiers: std::collections::HashMap<&str, Option<ainb_hangar_proto::agent_status::Tier>> =
-        projection
-            .sessions
-            .iter()
-            .map(|row| {
-                (
-                    row.session.session_key.as_str(),
-                    ainb_hangar_proto::agent_status::parse_tier(&row.session.tier),
-                )
-            })
-            .collect();
+    let stored_tiers: std::collections::HashMap<
+        &str,
+        Option<ainb_hangar_proto::agent_status::Tier>,
+    > = projection
+        .sessions
+        .iter()
+        .map(|row| {
+            (
+                row.session.session_key.as_str(),
+                ainb_hangar_proto::agent_status::parse_tier(&row.session.tier),
+            )
+        })
+        .collect();
     let mut rows: Vec<_> = snapshot
         .sessions
         .iter()
@@ -776,6 +778,29 @@ pub async fn status_rows(
             )
         })
         .collect();
+    // Why each unbound row is unbound. Computed only for the rows that are,
+    // because it re-runs the candidate query per row and an unbound row is the
+    // rare case: a healthy fleet pays nothing for this.
+    for row in rows.iter_mut().filter(|row| row.pane_unbound) {
+        // The STORE row, not the wire session: the provider token the binding
+        // query matches on is the stored string, and round-tripping it through
+        // the wire enum would turn an unrecognised provider into `unknown` and
+        // silently match nothing.
+        let Some(stored) = projection
+            .sessions
+            .iter()
+            .find(|candidate| candidate.session.session_key == row.session_key)
+        else {
+            continue;
+        };
+        row.pane_unbound_detail = crate::pane_binding::unbound_detail(
+            pool,
+            &row.session_key,
+            &stored.session.provider,
+            &stored.session.cwd,
+        )
+        .await;
+    }
     rows.sort_by(|a, b| a.session_key.cmp(&b.session_key));
     Ok(ainb_hangar_proto::agent_status::AgentStatusResult {
         rows,
@@ -2631,10 +2656,12 @@ fn tmux_event(session: &FleetSession, observed_at: i64) -> NewFleetEvent {
         payload,
         patch: FleetSessionPatch {
             // Tier 5. A scan reads a pane; it never hears from the agent.
-            tier: Some(ainb_hangar_proto::agent_status::tier_token(
-                ainb_hangar_proto::agent_status::Tier::PaneText,
-            )
-            .to_string()),
+            tier: Some(
+                ainb_hangar_proto::agent_status::tier_token(
+                    ainb_hangar_proto::agent_status::Tier::PaneText,
+                )
+                .to_string(),
+            ),
             session_incarnation: session.process_start_fingerprint.clone(),
             provider: Some(session.provider.as_str().to_string()),
             tmux_target: session.exact_tmux_target.clone(),

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -522,7 +522,14 @@ pub async fn apply_hook_with_attention(
     // discovered row it came from, so it retires that key directly instead of
     // re-deriving it from a fingerprint the scan may never have recorded.
     match &binding {
-        crate::pane_binding::PaneBinding::Correlated { legacy_key, .. } => {
+        // `None` is a RE-confirmed binding: the discovered row it came from was
+        // retired when the decision was first made, so there is nothing left to
+        // supersede and the query would match nothing every time the bound
+        // session emits a hook line.
+        crate::pane_binding::PaneBinding::Correlated {
+            legacy_key: Some(legacy_key),
+            ..
+        } => {
             if let Some(revision) = FleetRepo::supersede_session(
                 pool,
                 legacy_key,
@@ -534,6 +541,11 @@ pub async fn apply_hook_with_attention(
                 events.emit_fleet_revision(revision);
             }
         }
+        // A re-confirmed binding: the discovered row was retired when the
+        // decision was first made, so there is nothing left to supersede.
+        crate::pane_binding::PaneBinding::Correlated {
+            legacy_key: None, ..
+        } => {}
         crate::pane_binding::PaneBinding::FromHook { .. } => {
             if let (Some(target), Some(fingerprint)) =
                 (tmux_target.as_deref(), process_start_fingerprint.as_deref())

--- a/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/fleet.rs
@@ -423,6 +423,19 @@ pub async fn apply_hook_with_attention(
     }
     let tmux_target = binding.target().map(str::to_string);
     let process_start_fingerprint = binding.fingerprint().map(str::to_string);
+    // The decision itself, so a later pass has something to re-confirm against
+    // (#961). `bound` records what was chosen; `invalidate_binding` clears both
+    // the decision and the live route when the pane it chose has been taken
+    // over, which is what stops send-keys typing into the new occupant.
+    let bound = tmux_target
+        .clone()
+        .map(|target| (target, process_start_fingerprint.clone()));
+    let invalidate_binding = matches!(
+        &binding,
+        crate::pane_binding::PaneBinding::Unbound(
+            crate::pane_binding::UnboundReason::Invalidated { .. }
+        )
+    );
     let exact_tmux_identity = tmux_target.is_some() && process_start_fingerprint.is_some();
     let (model, reasoning_effort) = observed_model_pair(&observation);
     let (lifecycle_state, attention_state) = if preserve_active_request {
@@ -466,6 +479,8 @@ pub async fn apply_hook_with_attention(
             provider_session_id: Some(observation.provider_session_id.to_string()),
             tmux_target: tmux_target.clone(),
             process_start_fingerprint: process_start_fingerprint.clone(),
+            bound: bound.clone(),
+            invalidate_binding,
             // Tier 0, recorded rather than left to be reverse-engineered. This
             // is the one producer that may assert a human is needed, so it is
             // the one whose tier the read path must not have to guess.
@@ -6279,43 +6294,12 @@ mod tests {
         );
     }
 
+    /// A row with nothing set, for a test that cares about one column.
+    ///
+    /// `Default` rather than a literal: every column added to the row broke
+    /// this fixture, and the churn said nothing about the change causing it.
     fn blank_row() -> FleetSessionRow {
-        FleetSessionRow {
-            session_key: String::new(),
-            provider: String::new(),
-            provider_session_id: None,
-            tmux_target: None,
-            process_start_fingerprint: None,
-            cwd: String::new(),
-            display_name: None,
-            lifecycle_state: "UNKNOWN".to_string(),
-            active_work_count: 0,
-            workload_updated_at: 0,
-            workload_authority: "inferred".to_string(),
-            attention_state: "NONE".to_string(),
-            current_request_fingerprint: None,
-            management_state: "DEGRADED".to_string(),
-            transport_health: "HEALTHY".to_string(),
-            capabilities: "{}".to_string(),
-            provenance: "tmux".to_string(),
-            confidence: "INFERRED".to_string(),
-            discovered_at: 0,
-            last_observed_at: 0,
-            metadata_updated_at: 0,
-            metadata_authority: "inferred".to_string(),
-            lifecycle_updated_at: 0,
-            lifecycle_authority: "inferred".to_string(),
-            attention_updated_at: 0,
-            attention_authority: "inferred".to_string(),
-            transport_updated_at: 0,
-            transport_authority: "inferred".to_string(),
-            model: None,
-            reasoning_effort: None,
-            model_updated_at: 0,
-            model_authority: "inferred".to_string(),
-            version: 1,
-            updated_revision: 1,
-        }
+        FleetSessionRow::default()
     }
 
     /// The reap-then-archive pipeline, end to end on its two real clocks: a

--- a/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/lib.rs
@@ -877,6 +877,24 @@ pub async fn boot(once: bool) -> anyhow::Result<()> {
 
         let store: Store = Store::open_in(&dir).await?;
 
+        // D14 boot order, step one: every row that survived the restart is a
+        // MEMORY of the last incarnation until something in this one confirms
+        // it. A session that exited during the outage would otherwise keep
+        // rendering as working, on evidence from a daemon that is no longer
+        // running. The tier-0 drain below is what clears the stamp for the
+        // sessions that are genuinely still there, which is why this has to
+        // happen before the feed starts rather than alongside it.
+        match ainb_hangar_store::repo::fleet::FleetRepo::mark_restored_unconfirmed(store.pool())
+            .await
+        {
+            Ok(0) => {}
+            Ok(stamped) => tracing::info!(stamped, "hydrated fleet rows pending confirmation"),
+            // Non-fatal, like every other boot step here: a daemon that cannot
+            // stamp must still serve. The cost is that a stale row reads as
+            // confirmed, which is today's behaviour.
+            Err(error) => tracing::warn!(error = %error, "restored-unconfirmed stamp failed"),
+        }
+
         // Fresh-home boot seed: lay down the default workspace + runtime + one
         // starter agent so an empty home "just works" (a runtime shows in the Daemon
         // pane, the agent picker is non-empty, and the Squad create gate is already

--- a/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
@@ -167,8 +167,15 @@ pub async fn resolve(
     // pane that had been reused by a different agent kept receiving this
     // session's send-keys.
     if let Some(decision) = bound_decision(pool, managed_key).await? {
-        match confirm(pool, managed_key, provider, cwd, &decision, hook_fingerprint.as_deref())
-            .await?
+        match confirm(
+            pool,
+            managed_key,
+            provider,
+            cwd,
+            &decision,
+            hook_fingerprint.as_deref(),
+        )
+        .await?
         {
             Confirmation::Holds => {
                 return Ok(PaneBinding::Correlated {
@@ -419,6 +426,32 @@ pub async fn unbound_answer_reason(pool: &SqlitePool, provider_session_id: &str)
         PaneBinding::Correlated { .. } | PaneBinding::FromHook { .. } => return None,
     };
     Some(reason.describe(&provider, &cwd))
+}
+
+/// The operator-facing reason one row has no pane, for `ainb doctor` and the
+/// fleet panel detail.
+///
+/// Re-runs the binding decision for a row that is already known to be unbound,
+/// so the three cases stay distinguishable at the surface: nothing to bind, a
+/// collision, or a binding dropped because the pane changed hands (#961). The
+/// last one is the one an operator can act on immediately, and it is the one
+/// that used to be invisible, because the row simply stopped delivering.
+///
+/// `None` when the reason cannot be established, which is treated as "say
+/// nothing" rather than "no pane": a wrong explanation is worse than none.
+pub async fn unbound_detail(
+    pool: &SqlitePool,
+    managed_key: &str,
+    provider: &str,
+    cwd: &str,
+) -> Option<String> {
+    // A decision still on the row means the invalidation has not been written
+    // yet, or the pane is merely unobserved. Ask the same question `resolve`
+    // asks, so the surface and the router never disagree.
+    match resolve(pool, managed_key, provider, cwd, None, None).await {
+        Ok(PaneBinding::Unbound(reason)) => Some(reason.describe(provider, cwd)),
+        Ok(_) | Err(_) => None,
+    }
 }
 
 #[cfg(test)]

--- a/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
@@ -37,6 +37,17 @@ pub enum UnboundReason {
     /// no single pane can be attributed. Carries the candidate targets in
     /// scan order so the operator can see the collision.
     Ambiguous(Vec<String>),
+    /// The pane this row was bound to is now running a different process
+    /// (#961). Carries the target that was invalidated and the candidates
+    /// available now, because the operator's question is "where did my agent
+    /// go", not "why did this fail".
+    Invalidated {
+        /// The pane the row had been bound to.
+        previous_target: String,
+        /// Discovered panes for this `(provider, cwd)` right now, in scan
+        /// order. Empty is normal and means the agent is no longer in tmux.
+        candidates: Vec<String>,
+    },
 }
 
 impl UnboundReason {
@@ -54,6 +65,19 @@ impl UnboundReason {
                 candidates.len(),
                 candidates.join(", ")
             ),
+            Self::Invalidated {
+                previous_target,
+                candidates,
+            } => {
+                let now = if candidates.is_empty() {
+                    format!("no {provider} pane in {cwd} now")
+                } else {
+                    format!("{provider} panes in {cwd} now: {}", candidates.join(", "))
+                };
+                format!(
+                    "pane_unbound: {previous_target} is running a different process than the one bound to this session, so the binding was dropped rather than typed into ({now})"
+                )
+            }
         }
     }
 }
@@ -138,6 +162,43 @@ pub async fn resolve(
     hook_target: Option<String>,
     hook_fingerprint: Option<String>,
 ) -> Result<PaneBinding, FleetRepoError> {
+    // A binding this row already made is re-confirmed before anything else
+    // (#961). Until now a correlated decision was never checked again, so a
+    // pane that had been reused by a different agent kept receiving this
+    // session's send-keys.
+    if let Some(decision) = bound_decision(pool, managed_key).await? {
+        match confirm(pool, managed_key, provider, cwd, &decision, hook_fingerprint.as_deref())
+            .await?
+        {
+            Confirmation::Holds => {
+                return Ok(PaneBinding::Correlated {
+                    target: decision.target,
+                    fingerprint: decision.fingerprint,
+                    // Nothing to retire: the legacy row was retired when this
+                    // binding was first made.
+                    legacy_key: String::new(),
+                });
+            }
+            Confirmation::Broken(candidates) => {
+                return Ok(PaneBinding::Unbound(UnboundReason::Invalidated {
+                    previous_target: decision.target,
+                    candidates,
+                }));
+            }
+            // Nothing observed this pane on this pass, so there is no evidence
+            // either way. A binding is not dropped on silence: an unscanned
+            // pane and a reused one look identical from here, and only one of
+            // them is a reason to stop delivering.
+            Confirmation::Unobserved => {
+                return Ok(PaneBinding::Correlated {
+                    target: decision.target,
+                    fingerprint: decision.fingerprint,
+                    legacy_key: String::new(),
+                });
+            }
+        }
+    }
+
     if let Some(target) = hook_target {
         return Ok(PaneBinding::FromHook {
             target,
@@ -146,6 +207,104 @@ pub async fn resolve(
     }
     let candidates = discovered_candidates(pool, managed_key, provider, cwd).await?;
     Ok(bind(candidates))
+}
+
+/// The binding decision a row already holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BoundDecision {
+    target: String,
+    fingerprint: Option<String>,
+}
+
+/// What this pass can say about a binding the row already holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Confirmation {
+    /// The bound pane still runs the process it was bound to.
+    Holds,
+    /// It runs a different one. Carries the candidates available now.
+    Broken(Vec<String>),
+    /// Nothing observed the pane on this pass.
+    Unobserved,
+}
+
+/// Read the written-once decision, if this row has made one.
+///
+/// `bound_fingerprint IS NULL` is a decision with nothing to re-confirm
+/// against, which is the pre-0099 shape and the shape a hook that knew its
+/// target but not its process produces. Those are returned too, so the target
+/// is still carried, and `confirm` answers `Unobserved` for them rather than
+/// inventing a mismatch.
+async fn bound_decision(
+    pool: &SqlitePool,
+    managed_key: &str,
+) -> Result<Option<BoundDecision>, FleetRepoError> {
+    let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+        "SELECT bound_target, bound_fingerprint FROM fleet_session WHERE session_key = ?",
+    )
+    .bind(managed_key)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.and_then(|(target, fingerprint)| {
+        target.map(|target| BoundDecision {
+            target,
+            fingerprint,
+        })
+    }))
+}
+
+/// Compare the bound pane against what is in it now.
+///
+/// The hook's own fingerprint is preferred when the hook named the same pane:
+/// it is this agent reporting its own process, which is better evidence than a
+/// scan. Otherwise the tier-5 scan for `(provider, cwd)` is consulted, and a
+/// pane absent from it is `Unobserved` rather than broken.
+async fn confirm(
+    pool: &SqlitePool,
+    managed_key: &str,
+    provider: &str,
+    cwd: &str,
+    decision: &BoundDecision,
+    hook_fingerprint: Option<&str>,
+) -> Result<Confirmation, FleetRepoError> {
+    let Some(bound) = decision.fingerprint.as_deref() else {
+        return Ok(Confirmation::Unobserved);
+    };
+    if let Some(observed) = hook_fingerprint {
+        return Ok(if observed == bound {
+            Confirmation::Holds
+        } else {
+            Confirmation::Broken(
+                discovered_candidates(pool, managed_key, provider, cwd)
+                    .await?
+                    .into_iter()
+                    .map(|candidate| candidate.tmux_target)
+                    .collect(),
+            )
+        });
+    }
+    let live = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT tmux_target, process_start_fingerprint FROM fleet_session \
+         WHERE tmux_target = ? AND visible = 1 AND superseded_by IS NULL \
+           AND session_key != ? \
+         ORDER BY last_observed_at DESC LIMIT 1",
+    )
+    .bind(&decision.target)
+    .bind(managed_key)
+    .fetch_optional(pool)
+    .await?;
+    let Some((_, Some(observed))) = live else {
+        return Ok(Confirmation::Unobserved);
+    };
+    if observed == bound {
+        return Ok(Confirmation::Holds);
+    }
+    Ok(Confirmation::Broken(
+        discovered_candidates(pool, managed_key, provider, cwd)
+            .await?
+            .into_iter()
+            .map(|candidate| candidate.tmux_target)
+            .collect(),
+    ))
 }
 
 /// Choose a binding from the candidate set. Split from the query so the
@@ -408,6 +567,157 @@ mod tests {
             matches!(binding, PaneBinding::Unbound(UnboundReason::NoCandidate)),
             "zero candidates is `pane_unbound`, not a guess: {binding:?}"
         );
+    }
+
+    /// THE #961 hazard: a pane is reused by a different agent, and the row
+    /// bound to it keeps routing there.
+    ///
+    /// A correlated binding was never re-confirmed, so `tmux_target` survived
+    /// the pane changing hands and send-keys typed this session's answer into
+    /// whichever agent holds the pane now. The binding is dropped instead, and
+    /// the row says which pane it lost and what is available.
+    #[tokio::test]
+    async fn a_reused_pane_invalidates_the_binding_instead_of_typing_into_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.expect("open store");
+
+        apply(
+            &store,
+            "hook:bind",
+            "claude:sid-1",
+            1,
+            bound_patch("sid-1", "pane=%1;pid=1"),
+        )
+        .await;
+
+        // The same pane, now running a different process.
+        apply(
+            &store,
+            "scan:reused",
+            "tmux:dev:1.0",
+            2,
+            ainb_hangar_store::repo::fleet::FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                cwd: Some("/w/app".to_string()),
+                tmux_target: Some("dev:1.0".to_string()),
+                process_start_fingerprint: Some("pane=%1;pid=999".to_string()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let binding = resolve(store.pool(), "claude:sid-1", "claude", "/w/app", None, None)
+            .await
+            .expect("resolve");
+        let PaneBinding::Unbound(reason) = &binding else {
+            panic!("a reused pane must invalidate the binding, got {binding:?}");
+        };
+        let UnboundReason::Invalidated {
+            previous_target, ..
+        } = reason
+        else {
+            panic!("and say so as an invalidation, got {reason:?}");
+        };
+        assert_eq!(previous_target, "dev:1.0");
+        assert_eq!(
+            binding.target(),
+            None,
+            "the row must stop offering a target to send keys to"
+        );
+        assert!(
+            reason.describe("claude", "/w/app").contains("dev:1.0"),
+            "the operator is told which pane was lost: {}",
+            reason.describe("claude", "/w/app")
+        );
+    }
+
+    /// The agent's own hook re-confirms its pane, and the binding stands.
+    #[tokio::test]
+    async fn a_matching_fingerprint_confirms_the_binding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.expect("open store");
+        apply(
+            &store,
+            "hook:bind",
+            "claude:sid-2",
+            1,
+            bound_patch("sid-2", "pane=%1;pid=1"),
+        )
+        .await;
+
+        let binding = resolve(
+            store.pool(),
+            "claude:sid-2",
+            "claude",
+            "/w/app",
+            None,
+            Some("pane=%1;pid=1".to_string()),
+        )
+        .await
+        .expect("resolve");
+        assert_eq!(binding.target(), Some("dev:1.0"), "{binding:?}");
+    }
+
+    /// Silence is not evidence of reuse. An unscanned pane and a stolen one
+    /// look identical from here, and only one is a reason to stop delivering.
+    #[tokio::test]
+    async fn an_unobserved_pane_keeps_its_binding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = ainb_hangar_store::Store::open_in(dir.path()).await.expect("open store");
+        apply(
+            &store,
+            "hook:bind",
+            "claude:sid-3",
+            1,
+            bound_patch("sid-3", "pane=%1;pid=1"),
+        )
+        .await;
+
+        let binding = resolve(store.pool(), "claude:sid-3", "claude", "/w/app", None, None)
+            .await
+            .expect("resolve");
+        assert_eq!(binding.target(), Some("dev:1.0"), "{binding:?}");
+    }
+
+    /// A managed row bound to `dev:1.0` while `fingerprint` was in it.
+    fn bound_patch(
+        session_id: &str,
+        fingerprint: &str,
+    ) -> ainb_hangar_store::repo::fleet::FleetSessionPatch {
+        ainb_hangar_store::repo::fleet::FleetSessionPatch {
+            provider: Some("claude".to_string()),
+            provider_session_id: Some(session_id.to_string()),
+            cwd: Some("/w/app".to_string()),
+            management_state: Some("MANAGED".to_string()),
+            tmux_target: Some("dev:1.0".to_string()),
+            process_start_fingerprint: Some(fingerprint.to_string()),
+            bound: Some(("dev:1.0".to_string(), Some(fingerprint.to_string()))),
+            ..Default::default()
+        }
+    }
+
+    /// Apply one event, for the fixtures above.
+    async fn apply(
+        store: &ainb_hangar_store::Store,
+        event_id: &str,
+        session_key: &str,
+        observed_at: i64,
+        patch: ainb_hangar_store::repo::fleet::FleetSessionPatch,
+    ) {
+        ainb_hangar_store::repo::fleet::FleetRepo::apply_event(
+            store.pool(),
+            &ainb_hangar_store::repo::fleet::NewFleetEvent {
+                event_id: event_id.to_string(),
+                session_key: session_key.to_string(),
+                observed_at,
+                authority: ainb_hangar_store::repo::fleet::ObservationAuthority::Authoritative,
+                event_type: "SessionStart".to_string(),
+                payload: "{}".to_string(),
+                patch,
+            },
+        )
+        .await
+        .expect("fixture event applies");
     }
 
     /// An empty cwd carries no information. Matching on it would correlate a

--- a/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/src/pane_binding.rs
@@ -99,7 +99,7 @@ pub enum PaneBinding {
         /// The discovered row's fingerprint, when it had one.
         fingerprint: Option<String>,
         /// The discovered row's key, retired onto the managed key by the caller.
-        legacy_key: String,
+        legacy_key: Option<String>,
     },
     /// Nothing could be attributed. The row renders `pane_unbound`.
     Unbound(UnboundReason),
@@ -183,7 +183,7 @@ pub async fn resolve(
                     fingerprint: decision.fingerprint,
                     // Nothing to retire: the legacy row was retired when this
                     // binding was first made.
-                    legacy_key: String::new(),
+                    legacy_key: None,
                 });
             }
             Confirmation::Broken(candidates) => {
@@ -200,7 +200,7 @@ pub async fn resolve(
                 return Ok(PaneBinding::Correlated {
                     target: decision.target,
                     fingerprint: decision.fingerprint,
-                    legacy_key: String::new(),
+                    legacy_key: None,
                 });
             }
         }
@@ -324,7 +324,7 @@ pub fn bind(mut candidates: Vec<PaneCandidate>) -> PaneBinding {
             PaneBinding::Correlated {
                 target: only.tmux_target,
                 fingerprint: only.process_start_fingerprint,
-                legacy_key: only.session_key,
+                legacy_key: Some(only.session_key),
             }
         }
         0 => PaneBinding::Unbound(UnboundReason::NoCandidate),
@@ -473,7 +473,8 @@ mod tests {
         assert_eq!(binding.target(), Some("dev:1.0"));
         assert!(matches!(
             binding,
-            PaneBinding::Correlated { ref legacy_key, .. } if legacy_key == "tmux:dev:1.0"
+            PaneBinding::Correlated { ref legacy_key, .. }
+                if legacy_key.as_deref() == Some("tmux:dev:1.0")
         ));
     }
 

--- a/ainb-tui/crates/ainb-hangar-daemon/tests/pane_reuse_961.rs
+++ b/ainb-tui/crates/ainb-hangar-daemon/tests/pane_reuse_961.rs
@@ -1,0 +1,165 @@
+//! Issue #961: a pane that changes hands stops receiving the old session's
+//! keys.
+//!
+//! A correlated binding was decided once and never re-confirmed, so a managed
+//! row kept `tmux_target` pointing at a pane that a different agent had since
+//! taken over. Every send-keys path resolves its target from that column
+//! (`rpc/mod.rs` reads `session.tmux_target`, and the Codex path additionally
+//! compares `process_start_fingerprint` against the live scan), so the answer
+//! to one agent's question was typed into another agent's prompt.
+//!
+//! This drives the real reducer rather than the binding function: the refusal
+//! has to be visible in the COLUMN the router reads, because that is what makes
+//! it true for every caller rather than for the one that remembered to ask.
+
+use ainb_hangar_daemon::events::EventBroker;
+use ainb_hangar_store::Store;
+use ainb_hangar_store::repo::fleet::{
+    FleetRepo, FleetSessionPatch, NewFleetEvent, ObservationAuthority,
+};
+
+const CWD: &str = "/w/reuse";
+const PANE: &str = "dev:1.0";
+const SESSION: &str = "sid-961";
+const SESSION_KEY: &str = "claude:sid-961";
+const BASE_MS: i64 = 1_700_000_000_000;
+
+/// One hook observation, through the daemon's own reducer.
+///
+/// `fingerprint` of `None` is the #916 shape and the one that matters here: a
+/// hook forked from a shared provider daemon never saw `$TMUX_PANE`, so it
+/// cannot name its own pane and the daemon's correlation is the only binding
+/// there is. A hook that DOES name a pane is reporting the process running in
+/// that pane, which is why it is trusted when present.
+async fn hook(store: &Store, event_id: &str, fingerprint: Option<&str>, observed_at: i64) {
+    let mut inner = serde_json::json!({
+        "session_id": SESSION,
+        "cwd": CWD,
+        "hook_event_name": "PreToolUse",
+    });
+    let mut payload = serde_json::json!({
+        "session_id": SESSION,
+        "cwd": CWD,
+    });
+    if let Some(fingerprint) = fingerprint {
+        payload["tmux_target"] = serde_json::Value::String(PANE.to_string());
+        payload["process_start_fingerprint"] = serde_json::Value::String(fingerprint.to_string());
+        inner["tmux_target"] = serde_json::Value::String(PANE.to_string());
+        inner["process_start_fingerprint"] = serde_json::Value::String(fingerprint.to_string());
+    }
+    payload["payload"] = inner;
+    ainb_hangar_daemon::fleet::apply_hook(
+        store.pool(),
+        &EventBroker::new().sink(),
+        ainb_hangar_daemon::fleet::HookObservation {
+            event_id: event_id.to_string(),
+            provider: "claude",
+            provider_session_id: SESSION,
+            cwd: CWD,
+            event_type: "PreToolUse",
+            payload: &payload,
+            observed_at,
+            transcript_model: None,
+        },
+    )
+    .await
+    .expect("the hook applies");
+}
+
+/// Seed the tier-5 row for `PANE`, which is what "the pane is now running X"
+/// looks like to the daemon.
+async fn scan(store: &Store, event_id: &str, fingerprint: &str, observed_at: i64) {
+    FleetRepo::apply_event(
+        store.pool(),
+        &NewFleetEvent {
+            event_id: event_id.to_string(),
+            session_key: format!("tmux:{PANE}:{fingerprint}"),
+            observed_at,
+            authority: ObservationAuthority::Inferred,
+            event_type: "tmux_discovered".to_string(),
+            payload: "{}".to_string(),
+            patch: FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                cwd: Some(CWD.to_string()),
+                tmux_target: Some(PANE.to_string()),
+                process_start_fingerprint: Some(fingerprint.to_string()),
+                tier: Some("pane_text".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        },
+    )
+    .await
+    .expect("the scan row applies");
+}
+
+/// The whole point: after the pane changes hands, nothing can route to it.
+#[tokio::test]
+async fn a_pane_taken_over_by_another_agent_stops_receiving_this_session_s_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+
+    // The agent is in `dev:1.0`, and its hook says so.
+    hook(&store, "e-bind", Some("pane=%1;pid=100"), BASE_MS).await;
+    let bound = FleetRepo::get_session(store.pool(), SESSION_KEY)
+        .await
+        .expect("query")
+        .expect("the hook made a row");
+    assert_eq!(
+        bound.tmux_target.as_deref(),
+        Some(PANE),
+        "the hook named its own pane, so the row routes there"
+    );
+    assert_eq!(
+        bound.bound_target.as_deref(),
+        Some(PANE),
+        "and the decision is recorded, which is what a later pass re-confirms"
+    );
+    assert_eq!(bound.bound_fingerprint.as_deref(), Some("pane=%1;pid=100"));
+
+    // The agent dies. Something else takes the pane.
+    scan(&store, "e-reuse", "pane=%1;pid=999", BASE_MS + 60_000).await;
+
+    // A later event for the ORIGINAL session, in the #916 shape: the hook ran
+    // from a shared provider daemon and cannot name its own pane. The daemon
+    // therefore has only the scan to go on, and the scan says the pane it bound
+    // belongs to someone else now.
+    hook(&store, "e-after", None, BASE_MS + 120_000).await;
+
+    let after = FleetRepo::get_session(store.pool(), SESSION_KEY)
+        .await
+        .expect("query")
+        .expect("the row survives");
+    assert_eq!(
+        after.tmux_target, None,
+        "THE refusal: every send-keys path resolves its target from this \
+         column, so clearing it is what stops the answer reaching the agent \
+         that did not ask"
+    );
+    assert_eq!(
+        after.bound_target, None,
+        "and the stale decision goes with it, so nothing re-adopts the pane"
+    );
+}
+
+/// The same pane, still held by the same process, keeps working. A refusal that
+/// fired on every scan would be worse than the bug.
+#[tokio::test]
+async fn a_pane_still_held_by_its_own_agent_keeps_routing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open_in(dir.path()).await.expect("store");
+
+    hook(&store, "e-bind", Some("pane=%1;pid=100"), BASE_MS).await;
+    scan(&store, "e-scan", "pane=%1;pid=100", BASE_MS + 60_000).await;
+    hook(&store, "e-after", None, BASE_MS + 120_000).await;
+
+    let after = FleetRepo::get_session(store.pool(), SESSION_KEY)
+        .await
+        .expect("query")
+        .expect("the row survives");
+    assert_eq!(
+        after.tmux_target.as_deref(),
+        Some(PANE),
+        "an unchanged pane must keep its route"
+    );
+    assert_eq!(after.bound_target.as_deref(), Some(PANE));
+}

--- a/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
@@ -280,16 +280,6 @@ pub fn status_row_with_tier(
     }
 }
 
-/// Which tier's evidence this row's state rests on, DERIVED.
-///
-/// The fallback for a row written before migration 0099, and for a caller that
-/// holds only the wire session. It reaches three of the six values: an ACP
-/// session is tier 1 by construction, a row carrying a provider session id was
-/// keyed by a hook, and everything else reads as the tmux scan. A row actually
-/// written by an OSC frame, the process table or the transcript is
-/// indistinguishable here from a pane scrape, which is why 0099 stores it and
-/// [`status_row_with_tier`] prefers the column.
-
 /// Parse a stored tier token, or `None` for `unknown` and for anything this
 /// build does not recognise.
 ///
@@ -323,6 +313,15 @@ pub fn tier_token(tier: Tier) -> &'static str {
     }
 }
 
+/// Which tier's evidence this row's state rests on, DERIVED.
+///
+/// The fallback for a row written before migration 0099, and for a caller that
+/// holds only the wire session. It reaches three of the six values: an ACP
+/// session is tier 1 by construction, a row carrying a provider session id was
+/// keyed by a hook, and everything else reads as the tmux scan. A row actually
+/// written by an OSC frame, the process table or the transcript is
+/// indistinguishable here from a pane scrape, which is why 0099 stores it and
+/// [`status_row_with_tier`] prefers the column.
 #[must_use]
 pub fn tier_of(session: &FleetSession) -> Tier {
     if session.provider == FleetProvider::Acp {

--- a/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
@@ -194,6 +194,17 @@ pub struct AgentStatusRow {
     /// True when no tmux pane is bound (issue #916): the agent may be asking,
     /// and nothing can type an answer into it.
     pub pane_unbound: bool,
+    /// Why, in one operator-facing sentence, when `pane_unbound` is true.
+    ///
+    /// The three cases have different fixes, so they are never collapsed: no
+    /// candidate pane at all, two that collide, or a binding invalidated
+    /// because the pane it held is now running something else (#961). The last
+    /// one also names the pane that was lost and what is available now.
+    ///
+    /// `#[serde(default)]` so a daemon that does not compute it, and a client
+    /// reading an older reply, both see `None` rather than failing the read.
+    #[serde(default)]
+    pub pane_unbound_detail: Option<String>,
 }
 
 impl AgentStatusRow {
@@ -263,6 +274,9 @@ pub fn status_row_with_tier(
         evidence_observed_at: evidence_observed_at(session, state),
         has_open_request,
         pane_unbound: session.pane_binding == crate::fleet::PaneBinding::PaneUnbound,
+        // Filled in by the daemon, which holds the binding decision. The
+        // derivation here has only the wire session and cannot know why.
+        pane_unbound_detail: None,
     }
 }
 

--- a/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
+++ b/ainb-tui/crates/ainb-hangar-proto/src/agent_status.rs
@@ -228,7 +228,29 @@ impl AgentStatusRow {
 /// useless when a human is the thing it is waiting on.
 #[must_use]
 pub fn status_row(session: &FleetSession, has_open_request: bool) -> AgentStatusRow {
-    let tier = tier_of(session);
+    status_row_with_tier(session, has_open_request, None)
+}
+
+/// [`status_row`] for a caller holding the row's STORED tier (D14, migration
+/// 0099).
+///
+/// `stored` is `None` for a caller that has only the wire session, and for a
+/// row written before 0099, whose tier is `unknown`. Both fall back to
+/// [`tier_of`], so the pre-migration behaviour is exactly today's and no row
+/// is given a tier that was reconstructed rather than recorded.
+///
+/// Separate from `status_row` rather than a new field on [`FleetSession`]:
+/// the wire session is built by 34 struct literals across the workspace, and
+/// the one surface that needs the stored value today is the daemon's own
+/// `fleet/status`, which holds the store row. The panel picks it up when it
+/// moves onto `fleet/status`.
+#[must_use]
+pub fn status_row_with_tier(
+    session: &FleetSession,
+    has_open_request: bool,
+    stored: Option<Tier>,
+) -> AgentStatusRow {
+    let tier = stored.unwrap_or_else(|| tier_of(session));
     let state = state_of(session, tier);
     AgentStatusRow {
         session_key: session.session_key.clone(),
@@ -244,12 +266,49 @@ pub fn status_row(session: &FleetSession, has_open_request: bool) -> AgentStatus
     }
 }
 
-/// Which tier's evidence this row's state rests on.
+/// Which tier's evidence this row's state rests on, DERIVED.
 ///
-/// Derived from what the store already records, because the tier column itself
-/// arrives with the D14 migration. An ACP session is tier 1 by construction; a
-/// row whose state groups were written by an authoritative observer is a hook
-/// push; everything else is the tmux scan.
+/// The fallback for a row written before migration 0099, and for a caller that
+/// holds only the wire session. It reaches three of the six values: an ACP
+/// session is tier 1 by construction, a row carrying a provider session id was
+/// keyed by a hook, and everything else reads as the tmux scan. A row actually
+/// written by an OSC frame, the process table or the transcript is
+/// indistinguishable here from a pane scrape, which is why 0099 stores it and
+/// [`status_row_with_tier`] prefers the column.
+
+/// Parse a stored tier token, or `None` for `unknown` and for anything this
+/// build does not recognise.
+///
+/// `unknown` is not an error and not a tier: it is a row from before 0099
+/// saying so, and the caller falls back to [`tier_of`]. An unrecognised token
+/// takes the same path rather than failing the read, for the same reason the
+/// event normalizer answers `None` instead of erroring.
+#[must_use]
+pub fn parse_tier(token: &str) -> Option<Tier> {
+    match token {
+        "hook" => Some(Tier::Hook),
+        "acp_feed" => Some(Tier::AcpFeed),
+        "osc_frame" => Some(Tier::OscFrame),
+        "process" => Some(Tier::Process),
+        "transcript" => Some(Tier::Transcript),
+        "pane_text" => Some(Tier::PaneText),
+        _ => None,
+    }
+}
+
+/// The stored token for a tier, the inverse of [`parse_tier`].
+#[must_use]
+pub fn tier_token(tier: Tier) -> &'static str {
+    match tier {
+        Tier::Hook => "hook",
+        Tier::AcpFeed => "acp_feed",
+        Tier::OscFrame => "osc_frame",
+        Tier::Process => "process",
+        Tier::Transcript => "transcript",
+        Tier::PaneText => "pane_text",
+    }
+}
+
 #[must_use]
 pub fn tier_of(session: &FleetSession) -> Tier {
     if session.provider == FleetProvider::Acp {

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0099_d14_status_identity.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0099_d14_status_identity.sql
@@ -108,9 +108,12 @@ ALTER TABLE fleet_event ADD COLUMN tier TEXT NOT NULL DEFAULT 'unknown'
         'unknown'
     ));
 
--- The spec's idempotency key, recorded and enforced. `event_id` keeps its own
--- narrower UNIQUE for the reason in the header.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_fleet_event_identity
+-- The spec's idempotency key, recorded and indexed. Deliberately NOT UNIQUE:
+-- `UNIQUE(event_id)` already implies uniqueness of any tuple containing it, so
+-- a unique index here would enforce nothing and still cost a second b-tree
+-- write per insert on the highest-volume table in the schema. It exists so a
+-- reader can key on the tuple, which is what the spec asks for.
+CREATE INDEX IF NOT EXISTS idx_fleet_event_identity
     ON fleet_event (host_id, session_key, tier, event_id);
 
 -- The binding invalidation sweep and `ainb doctor` both ask "which rows claim a

--- a/ainb-tui/crates/ainb-hangar-store/migrations/0099_d14_status_identity.sql
+++ b/ainb-tui/crates/ainb-hangar-store/migrations/0099_d14_status_identity.sql
@@ -1,0 +1,119 @@
+-- Hangar v1 schema, migration 0099: the D14 status identity that #934 deferred.
+--
+-- #934 landed the apply transaction, the normalizers, retention and the
+-- authority repair, and declared two gaps. This closes both: the stored
+-- evidence identity a row's tier and clocks come from (#960), and the
+-- written-once pane binding that stops send-keys typing into a reused pane
+-- (#961). They are one migration because the second needs the first: a binding
+-- decision is only trustworthy if the row can say which incarnation made it.
+--
+-- # Why `tier` is stored and `provenance` is not
+--
+-- `agent_status::tier_of` derives a tier from `management_state` and
+-- `provider_session_id`, which can only ever reach three of the six: hook, acp
+-- and pane_text. A row written by an OSC frame, the process table or the
+-- transcript is indistinguishable from a pane scrape, and no amount of reading
+-- the row afterwards recovers what wrote it. Storing it is the only fix, and it
+-- has to land before T0-section renders from the column.
+--
+-- `provenance` is NOT stored, deliberately, and this is a documented deviation
+-- from the issue text. `fleet_session.provenance` ALREADY EXISTS on this table
+-- with an unrelated meaning (`authoritative` / `inferred`, the observation
+-- authority), so a D14 provenance column would be the second column of that
+-- name on one row. It is also a pure function of the tier
+-- (`agent_status::provenance_of`), so storing it would be a second source for
+-- one fact, which is what this phase exists to remove. The derivation stays the
+-- single mapping.
+--
+-- # The tier vocabulary
+--
+-- `unknown` is a real member here and is the DEFAULT, which is the whole point
+-- of the backfill. Every row written before this migration was written by code
+-- that recorded no tier, so the honest value is "nobody knows", not a tier
+-- reconstructed from columns that cannot carry the answer. `tier_of` reads the
+-- column and falls back to its old derivation only for `unknown`, so existing
+-- rows keep exactly today's behaviour and new rows get the truth.
+--
+-- # `host_id`
+--
+-- Placeholder defaulted to `local`, the same shape and for the same reason as
+-- `mutation_ledger.host_id` in 0097: R1 mints a real `HostId` ULID and
+-- backfills. Present now so the `(host_id, session_key, tier, event_id)`
+-- idempotency key the spec names can be written today rather than needing a
+-- second rebuild of the event table later.
+--
+-- # Why `fleet_event.event_id` keeps its own UNIQUE
+--
+-- The spec's key is `(host_id, session_key, tier, event_id)`. That is WIDER
+-- than the existing `event_id UNIQUE`, so honouring it exactly would mean
+-- dropping a constraint, which in SQLite means rebuilding the table. Not done
+-- here, on purpose: `fleet_event` carries the payloads that the 1 GB ceiling
+-- and the rate-aware eviction path exist to bound, so it is the one table in
+-- this schema that can be measured in gigabytes, and a rebuild of it at boot is
+-- a multi-minute upgrade with the daemon down.
+--
+-- Keeping the narrower constraint is safe in the only direction that matters:
+-- it is a SUPERSET guarantee. Every duplicate the spec key would reject is
+-- already rejected, and the tuple is recorded and indexed so a reader can key
+-- on it. What it costs is the ability to store the same `event_id` twice at
+-- different tiers, which no producer does: every tier mints its own id space
+-- (`att:<session>:<event_id>`, `tmux:discovered:...`, `tmux:model:...`).
+
+ALTER TABLE fleet_session ADD COLUMN host_id TEXT NOT NULL DEFAULT 'local';
+
+-- The evidence tier that last wrote this row's state.
+ALTER TABLE fleet_session ADD COLUMN tier TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (tier IN (
+        'hook', 'acp_feed', 'osc_frame', 'process', 'transcript', 'pane_text',
+        'unknown'
+    ));
+
+-- The daemon's own clock when it took delivery of the evidence. Distinct from
+-- `last_observed_at`, which is the SOURCE's clock: a replay moves this and must
+-- never move that.
+ALTER TABLE fleet_session ADD COLUMN received_at INTEGER NOT NULL DEFAULT 0;
+
+-- When `state` last CHANGED, for "working since" and attention ordering. A
+-- repeated observation of the same state must not move it, or every surface
+-- reports a session that just started working every time it is re-observed.
+ALTER TABLE fleet_session ADD COLUMN state_started_at INTEGER NOT NULL DEFAULT 0;
+
+-- The fence. `process_start_fingerprint` for a tmux pane, the pool session id
+-- for an ACP child. An event whose incarnation differs from the live row is a
+-- restart (a new row) or a suppression (an older incarnation), never an
+-- in-place update of a row that belongs to a process that has gone.
+ALTER TABLE fleet_session ADD COLUMN session_incarnation TEXT;
+
+-- Hydrated at boot and not yet confirmed by a tier 0/1 event in THIS daemon
+-- incarnation. A restored row is a memory of what was true before the restart,
+-- and rendering it as fact is how a dead session keeps showing as working.
+ALTER TABLE fleet_session ADD COLUMN restored_unconfirmed INTEGER NOT NULL DEFAULT 0
+    CHECK (restored_unconfirmed IN (0, 1));
+
+-- The pane binding as a WRITTEN-ONCE decision (#961).
+--
+-- `tmux_target` is the live routing field and is cleared on invalidation.
+-- These three record the decision that produced it: which pane was chosen,
+-- which process was in it at the time, and when. Without the fingerprint there
+-- is nothing to re-confirm against, so a correlated binding survived pane reuse
+-- and send-keys typed into whichever agent holds the pane now.
+ALTER TABLE fleet_session ADD COLUMN bound_target TEXT;
+ALTER TABLE fleet_session ADD COLUMN bound_fingerprint TEXT;
+ALTER TABLE fleet_session ADD COLUMN bound_at INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE fleet_event ADD COLUMN host_id TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE fleet_event ADD COLUMN tier TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (tier IN (
+        'hook', 'acp_feed', 'osc_frame', 'process', 'transcript', 'pane_text',
+        'unknown'
+    ));
+
+-- The spec's idempotency key, recorded and enforced. `event_id` keeps its own
+-- narrower UNIQUE for the reason in the header.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fleet_event_identity
+    ON fleet_event (host_id, session_key, tier, event_id);
+
+-- The binding invalidation sweep and `ainb doctor` both ask "which rows claim a
+-- pane", and the answer is a small slice of a large table.
+CREATE INDEX IF NOT EXISTS idx_fleet_session_bound_target
+    ON fleet_session (bound_target) WHERE bound_target IS NOT NULL;

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -801,8 +801,7 @@ impl FleetRepo {
                     // live row backwards. The event is still RECORDED, with
                     // `applied = 0`: "we saw this and refused it" is exactly
                     // what an operator needs when a session looks stuck.
-                    let revision =
-                        insert_fleet_event(tx, event, row.version, false).await?;
+                    let revision = insert_fleet_event(tx, event, row.version, false).await?;
                     let session = row.clone();
                     return Ok(ApplyFleetEventResult {
                         revision,
@@ -1847,9 +1846,7 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
             // finding a pane proves a pane exists, not that the agent in it is
             // the one this row remembers, which is the whole reason the stamp
             // is not cleared by the discovery sweep.
-            if row.restored_unconfirmed
-                && matches!(tier.as_str(), "hook" | "acp_feed")
-            {
+            if row.restored_unconfirmed && matches!(tier.as_str(), "hook" | "acp_feed") {
                 row.restored_unconfirmed = false;
             }
             row.tier.clone_from(tier);
@@ -1899,7 +1896,6 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
 
     changed
 }
-
 
 /// Append one row to `fleet_event`, the durable record of what the daemon was
 /// told.
@@ -1966,9 +1962,10 @@ enum Fence {
 /// incarnation the row last accepted is the new run; one from before it is the
 /// old run still draining.
 fn fence(row: &FleetSessionRow, event: &NewFleetEvent) -> Fence {
-    let (Some(incoming), Some(current)) =
-        (event.patch.session_incarnation.as_deref(), row.session_incarnation.as_deref())
-    else {
+    let (Some(incoming), Some(current)) = (
+        event.patch.session_incarnation.as_deref(),
+        row.session_incarnation.as_deref(),
+    ) else {
         return Fence::Pass;
     };
     if incoming == current {
@@ -2614,7 +2611,10 @@ mod tests {
             },
         );
         let result = FleetRepo::apply_event(store.pool(), &late).await.unwrap();
-        assert!(!result.applied, "the dead run's event must not move the row");
+        assert!(
+            !result.applied,
+            "the dead run's event must not move the row"
+        );
         assert!(!result.duplicate, "it is a real event, not a replay");
 
         let row = FleetRepo::get_session(store.pool(), "claude:s-suppress")

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -174,6 +174,30 @@ pub struct FleetSessionPatch {
     pub model: Option<String>,
     /// Provider-reported reasoning effort, verbatim.
     pub reasoning_effort: Option<String>,
+    /// The evidence tier this observation came from (D14).
+    ///
+    /// A snake_case `agent_status::Tier` token. `None` leaves the row's tier
+    /// alone, which is what a patch carrying no state should do; an observation
+    /// that DOES move the state names the tier that moved it, so the row stops
+    /// having to be reverse-engineered from `management_state`.
+    pub tier: Option<String>,
+    /// The incarnation this observation belongs to: `process_start_fingerprint`
+    /// for a tmux pane, the pool session id for an ACP child.
+    ///
+    /// The fence reads it BEFORE the patch is applied, so a mismatch can be
+    /// turned into a restart or a suppression instead of an in-place update of
+    /// a row whose process has gone.
+    pub session_incarnation: Option<String>,
+    /// The pane binding decision, written once (#961).
+    ///
+    /// `Some((target, fingerprint))` records the chosen pane and the process in
+    /// it at the time. `None` leaves any existing decision standing; clearing
+    /// one is [`FleetSessionPatch::invalidate_binding`], which is a different
+    /// act and says so.
+    pub bound: Option<(String, Option<String>)>,
+    /// Clear the binding: the pane a correlated decision chose is now running
+    /// something else, so the row must stop routing to it.
+    pub invalidate_binding: bool,
 }
 
 impl FleetSessionPatch {
@@ -280,6 +304,36 @@ pub struct FleetSessionRow {
     pub version: i64,
     /// Revision that last changed this row.
     pub updated_revision: i64,
+    /// Owning host. `local` until R1 mints a real `HostId`.
+    pub host_id: String,
+    /// The evidence tier that last wrote this row's state (D14).
+    ///
+    /// `unknown` for a row written before migration 0099, which is the honest
+    /// answer rather than a tier reconstructed from columns that cannot carry
+    /// it. `agent_status::tier_of` falls back to its old derivation for those.
+    pub tier: String,
+    /// The daemon's own clock when it took delivery of the evidence.
+    ///
+    /// Distinct from `last_observed_at`, which is the SOURCE's clock. A replay
+    /// moves this and must never move that.
+    pub received_at: i64,
+    /// When the derived state last CHANGED, for "working since" and attention
+    /// ordering. A repeated observation of the same state does not move it.
+    pub state_started_at: i64,
+    /// The incarnation fence: `process_start_fingerprint` for a tmux pane, the
+    /// pool session id for an ACP child. `None` until something observes one.
+    pub session_incarnation: Option<String>,
+    /// Hydrated at boot and not yet confirmed by a tier 0/1 event in this
+    /// daemon incarnation.
+    pub restored_unconfirmed: bool,
+    /// The pane this row's binding decision chose. `tmux_target` is the live
+    /// routing field; this is the decision it came from.
+    pub bound_target: Option<String>,
+    /// The process that was in `bound_target` when the binding was made. What a
+    /// later observation is re-confirmed against.
+    pub bound_fingerprint: Option<String>,
+    /// When the binding was decided.
+    pub bound_at: i64,
 }
 
 /// One durable Fleet change-log row.
@@ -1400,7 +1454,9 @@ const SESSION_SELECT_BY_KEY: &str = "SELECT session_key, provider, provider_sess
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
     transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision, \
-    model, reasoning_effort, model_updated_at, model_authority \
+    model, reasoning_effort, model_updated_at, model_authority, \
+    host_id, tier, received_at, state_started_at, session_incarnation, \
+    restored_unconfirmed, bound_target, bound_fingerprint, bound_at \
     FROM fleet_session WHERE session_key = ?";
 
 const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session_id, \
@@ -1410,7 +1466,9 @@ const SESSION_SELECT_ALL: &str = "SELECT session_key, provider, provider_session
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
     transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision, \
-    model, reasoning_effort, model_updated_at, model_authority \
+    model, reasoning_effort, model_updated_at, model_authority, \
+    host_id, tier, received_at, state_started_at, session_incarnation, \
+    restored_unconfirmed, bound_target, bound_fingerprint, bound_at \
     FROM fleet_session WHERE visible = 1 ORDER BY session_key ASC";
 
 /// The ERR roster, read by [`FleetRepo::list_attention_error`]. Same column
@@ -1423,7 +1481,9 @@ const SESSION_SELECT_ERRORING: &str = "SELECT session_key, provider, provider_se
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
     transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision, \
-    model, reasoning_effort, model_updated_at, model_authority \
+    model, reasoning_effort, model_updated_at, model_authority, \
+    host_id, tier, received_at, state_started_at, session_incarnation, \
+    restored_unconfirmed, bound_target, bound_fingerprint, bound_at \
     FROM fleet_session WHERE visible = 1 AND attention_state = 'ERROR' \
     AND lifecycle_state != 'EXITED' ORDER BY session_key ASC";
 
@@ -1437,7 +1497,9 @@ const SESSION_SELECT_ARCHIVED: &str = "SELECT session_key, provider, provider_se
     metadata_authority, lifecycle_updated_at, lifecycle_authority, \
     attention_updated_at, attention_authority, transport_updated_at, \
     transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision, \
-    model, reasoning_effort, model_updated_at, model_authority \
+    model, reasoning_effort, model_updated_at, model_authority, \
+    host_id, tier, received_at, state_started_at, session_incarnation, \
+    restored_unconfirmed, bound_target, bound_fingerprint, bound_at \
     FROM fleet_session WHERE visible = 0 AND superseded_by IS NULL \
     ORDER BY last_observed_at DESC LIMIT ?";
 
@@ -1465,6 +1527,15 @@ async fn event_by_id(
     .fetch_optional(&mut **tx)
     .await?;
     row.as_ref().map(event_from_row).transpose()
+}
+
+/// The daemon's delivery clock for an event being applied now.
+///
+/// Its own function so the two writers (a new row, and `apply_patch` on an
+/// existing one) cannot drift, and so a test can see one name to reason about.
+fn received_now() -> i64 {
+    use ainb_hangar_core::clock::{HangarClock as _, SystemClock};
+    SystemClock.now_ms()
 }
 
 fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
@@ -1558,6 +1629,33 @@ fn new_session(event: &NewFleetEvent) -> FleetSessionRow {
         },
         version: 1,
         updated_revision: 0,
+        // `local` until R1 mints a real `HostId`; the column exists now so the
+        // idempotency key can be written without a second event-table rebuild.
+        host_id: "local".to_string(),
+        // A first event that names its tier gets it. One that does not leaves
+        // the row `unknown`, which is the honest answer and what `tier_of`
+        // falls back on.
+        tier: event.patch.tier.clone().unwrap_or_else(|| "unknown".to_string()),
+        // The daemon's clock, not the source's. `observed_at` is already the
+        // source's and is kept apart from it on purpose, so a replay moves
+        // this and never moves that. Stamped here rather than passed in
+        // because "when the daemon took delivery" is a fact only the apply
+        // path knows, and threading it through 47 event constructors would
+        // invite a caller to supply the source clock twice.
+        received_at: received_now(),
+        // A row's first state is a state change.
+        state_started_at: event.observed_at,
+        session_incarnation: event.patch.session_incarnation.clone(),
+        // A row born from an event is confirmed by construction; only boot
+        // hydration sets this.
+        restored_unconfirmed: false,
+        bound_target: event.patch.bound.as_ref().map(|(target, _)| target.clone()),
+        bound_fingerprint: event
+            .patch
+            .bound
+            .as_ref()
+            .and_then(|(_, fingerprint)| fingerprint.clone()),
+        bound_at: event.patch.bound.as_ref().map_or(0, |_| event.observed_at),
     }
 }
 
@@ -1565,6 +1663,11 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
     let mut changed = false;
     let authority = event.authority;
     let authority_token = authority.as_str().to_string();
+    // Snapshotted BEFORE any group is applied. `state_started_at` asks whether
+    // this event moved the state, and by the time the groups below have run the
+    // row already holds the new value, so comparing then would compare it with
+    // itself and the clock would never move.
+    let state_before = (row.lifecycle_state.clone(), row.attention_state.clone());
 
     if event.patch.has_metadata()
         && should_replace(
@@ -1672,8 +1775,64 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
         }
     }
 
+    // The D14 identity, maintained alongside the groups above rather than as a
+    // separate pass, so a row can never record a tier for a state it did not
+    // accept.
+    //
+    // `changed` is the gate for the tier and the state clock deliberately: an
+    // observation that lost every authority check did not move this row, so it
+    // did not write its state either, and claiming its tier would attribute the
+    // row's state to evidence that was refused.
+    if changed {
+        if let Some(tier) = &event.patch.tier {
+            row.tier.clone_from(tier);
+        }
+        row.received_at = received_now();
+        // Only a real transition moves the state clock. Re-observing the same
+        // state must not reset "working since", or a session that is
+        // re-observed every 3s reads as having just started, forever.
+        if row.lifecycle_state != state_before.0 || row.attention_state != state_before.1 {
+            row.state_started_at = event.observed_at;
+        }
+    }
+
+    // The incarnation and the binding are row IDENTITY, not state, so they are
+    // written whether or not a state group won. A fence that only updated on an
+    // accepted state change could never learn about the process that refused
+    // one.
+    if let Some(incarnation) = &event.patch.session_incarnation {
+        if row.session_incarnation.as_deref() != Some(incarnation.as_str()) {
+            row.session_incarnation = Some(incarnation.clone());
+            changed = true;
+        }
+    }
+    if let Some((target, fingerprint)) = &event.patch.bound {
+        // Written ONCE. A second decision for the same pane is the same
+        // decision; a decision for a different pane replaces it, which is what
+        // a re-bind after an invalidation is.
+        if row.bound_target.as_deref() != Some(target.as_str())
+            || (fingerprint.is_some() && row.bound_fingerprint != *fingerprint)
+        {
+            row.bound_target = Some(target.clone());
+            row.bound_fingerprint.clone_from(fingerprint);
+            row.bound_at = event.observed_at;
+            changed = true;
+        }
+    }
+    if event.patch.invalidate_binding && row.bound_target.is_some() {
+        // Clear the decision AND the live route it produced. Leaving
+        // `tmux_target` standing is exactly the bug: send-keys would keep
+        // typing into a pane that now belongs to someone else.
+        row.bound_target = None;
+        row.bound_fingerprint = None;
+        row.bound_at = 0;
+        row.tmux_target = None;
+        changed = true;
+    }
+
     changed
 }
+
 
 fn should_replace(
     incoming: ObservationAuthority,
@@ -1710,8 +1869,11 @@ async fn insert_session(
             metadata_authority, lifecycle_updated_at, lifecycle_authority, \
             attention_updated_at, attention_authority, transport_updated_at, \
             transport_authority, active_work_count, workload_updated_at, workload_authority, version, updated_revision, \
-            model, reasoning_effort, model_updated_at, model_authority) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            model, reasoning_effort, model_updated_at, model_authority, \
+            host_id, tier, received_at, state_started_at, session_incarnation, \
+            restored_unconfirmed, bound_target, bound_fingerprint, bound_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     );
     bind_session(query, row).execute(&mut **tx).await?;
     Ok(())
@@ -1748,7 +1910,9 @@ async fn update_session(
             metadata_authority = ?, lifecycle_updated_at = ?, lifecycle_authority = ?, \
             attention_updated_at = ?, attention_authority = ?, transport_updated_at = ?, \
             transport_authority = ?, active_work_count = ?, workload_updated_at = ?, workload_authority = ?, version = ?, updated_revision = ?, \
-            model = ?, reasoning_effort = ?, model_updated_at = ?, model_authority = ? \
+            model = ?, reasoning_effort = ?, model_updated_at = ?, model_authority = ?, \
+            tier = ?, received_at = ?, state_started_at = ?, session_incarnation = ?, \
+            restored_unconfirmed = ?, bound_target = ?, bound_fingerprint = ?, bound_at = ? \
          WHERE session_key = ?",
     )
     .bind(&row.provider)
@@ -1784,6 +1948,14 @@ async fn update_session(
     .bind(&row.reasoning_effort)
     .bind(row.model_updated_at)
     .bind(&row.model_authority)
+    .bind(&row.tier)
+    .bind(row.received_at)
+    .bind(row.state_started_at)
+    .bind(&row.session_incarnation)
+    .bind(i64::from(row.restored_unconfirmed))
+    .bind(&row.bound_target)
+    .bind(&row.bound_fingerprint)
+    .bind(row.bound_at)
     .bind(&row.session_key)
     .execute(&mut **tx)
     .await?;
@@ -1829,6 +2001,15 @@ fn bind_session<'q>(
         .bind(&row.reasoning_effort)
         .bind(row.model_updated_at)
         .bind(&row.model_authority)
+        .bind(&row.host_id)
+        .bind(&row.tier)
+        .bind(row.received_at)
+        .bind(row.state_started_at)
+        .bind(&row.session_incarnation)
+        .bind(i64::from(row.restored_unconfirmed))
+        .bind(&row.bound_target)
+        .bind(&row.bound_fingerprint)
+        .bind(row.bound_at)
 }
 
 fn session_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetSessionRow, sqlx::Error> {
@@ -1867,6 +2048,15 @@ fn session_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<FleetSessionRow, sq
         model_authority: row.try_get("model_authority")?,
         version: row.try_get("version")?,
         updated_revision: row.try_get("updated_revision")?,
+        host_id: row.try_get("host_id")?,
+        tier: row.try_get("tier")?,
+        received_at: row.try_get("received_at")?,
+        state_started_at: row.try_get("state_started_at")?,
+        session_incarnation: row.try_get("session_incarnation")?,
+        restored_unconfirmed: row.try_get::<i64, _>("restored_unconfirmed")? != 0,
+        bound_target: row.try_get("bound_target")?,
+        bound_fingerprint: row.try_get("bound_fingerprint")?,
+        bound_at: row.try_get("bound_at")?,
     })
 }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -1992,10 +1992,30 @@ enum Fence {
 /// been told, so it has nothing to be fenced against and the event's own
 /// incarnation becomes the row's.
 ///
-/// Restart and suppress are told apart by the CLOCK, not by the strings: a
-/// fingerprint is opaque and carries no order. An event at or after the
-/// incarnation the row last accepted is the new run; one from before it is the
-/// old run still draining.
+/// **Which rows stay unfenced.** A row whose incarnation is `NULL` is not
+/// protected by this at all, and that is exactly the population #916 is about:
+/// a hook forked from a shared provider daemon reports no
+/// `process_start_fingerprint`, so its row carries no incarnation and any event
+/// for that key applies in place. The fence protects rows that have been told
+/// who they are; the rest are covered by pane binding and by the live
+/// fingerprint check before send-keys, not by this.
+///
+/// # Ordering
+///
+/// The two incarnations are ordered by `session_started`, which the fingerprint
+/// carries (`pane=%N;pid=N;session_started=N`) and which is the fact that
+/// actually orders two runs of one agent. A pane id is stable across a restart
+/// and a pid is not ordered at all, since the kernel recycles them.
+///
+/// Only when a `session_started` cannot be read from BOTH sides does this fall
+/// back to comparing `event.observed_at` against `last_observed_at`, and that
+/// fallback is weaker in a way worth naming: `last_observed_at` is a monotonic
+/// maximum across every tier, so it mixes provider-stamped hook clocks with
+/// daemon-stamped scan clocks. A genuine restart whose first event trails a
+/// tier-5 scan is then classified `Suppress`. It self-heals, because a
+/// suppression returns without touching the row and the next event of the new
+/// run carries a later stamp, so the cost is one refused event rather than a
+/// stranded row.
 fn fence(row: &FleetSessionRow, event: &NewFleetEvent) -> Fence {
     let (Some(incoming), Some(current)) = (
         event.patch.session_incarnation.as_deref(),
@@ -2006,11 +2026,33 @@ fn fence(row: &FleetSessionRow, event: &NewFleetEvent) -> Fence {
     if incoming == current {
         return Fence::Pass;
     }
+    if let (Some(started), Some(current_started)) =
+        (session_started(incoming), session_started(current))
+    {
+        return if started > current_started {
+            Fence::Restart
+        } else {
+            Fence::Suppress
+        };
+    }
     if event.observed_at >= row.last_observed_at {
         Fence::Restart
     } else {
         Fence::Suppress
     }
+}
+
+/// The `session_started` stamp inside a process fingerprint, when it has one.
+///
+/// `pane=%N;pid=N;session_started=N`, as minted by the tmux scan
+/// (`discover/tmux.rs`) and by the hook (`cli/fleet/atc.rs`). Absent, or
+/// unparseable, means this fingerprint cannot order anything and the caller
+/// falls back to its clock.
+fn session_started(fingerprint: &str) -> Option<i64> {
+    fingerprint
+        .split(';')
+        .find_map(|field| field.strip_prefix("session_started="))
+        .and_then(|value| value.trim().parse().ok())
 }
 
 /// Reset a row for a new incarnation of the same session key.
@@ -2710,6 +2752,133 @@ mod tests {
             .find(|row| row.event_id == "e-late")
             .expect("a suppressed event is still durable");
         assert!(!refused.applied, "and is marked as not applied");
+    }
+
+    /// A restart is ordered by `session_started`, not by whichever clock last
+    /// touched the row.
+    ///
+    /// `last_observed_at` is a monotonic maximum across every tier, so a
+    /// daemon-stamped tier-5 scan routinely pushes it past a provider-stamped
+    /// hook payload. Ordering on it alone classified a genuine restart as a
+    /// suppression whenever the new run's first event trailed a scan, which on
+    /// a 3s discovery loop is most of them.
+    #[tokio::test]
+    async fn a_restart_is_ordered_by_session_started_not_by_the_last_observer() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-old",
+                "claude:s-clock",
+                1_000,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    session_incarnation: Some("pane=%1;pid=1;session_started=100".to_string()),
+                    lifecycle_state: Some("IDLE".to_string()),
+                    tier: Some("hook".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        // A scan touches the row and pushes the high-water mark well past
+        // anything the next hook payload will carry.
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-scan",
+                "claude:s-clock",
+                9_000,
+                ObservationAuthority::Inferred,
+                FleetSessionPatch {
+                    transport_health: Some("HEALTHY".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        // The new run: a LATER `session_started`, but a payload clock behind
+        // the scan that just ran.
+        let restarted = event(
+            "e-new",
+            "claude:s-clock",
+            2_000,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                session_incarnation: Some("pane=%1;pid=2;session_started=500".to_string()),
+                lifecycle_state: Some("RUNNING".to_string()),
+                tier: Some("hook".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        let applied = FleetRepo::apply_event(store.pool(), &restarted).await.unwrap();
+        assert!(
+            applied.applied,
+            "a later session_started is a restart even when its payload clock \
+             trails the scan that last touched the row"
+        );
+        let row = FleetRepo::get_session(store.pool(), "claude:s-clock").await.unwrap().unwrap();
+        assert_eq!(
+            row.session_incarnation.as_deref(),
+            Some("pane=%1;pid=2;session_started=500")
+        );
+    }
+
+    /// And the reverse: an EARLIER `session_started` is the old run draining,
+    /// however recent its arrival.
+    #[tokio::test]
+    async fn an_earlier_session_started_is_suppressed_however_late_it_arrives() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-live",
+                "claude:s-late",
+                1_000,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    session_incarnation: Some("pane=%1;pid=2;session_started=500".to_string()),
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    tier: Some("hook".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        let late = event(
+            "e-drain",
+            "claude:s-late",
+            9_999,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                session_incarnation: Some("pane=%1;pid=1;session_started=100".to_string()),
+                lifecycle_state: Some("EXITED".to_string()),
+                tier: Some("hook".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        assert!(
+            !FleetRepo::apply_event(store.pool(), &late).await.unwrap().applied,
+            "the dead run cannot bury the live one by arriving last"
+        );
+        assert_eq!(
+            FleetRepo::get_session(store.pool(), "claude:s-late")
+                .await
+                .unwrap()
+                .unwrap()
+                .lifecycle_state,
+            "RUNNING"
+        );
     }
 
     /// An event that names no incarnation is most of the traffic, and the fence

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -754,6 +754,46 @@ impl FleetRepo {
                 });
             }
         }
+        // The incarnation fence (D14). An event whose incarnation differs from
+        // the live row is not an ordinary update: one of the two belongs to a
+        // process that has gone.
+        let mut prior = prior;
+        if let Some(row) = prior.as_mut() {
+            match fence(row, event) {
+                Fence::Pass => {}
+                Fence::Suppress => {
+                    // An older incarnation arriving late. Its evidence is about
+                    // a run that has already ended, so applying it would move a
+                    // live row backwards. The event is still RECORDED, with
+                    // `applied = 0`: "we saw this and refused it" is exactly
+                    // what an operator needs when a session looks stuck.
+                    let revision =
+                        insert_fleet_event(tx, event, row.version, false).await?;
+                    let session = row.clone();
+                    return Ok(ApplyFleetEventResult {
+                        revision,
+                        session_version: session.version,
+                        applied: false,
+                        duplicate: false,
+                        session,
+                    });
+                }
+                Fence::Restart => {
+                    // The agent was restarted under the same key. `session_key`
+                    // is the primary key, so this resets the row in place
+                    // rather than adding a second one: the previous run's state
+                    // is not this run's state, and carrying it over is how a
+                    // fresh agent shows as still waiting on a question that
+                    // died with the old process.
+                    //
+                    // The old lifecycle is NOT set to `EXITED`. The spec
+                    // reserves that for process proof, and a newer incarnation
+                    // proves this run started, not how the last one ended.
+                    reset_for_restart(row, event);
+                }
+            }
+        }
+
         let is_new = prior.is_none();
         let (mut session, changed) = match prior {
             Some(mut row) => {
@@ -772,24 +812,7 @@ impl FleetRepo {
             insert_session(tx, &session).await?;
         }
 
-        let revision = sqlx::query(
-            "INSERT INTO fleet_event \
-             (event_id, session_key, observed_at, authority, event_type, payload, \
-              request_fingerprint, session_version, applied) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&event.event_id)
-        .bind(&event.session_key)
-        .bind(event.observed_at)
-        .bind(event.authority.as_str())
-        .bind(&event.event_type)
-        .bind(&event.payload)
-        .bind(event.patch.current_request_fingerprint.as_ref().and_then(Clone::clone))
-        .bind(session.version)
-        .bind(i64::from(changed))
-        .execute(&mut **tx)
-        .await?
-        .last_insert_rowid();
+        let revision = insert_fleet_event(tx, event, session.version, changed).await?;
 
         if changed {
             session.updated_revision = revision;
@@ -1834,6 +1857,135 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
 }
 
 
+/// Append one row to `fleet_event`, the durable record of what the daemon was
+/// told.
+///
+/// `applied` is the honest outcome, not a success flag: an event the fence
+/// suppressed, or one that lost every authority check, is still recorded with
+/// `applied = 0`. "We saw this and refused it" is the fact that makes a stuck
+/// session diagnosable.
+///
+/// `host_id` and `tier` complete the spec's
+/// `(host_id, session_key, tier, event_id)` identity, which migration 0099
+/// indexes.
+async fn insert_fleet_event(
+    tx: &mut Transaction<'_, Sqlite>,
+    event: &NewFleetEvent,
+    session_version: i64,
+    applied: bool,
+) -> Result<i64, sqlx::Error> {
+    Ok(sqlx::query(
+        "INSERT INTO fleet_event \
+         (event_id, session_key, observed_at, authority, event_type, payload, \
+          request_fingerprint, session_version, applied, host_id, tier) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&event.event_id)
+    .bind(&event.session_key)
+    .bind(event.observed_at)
+    .bind(event.authority.as_str())
+    .bind(&event.event_type)
+    .bind(&event.payload)
+    .bind(event.patch.current_request_fingerprint.as_ref().and_then(Clone::clone))
+    .bind(session_version)
+    .bind(i64::from(applied))
+    .bind("local")
+    .bind(event.patch.tier.as_deref().unwrap_or("unknown"))
+    .execute(&mut **tx)
+    .await?
+    .last_insert_rowid())
+}
+
+/// What an event's incarnation says about the row it addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Fence {
+    /// Same incarnation, or not enough information to say. Apply normally.
+    Pass,
+    /// A DIFFERENT incarnation arriving after this row was established. The
+    /// agent was restarted under the same key.
+    Restart,
+    /// An incarnation this row has already moved past.
+    Suppress,
+}
+
+/// Decide the fence for one event against the live row (D14).
+///
+/// Silence is `Pass`, in both directions and on purpose. An event that names no
+/// incarnation is most of the traffic (a model observation, a workload count, a
+/// transport flip), and refusing those would make the fence a filter on
+/// everything rather than a guard on identity. A row that names none has never
+/// been told, so it has nothing to be fenced against and the event's own
+/// incarnation becomes the row's.
+///
+/// Restart and suppress are told apart by the CLOCK, not by the strings: a
+/// fingerprint is opaque and carries no order. An event at or after the
+/// incarnation the row last accepted is the new run; one from before it is the
+/// old run still draining.
+fn fence(row: &FleetSessionRow, event: &NewFleetEvent) -> Fence {
+    let (Some(incoming), Some(current)) =
+        (event.patch.session_incarnation.as_deref(), row.session_incarnation.as_deref())
+    else {
+        return Fence::Pass;
+    };
+    if incoming == current {
+        return Fence::Pass;
+    }
+    if event.observed_at >= row.last_observed_at {
+        Fence::Restart
+    } else {
+        Fence::Suppress
+    }
+}
+
+/// Reset a row for a new incarnation of the same session key.
+///
+/// Everything the PREVIOUS run established is dropped: its state, its clocks,
+/// its authority stamps and its pane binding. A restarted agent is not waiting
+/// on the question the old process was waiting on, and the pane it now occupies
+/// is a fresh decision, so keeping either is how a new agent inherits a dead
+/// one's attention.
+///
+/// Identity is kept: the key, the provider, the cwd, the display name. Those
+/// describe the session, not the run.
+fn reset_for_restart(row: &mut FleetSessionRow, event: &NewFleetEvent) {
+    row.lifecycle_state = "UNKNOWN".to_string();
+    row.attention_state = "NONE".to_string();
+    row.current_request_fingerprint = None;
+    row.active_work_count = 0;
+    // Every group goes back to `inferred` so the incoming event's own authority
+    // decides the new run, rather than losing to a stamp the old one left.
+    for authority in [
+        &mut row.lifecycle_authority,
+        &mut row.attention_authority,
+        &mut row.transport_authority,
+        &mut row.workload_authority,
+        &mut row.metadata_authority,
+        &mut row.model_authority,
+    ] {
+        *authority = "inferred".to_string();
+    }
+    for at in [
+        &mut row.lifecycle_updated_at,
+        &mut row.attention_updated_at,
+        &mut row.transport_updated_at,
+        &mut row.workload_updated_at,
+        &mut row.model_updated_at,
+    ] {
+        *at = 0;
+    }
+    row.state_started_at = event.observed_at;
+    row.session_incarnation.clone_from(&event.patch.session_incarnation);
+    // The binding belonged to the old process. A pane that still holds the new
+    // one will be re-bound by the next observation that says so.
+    row.bound_target = None;
+    row.bound_fingerprint = None;
+    row.bound_at = 0;
+    row.tmux_target = None;
+    // A restart is confirmation that this run exists, so the row is not a
+    // hydrated memory any more.
+    row.restored_unconfirmed = false;
+}
+
 fn should_replace(
     incoming: ObservationAuthority,
     observed_at: i64,
@@ -2213,6 +2365,177 @@ mod tests {
         // does no work per boot beyond the rows it still cannot name.
         let second = FleetRepo::backfill_display_names(store.pool(), derive).await.unwrap();
         assert_eq!(second, 0, "second boot names nothing new");
+    }
+
+    /// A restart under the same key does not inherit the previous run's state.
+    ///
+    /// The failure this prevents: an agent is killed while blocked on a
+    /// question, a new one starts in the same pane under the same session key,
+    /// and every surface shows the fresh agent as waiting on a question that
+    /// died with the old process. Nothing can answer it.
+    #[tokio::test]
+    async fn a_newer_incarnation_restarts_the_row_instead_of_inheriting_it() {
+        let (_dir, store) = store().await;
+        let asking = event(
+            "e-ask",
+            "claude:s-restart",
+            100,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                session_incarnation: Some("pane=%1;pid=1".to_string()),
+                lifecycle_state: Some("IDLE".to_string()),
+                attention_state: Some("ASK".to_string()),
+                tier: Some("hook".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        FleetRepo::apply_event(store.pool(), &asking).await.unwrap();
+
+        // Same key, later, different process.
+        let restarted = event(
+            "e-restart",
+            "claude:s-restart",
+            200,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                session_incarnation: Some("pane=%1;pid=2".to_string()),
+                lifecycle_state: Some("RUNNING".to_string()),
+                tier: Some("hook".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        let applied = FleetRepo::apply_event(store.pool(), &restarted).await.unwrap();
+        assert!(applied.applied, "a newer incarnation is accepted");
+
+        let row = FleetRepo::get_session(store.pool(), "claude:s-restart")
+            .await
+            .unwrap()
+            .expect("the row survives a restart, it is the same session");
+        assert_eq!(
+            row.attention_state, "NONE",
+            "the dead run's question must not follow the new process"
+        );
+        assert_eq!(row.lifecycle_state, "RUNNING");
+        assert_eq!(row.session_incarnation.as_deref(), Some("pane=%1;pid=2"));
+        assert_eq!(
+            row.state_started_at, 200,
+            "the new run's clock starts at the restart, not at the old run's ask"
+        );
+    }
+
+    /// An older incarnation arriving late is recorded and refused.
+    ///
+    /// The hook spool replays from a cursor, so an event from a process that
+    /// has already been replaced can arrive after the row has moved on.
+    /// Applying it would drag a live session backwards into a dead run's state.
+    #[tokio::test]
+    async fn an_older_incarnation_is_suppressed_but_still_recorded() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-new",
+                "claude:s-suppress",
+                200,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    session_incarnation: Some("pane=%1;pid=2".to_string()),
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    tier: Some("hook".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        let late = event(
+            "e-late",
+            "claude:s-suppress",
+            100,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                provider: Some("claude".to_string()),
+                session_incarnation: Some("pane=%1;pid=1".to_string()),
+                lifecycle_state: Some("EXITED".to_string()),
+                tier: Some("hook".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        let result = FleetRepo::apply_event(store.pool(), &late).await.unwrap();
+        assert!(!result.applied, "the dead run's event must not move the row");
+        assert!(!result.duplicate, "it is a real event, not a replay");
+
+        let row = FleetRepo::get_session(store.pool(), "claude:s-suppress")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.lifecycle_state, "RUNNING",
+            "the live run keeps its own state"
+        );
+        assert_eq!(row.session_incarnation.as_deref(), Some("pane=%1;pid=2"));
+
+        // Recorded, so an operator can see what was refused and why.
+        let events = FleetRepo::events_after(store.pool(), 0, 100).await.unwrap();
+        let refused = events
+            .iter()
+            .find(|row| row.event_id == "e-late")
+            .expect("a suppressed event is still durable");
+        assert!(!refused.applied, "and is marked as not applied");
+    }
+
+    /// An event that names no incarnation is most of the traffic, and the fence
+    /// must not become a filter on everything.
+    #[tokio::test]
+    async fn an_event_with_no_incarnation_passes_the_fence() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-base",
+                "claude:s-quiet",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    session_incarnation: Some("pane=%1;pid=1".to_string()),
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    tier: Some("hook".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        let model_only = event(
+            "e-model",
+            "claude:s-quiet",
+            150,
+            ObservationAuthority::Authoritative,
+            FleetSessionPatch {
+                model: Some("gpt-5.6-terra".to_string()),
+                ..FleetSessionPatch::default()
+            },
+        );
+        let result = FleetRepo::apply_event(store.pool(), &model_only).await.unwrap();
+        assert!(result.applied, "a model observation is not fenced out");
+
+        let row = FleetRepo::get_session(store.pool(), "claude:s-quiet").await.unwrap().unwrap();
+        assert_eq!(row.model.as_deref(), Some("gpt-5.6-terra"));
+        assert_eq!(
+            row.session_incarnation.as_deref(),
+            Some("pane=%1;pid=1"),
+            "and it does not disturb the incarnation it said nothing about"
+        );
+        assert_eq!(
+            row.tier, "hook",
+            "nor re-tier the row: it made no claim about the state"
+        );
     }
 
     #[tokio::test]

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -823,6 +823,41 @@ impl FleetRepo {
                     // reserves that for process proof, and a newer incarnation
                     // proves this run started, not how the last one ended.
                     reset_for_restart(row, event);
+                    // Clearing `attention_state` is not enough. The inbox row
+                    // is a separate table, and leaving it open means the dead
+                    // run's card keeps advertising an answer route into a
+                    // process that is gone, which is the harm #961 exists to
+                    // close arriving by another door. It also trips
+                    // `drift_against_fleet_session` permanently, on exactly its
+                    // first direction: an open card whose session is not
+                    // asking. That assertion is this lane's own regression
+                    // detector, so poisoning it is worse than the stale card.
+                    //
+                    // In THIS transaction, with the row reset, so a crash
+                    // between the two cannot leave a restarted session holding
+                    // its predecessor's question.
+                    if let Some(provider_session_id) = row.provider_session_id.clone() {
+                        let stale =
+                            crate::repo::attention::AttentionRepo::open_ask_ids_for_session_in_tx(
+                                tx,
+                                &provider_session_id,
+                            )
+                            .await?;
+                        for id in stale {
+                            crate::repo::attention::AttentionRepo::mark_answered_if_open_in_tx(
+                                tx,
+                                &id,
+                                "resolved:restart",
+                                "the agent restarted; this question died with the previous run",
+                                event.observed_at,
+                                // No client version to fence on: this close is
+                                // the store's own, driven by the incarnation
+                                // change in this same transaction.
+                                None,
+                            )
+                            .await?;
+                        }
+                    }
                 }
             }
         }
@@ -2528,6 +2563,7 @@ mod tests {
             ObservationAuthority::Authoritative,
             FleetSessionPatch {
                 provider: Some("claude".to_string()),
+                provider_session_id: Some("s-restart".to_string()),
                 session_incarnation: Some("pane=%1;pid=1".to_string()),
                 lifecycle_state: Some("IDLE".to_string()),
                 attention_state: Some("ASK".to_string()),
@@ -2536,6 +2572,27 @@ mod tests {
             },
         );
         FleetRepo::apply_event(store.pool(), &asking).await.unwrap();
+
+        // The card the dead run raised. This is the thing an operator can still
+        // click, so it is the thing a restart has to retire.
+        crate::repo::attention::AttentionRepo::insert_if_absent(
+            store.pool(),
+            &crate::repo::attention::NewAttention {
+                id: "att:s-restart:e-ask".to_string(),
+                session_id: "s-restart".to_string(),
+                cwd: "/w/app".to_string(),
+                workspace_id: None,
+                kind: crate::repo::attention::AttentionKind::AskUserQuestion,
+                payload: r#"{"kind":"ASK"}"#.to_string(),
+                degraded: false,
+                created_at: 100,
+                raise_transcript: None,
+                channels: ainb_hangar_core::channel::ChannelSet::NONE,
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
         // Same key, later, different process.
         let restarted = event(
@@ -2567,6 +2624,25 @@ mod tests {
         assert_eq!(
             row.state_started_at, 200,
             "the new run's clock starts at the restart, not at the old run's ask"
+        );
+
+        // The card died with the run that raised it. Leaving it open would
+        // advertise an answer route into a process that is gone, and would trip
+        // the drift assertion forever.
+        assert!(
+            crate::repo::attention::AttentionRepo::list_fleet(store.pool())
+                .await
+                .unwrap()
+                .is_empty(),
+            "a restart must leave no open card for the old incarnation"
+        );
+        let drift =
+            crate::repo::attention::AttentionRepo::drift_against_fleet_session(store.pool())
+                .await
+                .unwrap();
+        assert!(
+            drift.is_clean(),
+            "and must not poison this lane's own regression detector: {drift:?}"
         );
     }
 

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -234,7 +234,12 @@ pub struct NewFleetEvent {
 }
 
 /// Canonical Fleet session row.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Default` is derived so a test fixture can name the columns it cares about
+/// and inherit the rest. Every D14 column added in 0099 broke a handful of
+/// literals across the workspace before this existed, which is churn that says
+/// nothing about the change causing it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FleetSessionRow {
     /// Stable Fleet identity.
     pub session_key: String,

--- a/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
+++ b/ainb-tui/crates/ainb-hangar-store/src/repo/fleet.rs
@@ -689,6 +689,35 @@ impl FleetRepo {
         Ok(result)
     }
 
+    /// Mark every live row as a memory of the last daemon incarnation (D14 boot
+    /// order).
+    ///
+    /// A row that survives a restart records what was true when the daemon
+    /// died, and rendering it as present tense is how a session that exited
+    /// during the outage keeps showing as working. The spec's order is:
+    /// hydrate and stamp every non-`exited` row, drain the tier-0 cursor, then
+    /// start the feed, so the drain is what clears the stamp for sessions that
+    /// are genuinely still there.
+    ///
+    /// `EXITED` rows are skipped because they make no present-tense claim: the
+    /// row already says the process is gone, and marking it unconfirmed would
+    /// suggest that might have changed.
+    ///
+    /// Returns the number of rows stamped, for the boot log.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`sqlx::Error`] if the update fails.
+    pub async fn mark_restored_unconfirmed(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE fleet_session SET restored_unconfirmed = 1 \
+             WHERE lifecycle_state != 'EXITED' AND restored_unconfirmed = 0",
+        )
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     /// Apply one normalized event inside a CALLER-OWNED transaction, without
     /// committing it.
     ///
@@ -1808,6 +1837,16 @@ fn apply_patch(row: &mut FleetSessionRow, event: &NewFleetEvent) -> bool {
     // row's state to evidence that was refused.
     if changed {
         if let Some(tier) = &event.patch.tier {
+            // A hydrated row is confirmed by a tier 0/1 event in THIS daemon
+            // incarnation, and by nothing else (D14 boot order). A tier-5 scan
+            // finding a pane proves a pane exists, not that the agent in it is
+            // the one this row remembers, which is the whole reason the stamp
+            // is not cleared by the discovery sweep.
+            if row.restored_unconfirmed
+                && matches!(tier.as_str(), "hook" | "acp_feed")
+            {
+                row.restored_unconfirmed = false;
+            }
             row.tier.clone_from(tier);
         }
         row.received_at = received_now();
@@ -2365,6 +2404,110 @@ mod tests {
         // does no work per boot beyond the rows it still cannot name.
         let second = FleetRepo::backfill_display_names(store.pool(), derive).await.unwrap();
         assert_eq!(second, 0, "second boot names nothing new");
+    }
+
+    /// A hydrated row is a memory until this incarnation confirms it, and only
+    /// a tier 0/1 event counts as confirmation.
+    ///
+    /// The failure: the daemon restarts, a session exited during the outage,
+    /// and its row keeps rendering as working on evidence from a daemon that is
+    /// no longer running. A tier-5 scan finding a pane is not confirmation
+    /// either, because a pane existing says nothing about which agent is in it.
+    #[tokio::test]
+    async fn only_a_tier_zero_or_one_event_confirms_a_hydrated_row() {
+        let (_dir, store) = store().await;
+        let base = |id: &str, at: i64, tier: &str| {
+            event(
+                id,
+                "claude:s-boot",
+                at,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    lifecycle_state: Some("RUNNING".to_string()),
+                    tier: Some(tier.to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            )
+        };
+        FleetRepo::apply_event(store.pool(), &base("e-1", 100, "hook")).await.unwrap();
+
+        // The daemon restarts.
+        let stamped = FleetRepo::mark_restored_unconfirmed(store.pool()).await.unwrap();
+        assert_eq!(stamped, 1, "a live row is stamped at boot");
+        assert!(
+            FleetRepo::get_session(store.pool(), "claude:s-boot")
+                .await
+                .unwrap()
+                .unwrap()
+                .restored_unconfirmed
+        );
+
+        // A pane scan finds a pane. That is not confirmation.
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-scan",
+                "claude:s-boot",
+                150,
+                ObservationAuthority::Inferred,
+                FleetSessionPatch {
+                    lifecycle_state: Some("IDLE".to_string()),
+                    tier: Some("pane_text".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(
+            FleetRepo::get_session(store.pool(), "claude:s-boot")
+                .await
+                .unwrap()
+                .unwrap()
+                .restored_unconfirmed,
+            "a pane existing says nothing about the agent this row remembers"
+        );
+
+        // The agent's own hook does confirm it.
+        FleetRepo::apply_event(store.pool(), &base("e-2", 200, "hook")).await.unwrap();
+        assert!(
+            !FleetRepo::get_session(store.pool(), "claude:s-boot")
+                .await
+                .unwrap()
+                .unwrap()
+                .restored_unconfirmed,
+            "a tier-0 event in this incarnation confirms the row"
+        );
+    }
+
+    /// An exited row makes no present-tense claim, so it is not stamped.
+    #[tokio::test]
+    async fn boot_does_not_stamp_a_row_that_already_says_the_process_is_gone() {
+        let (_dir, store) = store().await;
+        FleetRepo::apply_event(
+            store.pool(),
+            &event(
+                "e-exit",
+                "claude:s-dead",
+                100,
+                ObservationAuthority::Authoritative,
+                FleetSessionPatch {
+                    provider: Some("claude".to_string()),
+                    lifecycle_state: Some("EXITED".to_string()),
+                    tier: Some("hook".to_string()),
+                    ..FleetSessionPatch::default()
+                },
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            FleetRepo::mark_restored_unconfirmed(store.pool()).await.unwrap(),
+            0,
+            "marking a dead row unconfirmed would suggest that might have changed"
+        );
     }
 
     /// A restart under the same key does not inherit the previous run's state.


### PR DESCRIPTION
## What this is

The two gaps PR #934 declared and deferred, closed together: **#960** (stored D14 status identity, the clocks, the incarnation fence and the boot order) and **#961** (the written-once pane binding, re-confirmed and invalidated on mismatch).

They are one PR because the second needs the first. A binding decision is only trustworthy if the row can say which incarnation made it, and until 0099 the decision recorded no fingerprint to re-confirm against.

Base `v2`. Commits are unsigned because the GPG passphrase is not cached on this box; the orchestrator re-signs at merge.

## Decisions

Three calls worth reviewing, all recorded in the migration header.

**`provenance` is stored as a derivation, not a column.** `fleet_session.provenance` already exists with an unrelated meaning (`authoritative` / `inferred`, the observation authority), so a D14 provenance column would be the second column of that name on one row. It is also a pure function of the tier through `provenance_of`. Storing both would be two sources for one fact, which is what this phase exists to remove, so `tier` is stored and provenance stays derived.

**`fleet_event.event_id` keeps its narrower `UNIQUE`, and the spec's 4-tuple is recorded and indexed.** The spec key `(host_id, session_key, tier, event_id)` is WIDER than the existing constraint, so honouring it exactly means dropping one, which in SQLite means rebuilding the table. `fleet_event` carries the payloads the 1 GB ceiling and the rate-aware eviction path exist to bound, making it the one table here that can reach gigabytes, and rebuilding it at boot is a multi-minute upgrade with the daemon down. The narrow rule is a superset guarantee: every duplicate the spec key would reject is already rejected. What it costs is storing one `event_id` twice at different tiers, which no producer does, since each tier mints its own id space.

**`host_id` is a `local` placeholder**, the same shape and for the same reason as `mutation_ledger.host_id` in 0097. R1 mints the real `HostId`.

The index on the spec tuple is a plain index, not a unique one: `UNIQUE(event_id)` already implies uniqueness of any tuple containing it, so a unique index would enforce nothing and still cost a second b-tree write per insert on the highest-volume table in the schema.

## #960, what changed

- **Migration `0099`** adds `tier`, `received_at`, `state_started_at`, `session_incarnation`, `restored_unconfirmed`, `host_id` and the three binding columns, plus `host_id`/`tier` on `fleet_event` with a plain index on the spec tuple.
- **`tier` is stored because it cannot be recovered.** `tier_of` derives from `management_state` and `provider_session_id`, which reaches three of six values; a row written by an OSC frame, the process table or the transcript reads as a pane scrape and nothing afterwards says otherwise. The three live producers now record their own: hook, `pane_text`, `acp_feed`.
- **The backfill records `unknown`,** which is the column default, so every pre-0099 row says "nobody knows" rather than carrying a tier reconstructed from columns that cannot hold the answer. `status_row_with_tier` falls back to the old derivation for those, so existing rows read exactly as they do today.
- **The clocks are kept apart.** `received_at` is the daemon's delivery clock, stamped in the apply path; `observed_at` stays the source's, so a replay moves one and never the other. `state_started_at` moves only on a real transition, compared against a snapshot taken before the groups apply.
- **The incarnation fence** decides restart versus suppress. Restart resets the row in place, because `session_key` is the primary key and this is a later run of the same session: the previous run's state, clocks, authority stamps and binding all go, or a fresh agent inherits a dead one's question and nothing can answer it. The old lifecycle is not set to `EXITED`, since the spec reserves that for process proof. Suppress records the event with `applied = 0` rather than dropping it, because the hook spool replays from a cursor and "we saw this and refused it" is what makes a stuck session diagnosable. The two are told apart by the clock, never by the strings, since a fingerprint is opaque.
- **Silence passes the fence** in both directions. An event naming no incarnation is most of the traffic, and a fence that refused those would be a filter on everything.
- **Boot order**: every non-`EXITED` row is stamped `restored_unconfirmed` before the feed starts, and only a tier 0/1 event in this incarnation clears it. A tier-5 scan finding a pane proves a pane exists, not that the agent in it is the one the row remembers.

## #961, what changed

- **The binding is a written-once decision** (`bound_target`, `bound_fingerprint`, `bound_at`) that `tmux_target` is the live result of.
- **`resolve` re-confirms before deciding anything new.** The agent's own hook fingerprint is preferred when the hook named the pane, because that is the agent reporting the process in that pane rather than a scan inferring it; otherwise the tier-5 view of that target decides.
- **Invalidation clears the decision and the route together.** Leaving `tmux_target` standing while dropping the decision would preserve the exact bug.
- **Silence keeps the binding.** An unscanned pane and a stolen one look identical from here, so the binding drops on evidence of a different process, never on absence of evidence.
- **`ainb doctor` says why**, with the pane that was lost and the candidates available now.

## Test state

```
cargo test --no-fail-fast -p ainb-hangar-daemon -p ainb-hangar-store \
                          -p ainb-fleet-core   -p ainb-hangar-proto      0 failed
cargo test --no-fail-fast -p ainb --lib --test status_one_truth          0 failed
cargo test --no-run --workspace --all-features                           compiles
cargo fmt --all --check                                                  clean
cargo clippy -p ainb-hangar-daemon -p ainb-hangar-store -p ainb-hangar-proto \
             -p ainb-fleet-core -p ainb --all-targets                    0 errors
em-dashes on branch-added lines                                          0
```

New gates: three fence tests (restart, suppress, silence), two boot-order tests, three binding tests (reuse, confirm, unobserved) and `tests/pane_reuse_961.rs`, which drives the real reducer and asserts the refusal in the column every router reads.

Four assertions were checked against the bug rather than observed green: stubbing the binding re-confirmation reds the reuse test, stubbing the restart card close reds the drift assertion, forcing the fence back onto the clock reds the ordering test, and an earlier draft of the reuse test passed for the wrong reason (its later hook still reported its own old fingerprint, describing a situation that cannot happen) and was rewritten to the #916 shape.

## Follow-ups, named rather than fixed here

- **Binding re-confirmation runs only on a hook line from the bound session.** A session that goes silent while waiting keeps a stale `tmux_target` until it emits something. Mitigated by the live fingerprint check the Codex send-keys path already makes before typing, so the stale target is caught at delivery rather than acted on; a sweep that re-confirms on the discovery tick instead would close it properly.
- **`restored_unconfirmed` is stamped at boot and surfaced nowhere.** The column is correct and the confirmation rule is tested, but no surface renders it, so a hydrated row still reads as fact to an operator. It wants a badge on the fleet panel and a line in `ainb doctor`, which is natural to do with #962's panel work.
- **R1's real `host_id` needs the wider key.** When `HostId` stops being `local`, `(host_id, session_key, tier, event_id)` has to become the enforced constraint, and that is the `fleet_event` table rebuild this PR deliberately defers. It should be planned as part of R1's migration rather than discovered there.

## Not in here

`FleetSessionRow` now derives `Default`. Every column 0099 added broke a fixture that built the row by literal, in three crates, and that churn says nothing about the change causing it.

#962 (panel on `fleet/status`, `TestBackend` gate, supersede inside the apply transaction, drift window) is out of scope and untouched; the supersede move did not fall out naturally.


## Round two

Both majors and the design item from the f0d02a11 review:

1. **A restart orphaned the dead run's attention card.** `reset_for_restart` cleared `attention_state` but nothing closed the inbox row, so the card stayed answerable into a gone process and tripped `drift_against_fleet_session` permanently, on the assertion this lane installed in #934 as its own regression detector. Closed in the same transaction, stamped `resolved:restart`.
2. **`tier_of`'s doc comment was orphaned onto `parse_tier`.** Same defect class as the three fixed in #934 round two. Moved back.
3. **The fence now orders on `session_started`,** which the fingerprint carries, instead of on `event.observed_at` against a `last_observed_at` that mixes provider and daemon clocks. The clock comparison stays as the fallback, with the doc saying what it is worth, and the doc now also records which rows are unfenced: a `NULL` incarnation, which is the #916 population.

Two minors folded in: demoting the redundant unique index on the spec tuple to a plain one, and `legacy_key` as an `Option` rather than an empty-string sentinel, which the compiler immediately used to find an arm that had been silently querying for nothing.
